### PR TITLE
Add INT8 VAE decode engine

### DIFF
--- a/acestep/engine/trt/vae_decode_int8.py
+++ b/acestep/engine/trt/vae_decode_int8.py
@@ -1,0 +1,263 @@
+"""INT8 TensorRT engine build for the VAE decoder.
+
+Strategy
+--------
+- Pure 1D conv network → TRT's mature INT8 CNN path is a natural fit.
+- Snake activation (sin/exp/reciprocal/pow) isn't int8-friendly → enable FP16
+  fallback so TRT auto-chooses per-layer precision.
+- Narrow dynamic profile matching ``vae_window`` in production.
+- PTQ via IInt8EntropyCalibrator2 (default) or IInt8MinMaxCalibrator.
+- Optional fp16 pinning for the first / last conv layers, which sit closest
+  to the audio output and dominate quantization-induced reconstruction error.
+
+The engine's I/O binding names (``latents``, ``audio``) match
+:func:`acestep.nodes.vae_nodes._trt_vae_decode` so no wiring changes are
+needed on the runtime side.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Union
+
+from loguru import logger
+import torch
+
+
+# ------------------------------------------------------------------
+# Calibrator
+# ------------------------------------------------------------------
+
+def _make_calibrator(
+    latent_dir: Path,
+    cache_path: Path,
+    *,
+    batch_size: int = 1,
+    kind: str = "entropy",
+):
+    """Construct an INT8 calibrator over .pt latents in ``latent_dir``.
+
+    Each .pt must be a tensor of shape ``[1, 64, opt_frames]`` (matching
+    the calibration profile's pinned shape). The calibrator iterates
+    them once, feeding one batch at a time from a persistent GPU buffer.
+
+    Args:
+        kind: "entropy" → IInt8EntropyCalibrator2 (KL divergence; default,
+              tuned for image classifiers but works fine on most CNNs).
+              "minmax" → IInt8MinMaxCalibrator (uses observed min/max,
+              clipping nothing). Better when activations have heavy
+              tails the entropy method clips off; worse when there are
+              outlier activations that should be clipped.
+    """
+    import tensorrt as trt
+
+    latents: List[Path] = sorted(latent_dir.glob("latent_*.pt"))
+    if not latents:
+        raise FileNotFoundError(
+            f"No calibration latents found in {latent_dir}. "
+            f"Run scripts/collect_vae_calibration.py first."
+        )
+    logger.info(f"Calibrator[{kind}]: {len(latents)} latent samples in {latent_dir}")
+
+    if kind == "entropy":
+        Base = trt.IInt8EntropyCalibrator2
+    elif kind == "minmax":
+        Base = trt.IInt8MinMaxCalibrator
+    else:
+        raise ValueError(f"Unknown calibrator kind: {kind}")
+
+    class LatentCalibrator(Base):
+        def __init__(self):
+            super().__init__()
+            self._idx = 0
+            self._cache_path = cache_path
+            self._batch_size = batch_size
+            self._gpu_buf: Optional[torch.Tensor] = None
+
+        def get_batch_size(self):
+            return self._batch_size
+
+        def get_batch(self, names):
+            if self._idx >= len(latents):
+                return None
+            path = latents[self._idx]
+            self._idx += 1
+            try:
+                t = torch.load(path, weights_only=True, map_location="cuda")
+            except Exception as e:
+                logger.warning("Skip %s: %s", path, e)
+                return None
+            t = t.to(device="cuda", dtype=torch.float32).contiguous()
+            if self._gpu_buf is None or self._gpu_buf.shape != t.shape:
+                self._gpu_buf = t.clone()
+            else:
+                self._gpu_buf.copy_(t)
+            if self._idx % 8 == 0 or self._idx == len(latents):
+                logger.info(f"Calibrator: {self._idx}/{len(latents)}")
+            return [int(self._gpu_buf.data_ptr())]
+
+        def read_calibration_cache(self):
+            if self._cache_path.exists():
+                logger.info("Reusing calibration cache: %s", self._cache_path)
+                return self._cache_path.read_bytes()
+            return None
+
+        def write_calibration_cache(self, cache):
+            self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+            self._cache_path.write_bytes(bytes(cache))
+            logger.info(f"Wrote calibration cache: {self._cache_path} ({len(cache)/1024:.1f} KB)")
+
+    return LatentCalibrator()
+
+
+# ------------------------------------------------------------------
+# Layer pinning
+# ------------------------------------------------------------------
+
+def _pin_first_last_conv(network, *, n_first: int = 1, n_last: int = 1) -> List[str]:
+    """Force the first ``n_first`` and last ``n_last`` Conv layers (in
+    topological order) to fp16. These sit closest to the latent input
+    and audio output respectively, where quantization error is most
+    audible.
+
+    Returns the list of pinned layer names.
+    """
+    import tensorrt as trt
+
+    convs = [
+        i for i in range(network.num_layers)
+        if network.get_layer(i).type == trt.LayerType.CONVOLUTION
+    ]
+    if not convs:
+        logger.warning("No Conv layers found to pin")
+        return []
+
+    indices = list(dict.fromkeys(convs[:n_first] + convs[-n_last:]))
+    pinned: List[str] = []
+    for i in indices:
+        layer = network.get_layer(i)
+        layer.precision = trt.float16
+        for j in range(layer.num_outputs):
+            layer.set_output_type(j, trt.float16)
+        pinned.append(f"#{i} {layer.name}")
+    logger.info(f"Pinned to fp16: {pinned}")
+    return pinned
+
+
+# ------------------------------------------------------------------
+# Build
+# ------------------------------------------------------------------
+
+@dataclass
+class VAEDecodeInt8Config:
+    """Configuration for INT8 VAE decoder engine build.
+
+    Default dynamic profile (5s/10s/15s) matches typical short ``vae_window``
+    usage. For 60s engines pass min=125, opt=1500, max=1500 to match the
+    fp16 60s engine profile.
+    """
+    workspace_gb: float = 6.0
+    # latent frames @ 25 Hz
+    min_frames: int = 125   # 5s
+    opt_frames: int = 250   # 10s (== default vae_window)
+    max_frames: int = 375   # 15s
+
+    calibrator_kind: str = "entropy"  # entropy | minmax
+    pin_first_conv: int = 0           # how many leading Conv layers to fp16-pin
+    pin_last_conv: int = 0            # how many trailing Conv layers to fp16-pin
+
+
+def build_vae_decode_int8_engine(
+    onnx_path: Union[str, Path],
+    engine_path: Union[str, Path],
+    calibration_dir: Union[str, Path],
+    *,
+    config: Optional[VAEDecodeInt8Config] = None,
+    cache_path: Optional[Union[str, Path]] = None,
+) -> Path:
+    """Build an INT8-quantized TRT engine for the VAE decoder."""
+    import tensorrt as trt
+
+    if config is None:
+        config = VAEDecodeInt8Config()
+    onnx_path = Path(onnx_path)
+    engine_path = Path(engine_path)
+    calibration_dir = Path(calibration_dir)
+    engine_path.parent.mkdir(parents=True, exist_ok=True)
+    if cache_path is None:
+        cache_path = engine_path.with_suffix(".calib")
+    cache_path = Path(cache_path)
+
+    trt_logger = trt.Logger(trt.Logger.INFO)
+    builder = trt.Builder(trt_logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+    )
+
+    parser = trt.OnnxParser(network, trt_logger)
+    if not parser.parse_from_file(str(onnx_path.resolve())):
+        for i in range(parser.num_errors):
+            logger.error("ONNX parse error: %s", parser.get_error(i))
+        raise RuntimeError(f"ONNX parsing failed: {onnx_path}")
+
+    build_config = builder.create_builder_config()
+    build_config.set_memory_pool_limit(
+        trt.MemoryPoolType.WORKSPACE, int(config.workspace_gb * (1 << 30))
+    )
+    # INT8 with FP16 fallback: TRT picks per-layer precision automatically,
+    # keeping Snake ops in fp16 while running conv/conv_transpose in int8.
+    build_config.set_flag(trt.BuilderFlag.INT8)
+    build_config.set_flag(trt.BuilderFlag.FP16)
+
+    # Optional layer pinning.
+    if config.pin_first_conv or config.pin_last_conv:
+        _pin_first_last_conv(
+            network,
+            n_first=config.pin_first_conv,
+            n_last=config.pin_last_conv,
+        )
+        # OBEY = TRT must honour layer.precision (vs PREFER which is advisory).
+        build_config.set_flag(trt.BuilderFlag.OBEY_PRECISION_CONSTRAINTS)
+
+    # Optimization profile + calibration profile (both required for dynamic
+    # INT8 on TRT 10+).
+    profile = builder.create_optimization_profile()
+    profile.set_shape(
+        "latents",
+        min=(1, 64, config.min_frames),
+        opt=(1, 64, config.opt_frames),
+        max=(1, 64, config.max_frames),
+    )
+    build_config.add_optimization_profile(profile)
+
+    calib_profile = builder.create_optimization_profile()
+    calib_profile.set_shape(
+        "latents",
+        min=(1, 64, config.opt_frames),
+        opt=(1, 64, config.opt_frames),
+        max=(1, 64, config.opt_frames),
+    )
+    build_config.set_calibration_profile(calib_profile)
+
+    calibrator = _make_calibrator(
+        calibration_dir, cache_path, kind=config.calibrator_kind,
+    )
+    build_config.int8_calibrator = calibrator
+
+    logger.info(
+        f"Building INT8 VAE decode engine: frames min={config.min_frames} "
+        f"opt={config.opt_frames} max={config.max_frames}  "
+        f"calibrator={config.calibrator_kind}  "
+        f"pin_first={config.pin_first_conv} pin_last={config.pin_last_conv}  "
+        f"calib_dir={calibration_dir}"
+    )
+    serialized = builder.build_serialized_network(network, build_config)
+    if serialized is None:
+        raise RuntimeError("INT8 engine build failed (see TRT logger output)")
+    engine_path.write_bytes(serialized)
+
+    size_mb = engine_path.stat().st_size / (1 << 20)
+    logger.info(f"Engine written: {engine_path} ({size_mb:.1f} MB)")
+    return engine_path

--- a/demos/test_stream_cover_graph.py
+++ b/demos/test_stream_cover_graph.py
@@ -38,7 +38,7 @@ from acestep.nodes.types import Audio, Latent
 from acestep.paths import checkpoints_dir, project_root, trt_engine_path, select_trt_engines
 
 PROJECT_ROOT = project_root()
-SOURCE_AUDIO = PROJECT_ROOT / "tests/fixtures" / "new_order_confusion_60seconds.wav"
+DEFAULT_SOURCE_AUDIO = PROJECT_ROOT / "tests/fixtures" / "new_order_confusion_60seconds.wav"
 OUTPUT_DIR = PROJECT_ROOT / "_debug_tests" / "stream_output"
 
 SAMPLE_RATE = 48000
@@ -60,6 +60,13 @@ def _get_arg(name, default=None, cast=str):
 vae_window = _get_arg("--vae-window", 0.0, float)
 depth = _get_arg("--depth", 8, int)
 use_fast_vae = "--fast-vae" in _args
+vae_decode_engine_override = _get_arg("--vae-decode-engine", None, str)
+source_audio_override = _get_arg("--source-audio", None, str)
+if source_audio_override is not None:
+    _p = Path(source_audio_override)
+    SOURCE_AUDIO = _p if _p.is_absolute() else PROJECT_ROOT / _p
+else:
+    SOURCE_AUDIO = DEFAULT_SOURCE_AUDIO
 use_lora = "--lora" in _args
 if use_lora:
     _i = _args.index("--lora")
@@ -200,6 +207,11 @@ if use_fast_vae:
         print(f"[Setup] WARNING: {fast_name} engine missing, using {Path(trt_engines['vae_decode']).stem}")
     else:
         trt_engines["vae_decode"] = str(trt_engine_path(fast_name))
+if vae_decode_engine_override is not None:
+    override_path = trt_engine_path(vae_decode_engine_override)
+    if not Path(str(override_path)).exists():
+        raise FileNotFoundError(f"--vae-decode-engine {vae_decode_engine_override}: engine not found at {override_path}")
+    trt_engines["vae_decode"] = str(override_path)
 if not no_trt_decoder:
     trt_engines["decoder"] = str(TRT_ENGINE)
 
@@ -208,6 +220,7 @@ print(
     f"[Setup] decoder backend={'PT' if no_trt_decoder else 'TRT (' + decoder_engine_name + ')'}"
 )
 print(f"[Setup] vae backend=TRT  vae_window={vae_window}  depth={depth}")
+print(f"[Setup] vae_decode engine: {Path(trt_engines['vae_decode']).stem}")
 if use_dcw:
     print(
         f"[Setup] DCW=ON  mode={dcw_mode}  scaler={dcw_scaler}  "

--- a/docs/int8_vae_decode.md
+++ b/docs/int8_vae_decode.md
@@ -1,0 +1,176 @@
+# INT8 VAE decode, variant comparison
+
+_2026-05-01 17:00:00_
+
+> **Source artifacts** (per-variant `.wav` outputs, raw bench JSONs, the failed
+> hybrid + autotune build scripts, and the matrix orchestrator) live on the
+> archive branch `archive/ryanontheinside/int8-research-2026-05-01`. This doc
+> ships with the production build path only: variant A's builder, driver,
+> calibration tooling, and regression bench.
+
+## TL;DR
+
+**Practical winner: Variant A** (`vae_decode_int8_60s`), TRT entropy calibrator, 32 calibration latents, no layer pinning.
+
+- **1.64x faster than fp16** on standalone 60 s decode (33 ms vs 54 ms)
+- **32.5 dB PSNR vs fp16** on synthetic latents; below the encoder noise floor in encode/decode round-trips (both fp16 and int8 within 0.2 dB of PT)
+- **+88 MB VRAM** vs fp16 (engine binary grows because TRT retains both int8 and fp16 kernels; activation savings don't offset)
+
+**Worth shipping for**: large `vae_window` configurations and batch generation, where standalone VAE decode dominates and the 1.6x speedup compounds across long passes. For a 60 s decode chain, you save ~21 ms per call; if `vae_window` keeps the decoder hot, that's real time recovered.
+
+**Marginal for**: streaming pipelines with short `vae_window` and skip-cache reuse. The diffusion decoder dominates the tick (~88 ms) and int8 VAE saves <2 % end-to-end (260 ms over a 15 s run, see "Streaming pipeline" below).
+
+**Two negative results that closed the search**:
+- Variant H (hybrid: modelopt scales fed into TRT-native build path) was *worse* than A on quality (29.9 dB vs 32.5 dB) despite matching A on speed. Scales and graph structure are entangled, not independently swappable.
+- Variant I (modelopt autotune) failed structurally; its per-region trtexec timing harness can't build sub-graphs of this audio decoder in isolation. Designed for transformer-shaped graphs.
+
+## Key findings
+
+1. **Profile-matching the calibration data** to the deployed engine profile (1500-frame opt instead of 250-frame opt) was the first big win, moving fp16-vs-int8 PSNR from 28.3 dB to 32.5 dB on the same recipe (4.2 dB free).
+2. **modelopt closes the quality gap further** (+3.0 dB to 35.5 dB) but at a 2.4x latency penalty, ending up *slower* than fp16 and defeating the purpose. modelopt-entropy and modelopt-percentile produce essentially identical scales; the quality win is the modelopt pipeline (offline ORT scale computation), not the calibration algorithm.
+3. **modelopt's quality and speed are entangled**, not separable. A hybrid that injects modelopt scales into TRT-native's build pipeline (variant H) hits TRT-native's speed but produces *worse* quality than either parent (29.9 dB), because mixing wider modelopt scales on 16 % of tensors with narrower TRT-entropy scales on the surrounding 84 % creates boundary mismatches that add quantization error.
+4. **Layer pinning, MinMax, and more calibration data with the TRT-native pipeline all hurt or did nothing.**
+5. **The Pareto frontier vs fp16** has only one int8 point that is strictly better than fp16 on the speed axis: Variant A. All modelopt variants are dominated by fp16 on speed.
+6. **For streaming**, int8's win is dilute: 1.7 % end-to-end despite a 1.58x per-VAE-call speedup, because VAE decode is only 13 % of the streaming tick (88 ms diffusion + 12 ms VAE → 7 ms VAE).
+7. **int8 costs VRAM, doesn't save it.** The INT8+FP16 builder flag retains kernels for both precisions, so int8 engines are larger than fp16 engines. Most ops stay in fp16 anyway (Snake activations are not int8-friendly), so activation memory is similar.
+
+## Setup
+
+- All INT8 variants share the same 60 s dynamic profile (min=125, opt=1500, max=1500 latent frames).
+- Calibration set: 32 generated latents at 1500 frames each (prompt-diverse: dance / jazz / ambient / metal / hip hop / classical / folk / synthwave; cfg=7.5; 8 steps).
+- fp16 baseline is `vae_decode_fp16_60s` (existing build, same 60 s profile).
+- PT eager reference is the bf16 ACE-Step Oobleck VAE (`session.handler.vae`).
+- All measurements on RTX 5090, TRT 10.13.3, torch 2.9.1+cu128.
+
+## Variant matrix
+
+| Variant | Description | Engine | MB |
+|---|---|---|---:|
+| A | TRT entropy, 32 latents, no pinning | `vae_decode_int8_60s` | 245 |
+| B | TRT minmax, 32 latents, no pinning | `vae_decode_int8_60s_minmax` | 250 |
+| C | TRT entropy, 32 latents, pin first/last conv to fp16 | `vae_decode_int8_60s_pin` | 240 |
+| D | TRT entropy + pin (orchestrator pick, dup of C) | `vae_decode_int8_60s_combined` | 251 |
+| E | TRT minmax, 32 latents, pin first/last conv | `vae_decode_int8_60s_minmax_pin` | 226 |
+| F | TRT entropy, 128 transient-biased latents | `vae_decode_int8_60s_data128` | 259 |
+| G1 | modelopt percentile-99.999, 32 latents | `vae_decode_int8_60s_modelopt_pct32` | 88 |
+| G2 | modelopt entropy, 32 latents | `vae_decode_int8_60s_modelopt_ent32` | 88 |
+| G3 | modelopt percentile-99.999, 128 latents | `vae_decode_int8_60s_modelopt_pct128` | 88 |
+| H | hybrid: G2 scales injected into TRT-native build path | `vae_decode_int8_60s_hybrid` | 341 |
+| I | modelopt autotune (G2 baseline + per-region search) | (build failed: 0 Q/DQ pairs produced) | n/a |
+
+## Synthetic latent (Session.generate, 60 s, seed=42)
+
+Decode-only quality, measured on a freshly-generated 1500-frame latent. **Speedup vs fp16 = fp16_ms / int8_ms** (>1.0x = int8 is faster, <1.0x = int8 is slower than fp16 and should be discarded).
+
+| Variant | int8 ms | fp16 ms | **Speedup vs fp16** | int8 MSE vs PT | fp16 MSE vs PT | fp16-vs-int8 PSNR (dB) | Verdict |
+|---|---:|---:|---:|---:|---:|---:|---|
+| A | 32.9 | 54.0 | 1.64x | 6.87e-04 | 3.46e-06 | 32.52 | **1.64x faster, ship** |
+| B | 34.8 | 54.8 | 1.57x | 1.53e-03 | 3.46e-06 | 29.02 | 1.57x faster, lower quality |
+| C | 34.1 | 54.0 | 1.58x | 9.98e-04 | 3.46e-06 | 30.87 | 1.58x faster, lower quality |
+| D | 34.2 | 54.0 | 1.58x | 9.43e-04 | 3.46e-06 | 31.11 | 1.58x faster, lower quality |
+| E | 34.5 | 54.3 | 1.58x | 1.06e-03 | 3.46e-06 | 30.62 | 1.58x faster, lower quality |
+| F | 33.9 | 55.4 | 1.63x | 8.03e-04 | 3.46e-06 | 31.83 | 1.63x faster, similar to A |
+| G1 | 78.7 | 54.2 | 0.69x | 3.46e-04 | 3.46e-06 | 35.51 | _slower than fp16, DISCARD_ |
+| G2 | 79.1 | 54.2 | 0.69x | 3.46e-04 | 3.46e-06 | 35.51 | _slower than fp16, DISCARD_ |
+| G3 | 82.1 | 57.0 | 0.69x | 8.54e-04 | 3.46e-06 | 31.57 | _slower than fp16, DISCARD_ |
+| H | 34.2 | 55.9 | 1.63x | 1.24e-03 | 3.46e-06 | 29.88 | 1.63x faster but *worse quality than A* |
+
+## Wav round-trip (encode->decode of `tests/fixtures/inside_confusion.wav`, first 60 s)
+
+The wav is PT-encoded once and the same latents are decoded by all three paths. PSNR vs fp16 is the metric that matters for the int8-vs-fp16 question; PSNR vs original is mostly encoder-dominated noise (~0.2 dB spread across all decoders).
+
+| Variant | int8 ms | fp16 ms | **Speedup vs fp16** | fp16-vs-int8 PSNR (dB) | int8 PSNR vs orig | fp16 PSNR vs orig | Verdict |
+|---|---:|---:|---:|---:|---:|---:|---|
+| A | 33.3 | 55.0 | 1.65x | 26.25 | 18.27 | 18.11 | **1.65x faster, ship** |
+| B | 32.8 | 54.7 | 1.67x | 25.54 | 16.20 | 18.11 | 1.67x faster |
+| C | 34.4 | 55.0 | 1.60x | 25.79 | 18.20 | 18.11 | 1.60x faster |
+| D | 35.1 | 54.6 | 1.56x | 25.76 | 18.04 | 18.11 | 1.56x faster |
+| E | 34.1 | 55.0 | 1.61x | 27.31 | 17.04 | 18.11 | 1.61x faster |
+| F | 33.5 | 55.9 | 1.67x | 25.90 | 18.30 | 18.11 | 1.67x faster |
+| G1 | 79.0 | 54.3 | 0.69x | 31.74 | 17.78 | 18.11 | _slower, DISCARD_ |
+| G2 | 79.1 | 54.1 | 0.68x | 31.76 | 17.79 | 18.11 | _slower, DISCARD_ |
+| G3 | 82.9 | 57.8 | 0.70x | 30.16 | 17.57 | 18.11 | _slower, DISCARD_ |
+| H | 35.1 | 58.3 | 1.66x | 24.76 | 18.11 | 18.11 | 1.66x faster but *worse than A* |
+
+## Streaming pipeline (`demos/test_stream_cover_graph.py`, 60 s cover, vae-window=5)
+
+Why this matters: the standalone decode benches above measure VAE decode in isolation. The streaming pipeline is the actual production path, where VAE decode is one of many stages and the 53 % skip-cache rate (latents that didn't change enough between ticks reuse the prior wav) further dilutes the int8 contribution.
+
+| Metric | fp16 | int8 (A) | win |
+|---|---:|---:|---:|
+| Per-call VAE decode (avg of 75 calls) | 12.5 ms | 7.9 ms | 1.58x |
+| Amortized decode (53 % skip rate) | 5.9 ms | 3.7 ms | 2.2 ms saved |
+| Diffusion + everything-else tick | 88.0 ms | 88.6 ms | ~noise |
+| **Per-generation total** | **93.9 ms** | **92.3 ms** | **1.7 %** |
+| Total run time (160 generations) | 15055 ms | 14797 ms | 258 ms |
+
+In streaming, VAE decode is ~13 % of the tick. The 1.58x decode speedup compresses that 13 % to ~8 %, recovering 1.7 % of total time. Real but small.
+
+The standalone wins (1.64x on the bench) translate fully when `vae_window` is large enough that decode runs unbroken (no skip cache, full 60 s passes). They translate marginally in tight streaming.
+
+## VRAM
+
+| | fp16 | int8 (A) | int8 (G2 modelopt) |
+|---|---:|---:|---:|
+| Engine binary | 181 MB | **245 MB** | 88 MB |
+| Engine vs fp16 | baseline | **+64 MB** | -93 MB |
+| Peak runtime alloc | 6.621 GB | 6.644 GB | (not measured) |
+| Alloc vs fp16 | baseline | **+24 MB** | -- |
+| **Net VRAM impact vs fp16** | -- | **+88 MB** | -93 MB (but slower, discarded) |
+
+Why int8 (A) costs more VRAM, not less:
+
+1. **TRT retains kernels for both precisions.** With `INT8+FP16` builder flags, TRT keeps int8 and fp16 tactics in the engine and selects per-layer at runtime. Engine binary grows.
+2. **Snake activations stay fp16.** `sin`, `exp`, `reciprocal`, `pow` are not int8-friendly; TRT picks fp16 for them automatically. Most of the activation memory is for these layers, where there's no int8 saving.
+3. **Activation savings on the conv layers** (1 byte vs 2 bytes per element) are real but small relative to the doubled kernel storage in the engine binary.
+
+The only int8 build that's actually *smaller* than fp16 is G2 (modelopt) at 88 MB, because modelopt commits each op to one precision (no fallback kernels). G2 is slower than fp16 (0.69x), so it's discarded for shipping; but on a VRAM-constrained box where you can tolerate slower decode, G2 is the only int8 build that wins on memory.
+
+## When to ship int8 (A)
+
+Ship A when **standalone VAE decode latency matters**:
+- **Large `vae_window`**: decoding long contiguous spans of audio. Each call does the full 60 s decode; the 33 ms vs 54 ms gap (21 ms saved per call) compounds.
+- **Batch generation**: producing many independent generations back-to-back, decoding each. No skip cache to mask the difference.
+- **Non-realtime decode**: any pipeline where `Session.decode()` is called outside the streaming tick loop (e.g., final-pass decode of a fully-denoised latent for export).
+
+Stick with fp16 when:
+- **Streaming with short `vae_window`** (the demo's default `vae_window=5` case): VAE is too small a fraction of tick time for the int8 win to show. The 1.7 % end-to-end speedup is below the noise floor of the diffusion decoder's variability.
+- **VRAM is tight**: int8 costs +88 MB. If you're at the edge of VRAM, that pushes you over.
+
+## Decision guide (metrics)
+
+- The **synthetic int8-MSE-vs-PT** is the cleanest signal of decoder fidelity. Use that to pick the variant. modelopt variants (G1, G2, G3) win by 2-3x on this metric, but they cost so much speed they ship as fp16 instead.
+- The **wav round-trip PSNR vs the original audio is dominated by the encoder**: PT, fp16, and int8 all sit within ~0.2 dB of each other. Decoder differences are not audible at this granularity for full encode/decode cycles, but they do matter when the latent comes from generation (not encoding), since there is no encoder error to mask.
+- TRT-native int8 variants run at ~33 ms/60 s (1800x realtime). modelopt variants run at ~79 ms/60 s (760x realtime). For non-realtime decoding, latency doesn't matter. For streaming/realtime, both are fine; the question is whether the int8 path's marginal streaming win is worth the +88 MB VRAM.
+
+Engines and wavs:
+- Engines: `~/.daydream-scope/models/demon/trt_engines/<engine_name>/`
+- Per-variant wavs: `bench_outputs/vae_int8/<engine_name>/`
+  - `wav_original.wav`: the source clip, trimmed to 60 s
+  - `wav_pt_eager.wav` / `wav_trt_fp16.wav` / `wav_trt_int8.wav`: decoded outputs
+  - `synth_*.wav`: decoded synthetic latents
+- Streaming outputs: `_debug_tests/stream_output/stream_cover_vae_{fp16,int8}_w5.wav`
+
+## What didn't work
+
+**MinMax calibrator (B, E):** MinMax sets per-tensor int8 scales from observed (min, max), with no clipping. Snake-activated audio decoders have heavy-tailed activations; a single transient sample sets the scale and most of the int8 range is wasted. KL-entropy calibration clips outliers for better resolution on the bulk distribution. MSE doubled going entropy->minmax in TRT-native (A 6.87e-4 -> B 1.53e-3).
+
+**Pinning first/last Conv to fp16 (C, D, E):** in theory the input and output convs are the most sensitive layers. In practice TRT inserts reformat kernels at int8/fp16 boundaries and `OBEY_PRECISION_CONSTRAINTS` removes tactics from the search. Pinned layers run fp16 but eat quantization error from input reformats, and neighbouring layers can't opportunistically stay fp16. A's MSE 6.87e-4 vs C's 9.98e-4 is a 45 % degradation.
+
+**More calibration data with TRT-native (F):** going from 32 to 128 prompt-diverse, transient-biased latents with the same TRT-entropy recipe slightly *hurt* synthetic MSE (8.03e-4 vs 6.87e-4). TRT's calibrator appears to plateau quickly; the bottleneck is the calibrator, not the data volume. Same data through modelopt (G3) does help.
+
+**modelopt percentile vs entropy (G1 vs G2):** **identical** results to four significant figures (MSE 3.46e-04 each). The win is the modelopt pipeline (offline ORT-based scale computation, more aggressive fp16 fallback for non-quantized ops), not the choice of calibration algorithm.
+
+**modelopt percentile + transient-biased 128 latents (G3) was *worse* than 32 mixed-prompt (G1/G2):** MSE 8.54e-04 vs 3.46e-04, a 2.5x degradation. Reason: the extra prompts I added were percussion- and quiet-ambient-heavy (drums, claps, vinyl crackle, drone). Their activation tails are *wider* than the original diverse mix, so the 99.999th percentile picks a wider per-tensor scale, sacrificing precision on the bulk distribution to accommodate transients that the production stream rarely sees. **Lesson**: for percentile calibration, the calibration set must match the inference distribution, not artificially stretch it. The original 32-latent mixed-prompt set was already the right distribution. "More data" was the wrong axis to optimize.
+
+**Hybrid (variant H), modelopt scales + TRT-native build path:** the hypothesis was that modelopt's scale quality and TRT-native's build speed could be combined. Implementation: walk G2's QDQ ONNX, extract `y_scale` from each `QuantizeLinear` for per-tensor activations (124 of them, the per-channel weight scales TRT folds from the embedded Q/DQ pattern), merge into TRT-native's calibration cache by tensor-name match, build with the same TRT-native pipeline. Coverage: 165 of 1035 TRT cache entries got modelopt scales (16 %); the remaining 84 % retained TRT-entropy values.
+
+Result: 1.63x speed (matched A), 29.88 dB PSNR (worse than A's 32.52 dB).
+
+The empirical scale check showed modelopt's scales are roughly 2x wider than TRT-entropy's on the same tensors (median ratio 0.5 with quartile spread 0.4 to 0.6). modelopt deliberately preserves outliers; TRT-entropy aggressively clips them. The wider modelopt scales work coherently graph-wide because modelopt also keeps heavy-tailed ops in fp16, so the wider scales never have to compete with narrow ones at int8-int8 boundaries. In the hybrid, that coherence breaks: 16 % of layers use wider scales, 84 % use narrower ones, and the boundary mismatches *add* quantization error rather than reducing it.
+
+**Insight**: scales and graph structure are entangled. modelopt's quality advantage cannot be transplanted into TRT-native's build path by scale substitution alone. Future hybrids would need to also transplant modelopt's per-op precision decisions, at which point you've reproduced modelopt's full pipeline and inherited its speed problem.
+
+**Autotune (variant I), modelopt with `autotune=True`:** modelopt's autotune extracts each region of the graph as a sub-ONNX, builds it via trtexec, and times candidate quantization schemes per region to find the fastest config that meets a quality threshold. Discovers 322 regions on this graph and seeds 27 patterns from G2. Every per-region timing returned `error: true`: the extracted sub-graphs (Snake activations `Mul→Sin→Pow→Mul→Add`, dynamic-shape ConvTranspose with stride-10 upsampling, Reshape→Conv chains) cannot be compiled in isolation without the full graph's shape context.
+
+Autotune correctly concluded "no scheme is faster than the baseline" because every measurement was `.inf`, exported a final ONNX with 0 Q/DQ pairs, and the subsequent TRT build failed because there were no scales. The result is informative: modelopt autotune is designed for transformer-shaped graphs with self-contained MHA/feed-forward blocks. A 1D conv VAE decoder with Snake activations and dynamic time dim doesn't fit the assumption.

--- a/scripts/build_vae_int8_engine.py
+++ b/scripts/build_vae_int8_engine.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Build the INT8 VAE decode TRT engine.
+
+Reads the existing VAE decode ONNX export and the calibration latents
+dumped by ``scripts/collect_vae_calibration.py``, runs PTQ via TRT's
+calibrator, and writes the engine to
+``<trt_engines>/<engine-name>/<engine-name>.engine``.
+
+Usage:
+    uv run python scripts/build_vae_int8_engine.py
+    uv run python scripts/build_vae_int8_engine.py \\
+        --engine-name vae_decode_int8_60s_minmax --calibrator minmax \\
+        --calib-dir <path> --opt-frames 1500 --max-frames 1500
+    uv run python scripts/build_vae_int8_engine.py \\
+        --engine-name vae_decode_int8_60s_pin --pin-first 1 --pin-last 1 \\
+        --calib-dir <path> --opt-frames 1500 --max-frames 1500
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from acestep.engine.trt.vae_decode_int8 import (
+    VAEDecodeInt8Config,
+    build_vae_decode_int8_engine,
+)
+from acestep.paths import models_dir, trt_engines_dir
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--engine-name", default="vae_decode_int8_15s")
+    ap.add_argument("--onnx", default=None,
+                    help="Default: <trt_engines>/_onnx_vae/vae_decode/vae_decode.onnx")
+    ap.add_argument("--calib-dir", default=None,
+                    help="Default: <models>/calibration/vae_latents")
+    ap.add_argument("--workspace-gb", type=float, default=8.0)
+    ap.add_argument("--min-frames", type=int, default=125)
+    ap.add_argument("--opt-frames", type=int, default=250)
+    ap.add_argument("--max-frames", type=int, default=375)
+    ap.add_argument("--calibrator", choices=["entropy", "minmax"],
+                    default="entropy")
+    ap.add_argument("--pin-first", type=int, default=0,
+                    help="Pin first N Conv layers to fp16 (0 = no pinning)")
+    ap.add_argument("--pin-last", type=int, default=0,
+                    help="Pin last N Conv layers to fp16 (0 = no pinning)")
+    args = ap.parse_args()
+
+    onnx_path = (
+        Path(args.onnx) if args.onnx
+        else trt_engines_dir() / "_onnx_vae" / "vae_decode" / "vae_decode.onnx"
+    )
+    calib_dir = (
+        Path(args.calib_dir) if args.calib_dir
+        else models_dir() / "calibration" / "vae_latents"
+    )
+    engine_path = trt_engines_dir() / args.engine_name / f"{args.engine_name}.engine"
+
+    if not onnx_path.exists():
+        raise FileNotFoundError(f"ONNX not found: {onnx_path}")
+    latents = sorted(calib_dir.glob("latent_*.pt")) if calib_dir.exists() else []
+    if not latents:
+        raise FileNotFoundError(
+            f"No calibration latents in {calib_dir}. "
+            f"Run scripts/collect_vae_calibration.py first."
+        )
+
+    config = VAEDecodeInt8Config(
+        workspace_gb=args.workspace_gb,
+        min_frames=args.min_frames,
+        opt_frames=args.opt_frames,
+        max_frames=args.max_frames,
+        calibrator_kind=args.calibrator,
+        pin_first_conv=args.pin_first,
+        pin_last_conv=args.pin_last,
+    )
+    print(f"ONNX:        {onnx_path}")
+    print(f"Calibration: {calib_dir}  ({len(latents)} latents)")
+    print(f"Engine:      {engine_path}")
+    print(f"Profile:     min={config.min_frames}  opt={config.opt_frames}  max={config.max_frames}")
+    print(f"Calibrator:  {config.calibrator_kind}")
+    print(f"Pin:         first={config.pin_first_conv}  last={config.pin_last_conv}")
+    print()
+
+    build_vae_decode_int8_engine(
+        onnx_path=onnx_path,
+        engine_path=engine_path,
+        calibration_dir=calib_dir,
+        config=config,
+    )
+
+    size_mb = engine_path.stat().st_size / 1e6
+    print(f"\nDone: {engine_path}  ({size_mb:.1f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/collect_vae_calibration.py
+++ b/scripts/collect_vae_calibration.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Dump VAE calibration latents for INT8 PTQ.
+
+Generates ``--num-latents`` latents through ``Session.generate()`` over a
+varied prompt mix, slices each to ``[1, 64, --frames]`` (matching the
+:class:`VAEDecodeInt8Config` opt shape), and saves as ``latent_NNNN.pt``
+under ``<models>/calibration/vae_latents/``.
+
+The TRT INT8 entropy calibrator in :mod:`acestep.engine.trt.vae_decode_int8`
+reads exactly that directory pattern.
+
+Usage:
+    uv run python scripts/collect_vae_calibration.py
+    uv run python scripts/collect_vae_calibration.py --num-latents 64
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import torch
+torch.set_grad_enabled(False)
+
+from acestep.constants import TASK_INSTRUCTIONS
+from acestep.engine.session import Session
+from acestep.nodes.types import Curve
+from acestep.paths import default_trt_engines, models_dir, trt_engine_path
+
+
+PROMPTS = [
+    # Original mix
+    ("dance music, four on the floor, kick drum, electronic, club, energetic synth bass, bright leads", 128, "F minor"),
+    ("jazz piano trio, brushed drums, walking bass", 140, "Bb major"),
+    ("ambient electronic, slow pads, evolving textures", 80, "C minor"),
+    ("metal, aggressive guitar riffs, fast double kick, growling vocals", 180, "E minor"),
+    ("hip hop beat, 808 bass, trap hi-hats, dark synths", 140, "F# minor"),
+    ("classical orchestral, sweeping strings, brass, timpani", 90, "D major"),
+    ("acoustic folk, fingerpicked guitar, soft harmonica, brushes", 100, "G major"),
+    ("synthwave, retro drum machine, analog synth, neon", 120, "A minor"),
+    # Transient-heavy: where int8 saturation hurts most
+    ("techno, hard punchy kick drums, fast hi-hats, snare hits, 140 bpm, no melody", 140, "C minor"),
+    ("rock drum kit solo, kick snare hi-hat, fast fills, no other instruments", 160, "A minor"),
+    ("trap beat, 808 sub bass, snappy snares, claps, hi-hat rolls, sparse", 140, "G minor"),
+    ("fingerstyle acoustic guitar, sharp transient plucks, percussive slaps, no vocals", 110, "D major"),
+    ("marimba and xylophone duet, percussive mallets, quick attacks", 120, "C major"),
+    ("hard rock, distorted power chords, heavy double kick drums, snare cracks", 150, "E minor"),
+    # Low-signal: where int8 noise floor hurts most
+    ("ambient drone, very quiet, slow evolving texture, sub-bass rumble", 60, "A minor"),
+    ("vinyl crackle and room tone, distant piano hits, sparse, dynamic range", 80, "F major"),
+]
+
+
+def _load_session(use_trt: bool) -> Session:
+    """Prefer TRT decoder if engines exist (much faster generation).
+
+    Falls back to eager when any required engine is missing.
+    """
+    if use_trt:
+        try:
+            engines = default_trt_engines(
+                decoder="decoder_mixed_refit_b8_60s",
+                vae_encode="vae_encode_fp16_60s",
+                vae_decode="vae_decode_fp16_60s",
+            )
+            for k, p in engines.items():
+                if not Path(p).exists():
+                    print(f"  [trt] missing {k}: {p}; falling back to eager")
+                    use_trt = False
+                    break
+            if use_trt:
+                print("  [trt] using existing 60s engines for decoder + vae")
+                return Session(
+                    decoder_backend="tensorrt",
+                    vae_backend="tensorrt",
+                    use_flash_attention=True,
+                    trt_engines=engines,
+                )
+        except Exception as e:
+            print(f"  [trt] init failed: {e}; falling back to eager")
+
+    return Session(decoder_backend="eager", vae_backend="eager", use_flash_attention=True)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--num-latents", type=int, default=32,
+                    help="Total latents to collect (default: 32)")
+    ap.add_argument("--frames", type=int, default=250,
+                    help="Latent frames per sample. Must equal "
+                         "VAEDecodeInt8Config.opt_frames (default: 250 = 10s)")
+    ap.add_argument("--steps", type=int, default=8)
+    ap.add_argument("--shift", type=float, default=3.0)
+    ap.add_argument("--cfg", type=float, default=7.5)
+    ap.add_argument("--no-trt", action="store_true",
+                    help="Skip TRT decoder fast-path; use eager Session")
+    ap.add_argument("--output-dir", default=None,
+                    help="Default: <models>/calibration/vae_latents")
+    args = ap.parse_args()
+
+    out_dir = Path(args.output_dir) if args.output_dir else models_dir() / "calibration" / "vae_latents"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Need at least frames worth, but the 60s TRT decoder profile maxes at
+    # T=1500 (60s). Cap so we don't trip its profile.
+    DECODER_MAX_S = 60.0
+    desired = args.frames / 25.0
+    if desired >= DECODER_MAX_S:
+        duration = DECODER_MAX_S  # exact: T == frames
+    else:
+        duration = min(desired + 2.0, DECODER_MAX_S)
+
+    print(f"Calibration output: {out_dir}")
+    print(f"Per-latent shape:   [1, 64, {args.frames}]  ({args.frames / 25.0:.1f}s)")
+    print(f"Generate duration:  {duration:.1f}s, {args.steps} steps, cfg={args.cfg}")
+    print(f"Target count:       {args.num_latents}")
+    print()
+
+    print("Loading session...")
+    t0 = time.time()
+    session = _load_session(use_trt=not args.no_trt)
+    print(f"  Session ready in {time.time() - t0:.1f}s")
+
+    # Pre-encode each prompt's conditioning once and reuse across seeds.
+    print("\nPre-encoding prompts...")
+    prompt_packs = []
+    for tags, bpm, key in PROMPTS:
+        cond = session.encode_text(
+            tags=tags, lyrics="[instrumental]",
+            instruction=TASK_INSTRUCTIONS["text2music"],
+            bpm=bpm, duration=duration, key=key,
+        )
+        neg = session.null_conditioning(cond)
+        prompt_packs.append((cond, neg, tags))
+    print(f"  {len(prompt_packs)} prompts ready")
+
+    T = int(round(duration * 25))
+    guidance = Curve(tensor=torch.full((T,), args.cfg, dtype=torch.bfloat16))
+
+    saved = 0
+    seed = 1000
+    print(f"\nGenerating {args.num_latents} latents...")
+    while saved < args.num_latents:
+        cond, neg, tags = prompt_packs[saved % len(prompt_packs)]
+
+        t0 = time.time()
+        latent = session.generate(
+            conditioning=cond,
+            negative=neg,
+            guidance_curve=guidance,
+            seed=seed,
+            duration=duration,
+            steps=args.steps,
+            shift=args.shift,
+            denoise=1.0,
+        )
+        gen_dt = time.time() - t0
+
+        lat_bdt = latent.tensor.transpose(1, 2).contiguous()  # [B, D, T]
+        if lat_bdt.shape[1] != 64:
+            raise RuntimeError(f"Expected D=64, got {lat_bdt.shape[1]}")
+        if lat_bdt.shape[2] < args.frames:
+            raise RuntimeError(
+                f"Latent has {lat_bdt.shape[2]} frames, need >= {args.frames}"
+            )
+
+        chunk = lat_bdt[:, :, :args.frames].contiguous().float().cpu()
+        path = out_dir / f"latent_{saved:04d}.pt"
+        torch.save(chunk, path)
+
+        prompt_short = tags[:40] + ("..." if len(tags) > 40 else "")
+        print(f"  [{saved + 1:>3}/{args.num_latents}] seed={seed:<5} dt={gen_dt:5.1f}s  "
+              f"{path.name}  ({prompt_short})")
+
+        saved += 1
+        seed += 1
+
+    print(f"\nSaved {saved} latents to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/bench_vae_int8_regular.py
+++ b/tests/benchmarks/bench_vae_int8_regular.py
@@ -1,0 +1,361 @@
+"""Compare VAE decode for the ACE-Step Oobleck VAE: PT eager vs TRT fp16 vs TRT int8.
+
+Two tests, both run by default:
+
+  Test A (synthetic):  generate one latent, decode it three ways.
+                       Reports per-path latency, peak alloc, MSE vs PT.
+                       Writes pt_eager.wav / trt_fp16.wav / trt_int8.wav.
+
+  Test B (wav round-trip):
+                       Load --wav, encode via PT VAE, decode three ways,
+                       save round-tripped wavs alongside the original.
+                       Reports MSE vs the PT round-trip (decode-only error)
+                       AND vs the original wav (full round-trip error).
+
+Usage:
+    uv run python tests/benchmarks/bench_vae_int8_regular.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import numpy as np
+import torch
+torch.set_grad_enabled(False)
+
+import soundfile as sf
+
+from acestep.constants import TASK_INSTRUCTIONS
+from acestep.engine.session import Session
+from acestep.nodes.vae_nodes import _trt_vae_decode
+from acestep.paths import trt_engines_dir
+
+
+# -------------------------------------------------------------------
+# Helpers
+# -------------------------------------------------------------------
+
+def _bench_one(label, fn, reference=None):
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    t0 = time.perf_counter()
+    out = fn()
+    torch.cuda.synchronize()
+    dt_ms = (time.perf_counter() - t0) * 1000
+    peak_gb = torch.cuda.max_memory_allocated() / 1e9
+    mse = None
+    if reference is not None:
+        mse = ((out.float() - reference.float()) ** 2).mean().item()
+    if mse is not None:
+        print(f"  [{label:>16}] {dt_ms:7.1f} ms  peak_alloc={peak_gb:.3f} GB  mse={mse:.2e}")
+    else:
+        print(f"  [{label:>16}] {dt_ms:7.1f} ms  peak_alloc={peak_gb:.3f} GB")
+    return {"label": label, "ms": dt_ms, "peak_alloc_gb": peak_gb, "mse": mse}, out
+
+
+def _save_wav(audio_bcs: torch.Tensor, path: Path, sr: int = 48000):
+    wav = audio_bcs.detach().squeeze(0).float().cpu().numpy().T  # [samples, channels]
+    sf.write(str(path), wav, sr)
+    print(f"  wav: {path}")
+
+
+def _summarize(runs):
+    ms = sorted(r["ms"] for r in runs)
+    peak = max(r["peak_alloc_gb"] for r in runs)
+    med = ms[len(ms) // 2]
+    mses = [r["mse"] for r in runs if r["mse"] is not None]
+    mse = sum(mses) / len(mses) if mses else None
+    return med, peak, mse
+
+
+def _print_table(rows, mse_label="MSE vs PT"):
+    print("\n" + "=" * 78)
+    print(f"{'Path':<18}{'Median ms':>12}{'Peak alloc GB':>18}{mse_label:>30}")
+    print("-" * 78)
+    for name, med, peak, mse in rows:
+        s = f"{mse:.2e}" if mse is not None else "(reference)"
+        print(f"{name:<18}{med:>12.1f}{peak:>18.3f}{s:>30}")
+    print("=" * 78)
+
+
+def _audio_metrics(out: torch.Tensor, ref: torch.Tensor):
+    """RMSE + PSNR (assuming roughly [-1, 1] range)."""
+    diff = (out.float() - ref.float()).flatten()
+    rmse = diff.pow(2).mean().sqrt().item()
+    peak = max(ref.float().abs().max().item(), 1e-9)
+    psnr = 20.0 * math.log10(peak / max(rmse, 1e-12))
+    return rmse, psnr
+
+
+# -------------------------------------------------------------------
+# Test A: synthetic latent
+# -------------------------------------------------------------------
+
+def run_synthetic(session, fp16_path, int8_path, args, out_dir, device, results=None):
+    print("\n" + "#" * 78)
+    print("# Test A: synthetic latent")
+    print("#" * 78)
+    handler = session.handler
+
+    print("Generating a latent...")
+    cond = session.encode_text(
+        tags="electronic ambient, evolving pads, 120 bpm",
+        lyrics="[instrumental]",
+        duration=args.duration,
+        instruction=TASK_INSTRUCTIONS["text2music"],
+    )
+    neg = session.null_conditioning(cond)
+    latent = session.generate(
+        conditioning=cond, negative=neg,
+        seed=args.seed, duration=args.duration,
+        steps=args.steps, shift=3.0, denoise=1.0,
+    )
+    lat_bdt = latent.tensor.transpose(1, 2).contiguous()
+    chunk = lat_bdt[:, :, :args.chunk_frames].contiguous()
+    print(f"  chunk: shape={tuple(chunk.shape)}  dtype={chunk.dtype}")
+
+    def pt_decode():
+        return handler.vae.decode(chunk.to(handler.vae.dtype)).sample
+
+    print("\nWarmup (1 each)...")
+    _ = pt_decode()
+    _ = _trt_vae_decode(chunk, str(fp16_path), device)
+    _ = _trt_vae_decode(chunk, str(int8_path), device)
+    torch.cuda.synchronize()
+
+    print(f"\n{args.runs} timed runs each:")
+    pt_runs, fp16_runs, int8_runs = [], [], []
+    pt_out = fp16_out = int8_out = None
+    for _ in range(args.runs):
+        r, o = _bench_one("PT eager bf16", pt_decode); pt_runs.append(r); pt_out = o
+    reference = pt_out.detach().clone()
+    for _ in range(args.runs):
+        r, o = _bench_one("TRT fp16",
+                          lambda: _trt_vae_decode(chunk, str(fp16_path), device),
+                          reference=reference); fp16_runs.append(r); fp16_out = o
+    for _ in range(args.runs):
+        r, o = _bench_one("TRT int8",
+                          lambda: _trt_vae_decode(chunk, str(int8_path), device),
+                          reference=reference); int8_runs.append(r); int8_out = o
+
+    print("\nSaving wavs (synthetic)...")
+    _save_wav(pt_out, out_dir / "synth_pt_eager.wav")
+    _save_wav(fp16_out, out_dir / "synth_trt_fp16.wav")
+    _save_wav(int8_out, out_dir / "synth_trt_int8.wav")
+
+    rows = []
+    for runs, name in [(pt_runs, "PT eager bf16"), (fp16_runs, "TRT fp16"), (int8_runs, "TRT int8")]:
+        med, peak, mse = _summarize(runs)
+        rows.append((name, med, peak, mse))
+    _print_table(rows, mse_label="MSE vs PT")
+
+    rmse_fp16_int8, psnr_fp16_int8 = _audio_metrics(int8_out, fp16_out)
+    print(f"  fp16 vs int8 (audio):  RMSE={rmse_fp16_int8:.6f}  PSNR={psnr_fp16_int8:.2f} dB")
+
+    if results is not None:
+        results["synthetic"] = {
+            "pt": {"median_ms": rows[0][1], "peak_alloc_gb": rows[0][2]},
+            "fp16": {"median_ms": rows[1][1], "peak_alloc_gb": rows[1][2], "mse_vs_pt": rows[1][3]},
+            "int8": {"median_ms": rows[2][1], "peak_alloc_gb": rows[2][2], "mse_vs_pt": rows[2][3]},
+            "fp16_vs_int8": {"rmse": rmse_fp16_int8, "psnr_db": psnr_fp16_int8},
+        }
+
+
+# -------------------------------------------------------------------
+# Test B: wav round-trip
+# -------------------------------------------------------------------
+
+def run_wav_roundtrip(session, fp16_path, int8_path, args, out_dir, device, results=None):
+    print("\n" + "#" * 78)
+    print(f"# Test B: wav round-trip — {args.wav}")
+    print("#" * 78)
+    handler = session.handler
+
+    wav_data, sr = sf.read(str(args.wav), dtype="float32", always_2d=True)
+    if sr != 48000:
+        raise RuntimeError(f"Expected 48kHz, got {sr}")
+    if wav_data.shape[1] == 1:
+        wav_data = np.repeat(wav_data, 2, axis=1)
+
+    # Trim to chunk_frames * 1920 samples (1500 frames -> 60s -> 2_880_000 samples).
+    samples_per_frame = 1920  # 48000 / 25
+    n_samples = args.chunk_frames * samples_per_frame
+    if wav_data.shape[0] < n_samples:
+        raise RuntimeError(
+            f"Wav has {wav_data.shape[0]} samples, need {n_samples} for {args.chunk_frames} latent frames"
+        )
+    wav_data = wav_data[:n_samples]
+
+    audio = torch.from_numpy(wav_data.T).unsqueeze(0).to(device)  # [1, 2, S]
+    print(f"  input audio: shape={tuple(audio.shape)}  ({n_samples / sr:.1f}s)")
+
+    print("Encoding via PT VAE (mean of moments — deterministic)...")
+    vae_input = audio.to(handler.vae.dtype)
+    enc_out = handler.vae.encode(vae_input)
+    latents = enc_out.latent_dist.mean  # [1, 64, T]
+    print(f"  latents: shape={tuple(latents.shape)}  dtype={latents.dtype}")
+
+    if latents.shape[2] != args.chunk_frames:
+        # vae_encoder downsample factor may give a slightly different T;
+        # use whatever it returns.
+        print(f"  (encoder gave T={latents.shape[2]}, not {args.chunk_frames})")
+
+    chunk = latents.contiguous()
+
+    def pt_decode():
+        return handler.vae.decode(chunk).sample
+
+    print("\nWarmup (1 each)...")
+    _ = pt_decode()
+    _ = _trt_vae_decode(chunk, str(fp16_path), device)
+    _ = _trt_vae_decode(chunk, str(int8_path), device)
+    torch.cuda.synchronize()
+
+    print(f"\n{args.runs} timed runs each:")
+    pt_runs, fp16_runs, int8_runs = [], [], []
+    pt_out = fp16_out = int8_out = None
+    for _ in range(args.runs):
+        r, o = _bench_one("PT eager bf16", pt_decode); pt_runs.append(r); pt_out = o
+    reference = pt_out.detach().clone()
+    for _ in range(args.runs):
+        r, o = _bench_one("TRT fp16",
+                          lambda: _trt_vae_decode(chunk, str(fp16_path), device),
+                          reference=reference); fp16_runs.append(r); fp16_out = o
+    for _ in range(args.runs):
+        r, o = _bench_one("TRT int8",
+                          lambda: _trt_vae_decode(chunk, str(int8_path), device),
+                          reference=reference); int8_runs.append(r); int8_out = o
+
+    # Trim/clip outputs to original length and save round-tripped wavs
+    print("\nSaving wavs (round-trip)...")
+    sf.write(str(out_dir / "wav_original.wav"),
+             audio.squeeze(0).float().cpu().numpy().T, sr)
+    print(f"  wav: {out_dir / 'wav_original.wav'}")
+    _save_wav(pt_out, out_dir / "wav_pt_eager.wav")
+    _save_wav(fp16_out, out_dir / "wav_trt_fp16.wav")
+    _save_wav(int8_out, out_dir / "wav_trt_int8.wav")
+
+    # Decode-only error (vs PT)
+    rows_decode = []
+    for runs, name in [(pt_runs, "PT eager bf16"), (fp16_runs, "TRT fp16"), (int8_runs, "TRT int8")]:
+        med, peak, mse = _summarize(runs)
+        rows_decode.append((name, med, peak, mse))
+    _print_table(rows_decode, mse_label="MSE vs PT decode")
+
+    # Full round-trip error (vs original audio): truncate decoded to source length
+    src = audio.float()
+    s_len = src.shape[-1]
+
+    def _aligned(x: torch.Tensor) -> torch.Tensor:
+        # crop or pad decoded to match source length
+        if x.shape[-1] >= s_len:
+            return x[..., :s_len]
+        pad = s_len - x.shape[-1]
+        return torch.nn.functional.pad(x, (0, pad))
+
+    print("\nFull round-trip vs original audio:")
+    print(f"{'Path':<18}{'RMSE':>14}{'PSNR (dB)':>14}")
+    print("-" * 46)
+    rt_metrics = {}
+    for out, key, name in [(pt_out, "pt", "PT eager bf16"),
+                           (fp16_out, "fp16", "TRT fp16"),
+                           (int8_out, "int8", "TRT int8")]:
+        out_aligned = _aligned(out.float())
+        rmse, psnr = _audio_metrics(out_aligned, src)
+        rt_metrics[key] = {"rmse": rmse, "psnr_db": psnr}
+        print(f"{name:<18}{rmse:>14.6f}{psnr:>14.2f}")
+
+    rmse_fp16_int8, psnr_fp16_int8 = _audio_metrics(int8_out, fp16_out)
+    print(f"\n  fp16 vs int8 (audio): RMSE={rmse_fp16_int8:.6f}  PSNR={psnr_fp16_int8:.2f} dB")
+
+    if results is not None:
+        results["wav_roundtrip"] = {
+            "wav": str(args.wav),
+            "samples": int(s_len),
+            "decode": {
+                "pt": {"median_ms": rows_decode[0][1], "peak_alloc_gb": rows_decode[0][2]},
+                "fp16": {"median_ms": rows_decode[1][1], "peak_alloc_gb": rows_decode[1][2], "mse_vs_pt": rows_decode[1][3]},
+                "int8": {"median_ms": rows_decode[2][1], "peak_alloc_gb": rows_decode[2][2], "mse_vs_pt": rows_decode[2][3]},
+            },
+            "vs_original_audio": rt_metrics,
+            "fp16_vs_int8": {"rmse": rmse_fp16_int8, "psnr_db": psnr_fp16_int8},
+        }
+
+
+# -------------------------------------------------------------------
+# main
+# -------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--int8-engine", default="vae_decode_int8_60s")
+    ap.add_argument("--fp16-engine", default="vae_decode_fp16_60s")
+    ap.add_argument("--chunk-frames", type=int, default=1500,
+                    help="Latent frames decoded per pass (1500 = 60s, "
+                         "matching fp16/int8 60s profiles)")
+    ap.add_argument("--duration", type=float, default=60.0,
+                    help="Generate duration for synthetic test")
+    ap.add_argument("--steps", type=int, default=8)
+    ap.add_argument("--runs", type=int, default=5)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--wav", default="tests/fixtures/inside_confusion.wav",
+                    help="Wav fixture for round-trip test")
+    ap.add_argument("--skip-synthetic", action="store_true")
+    ap.add_argument("--skip-wav", action="store_true")
+    ap.add_argument("--out-dir", default="bench_outputs/vae_int8")
+    ap.add_argument("--json-out", default=None,
+                    help="Write structured results to this JSON path")
+    ap.add_argument("--label", default=None,
+                    help="Label this run in the JSON (variant name)")
+    args = ap.parse_args()
+
+    device = torch.device("cuda")
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    int8_path = trt_engines_dir() / args.int8_engine / f"{args.int8_engine}.engine"
+    fp16_path = trt_engines_dir() / args.fp16_engine / f"{args.fp16_engine}.engine"
+    if not int8_path.exists():
+        raise FileNotFoundError(f"Missing INT8 engine: {int8_path}")
+    if not fp16_path.exists():
+        raise FileNotFoundError(f"Missing fp16 engine: {fp16_path}")
+
+    print(f"INT8: {int8_path}")
+    print(f"FP16: {fp16_path}")
+    print(f"Chunk: [1, 64, {args.chunk_frames}]  ({args.chunk_frames / 25.0:.1f}s)")
+
+    print("\nLoading session (eager VAE for PT reference)...")
+    session = Session(decoder_backend="eager", vae_backend="eager", use_flash_attention=True)
+
+    results = {
+        "label": args.label or args.int8_engine,
+        "int8_engine": str(int8_path),
+        "fp16_engine": str(fp16_path),
+        "engine_size_mb": int8_path.stat().st_size / 1e6,
+        "chunk_frames": args.chunk_frames,
+        "runs": args.runs,
+    }
+
+    if not args.skip_synthetic:
+        run_synthetic(session, fp16_path, int8_path, args, out_dir, device, results)
+    if not args.skip_wav:
+        run_wav_roundtrip(session, fp16_path, int8_path, args, out_dir, device, results)
+
+    if args.json_out:
+        Path(args.json_out).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.json_out, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"\nResults JSON: {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds an INT8-quantized TRT engine for the VAE decoder via TensorRT entropy calibration. **1.64x faster than fp16** on standalone 60s decode (33ms vs 54ms), **32.5 dB PSNR vs fp16**, **+88 MB VRAM** vs fp16 (TRT retains kernels for both precisions).
- Worth shipping for workloads where standalone VAE decode dominates (large `vae_window`, batch generation). For tight streaming with short `vae_window` and skip-cache reuse, the speedup dilutes to ~1.7% end-to-end because the diffusion decoder dominates the tick. See `docs/int8_vae_decode.md` for the full decision guide.
- Full research narrative including hybrid + autotune negative results lives on branch [`archive/ryanontheinside/int8-research-2026-05-01`](https://github.com/ryanontheinside/DEMON/tree/archive/ryanontheinside/int8-research-2026-05-01).

### What's in this PR
- `acestep/engine/trt/vae_decode_int8.py`: INT8 builder with entropy/minmax calibrators and optional first/last conv pinning
- `scripts/build_vae_int8_engine.py`: canonical CLI driver
- `scripts/collect_vae_calibration.py`: regenerate calibration latents (32 prompt-diverse, 1500-frame each)
- `tests/benchmarks/bench_vae_int8_regular.py`: regression bench harness (synthetic latent + wav round-trip)
- `demos/test_stream_cover_graph.py`: adds `--vae-decode-engine` and `--source-audio` flags so streaming runs can A/B engines
- `docs/int8_vae_decode.md`: full variant comparison report (matrix, streaming bench, VRAM analysis, decision guide, what-didn't-work)

## Test plan
- [ ] Generate calibration latents: `uv run python scripts/collect_vae_calibration.py --frames 1500 --output-dir ~/.daydream-scope/models/demon/calibration/vae_latents_60s`
- [ ] Build engine: `uv run python scripts/build_vae_int8_engine.py --engine-name vae_decode_int8_60s --opt-frames 1500 --max-frames 1500`
- [ ] Run bench: `uv run python tests/benchmarks/bench_vae_int8_regular.py --int8-engine vae_decode_int8_60s --fp16-engine vae_decode_fp16_60s` and confirm >=1.5x speedup, >=32 dB fp16-vs-int8 PSNR
- [ ] Streaming sanity: `uv run python demos/test_stream_cover_graph.py --vae-decode-engine vae_decode_int8_60s --vae-window 5` and confirm output is audibly comparable to the fp16 baseline run
- [ ] A/B listen to `bench_outputs/vae_int8/vae_decode_int8_60s/synth_trt_int8.wav` vs `synth_trt_fp16.wav` (synthetic latent reveals the decoder difference; wav round-trip masks it because the encoder dominates)
