### PR TITLE
trt: skip strength-0 LoRAs in refit

### DIFF
--- a/acestep/engine/trt/lora_refit.py
+++ b/acestep/engine/trt/lora_refit.py
@@ -195,7 +195,13 @@ class TRTLoRAManager:
             lora_id=lora_id, path=lora_path, strength=strength, deltas=deltas,
         ))
 
-        self._refit_weights(set(deltas.keys()))
+        # Strength-0 contributes nothing to any param's recomputed value,
+        # so the refit would be a mathematical no-op (engine already has
+        # the correct weights from the prior state). Skip it. The LoRA's
+        # deltas are still cached and will participate in the next refit
+        # once strength != 0.
+        if strength != 0.0:
+            self._refit_weights(set(deltas.keys()))
 
         elapsed = (time.perf_counter() - t0) * 1000
         logger.info(
@@ -233,6 +239,10 @@ class TRTLoRAManager:
         for lora in self._active_loras:
             if lora.lora_id == lora_id:
                 old = lora.strength
+                if old == strength:
+                    # Slider sometimes lands back on the previous value;
+                    # skip the full refit + GPU re-upload in that case.
+                    return
                 lora.strength = strength
                 self._refit_weights(set(lora.deltas.keys()))
                 logger.info(
@@ -293,8 +303,14 @@ class TRTLoRAManager:
             buf = self._refit_bufs[param_name]
             buf.copy_(self._base_weights[param_name])
 
-            # Accumulate LoRA contributions in-place (native dtype)
+            # Accumulate LoRA contributions in-place (native dtype). Skip
+            # strength-0 LoRAs; their delta contributes nothing but the
+            # add_ traverses the full weight, which is wasteful when the
+            # caller leaves placeholders in the stack at strength 0
+            # (a common pattern for slider-driven UIs).
             for lora in self._active_loras:
+                if lora.strength == 0.0:
+                    continue
                 if param_name in lora.deltas:
                     buf.add_(lora.deltas[param_name], alpha=lora.strength)
 

--- a/tests/unit/test_lora_refit.py
+++ b/tests/unit/test_lora_refit.py
@@ -1,0 +1,121 @@
+"""Unit tests for the strength-0 short-circuits in TRTLoRAManager.
+
+These don't build a real TRT engine; they bypass __init__ and wire up
+the manager with a fake refitter so we can assert what would have been
+sent to the engine.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from acestep.engine.trt.lora_refit import TRTLoRAManager, _ActiveLoRA
+
+
+def _make_mgr():
+    """Hand-build a TRTLoRAManager with two fake refittable fp16 params
+    (``q.weight`` and ``k.weight``, both 8x16 zeros)."""
+    mgr = TRTLoRAManager.__new__(TRTLoRAManager)
+    mgr._engine = None
+    mgr._device = torch.device("cpu")
+    mgr._trt_prefix = "decoder."
+
+    refitter = MagicMock()
+    refitter.refit_cuda_engine.return_value = True
+    mgr._refitter = refitter
+
+    base_q = torch.zeros(8, 16, dtype=torch.float16)
+    base_k = torch.zeros(8, 16, dtype=torch.float16)
+    mgr._param_to_trt = {
+        "q.weight": "decoder.q.weight",
+        "k.weight": "decoder.k.weight",
+    }
+    mgr._base_weights = {"q.weight": base_q, "k.weight": base_k}
+    mgr._refit_bufs = {
+        "q.weight": torch.empty_like(base_q),
+        "k.weight": torch.empty_like(base_k),
+    }
+    mgr._np_dtype = {"q.weight": np.float16, "k.weight": np.float16}
+    mgr._active_loras = []
+    mgr._next_id = 0
+    mgr._ever_dirty = set()
+    return mgr, refitter
+
+
+def test_strength_zero_lora_in_stack_does_not_leak_into_output():
+    """A LoRA sitting in the stack at strength 0 must not affect the
+    refitted weights, even when its delta is non-trivial."""
+    mgr, refitter = _make_mgr()
+    mgr._active_loras.append(_ActiveLoRA(
+        lora_id=0, path="zero.safetensors", strength=0.0,
+        deltas={"q.weight": torch.ones(8, 16, dtype=torch.float16)},
+    ))
+
+    mgr._refit_weights({"q.weight"})
+
+    refitter.set_named_weights.assert_called_once()
+    arr = refitter.set_named_weights.call_args[0][1]
+    np.testing.assert_array_equal(arr, np.zeros((8, 16), dtype=np.float16))
+
+
+def test_strength_zero_lora_skipped_when_other_active_present():
+    """Stack of [lora_zero (s=0), lora_active (s=0.5)] on the same param:
+    refitted weight must equal base + delta_active * 0.5; lora_zero's
+    delta must not contribute."""
+    mgr, refitter = _make_mgr()
+    delta_zero = torch.ones(8, 16, dtype=torch.float16)
+    delta_active = torch.full((8, 16), 2.0, dtype=torch.float16)
+    mgr._active_loras.append(_ActiveLoRA(
+        lora_id=0, path="zero.safetensors", strength=0.0,
+        deltas={"q.weight": delta_zero},
+    ))
+    mgr._active_loras.append(_ActiveLoRA(
+        lora_id=1, path="active.safetensors", strength=0.5,
+        deltas={"q.weight": delta_active},
+    ))
+
+    mgr._refit_weights({"q.weight"})
+
+    arr = refitter.set_named_weights.call_args[0][1]
+    expected = (delta_active.float() * 0.5).to(torch.float16).numpy()
+    np.testing.assert_allclose(arr, expected, rtol=1e-3)
+
+
+def test_set_lora_strength_same_value_is_noop():
+    """set_lora_strength to the LoRA's current value must short-circuit
+    before triggering a refit (no GPU re-upload, no buffer recompute)."""
+    mgr, refitter = _make_mgr()
+    mgr._active_loras.append(_ActiveLoRA(
+        lora_id=0, path="x.safetensors", strength=0.5,
+        deltas={"q.weight": torch.zeros(8, 16, dtype=torch.float16)},
+    ))
+
+    mgr.set_lora_strength(0, 0.5)
+
+    refitter.set_named_weights.assert_not_called()
+    refitter.refit_cuda_engine.assert_not_called()
+
+
+def test_set_lora_strength_changed_value_does_refit():
+    """Sanity check the inverse: a real strength change still refits."""
+    mgr, refitter = _make_mgr()
+    mgr._active_loras.append(_ActiveLoRA(
+        lora_id=0, path="x.safetensors", strength=0.5,
+        deltas={"q.weight": torch.ones(8, 16, dtype=torch.float16)},
+    ))
+
+    mgr.set_lora_strength(0, 0.7)
+
+    refitter.set_named_weights.assert_called_once()
+    refitter.refit_cuda_engine.assert_called_once()
+
+
+def test_set_lora_strength_unknown_id_raises():
+    mgr, _ = _make_mgr()
+    with pytest.raises(ValueError, match="not found"):
+        mgr.set_lora_strength(999, 0.5)


### PR DESCRIPTION
## Summary
Three small short-circuits in `acestep/engine/trt/lora_refit.py` that eliminate provably-redundant work in the TRT LoRA refit path. All output is identical to before; only wasted CPU traversals + GPU re-uploads are removed.

### What changed
1. **Skip strength-0 LoRAs in the inner refit loop.** `buf.add_(delta, alpha=0.0)` is mathematically a no-op but still traverses the full weight tensor. With a stack of N LoRAs and most at zero (the common slider-driven UI pattern), refits scaled with N instead of with the *active* count. Now scales with active count only.
2. **No-op `set_lora_strength` when value unchanged.** Sliders sometimes land back on the previous value; that triggered a full refit + GPU re-upload. Early-return when `old == new`.
3. **No-op `apply_lora` refit when strength=0.** The realtime demo applies LoRAs at strength 0 as placeholders (`server.py: engine_obj.apply_trt_lora(lp, strength=0.0)`); each used to trigger a full refit that produced bit-identical weights. After (1), the refit math is provably a no-op in this case, so we can skip the call entirely.

### Performance implications
- **Strength-0 stack tax goes away.** With 8 LoRAs in the stack and 7 at zero, a strength change on the active one used to do ~8x the per-param work; it now does 1x.
- **Slider chatter no longer roundtrips to the GPU.** Same-value `set_lora_strength` is now ~µs instead of full refit + `refit_cuda_engine()` cost.
- **Startup is cheaper** when the demo applies multiple LoRAs at strength 0; previously each one ran a full refit producing the same weights as before.

### Correctness
None of these affect output. After (1), strength-0 contributions don't reach the buffer regardless of stack composition. Tests in `tests/unit/test_lora_refit.py` cover:
- Strength-0 LoRA in stack alone → output equals base.
- Strength-0 + active LoRA on same param → output equals base + active_delta * active_strength only.
- `set_lora_strength` to same value → no `set_named_weights` / `refit_cuda_engine` call.
- `set_lora_strength` to different value → does refit.
- `set_lora_strength` on unknown id → raises.

5/5 pass on `pytest tests/unit/test_lora_refit.py`.

### Test plan
- [ ] `python -m pytest tests/unit/test_lora_refit.py -v`
- [ ] Manual: apply 2-3 LoRAs at strength 0 in the realtime demo, ramp one up to 0.5 — confirm output sounds the same as before this PR.
- [ ] Manual: with multiple LoRAs in the stack, drive a slider rapidly — confirm no audio glitches and that refit log latency drops as inactive LoRAs are skipped.
