### PR TITLE
Add CNN-based musical key detection (acestep.audio.key_detection)

### DIFF
--- a/acestep/audio/__init__.py
+++ b/acestep/audio/__init__.py
@@ -1,0 +1,1 @@
+"""Audio analysis utilities (key detection, etc.)."""

--- a/acestep/audio/key_detection.py
+++ b/acestep/audio/key_detection.py
@@ -1,0 +1,158 @@
+"""Musical key detection via a CNN ported from madmom.
+
+Architecture and pretrained weights are the 2018 model from madmom's
+``key_cnn.pkl`` (Korzeniowski & Widmer, "End-to-End Musical Key
+Estimation Using a Convolutional Neural Network", ICASSP 2018). madmom
+itself doesn't install on numpy>=2 / py>=3.11, so the conv layers were
+exported, the BatchNorm layers were folded into the preceding conv,
+and everything was re-saved as a torch state dict in
+``assets/key_cnn.pt``. See ``scripts/convert_madmom_key_cnn.py``.
+
+License of the original model and architecture: BSD 3-Clause (madmom).
+
+Public API:
+    detect_key(mono_np, sr) -> str   e.g. "F# minor"
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+
+_WEIGHTS_PATH = Path(__file__).parent / "assets" / "key_cnn.pt"
+
+
+class _KeyCNN(torch.nn.Module):
+    """Fully-convolutional key recognition network (24-class output).
+
+    Layout: nine conv layers in five blocks, ELU after each, max-pool
+    after blocks 1/2/3. Block 5 is a 1x1 conv classifier head followed
+    by global average pooling. The original network has BatchNorm
+    after every conv with an ELU on the BN; we fold BN into the conv
+    weights at export time so the runtime is conv->ELU->maybe-pool.
+
+    Input:  (B, 1, T, F=105) log-magnitude filterbank spectrogram
+    Output: (B, 24) class scores
+    """
+
+    def __init__(self, blocks: list[tuple[int, int]]):
+        super().__init__()
+        in_ch = 1
+        out_chs = (24, 24, 48, 48, 96, 96, 192, 192, 24)
+        self.convs = torch.nn.ModuleList()
+        for (k, p), out_ch in zip(blocks, out_chs):
+            self.convs.append(
+                torch.nn.Conv2d(in_ch, out_ch, kernel_size=k, padding=p)
+            )
+            in_ch = out_ch
+        # Indices after which to apply 2x2 max-pool (after blocks 1/3/5).
+        self._pool_after = {1, 3, 5}
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for i, conv in enumerate(self.convs):
+            x = F.elu(conv(x))
+            if i in self._pool_after:
+                x = F.max_pool2d(x, kernel_size=2, stride=2)
+        # Global average pool over (T, F) -> (B, 24).
+        return x.mean(dim=(2, 3))
+
+
+_CACHE: dict[str, Any] = {}
+
+
+def _load() -> dict[str, Any]:
+    """Lazily load the model + filterbank onto the appropriate device."""
+    if _CACHE:
+        return _CACHE
+    if not _WEIGHTS_PATH.is_file():
+        raise FileNotFoundError(
+            f"key_cnn.pt missing at {_WEIGHTS_PATH}. "
+            f"Run scripts/convert_madmom_key_cnn.py."
+        )
+    blob = torch.load(_WEIGHTS_PATH, map_location="cpu", weights_only=False)
+    state = blob["state_dict"]
+    filterbank = state.pop("filterbank")
+    model = _KeyCNN(blob["blocks"])
+    # Re-key to nn.ModuleList naming.
+    remapped = {}
+    for k, v in state.items():
+        idx = int(k.split(".")[0].removeprefix("conv"))
+        suffix = k.split(".", 1)[1]
+        remapped[f"convs.{idx}.{suffix}"] = v
+    model.load_state_dict(remapped, strict=True)
+    model.eval()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+    filterbank = filterbank.to(device)
+    window = torch.hann_window(blob["n_fft"], periodic=False, device=device)
+
+    _CACHE.update(
+        model=model,
+        filterbank=filterbank,
+        window=window,
+        labels=blob["key_labels"],
+        sr=int(blob["sample_rate"]),
+        n_fft=int(blob["n_fft"]),
+        hop=int(blob["hop"]),
+        device=device,
+    )
+    return _CACHE
+
+
+def _resample_to_44100(mono: np.ndarray, sr: int) -> np.ndarray:
+    if sr == 44100:
+        return mono.astype(np.float32, copy=False)
+    # Use soxr (already a project dep) for high-quality resampling.
+    import soxr
+    return soxr.resample(mono.astype(np.float32, copy=False), sr, 44100, "HQ")
+
+
+@torch.inference_mode()
+def detect_key(mono_np: np.ndarray, sr: int) -> str:
+    """Return the predicted key as a string like ``"F# minor"``.
+
+    Pipeline: resample to 44100 mono -> centered STFT (n_fft=8192,
+    hop=8820 = 5 fps, Hann) -> magnitude -> log-spaced triangular
+    filterbank (105 bands, 65-2100 Hz) -> log10(x + 1) -> CNN ->
+    argmax of 24 class scores.
+    """
+    if mono_np.size == 0:
+        return "C major"
+
+    bundle = _load()
+    sr_target = bundle["sr"]
+    n_fft = bundle["n_fft"]
+    hop = bundle["hop"]
+    device = bundle["device"]
+
+    audio = _resample_to_44100(np.ascontiguousarray(mono_np), sr)
+    if audio.size < n_fft:
+        # Need at least one frame's worth of samples.
+        pad = n_fft - audio.size
+        audio = np.pad(audio, (0, pad))
+
+    audio_t = torch.from_numpy(audio).to(device)
+    spec = torch.stft(
+        audio_t,
+        n_fft=n_fft,
+        hop_length=hop,
+        win_length=n_fft,
+        window=bundle["window"],
+        center=True,
+        pad_mode="reflect",
+        return_complex=True,
+    )
+    mag = spec.abs().T  # (T, F_fft)
+    filt = mag @ bundle["filterbank"]  # (T, 105)
+    log_spec = torch.log10(filt + 1.0)
+    x = log_spec.unsqueeze(0).unsqueeze(0)  # (1, 1, T, 105)
+
+    logits = bundle["model"](x)
+    idx = int(logits.argmax(dim=1).item())
+    return bundle["labels"][idx]

--- a/acestep/nodes/audio_nodes.py
+++ b/acestep/nodes/audio_nodes.py
@@ -6,71 +6,18 @@ import torch
 import torchaudio
 from typing import Any, ClassVar
 
+from ..audio.key_detection import detect_key
 from .base import BaseNode, NodeDefinition, NodePort, NodeRegistry
 from .types import Audio
 
 
-# Chroma-to-key mapping (Krumhansl-Schmuckler profiles)
-_MAJOR_PROFILE = torch.tensor(
-    [6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88]
-)
-_MINOR_PROFILE = torch.tensor(
-    [6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17]
-)
-_NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
-
-
 def _detect_key(waveform: torch.Tensor, sr: int) -> str:
-    """Detect musical key using chroma features and Krumhansl-Schmuckler."""
-    # Mono
+    """Detect musical key. Thin tensor->numpy bridge over the CNN module."""
     if waveform.dim() == 2:
         mono = waveform.mean(dim=0)
     else:
         mono = waveform
-    mono = mono.float()
-
-    # Compute spectrogram
-    n_fft = 4096
-    hop = 2048
-    spec = torch.stft(
-        mono, n_fft=n_fft, hop_length=hop, return_complex=True,
-        window=torch.hann_window(n_fft, device=mono.device),
-    )
-    power = spec.abs().pow(2)
-
-    # Build chroma from power spectrum
-    freqs = torch.linspace(0, sr / 2, power.shape[0])
-    chroma = torch.zeros(12)
-    for i in range(12):
-        # Accumulate energy for this pitch class across octaves
-        for octave in range(1, 9):
-            f0 = 440.0 * (2.0 ** ((i - 9) / 12.0 + (octave - 4)))
-            if f0 >= sr / 2:
-                break
-            bin_idx = int(f0 * n_fft / sr)
-            if 0 <= bin_idx < power.shape[0]:
-                lo = max(0, bin_idx - 1)
-                hi = min(power.shape[0], bin_idx + 2)
-                chroma[i] += power[lo:hi].sum().item()
-
-    if chroma.sum() < 1e-10:
-        return "C major"
-
-    chroma = chroma / chroma.sum()
-
-    # Correlate with all 24 key profiles
-    best_corr = -2.0
-    best_key = "C major"
-    for shift in range(12):
-        rotated = torch.roll(chroma, -shift)
-        for profile, mode in [(_MAJOR_PROFILE, "major"), (_MINOR_PROFILE, "minor")]:
-            norm_p = profile / profile.sum()
-            corr = torch.dot(rotated, norm_p).item()
-            if corr > best_corr:
-                best_corr = corr
-                best_key = f"{_NOTE_NAMES[shift]} {mode}"
-
-    return best_key
+    return detect_key(mono.detach().cpu().float().numpy(), sr)
 
 
 def _detect_bpm(waveform: torch.Tensor, sr: int) -> int:
@@ -125,9 +72,9 @@ def _detect_bpm(waveform: torch.Tensor, sr: int) -> int:
 class AudioInfo(BaseNode):
     """Detect BPM, key, and duration from audio.
 
-    Uses signal processing (onset autocorrelation for BPM,
-    chroma + Krumhansl-Schmuckler for key detection).
-    Duration is computed from sample count and rate.
+    Uses onset autocorrelation for BPM and a small CNN
+    (acestep.audio.key_detection) for key.  Duration is computed from
+    sample count and rate.
     """
 
     node_type_id: ClassVar[str] = "acestep.AudioInfo"

--- a/demos/realtime_motion_graph/server.py
+++ b/demos/realtime_motion_graph/server.py
@@ -338,7 +338,7 @@ def handle_client(ws):
                                 instruction=TASK_INSTRUCTIONS["cover"],
                                 refer_latent=source.latent,
                                 bpm=detected_bpm, duration=60.0,
-                                key="G# minor",
+                                key=detected_key,
                             )
                             stream.conditioning = cond
                             prompt_text[0] = data["tags"]

--- a/demos/realtime_motion_graph/server.py
+++ b/demos/realtime_motion_graph/server.py
@@ -27,6 +27,7 @@ torch._dynamo.config.disable = True
 from websockets.exceptions import ConnectionClosed
 from websockets.sync.server import serve
 
+from acestep.audio.key_detection import detect_key
 from acestep.constants import TASK_INSTRUCTIONS
 from acestep.engine.session import Session
 from acestep.nodes.types import Audio
@@ -194,12 +195,13 @@ def handle_client(ws):
 
     audio_in = Audio(waveform=waveform, sample_rate=SAMPLE_RATE)
 
-    print("[Server] Detecting BPM...")
+    print("[Server] Detecting BPM + key...")
     import librosa
     mono_np = waveform.mean(dim=0).numpy()
     detected_bpm, _ = librosa.beat.beat_track(y=mono_np, sr=SAMPLE_RATE)
     detected_bpm = int(round(float(np.asarray(detected_bpm).flat[0])))
-    print(f"  BPM: {detected_bpm}")
+    detected_key = detect_key(mono_np, SAMPLE_RATE)
+    print(f"  BPM: {detected_bpm}  Key: {detected_key}")
 
     print("[Server] Preparing source...")
     source = session.prepare_source(audio_in)
@@ -209,7 +211,7 @@ def handle_client(ws):
         tags=prompt,
         instruction=TASK_INSTRUCTIONS["cover"],
         refer_latent=source.latent,
-        bpm=detected_bpm, duration=60.0, key="G# minor",
+        bpm=detected_bpm, duration=60.0, key=detected_key,
     )
 
     print("[Server] Creating stream...")

--- a/scripts/convert_madmom_key_cnn.py
+++ b/scripts/convert_madmom_key_cnn.py
@@ -1,0 +1,203 @@
+"""Convert madmom's bundled key_cnn.pkl into a clean torch state dict
+plus a filterbank matrix. Run once; commit the output ``.pt``.
+
+The pickle is full of madmom-specific Python objects, so we use a
+tolerant unpickler that turns unknown classes into stubs that just
+record their pickled state. Conv layers + the following BatchNorm are
+folded into a single (weight, bias) pair so the runtime doesn't need
+BN buffers.
+
+Output: ``<repo>/acestep/audio/assets/key_cnn.pt``
+"""
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).parent))
+from inspect_madmom_pkl import load as load_pickle  # type: ignore
+
+
+# Frequencies of FFT bins for sr=44100 Hz, n_fft=8192. Used to build
+# madmom's logarithmic filterbank.
+SR = 44100
+N_FFT = 8192
+HOP = SR // 5  # fps=5
+FMIN = 65.0
+FMAX = 2100.0
+NUM_BANDS_PER_OCTAVE = 24
+A4 = 440.0
+
+
+# Class label ordering used by madmom's CNNKeyRecognitionProcessor
+# (must match the network's softmax output order).
+KEY_LABELS = [
+    'A major', 'Bb major', 'B major', 'C major', 'Db major',
+    'D major', 'Eb major', 'E major', 'F major', 'F# major',
+    'G major', 'Ab major', 'A minor', 'Bb minor', 'B minor',
+    'C minor', 'C# minor', 'D minor', 'D# minor', 'E minor',
+    'F minor', 'F# minor', 'G minor', 'G# minor',
+]
+
+
+def _log_frequencies(bands_per_octave: int, fmin: float, fmax: float, fref: float) -> np.ndarray:
+    """Port of madmom.audio.filters.log_frequencies."""
+    left = np.floor(np.log2(fmin / fref) * bands_per_octave)
+    right = np.ceil(np.log2(fmax / fref) * bands_per_octave)
+    freqs = fref * 2.0 ** (np.arange(left, right) / bands_per_octave)
+    freqs = freqs[np.searchsorted(freqs, fmin):]
+    freqs = freqs[:np.searchsorted(freqs, fmax, side="right")]
+    return freqs
+
+
+def _frequencies_to_bins(freqs: np.ndarray, bin_freqs: np.ndarray, unique: bool) -> np.ndarray:
+    """Port of madmom.audio.filters.frequencies2bins."""
+    indices = bin_freqs.searchsorted(freqs)
+    indices = np.clip(indices, 1, len(bin_freqs) - 1)
+    left = bin_freqs[indices - 1]
+    right = bin_freqs[indices]
+    indices -= freqs - left < right - freqs
+    if unique:
+        indices = np.unique(indices)
+    return indices
+
+
+def _build_filterbank() -> np.ndarray:
+    """Build the (num_fft_bins, num_filters) filterbank matrix madmom
+    uses for the key CNN. Triangular, log-spaced, no normalization."""
+    num_fft_bins = N_FFT // 2 + 1
+    bin_freqs = np.linspace(0, SR / 2, num_fft_bins)
+    centers_hz = _log_frequencies(NUM_BANDS_PER_OCTAVE, FMIN, FMAX, A4)
+    centers = _frequencies_to_bins(centers_hz, bin_freqs, unique=True)
+
+    filters = []
+    i = 0
+    while i + 3 <= len(centers):
+        start, center, stop = centers[i:i + 3]
+        if stop - start < 2:
+            center = start
+            stop = start + 1
+        col = np.zeros(num_fft_bins, dtype=np.float32)
+        # rising edge (without center)
+        if center > start:
+            col[start:center] = np.linspace(0.0, 1.0, center - start, endpoint=False)
+        # falling edge (incl. center, excl. stop)
+        if stop > center:
+            col[center:stop] = np.linspace(1.0, 0.0, stop - center, endpoint=False)
+        filters.append(col)
+        i += 1
+
+    fb = np.stack(filters, axis=1)  # (num_fft_bins, num_filters)
+    return fb
+
+
+def _fold_bn_into_conv(conv: dict, bn: dict) -> tuple[np.ndarray, np.ndarray]:
+    """Fold BN(gamma, beta, mean, inv_std) into the preceding conv.
+
+    madmom conv weights: (in_ch, out_ch, kH, kW), uses true convolution
+    (flipped kernel). torch Conv2d uses cross-correlation, so we flip
+    H and W and transpose (in,out,...) -> (out,in,...).
+
+    Returns (weight, bias) ready for torch state-dict population.
+    """
+    w = conv["weights"].astype(np.float32)
+    cb = np.asarray(conv["bias"], dtype=np.float32).reshape(-1)
+    gamma = bn["gamma"].astype(np.float32)
+    beta = bn["beta"].astype(np.float32)
+    mean = bn["mean"].astype(np.float32)
+    inv_std = bn["inv_std"].astype(np.float32)
+
+    # in,out,kH,kW -> out,in,kH,kW with flipped kernel
+    w = w.transpose(1, 0, 2, 3)[:, :, ::-1, ::-1].copy()
+
+    scale = (gamma * inv_std).astype(np.float32)
+    new_w = w * scale[:, None, None, None]
+
+    # madmom conv stored bias is shape (1,) and is functionally zero;
+    # broadcast it across all out channels.
+    if cb.size == 1:
+        cb = np.broadcast_to(cb, (gamma.size,)).astype(np.float32)
+    new_b = (cb - mean) * scale + beta
+    return new_w.astype(np.float32), new_b.astype(np.float32)
+
+
+# --- (kernel, padding) for each conv block, in order ----------------------
+# Mirrors the architecture dump from inspect_madmom_pkl.py.
+_BLOCKS = [
+    (5, 2),  # 1 -> 24
+    (3, 1),  # 24 -> 24
+    # maxpool
+    (3, 1),  # 24 -> 48
+    (3, 1),  # 48 -> 48
+    # maxpool
+    (3, 1),  # 48 -> 96
+    (3, 1),  # 96 -> 96
+    # maxpool
+    (3, 1),  # 96 -> 192
+    (3, 1),  # 192 -> 192
+    (1, 0),  # 192 -> 24 (classifier head, no pad)
+]
+
+
+def _walk_layers(net) -> list:
+    """Flatten the pickled madmom layer list into a list of (cls, state) tuples."""
+    out = []
+    for layer in net._state["layers"]:
+        out.append((layer._cls, layer._state))
+    return out
+
+
+def main() -> None:
+    pkl_path = sys.argv[1] if len(sys.argv) > 1 else "/tmp/madmom_weights/key_cnn.pkl"
+    out_path = (
+        Path(__file__).resolve().parent.parent
+        / "acestep" / "audio" / "assets" / "key_cnn.pt"
+    )
+
+    net = load_pickle(pkl_path)
+    layers = _walk_layers(net)
+
+    # Sanity-check layer pattern: pad, conv, bn, [pad, conv, bn,] pool, ...
+    convs_bns: list[tuple[dict, dict]] = []
+    for cls_name, state in layers:
+        if cls_name.endswith("ConvolutionalLayer"):
+            convs_bns.append([state, None])  # type: ignore[list-item]
+        elif cls_name.endswith("BatchNormLayer"):
+            convs_bns[-1][1] = state  # type: ignore[index]
+    if len(convs_bns) != len(_BLOCKS):
+        raise SystemExit(
+            f"expected {len(_BLOCKS)} conv blocks, got {len(convs_bns)}"
+        )
+
+    state_dict: dict[str, torch.Tensor] = {}
+    for i, (conv, bn) in enumerate(convs_bns):
+        w, b = _fold_bn_into_conv(conv, bn)
+        state_dict[f"conv{i}.weight"] = torch.from_numpy(w)
+        state_dict[f"conv{i}.bias"] = torch.from_numpy(b)
+
+    fb = _build_filterbank()
+    state_dict["filterbank"] = torch.from_numpy(fb)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save({
+        "state_dict": state_dict,
+        "key_labels": KEY_LABELS,
+        "sample_rate": SR,
+        "n_fft": N_FFT,
+        "hop": HOP,
+        "fmin": FMIN,
+        "fmax": FMAX,
+        "blocks": _BLOCKS,
+    }, out_path)
+    print(f"wrote {out_path}")
+    print(f"  filterbank: {fb.shape}, conv blocks: {len(convs_bns)}")
+    for i, (k, v) in enumerate(state_dict.items()):
+        print(f"  {k}: {tuple(v.shape)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/inspect_madmom_pkl.py
+++ b/scripts/inspect_madmom_pkl.py
@@ -1,0 +1,97 @@
+"""Tolerant unpickler for madmom's key_cnn.pkl — reads the layer structure
+without requiring madmom to be installed.
+
+For every unknown class encountered while unpickling we substitute a stub
+that records the class name plus whatever state the pickle attaches to
+it (via __dict__ / __setstate__). Walking the resulting tree gives the
+architecture and the numpy weight arrays.
+"""
+from __future__ import annotations
+
+import io
+import pickle
+import sys
+from typing import Any
+
+import numpy as np
+
+
+class Stub:
+    """Captures (module.classname, state) for any madmom class."""
+
+    _cls: str = "Stub"
+
+    def __init__(self, *args, **kwargs):
+        self._args = args
+        self._kwargs = kwargs
+        self._state: dict = {}
+
+    def __setstate__(self, state: Any) -> None:
+        if isinstance(state, dict):
+            self._state = state
+        else:
+            self._state = {"__raw_state__": state}
+
+    def __repr__(self) -> str:
+        return f"<Stub {self._cls}>"
+
+
+_FACTORIES: dict[tuple[str, str], type] = {}
+
+
+def _factory(module: str, name: str) -> type:
+    key = (module, name)
+    if key not in _FACTORIES:
+        cls_name = f"{module}.{name}"
+        # Make _cls a class attribute so it's set even when pickle skips
+        # __init__ (uses __new__ + __setstate__).
+        sub = type(name, (Stub,), {"_cls": cls_name})
+        _FACTORIES[key] = sub
+    return _FACTORIES[key]
+
+
+class TolerantUnpickler(pickle.Unpickler):
+    def find_class(self, module: str, name: str):
+        # Re-route numpy classes to the real numpy so arrays reconstruct
+        # correctly; everything else gets a stub.
+        if module.startswith("numpy"):
+            return super().find_class(module, name)
+        if module in {"builtins", "__builtin__", "copy_reg", "_codecs"}:
+            return super().find_class(module, name)
+        return _factory(module, name)
+
+
+def load(path: str):
+    with open(path, "rb") as f:
+        return TolerantUnpickler(f, encoding="latin1").load()
+
+
+def _shape_of(x: Any) -> str:
+    if isinstance(x, np.ndarray):
+        return f"ndarray{tuple(x.shape)} {x.dtype}"
+    return type(x).__name__
+
+
+def walk(node: Any, depth: int = 0, name: str = "root") -> None:
+    indent = "  " * depth
+    if isinstance(node, Stub):
+        print(f"{indent}{name}: {node._cls}")
+        for k, v in node._state.items():
+            walk(v, depth + 1, k)
+    elif isinstance(node, (list, tuple)):
+        print(f"{indent}{name}: {type(node).__name__}[{len(node)}]")
+        for i, v in enumerate(node):
+            walk(v, depth + 1, f"[{i}]")
+    elif isinstance(node, dict):
+        print(f"{indent}{name}: dict({len(node)})")
+        for k, v in node.items():
+            walk(v, depth + 1, str(k))
+    elif isinstance(node, np.ndarray):
+        print(f"{indent}{name}: ndarray{tuple(node.shape)} {node.dtype}")
+    else:
+        print(f"{indent}{name}: {type(node).__name__} = {node!r}"[:160])
+
+
+if __name__ == "__main__":
+    obj = load(sys.argv[1])
+    walk(obj)

--- a/scripts/sanity_check_key_cnn.py
+++ b/scripts/sanity_check_key_cnn.py
@@ -1,0 +1,32 @@
+"""Sanity check: feed synthetic triad arpeggios to detect_key. If the
+port is correct, the model should land in the right key family."""
+import numpy as np
+from acestep.audio.key_detection import detect_key
+
+sr = 44100
+duration = 8
+
+def arpeggio(notes_hz):
+    t = np.arange(int(duration * sr)) / sr
+    y = np.zeros_like(t)
+    seg_len = sr  # 1s per note
+    for i, f in enumerate(notes_hz):
+        s = i * seg_len
+        e = s + seg_len
+        if e > len(y):
+            break
+        # Fundamental + first 3 harmonics so it sounds like a real instrument
+        for h, amp in enumerate([1.0, 0.5, 0.25, 0.12], start=1):
+            y[s:e] += amp * np.sin(2 * np.pi * f * h * np.arange(seg_len) / sr)
+    y = y / np.max(np.abs(y))
+    return y.astype(np.float32)
+
+# Repeat 2x to get 8s of audio.
+def make(notes_hz):
+    one = arpeggio(notes_hz)[: 4 * sr]
+    return np.tile(one, 2).astype(np.float32)
+
+print("C major (C E G C):", detect_key(make([261.63, 329.63, 392.00, 523.25]), sr))
+print("A minor (A C E A):", detect_key(make([220.00, 261.63, 329.63, 440.00]), sr))
+print("E minor (E G B E):", detect_key(make([329.63, 392.00, 493.88, 659.25]), sr))
+print("F# major (F# A# C# F#):", detect_key(make([369.99, 466.16, 554.37, 739.99]), sr))

--- a/scripts/verify_against_madmom.py
+++ b/scripts/verify_against_madmom.py
@@ -1,0 +1,57 @@
+"""Compare our port's output against madmom's reference activations on
+the upstream sample files. Bit-close match means the port is faithful;
+mismatch tells us preprocessing/conv has a bug."""
+import sys
+import numpy as np
+import soundfile as sf
+import torch
+
+from acestep.audio.key_detection import _load, _resample_to_44100
+
+DATA = "C:/Users/ryanf/AppData/Local/Temp/madmom_test"
+
+def predict(path):
+    y, sr = sf.read(path)
+    if y.ndim > 1:
+        y = y.mean(axis=1)
+    bundle = _load()
+    audio = _resample_to_44100(np.ascontiguousarray(y), sr)
+    if audio.size < bundle["n_fft"]:
+        audio = np.pad(audio, (0, bundle["n_fft"] - audio.size))
+    audio_t = torch.from_numpy(audio.astype(np.float32)).to(bundle["device"])
+    spec = torch.stft(
+        audio_t, n_fft=bundle["n_fft"], hop_length=bundle["hop"],
+        win_length=bundle["n_fft"], window=bundle["window"],
+        center=True, pad_mode="reflect", return_complex=True,
+    )
+    mag = spec.abs().T
+    filt = mag @ bundle["filterbank"]
+    log_spec = torch.log10(filt + 1.0)
+    with torch.inference_mode():
+        logits = bundle["model"](log_spec.unsqueeze(0).unsqueeze(0)).squeeze().cpu().numpy()
+    # madmom applies softmax in the .pkl pipeline (network ends with softmax).
+    # Our model is the conv stack only (no softmax), so apply it here.
+    probs = np.exp(logits - logits.max())
+    probs /= probs.sum()
+    return probs, bundle["labels"]
+
+
+def reference(npz_path):
+    z = np.load(npz_path, allow_pickle=True)
+    arr = z[z.files[0]]
+    if arr.ndim == 2:
+        arr = arr[0]
+    return arr
+
+
+for name, expected in [("sample", "Ab major"), ("sample2", "A minor")]:
+    ours, labels = predict(f"{DATA}/{name}.wav")
+    ref = reference(f"{DATA}/{name}.key_cnn.npz")
+    our_label = labels[int(ours.argmax())]
+    ref_label = labels[int(ref.argmax())]
+    print(f"{name}: madmom-expected={expected}  ref-argmax={ref_label}  ours={our_label}")
+    print(f"  max abs diff:  {np.abs(ours - ref).max():.4e}")
+    print(f"  cosine sim:    {ours.dot(ref) / (np.linalg.norm(ours) * np.linalg.norm(ref)):.4f}")
+    print(f"  ours top3: {[labels[i] for i in np.argsort(-ours)[:3]]}  {ours[np.argsort(-ours)[:3]].round(3)}")
+    print(f"  ref  top3: {[labels[i] for i in np.argsort(-ref)[:3]]}  {ref[np.argsort(-ref)[:3]].round(3)}")
+    print()


### PR DESCRIPTION
## Summary
- New `acestep.audio.key_detection` module: a 9-layer CNN ported from madmom's 2018 `key_cnn.pkl` (Korzeniowski & Widmer 2018, BSD 3-Clause). 24-class major/minor output, ~20-30 ms warm on GPU.
- Replaces the chroma + Krumhansl-Schmuckler detector in `acestep/nodes/audio_nodes.py` (still re-exported as `_detect_key` for backwards compat with the `AudioInfo` node).
- Wires `detect_key` into `demos/realtime_motion_graph/server.py` so the realtime demo no longer hardcodes `key="G# minor"` (both initial-load and prompt re-encode paths).
- Pretrained weights bundled at `acestep/audio/assets/key_cnn.pt` (~4.4 MB, force-added past the `*.pt` gitignore rule).

## Why a port instead of `pip install madmom`
madmom's last release is from 2018 and doesn't compile against numpy >= 2 or py3.11. We extract the bundled `.pkl` via a tolerant unpickler, fold each BatchNorm into its preceding Conv, and re-save as a clean torch state dict — runtime has no dependency on madmom.

## Verification
- **madmom upstream test fixtures**: argmax matches exactly (`sample.wav` → "Ab major", cosine-sim 0.999 vs reference activations; `sample2.wav` → "A minor").
- **Project fixtures (`tests/fixtures/*.wav`)**: 5/8 exact, with the right answer always in top-2 on the misses (relative-key flips on lo-fi and metal — published madmom error pattern; model was trained on GiantSteps EDM).
- **Live demo run**: confirmed end-to-end on `keydetect-cnn-port`; demo starts and plays normally with detected key.

## Test plan
- [ ] `python scripts/verify_against_madmom.py`
- [ ] Smoke import of `acestep.audio.key_detection.detect_key`
- [ ] Run `demos.realtime_motion_graph.server` with a real source — confirm `[Server] Detecting BPM + key...` line shows a sensible key
- [ ] `AudioInfo` node still returns a valid 24-class key string
