### PR TITLE
trt: dynamic LoRA library with register/enable/disable lifecycle

### DIFF
--- a/acestep/engine/diffusion.py
+++ b/acestep/engine/diffusion.py
@@ -162,6 +162,14 @@ class DiffusionEngine:
                 trt_weight_prefix="decoder.",
                 checkpoint_path=ckpt_path,
             )
+            # Pre-register the on-disk library (MODELS_DIR/loras).  This
+            # is the catalog backing the "infinite library" workflow:
+            # register every .safetensors as REGISTERED (zero RAM cost),
+            # callers materialize on demand via enable_trt_lora.
+            try:
+                self._lora_manager.register_library()
+            except Exception as e:
+                logger.warning("Failed to scan LoRA library: %s", e)
         except RuntimeError as e:
             # Engine not built with REFIT, or TRT version too old
             logger.info("TRT LoRA refit not available: %s", e)
@@ -209,6 +217,70 @@ class DiffusionEngine:
         """Remove all LoRAs and restore the TRT engine to base weights."""
         if self._lora_manager is not None:
             self._lora_manager.remove_all()
+
+    # ------------------------------------------------------------------
+    # Lifecycle API: register / enable / disable / prewarm
+    # ------------------------------------------------------------------
+
+    def register_trt_lora(self, lora_path: str, name: str | None = None) -> str:
+        """Add a LoRA to the catalog without materializing deltas.
+
+        Returns the (filename-stem) id used for subsequent enable/disable
+        calls.  Idempotent on path.
+        """
+        if self._lora_manager is None:
+            raise RuntimeError("TRT LoRA refit not available")
+        return self._lora_manager.register_lora(lora_path, name=name)
+
+    def enable_trt_lora(
+        self, lora_id: str, strength: float | None = None,
+    ) -> None:
+        """Promote a registered LoRA to ENABLED (materialize + refit).
+
+        ``strength``, when provided, sets the entry's strength BEFORE the
+        refit so the streaming pipeline's first decode window already
+        sees the LoRA at its target strength — avoids the "first ~5s
+        sounds like the LoRA is missing" glitch caused by enabling at
+        strength 0 and waiting for the next per-tick set_strength call
+        to ramp it up.
+
+        Synchronous; if a prewarm is in flight, blocks on it.  Refit only
+        fires when the resulting strength is non-zero.
+        """
+        if self._lora_manager is None:
+            raise RuntimeError("TRT LoRA refit not available")
+        self._lora_manager.enable_lora(lora_id, strength=strength)
+
+    def disable_trt_lora(self, lora_id: str) -> None:
+        """Drop a LoRA's deltas from CPU RAM.  Strength is preserved."""
+        if self._lora_manager is None:
+            raise RuntimeError("TRT LoRA refit not available")
+        self._lora_manager.disable_lora(lora_id)
+
+    def prewarm_trt_lora(self, lora_id: str):
+        """Kick off background materialization.  Returns a Future.
+
+        Use this when the catalog is large but only some LoRAs will
+        actually be enabled — call ``prewarm_trt_lora`` for the
+        likely-enabled subset at session start so the eventual
+        ``enable_trt_lora`` call is fast.
+        """
+        if self._lora_manager is None:
+            raise RuntimeError("TRT LoRA refit not available")
+        return self._lora_manager.prewarm_lora(lora_id)
+
+    def list_trt_loras(self):
+        """Return a list of :class:`LoRADescriptor` for every entry in
+        the catalog.  Empty list if the manager is unavailable."""
+        if self._lora_manager is None:
+            return []
+        return self._lora_manager.list_loras()
+
+    def get_trt_lora(self, lora_id: str):
+        """Return the current :class:`LoRADescriptor` for ``lora_id``."""
+        if self._lora_manager is None:
+            raise RuntimeError("TRT LoRA refit not available")
+        return self._lora_manager.get_lora(lora_id)
 
     @property
     def trt_lora_available(self) -> bool:

--- a/acestep/engine/trt/lora_refit.py
+++ b/acestep/engine/trt/lora_refit.py
@@ -3,29 +3,39 @@
 Uses TensorRT's IRefitter API to modify engine weights at runtime,
 enabling LoRA application/removal without rebuilding the engine.
 
-Requirements:
-  - Engine built with trt.BuilderFlag.REFIT
-  - ONNX exported with do_constant_folding=False (preserves weight names)
+Lifecycle (per LoRA):
+  REGISTERED   - in the library catalog, no CPU RAM cost (only path + label)
+  MATERIALIZING - background prewarm in flight (worker computing B@A)
+  MATERIALIZED - deltas in CPU RAM, NOT yet contributing to engine state
+  ENABLED      - deltas applied to the engine; contributes at current strength
 
-Performance notes:
-  - Base weights and deltas are stored in the engine's native dtype
-    (typically fp16 for mixed-precision engines) to avoid per-refit
-    dtype conversion.
-  - Pre-allocated refit buffers eliminate memory allocation during
-    strength adjustment.
-  - The refitter object is cached across calls.
-  - numpy views are zero-copy from contiguous CPU tensors.
+Strength is orthogonal to the lifecycle: an ENABLED LoRA can sit at
+strength 0 indefinitely (placeholder pattern for slider-driven UIs).
+``set_lora_strength`` is rejected on non-ENABLED LoRAs to keep the
+materialization cost explicit at the call site rather than buried under
+a slider event.
 
-Thread safety: refit must not run concurrently with inference.
-Apply/remove LoRAs between generations, not during denoising steps.
+Library:
+  ``register_library(directory)`` discovers ``*.safetensors`` in a flat
+  directory and registers each as a REGISTERED entry whose id is the
+  filename stem. The catalog backs an "infinite library" workflow where
+  hundreds of LoRAs cost nothing until enabled.
+
+Threading:
+  - register / enable / disable / set_strength / refit run on the
+    inference-owning thread; refit and inference are mutually exclusive.
+  - prewarm runs on a background ThreadPoolExecutor; the worker only
+    fills the entry's deltas dict and never touches the engine.
 """
 
 from __future__ import annotations
 
+import concurrent.futures
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 from loguru import logger
 import numpy as np
@@ -39,16 +49,46 @@ _NP_TO_TORCH = {
 }
 
 
+class LoRAState(Enum):
+    REGISTERED = "registered"
+    MATERIALIZING = "materializing"
+    MATERIALIZED = "materialized"
+    ENABLED = "enabled"
+
+
 @dataclass
-class _ActiveLoRA:
-    """Internal state for one applied LoRA."""
-    lora_id: int
+class LoRADescriptor:
+    """Read-only public view of a LoRA in the library."""
+    id: str
     path: str
+    name: str
+    state: str
     strength: float
-    # Precomputed full-rank deltas (B @ A) WITHOUT strength multiplied.
-    # Stored in the engine's native dtype for zero-copy refit.
-    # Keyed by decoder param name (e.g., "layers.0.self_attn.q_proj.weight").
-    deltas: Dict[str, torch.Tensor]
+    materialized_bytes: int
+
+
+@dataclass
+class _LoRAEntry:
+    """Internal mutable state for one library entry.
+
+    ``strength`` is preserved across enable/disable cycles so flipping a
+    UI toggle off and back on doesn't reset the slider.
+    """
+    lora_id: str
+    path: str
+    name: str = ""
+    state: LoRAState = LoRAState.REGISTERED
+    strength: float = 0.0
+    deltas: Optional[Dict[str, torch.Tensor]] = None
+    future: Optional[concurrent.futures.Future] = None
+    materialized_bytes: int = 0
+
+
+# Backward-compat alias for tests / external code that imported the old
+# name.  The old type held only (lora_id, path, strength, deltas); the
+# new one is a superset, so kw-only construction with the old fields
+# still works.
+_ActiveLoRA = _LoRAEntry
 
 
 class TRTLoRAManager:
@@ -152,18 +192,149 @@ class TRTLoRAManager:
                 all_trt_names[:5],
             )
 
-        self._active_loras: List[_ActiveLoRA] = []
-        self._next_id = 0
+        # Library + lifecycle state.  Insertion order is preserved so
+        # ``remove_lora(-1)`` can pop the most-recently-registered entry,
+        # matching the legacy stack-style API.
+        self._loras: Dict[str, _LoRAEntry] = {}
         self._ever_dirty: Set[str] = set()
+        self._executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
 
     # ------------------------------------------------------------------
-    # Public API
+    # Library: catalog without RAM cost
     # ------------------------------------------------------------------
 
-    def apply_lora(self, lora_path: str, strength: float = 1.0) -> int:
-        """Apply a LoRA. Returns ID for removal/strength adjustment."""
+    @staticmethod
+    def _make_id(path: str) -> str:
+        """Filename-stem id. Two files with the same stem collide; the
+        registrar treats this as identity, so that's fine for a flat
+        library directory but means a caller can't register two distinct
+        LoRAs that happen to share a stem."""
+        return Path(path).stem
+
+    def register_lora(
+        self, path: str, name: Optional[str] = None,
+    ) -> str:
+        """Add a LoRA to the catalog without materializing deltas.
+
+        Idempotent: re-registering the same id (filename stem) returns
+        the existing id and leaves any in-flight prewarm / enabled
+        state alone.  The existing entry's name is NOT overwritten on
+        re-register; pass an explicit ``name`` only on first registration.
+        """
+        lora_id = self._make_id(path)
+        if lora_id in self._loras:
+            existing = self._loras[lora_id]
+            if existing.path != str(path):
+                logger.warning(
+                    "LoRA id %r already registered to %s; ignoring re-register from %s",
+                    lora_id, existing.path, path,
+                )
+            return lora_id
+        self._loras[lora_id] = _LoRAEntry(
+            lora_id=lora_id, path=str(path),
+            name=name if name is not None else lora_id,
+        )
+        logger.info("Registered TRT LoRA: %s (path=%s)", lora_id, path)
+        return lora_id
+
+    def register_library(
+        self, directory: Optional[Path] = None,
+    ) -> List[str]:
+        """Discover and register every ``*.safetensors`` in ``directory``.
+
+        Defaults to :func:`acestep.paths.loras_dir`.  Returns the list
+        of registered ids in directory order (sorted by filename).
+        Missing directory returns an empty list.
+        """
+        from acestep.paths import discover_loras, loras_dir
+        d = directory if directory is not None else loras_dir()
+        files = discover_loras(d)
+        ids: List[str] = []
+        for p in files:
+            try:
+                ids.append(self.register_lora(str(p)))
+            except Exception as e:
+                logger.warning("Failed to register %s: %s", p, e)
+        if files:
+            logger.info(
+                "Registered library: %d LoRAs from %s", len(ids), d,
+            )
+        return ids
+
+    # ------------------------------------------------------------------
+    # Lifecycle: REGISTERED <-> MATERIALIZING <-> MATERIALIZED <-> ENABLED
+    # ------------------------------------------------------------------
+
+    def _get_executor(self) -> concurrent.futures.ThreadPoolExecutor:
+        """Lazy-init single-worker pool for prewarm.  Single worker
+        because the materialization runs (B @ A) on the same CUDA device
+        as inference; oversubscribing would just block on the GPU."""
+        if self._executor is None:
+            self._executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="lora_prewarm",
+            )
+        return self._executor
+
+    def prewarm_lora(self, lora_id: str) -> concurrent.futures.Future:
+        """Kick off background materialization of ``lora_id``.
+
+        Returns a Future that resolves to ``None`` once deltas are in
+        CPU RAM.  Subsequent ``enable_lora`` will skip the materialization
+        step.  Calling on a MATERIALIZED / ENABLED entry returns an
+        already-completed future; calling on a MATERIALIZING entry
+        returns the in-flight future.
+        """
+        entry = self._require_entry(lora_id)
+        if entry.state in (LoRAState.MATERIALIZED, LoRAState.ENABLED):
+            f: concurrent.futures.Future = concurrent.futures.Future()
+            f.set_result(None)
+            return f
+        if entry.state == LoRAState.MATERIALIZING:
+            assert entry.future is not None
+            return entry.future
+        # REGISTERED -> MATERIALIZING
+        entry.state = LoRAState.MATERIALIZING
+        entry.future = self._get_executor().submit(
+            self._materialize_worker, entry,
+        )
+        logger.info("Prewarming TRT LoRA: %s", lora_id)
+        return entry.future
+
+    def _materialize_worker(self, entry: _LoRAEntry) -> None:
+        """Worker-thread body.  Loads safetensors, computes deltas,
+        writes them to the entry.  Engine state untouched.
+
+        If the entry was concurrently disabled (state changed away from
+        MATERIALIZING), the result is dropped to avoid resurrecting the
+        deltas after disable cleared them.
+        """
         t0 = time.perf_counter()
+        try:
+            deltas, bytes_ = self._compute_deltas(entry.path)
+        except Exception:
+            if entry.state == LoRAState.MATERIALIZING:
+                entry.state = LoRAState.REGISTERED
+                entry.future = None
+            raise
+        if entry.state == LoRAState.MATERIALIZING:
+            entry.deltas = deltas
+            entry.materialized_bytes = bytes_
+            entry.state = LoRAState.MATERIALIZED
+            elapsed = (time.perf_counter() - t0) * 1000
+            logger.info(
+                "Materialized TRT LoRA %s (%d params, %.1f MB) in %.1fms",
+                entry.lora_id, len(deltas), bytes_ / 1e6, elapsed,
+            )
+        # else: entry was disabled mid-prewarm; drop the deltas silently.
 
+    def _compute_deltas(
+        self, lora_path: str,
+    ) -> Tuple[Dict[str, torch.Tensor], int]:
+        """Load LoRA from disk and compute full-rank deltas (B @ A).
+
+        Pure compute; safe to call from a worker thread.  Returns
+        (deltas_dict, total_bytes_in_cpu_ram).
+        """
         raw = load_file(lora_path)
         pairs: Dict[str, Dict[str, torch.Tensor]] = {}
         for key, tensor in raw.items():
@@ -176,6 +347,7 @@ class TRTLoRAManager:
                 pairs.setdefault(param_name, {})["B"] = tensor
 
         deltas: Dict[str, torch.Tensor] = {}
+        total_bytes = 0
         skipped = 0
         for param_name, ab in pairs.items():
             if "A" not in ab or "B" not in ab:
@@ -183,97 +355,220 @@ class TRTLoRAManager:
             if param_name not in self._param_to_trt:
                 skipped += 1
                 continue
-            # Compute B @ A on GPU in fp32, then convert to engine dtype on CPU
             A = ab["A"].to(device=self._device, dtype=torch.float32)
             B = ab["B"].to(device=self._device, dtype=torch.float32)
             target_dt = self._base_weights[param_name].dtype
-            deltas[param_name] = (B @ A).to(dtype=target_dt).cpu().contiguous()
-
-        lora_id = self._next_id
-        self._next_id += 1
-        self._active_loras.append(_ActiveLoRA(
-            lora_id=lora_id, path=lora_path, strength=strength, deltas=deltas,
-        ))
-
-        # Strength-0 contributes nothing to any param's recomputed value,
-        # so the refit would be a mathematical no-op (engine already has
-        # the correct weights from the prior state). Skip it. The LoRA's
-        # deltas are still cached and will participate in the next refit
-        # once strength != 0.
-        if strength != 0.0:
-            self._refit_weights(set(deltas.keys()))
-
-        elapsed = (time.perf_counter() - t0) * 1000
-        logger.info(
-            "Applied TRT LoRA %d: %s (%d params, %d skipped, "
-            "scale=%.2f) in %.1fms",
-            lora_id, Path(lora_path).name, len(deltas), skipped,
-            strength, elapsed,
-        )
-        return lora_id
-
-    def remove_lora(self, lora_id: int = -1) -> bool:
-        """Remove a LoRA by ID. Default (-1) removes the most recent."""
-        if not self._active_loras:
-            return False
-        if lora_id == -1:
-            removed = self._active_loras.pop()
-        else:
-            idx = next(
-                (i for i, l in enumerate(self._active_loras)
-                 if l.lora_id == lora_id), None,
+            d = (B @ A).to(dtype=target_dt).cpu().contiguous()
+            deltas[param_name] = d
+            total_bytes += d.numel() * d.element_size()
+        if skipped:
+            logger.debug(
+                "_compute_deltas(%s): %d params skipped (not in engine)",
+                Path(lora_path).name, skipped,
             )
-            if idx is None:
-                return False
-            removed = self._active_loras.pop(idx)
+        return deltas, total_bytes
 
-        self._refit_weights(set(removed.deltas.keys()))
+    def enable_lora(
+        self, lora_id: str, strength: Optional[float] = None,
+    ) -> None:
+        """Promote a LoRA to ENABLED.  Synchronous; materializes if needed.
+
+        ``strength``, when provided, overrides the entry's stored strength
+        BEFORE the refit fires.  Pass it whenever you know the target
+        strength up-front: it lets a one-shot caller atomically transition
+        REGISTERED -> ENABLED-at-S without an intermediate refit at 0
+        followed by a second refit at S, which the streaming pipeline can
+        observe as a one-tick "missing LoRA" glitch in the first decode
+        window.
+
+        Refits the engine weights iff the resulting strength is non-zero
+        (a strength-0 enable is a placeholder for a slider that hasn't
+        ramped yet, and the refit would be a no-op).
+        """
+        entry = self._require_entry(lora_id)
+        if strength is not None:
+            entry.strength = float(strength)
+        if entry.state == LoRAState.ENABLED:
+            return
+        if entry.state == LoRAState.MATERIALIZING:
+            assert entry.future is not None
+            entry.future.result()
+            # state should now be MATERIALIZED (or REGISTERED on failure)
+        if entry.state == LoRAState.REGISTERED:
+            t0 = time.perf_counter()
+            deltas, bytes_ = self._compute_deltas(entry.path)
+            entry.deltas = deltas
+            entry.materialized_bytes = bytes_
+            entry.state = LoRAState.MATERIALIZED
+            elapsed = (time.perf_counter() - t0) * 1000
+            logger.info(
+                "Materialized TRT LoRA %s inline (%d params, %.1f MB) in %.1fms",
+                lora_id, len(deltas), bytes_ / 1e6, elapsed,
+            )
+        # MATERIALIZED -> ENABLED
+        entry.state = LoRAState.ENABLED
+        entry.future = None
+        if entry.strength != 0.0 and entry.deltas:
+            self._refit_weights(set(entry.deltas.keys()))
         logger.info(
-            "Removed TRT LoRA %d: %s (%d params)",
-            removed.lora_id, Path(removed.path).name, len(removed.deltas),
+            "Enabled TRT LoRA %s (%d params, %.1f MB, strength=%.2f)",
+            lora_id, len(entry.deltas or {}),
+            entry.materialized_bytes / 1e6, entry.strength,
         )
+
+    def disable_lora(self, lora_id: str) -> None:
+        """Drop deltas from CPU RAM and refit if the LoRA was contributing.
+
+        Strength is preserved on the entry so re-enable returns to the
+        same slider position.
+        """
+        entry = self._require_entry(lora_id)
+        if entry.state == LoRAState.REGISTERED:
+            return
+
+        # If a prewarm is in flight, wait it out so the worker can't
+        # later resurrect the deltas we're about to drop.  Worker checks
+        # state before assigning, so transitions during the wait are
+        # benign.
+        if entry.state == LoRAState.MATERIALIZING and entry.future is not None:
+            try:
+                entry.future.result()
+            except Exception:
+                pass
+
+        was_contributing = (
+            entry.state == LoRAState.ENABLED and entry.strength != 0.0
+        )
+        affected_params: Set[str] = (
+            set(entry.deltas.keys()) if entry.deltas else set()
+        )
+
+        entry.state = LoRAState.REGISTERED
+        entry.deltas = None
+        entry.materialized_bytes = 0
+        entry.future = None
+
+        if was_contributing:
+            self._refit_weights(affected_params)
+        logger.info(
+            "Disabled TRT LoRA %s (was_contributing=%s)",
+            lora_id, was_contributing,
+        )
+
+    def set_lora_strength(self, lora_id: str, strength: float) -> None:
+        """Adjust the strength of an ENABLED LoRA.
+
+        Raises ValueError if the LoRA is not enabled.  Auto-enable was
+        considered and rejected: it would hide materialization cost
+        (hundreds of ms) behind a slider event.  The UI is responsible
+        for calling ``enable_lora`` before a slider becomes interactive.
+        """
+        entry = self._require_entry(lora_id)
+        if entry.state != LoRAState.ENABLED:
+            raise ValueError(
+                f"LoRA {lora_id!r} is not enabled (state={entry.state.value}). "
+                "Call enable_lora() first."
+            )
+        if entry.strength == strength:
+            # Slider sometimes lands back on the previous value;
+            # skip the full refit + GPU re-upload in that case.
+            return
+        old = entry.strength
+        entry.strength = strength
+        if entry.deltas:
+            self._refit_weights(set(entry.deltas.keys()))
+        logger.info(
+            "TRT LoRA %s strength: %.3f -> %.3f (%d params)",
+            lora_id, old, strength, len(entry.deltas or {}),
+        )
+
+    def remove_lora(self, lora_id=-1) -> bool:
+        """Drop a LoRA from the catalog entirely.
+
+        Disables first if enabled.  Default ``-1`` removes the most
+        recently registered entry, preserving the legacy stack-pop API
+        used by ``acestep.nodes.lora_nodes.RemoveLoRA``.
+        """
+        if lora_id == -1:
+            if not self._loras:
+                return False
+            lora_id = next(reversed(self._loras))
+        if lora_id not in self._loras:
+            return False
+        self.disable_lora(lora_id)
+        del self._loras[lora_id]
+        logger.info("Removed TRT LoRA %s from catalog", lora_id)
         return True
 
-    def set_lora_strength(self, lora_id: int, strength: float) -> None:
-        """Adjust strength of an active LoRA and refit."""
-        for lora in self._active_loras:
-            if lora.lora_id == lora_id:
-                old = lora.strength
-                if old == strength:
-                    # Slider sometimes lands back on the previous value;
-                    # skip the full refit + GPU re-upload in that case.
-                    return
-                lora.strength = strength
-                self._refit_weights(set(lora.deltas.keys()))
-                logger.info(
-                    "TRT LoRA %d strength: %.3f -> %.3f (%d params)",
-                    lora_id, old, strength, len(lora.deltas),
-                )
-                return
-        raise ValueError(f"LoRA {lora_id} not found in active stack")
-
     def remove_all(self) -> None:
-        """Remove all LoRAs and restore engine to base weights."""
-        if not self._active_loras:
-            return
-        all_params: Set[str] = set()
-        for lora in self._active_loras:
-            all_params.update(lora.deltas.keys())
-        self._active_loras.clear()
-        self._refit_weights(all_params)
-        logger.info("All TRT LoRAs removed, engine restored to base weights")
+        """Remove every LoRA from the catalog and restore engine to base."""
+        for lid in list(self._loras.keys()):
+            self.remove_lora(lid)
+
+    # ------------------------------------------------------------------
+    # Backward-compat one-shot API
+    # ------------------------------------------------------------------
+
+    def apply_lora(self, lora_path: str, strength: float = 1.0) -> str:
+        """Register, set strength, and enable a LoRA in one call.
+
+        Idempotent on path: calling twice is the same as registering
+        once and setting the second-call's strength.  Kept for
+        ``workflows/``, ``acestep.nodes.lora_nodes``, and demo bootstrap
+        paths that haven't migrated to explicit register/enable.
+        """
+        lora_id = self.register_lora(lora_path)
+        self._loras[lora_id].strength = float(strength)
+        self.enable_lora(lora_id)
+        return lora_id
+
+    # ------------------------------------------------------------------
+    # Inspection
+    # ------------------------------------------------------------------
+
+    def list_loras(self) -> List[LoRADescriptor]:
+        return [
+            LoRADescriptor(
+                id=e.lora_id, path=e.path, name=e.name,
+                state=e.state.value, strength=e.strength,
+                materialized_bytes=e.materialized_bytes,
+            )
+            for e in self._loras.values()
+        ]
+
+    def get_lora(self, lora_id: str) -> LoRADescriptor:
+        e = self._require_entry(lora_id)
+        return LoRADescriptor(
+            id=e.lora_id, path=e.path, name=e.name,
+            state=e.state.value, strength=e.strength,
+            materialized_bytes=e.materialized_bytes,
+        )
+
+    def _require_entry(self, lora_id: str) -> _LoRAEntry:
+        if lora_id not in self._loras:
+            raise ValueError(f"LoRA {lora_id!r} not registered")
+        return self._loras[lora_id]
 
     @property
     def has_active_loras(self) -> bool:
-        return len(self._active_loras) > 0
+        return any(e.state == LoRAState.ENABLED for e in self._loras.values())
 
     @property
     def active_lora_count(self) -> int:
-        return len(self._active_loras)
+        return sum(
+            1 for e in self._loras.values() if e.state == LoRAState.ENABLED
+        )
 
     @property
-    def active_lora_ids(self) -> List[int]:
-        return [l.lora_id for l in self._active_loras]
+    def active_lora_ids(self) -> List[str]:
+        return [
+            e.lora_id for e in self._loras.values()
+            if e.state == LoRAState.ENABLED
+        ]
+
+    @property
+    def total_materialized_bytes(self) -> int:
+        return sum(e.materialized_bytes for e in self._loras.values())
 
     @property
     def refittable_param_count(self) -> int:
@@ -303,16 +598,17 @@ class TRTLoRAManager:
             buf = self._refit_bufs[param_name]
             buf.copy_(self._base_weights[param_name])
 
-            # Accumulate LoRA contributions in-place (native dtype). Skip
-            # strength-0 LoRAs; their delta contributes nothing but the
-            # add_ traverses the full weight, which is wasteful when the
-            # caller leaves placeholders in the stack at strength 0
-            # (a common pattern for slider-driven UIs).
-            for lora in self._active_loras:
-                if lora.strength == 0.0:
+            # Accumulate ENABLED LoRA contributions in-place (native
+            # dtype). Skip strength-0 contributions; they're a no-op
+            # but the add_ traverses the full weight, which is wasteful
+            # for slider-driven UIs that leave placeholders at 0.
+            for entry in self._loras.values():
+                if entry.state != LoRAState.ENABLED:
                     continue
-                if param_name in lora.deltas:
-                    buf.add_(lora.deltas[param_name], alpha=lora.strength)
+                if entry.strength == 0.0:
+                    continue
+                if entry.deltas and param_name in entry.deltas:
+                    buf.add_(entry.deltas[param_name], alpha=entry.strength)
 
             # Zero-copy numpy view (contiguous CPU tensor, matching dtype)
             refitter.set_named_weights(trt_name, buf.numpy())

--- a/acestep/paths.py
+++ b/acestep/paths.py
@@ -6,6 +6,7 @@ Nothing should hardcode paths or use relative symlinks.
 Directory layout under MODELS_DIR:
     checkpoints/          Model weights (acestep-v15-turbo, etc.)
     trt_engines/          TensorRT engines and ONNX exports
+    loras/                LoRA .safetensors files (flat — id is filename stem)
 
 Resolution order for MODELS_DIR:
     1. ACESTEP_MODELS_DIR environment variable
@@ -34,6 +35,28 @@ def checkpoints_dir() -> Path:
 def trt_engines_dir() -> Path:
     """Directory containing TensorRT engines and ONNX exports."""
     return models_dir() / "trt_engines"
+
+
+def loras_dir() -> Path:
+    """Directory containing LoRA .safetensors files.
+
+    Flat layout: each ``*.safetensors`` becomes one library entry whose
+    id is the filename stem. Subdirectories are not scanned.
+    """
+    return models_dir() / "loras"
+
+
+def discover_loras(directory: Path | None = None) -> list[Path]:
+    """List ``*.safetensors`` files in ``directory`` (default: ``loras_dir()``).
+
+    Returns an empty list if the directory does not exist; callers should
+    treat that as "no library", not as an error. Hidden files
+    (``.gitignore``, etc.) and subdirectories are ignored.
+    """
+    d = Path(directory) if directory is not None else loras_dir()
+    if not d.is_dir():
+        return []
+    return sorted(p for p in d.glob("*.safetensors") if p.is_file())
 
 
 def trt_engine_path(engine_name: str) -> Path:

--- a/tests/unit/test_lora_refit.py
+++ b/tests/unit/test_lora_refit.py
@@ -1,4 +1,4 @@
-"""Unit tests for the strength-0 short-circuits in TRTLoRAManager.
+"""Unit tests for ``TRTLoRAManager``.
 
 These don't build a real TRT engine; they bypass __init__ and wire up
 the manager with a fake refitter so we can assert what would have been
@@ -14,7 +14,9 @@ import torch
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from acestep.engine.trt.lora_refit import TRTLoRAManager, _ActiveLoRA
+from acestep.engine.trt.lora_refit import (
+    TRTLoRAManager, _LoRAEntry, LoRAState,
+)
 
 
 def _make_mgr():
@@ -41,20 +43,38 @@ def _make_mgr():
         "k.weight": torch.empty_like(base_k),
     }
     mgr._np_dtype = {"q.weight": np.float16, "k.weight": np.float16}
-    mgr._active_loras = []
-    mgr._next_id = 0
+    mgr._loras = {}
     mgr._ever_dirty = set()
+    mgr._executor = None
     return mgr, refitter
+
+
+def _add_enabled_entry(mgr, lora_id, deltas, strength):
+    """Insert a fully-materialized ENABLED entry without going through
+    enable_lora() (which would try to read a real file from disk)."""
+    bytes_ = sum(d.numel() * d.element_size() for d in deltas.values())
+    mgr._loras[lora_id] = _LoRAEntry(
+        lora_id=lora_id, path=f"{lora_id}.safetensors", name=lora_id,
+        state=LoRAState.ENABLED, strength=strength,
+        deltas=deltas, materialized_bytes=bytes_,
+    )
+
+
+# ----------------------------------------------------------------------
+# Existing strength-0 invariants (refit math) - preserved verbatim under
+# the new lifecycle so the b20fba9 short-circuits stay covered.
+# ----------------------------------------------------------------------
 
 
 def test_strength_zero_lora_in_stack_does_not_leak_into_output():
     """A LoRA sitting in the stack at strength 0 must not affect the
     refitted weights, even when its delta is non-trivial."""
     mgr, refitter = _make_mgr()
-    mgr._active_loras.append(_ActiveLoRA(
-        lora_id=0, path="zero.safetensors", strength=0.0,
+    _add_enabled_entry(
+        mgr, "zero",
         deltas={"q.weight": torch.ones(8, 16, dtype=torch.float16)},
-    ))
+        strength=0.0,
+    )
 
     mgr._refit_weights({"q.weight"})
 
@@ -70,14 +90,8 @@ def test_strength_zero_lora_skipped_when_other_active_present():
     mgr, refitter = _make_mgr()
     delta_zero = torch.ones(8, 16, dtype=torch.float16)
     delta_active = torch.full((8, 16), 2.0, dtype=torch.float16)
-    mgr._active_loras.append(_ActiveLoRA(
-        lora_id=0, path="zero.safetensors", strength=0.0,
-        deltas={"q.weight": delta_zero},
-    ))
-    mgr._active_loras.append(_ActiveLoRA(
-        lora_id=1, path="active.safetensors", strength=0.5,
-        deltas={"q.weight": delta_active},
-    ))
+    _add_enabled_entry(mgr, "zero", deltas={"q.weight": delta_zero}, strength=0.0)
+    _add_enabled_entry(mgr, "active", deltas={"q.weight": delta_active}, strength=0.5)
 
     mgr._refit_weights({"q.weight"})
 
@@ -90,12 +104,13 @@ def test_set_lora_strength_same_value_is_noop():
     """set_lora_strength to the LoRA's current value must short-circuit
     before triggering a refit (no GPU re-upload, no buffer recompute)."""
     mgr, refitter = _make_mgr()
-    mgr._active_loras.append(_ActiveLoRA(
-        lora_id=0, path="x.safetensors", strength=0.5,
+    _add_enabled_entry(
+        mgr, "x",
         deltas={"q.weight": torch.zeros(8, 16, dtype=torch.float16)},
-    ))
+        strength=0.5,
+    )
 
-    mgr.set_lora_strength(0, 0.5)
+    mgr.set_lora_strength("x", 0.5)
 
     refitter.set_named_weights.assert_not_called()
     refitter.refit_cuda_engine.assert_not_called()
@@ -104,12 +119,13 @@ def test_set_lora_strength_same_value_is_noop():
 def test_set_lora_strength_changed_value_does_refit():
     """Sanity check the inverse: a real strength change still refits."""
     mgr, refitter = _make_mgr()
-    mgr._active_loras.append(_ActiveLoRA(
-        lora_id=0, path="x.safetensors", strength=0.5,
+    _add_enabled_entry(
+        mgr, "x",
         deltas={"q.weight": torch.ones(8, 16, dtype=torch.float16)},
-    ))
+        strength=0.5,
+    )
 
-    mgr.set_lora_strength(0, 0.7)
+    mgr.set_lora_strength("x", 0.7)
 
     refitter.set_named_weights.assert_called_once()
     refitter.refit_cuda_engine.assert_called_once()
@@ -117,5 +133,275 @@ def test_set_lora_strength_changed_value_does_refit():
 
 def test_set_lora_strength_unknown_id_raises():
     mgr, _ = _make_mgr()
-    with pytest.raises(ValueError, match="not found"):
-        mgr.set_lora_strength(999, 0.5)
+    with pytest.raises(ValueError, match="not registered"):
+        mgr.set_lora_strength("missing", 0.5)
+
+
+# ----------------------------------------------------------------------
+# Lifecycle: register / enable / disable / prewarm
+# ----------------------------------------------------------------------
+
+
+def test_register_does_not_materialize():
+    """register_lora is the cheap catalog op: no deltas in RAM, no refit,
+    no disk read.  This is the property that lets the library hold N
+    placeholders at near-zero cost."""
+    mgr, refitter = _make_mgr()
+
+    lid = mgr.register_lora("/tmp/death.safetensors", name="Death")
+
+    assert lid == "death"
+    desc = mgr.get_lora("death")
+    assert desc.state == "registered"
+    assert desc.strength == 0.0
+    assert desc.materialized_bytes == 0
+    assert mgr.total_materialized_bytes == 0
+    refitter.set_named_weights.assert_not_called()
+    refitter.refit_cuda_engine.assert_not_called()
+
+
+def test_register_is_idempotent_on_path():
+    """Calling register_lora twice with the same filename returns the
+    same id and does not duplicate the entry."""
+    mgr, _ = _make_mgr()
+    a = mgr.register_lora("/tmp/x.safetensors")
+    b = mgr.register_lora("/tmp/x.safetensors")
+    assert a == b
+    assert len(mgr.list_loras()) == 1
+
+
+def test_set_strength_on_non_enabled_errors():
+    """set_lora_strength is rejected on REGISTERED / MATERIALIZED entries
+    so materialization cost can't be hidden behind a slider event."""
+    mgr, refitter = _make_mgr()
+    mgr.register_lora("/tmp/x.safetensors")
+
+    with pytest.raises(ValueError, match="not enabled"):
+        mgr.set_lora_strength("x", 0.5)
+
+    refitter.set_named_weights.assert_not_called()
+
+
+def test_enable_with_strength_refits_once_at_target(monkeypatch):
+    """enable_lora(id, strength=S) must apply the LoRA at S in a single
+    refit, not enable-at-0 + later set_strength-to-S. The streaming
+    pipeline relies on this: an enable-at-0 followed by ramp-to-S means
+    the first decode window sees base weights and produces a glitch.
+    """
+    mgr, refitter = _make_mgr()
+    delta = torch.full((8, 16), 4.0, dtype=torch.float16)
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: ({"q.weight": delta}, delta.numel() * 2),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    mgr.enable_lora("x", strength=0.5)
+
+    # Exactly one refit, with the LoRA contributing at 0.5.
+    refitter.refit_cuda_engine.assert_called_once()
+    arr = refitter.set_named_weights.call_args_list[0][0][1]
+    expected = (delta.float() * 0.5).to(torch.float16).numpy()
+    np.testing.assert_allclose(arr, expected, rtol=1e-3)
+    assert mgr.get_lora("x").strength == 0.5
+
+
+def test_enable_with_strength_zero_is_still_placeholder(monkeypatch):
+    """enable_lora(id, strength=0.0) is the explicit placeholder form:
+    the deltas materialize but no refit fires."""
+    mgr, refitter = _make_mgr()
+    canned = {"q.weight": torch.ones(8, 16, dtype=torch.float16)}
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: (dict(canned), canned["q.weight"].numel() * 2),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    mgr.enable_lora("x", strength=0.0)
+
+    assert mgr.get_lora("x").state == "enabled"
+    assert mgr.get_lora("x").strength == 0.0
+    refitter.refit_cuda_engine.assert_not_called()
+
+
+def test_enable_then_disable_refits_only_when_contributing(monkeypatch):
+    """Enable with non-zero strength refits.  Disable while contributing
+    refits back.  Strength-0 enable + disable: both no-op refits."""
+    mgr, refitter = _make_mgr()
+
+    # Stub _compute_deltas so we don't need a real safetensors file.
+    canned = {"q.weight": torch.full((8, 16), 3.0, dtype=torch.float16)}
+    bytes_ = canned["q.weight"].numel() * canned["q.weight"].element_size()
+    monkeypatch.setattr(mgr, "_compute_deltas", lambda p: (dict(canned), bytes_))
+
+    mgr.register_lora("/tmp/x.safetensors")
+
+    # Enable with strength 0: materializes but no refit (math no-op).
+    mgr.enable_lora("x")
+    assert mgr.get_lora("x").state == "enabled"
+    assert mgr.get_lora("x").materialized_bytes == bytes_
+    refitter.refit_cuda_engine.assert_not_called()
+
+    # Bump strength: refit fires.
+    mgr.set_lora_strength("x", 0.5)
+    assert refitter.refit_cuda_engine.call_count == 1
+
+    # Disable: deltas freed, contributing -> refits back to base.
+    mgr.disable_lora("x")
+    assert mgr.get_lora("x").state == "registered"
+    assert mgr.get_lora("x").materialized_bytes == 0
+    assert mgr.total_materialized_bytes == 0
+    assert refitter.refit_cuda_engine.call_count == 2
+
+
+def test_disable_strength_zero_skips_refit(monkeypatch):
+    """A LoRA that was enabled but never had non-zero strength shouldn't
+    refit on disable — there's nothing to undo."""
+    mgr, refitter = _make_mgr()
+    canned = {"q.weight": torch.ones(8, 16, dtype=torch.float16)}
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: (dict(canned), canned["q.weight"].numel() * 2),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    mgr.enable_lora("x")  # strength 0: no refit
+    mgr.disable_lora("x")  # was_contributing=False: no refit
+
+    refitter.refit_cuda_engine.assert_not_called()
+
+
+def test_re_enable_restores_last_strength(monkeypatch):
+    """Disable preserves strength so re-enabling returns to the same
+    slider position (and the resulting refit picks up the strength)."""
+    mgr, refitter = _make_mgr()
+    canned = {"q.weight": torch.ones(8, 16, dtype=torch.float16)}
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: (dict(canned), canned["q.weight"].numel() * 2),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    mgr.enable_lora("x")
+    mgr.set_lora_strength("x", 0.7)
+    mgr.disable_lora("x")
+    assert mgr.get_lora("x").strength == 0.7
+
+    refitter.refit_cuda_engine.reset_mock()
+    refitter.set_named_weights.reset_mock()
+    mgr.enable_lora("x")
+
+    # Re-enable with strength 0.7 should refit and apply the contribution.
+    refitter.refit_cuda_engine.assert_called_once()
+    arr = refitter.set_named_weights.call_args_list[0][0][1]
+    expected = (canned["q.weight"].float() * 0.7).to(torch.float16).numpy()
+    np.testing.assert_allclose(arr, expected, rtol=1e-3)
+
+
+def test_prewarm_completes_then_enable_skips_inline_materialization(monkeypatch):
+    """After prewarm resolves the entry should be MATERIALIZED, and
+    enable_lora must not call _compute_deltas again."""
+    mgr, refitter = _make_mgr()
+    canned = {"q.weight": torch.ones(8, 16, dtype=torch.float16)}
+    bytes_ = canned["q.weight"].numel() * 2
+    call_count = {"n": 0}
+
+    def fake_compute(path):
+        call_count["n"] += 1
+        return dict(canned), bytes_
+
+    monkeypatch.setattr(mgr, "_compute_deltas", fake_compute)
+
+    mgr.register_lora("/tmp/x.safetensors")
+    f = mgr.prewarm_lora("x")
+    f.result(timeout=5)
+    assert mgr.get_lora("x").state == "materialized"
+    assert call_count["n"] == 1
+
+    mgr.enable_lora("x")
+    assert mgr.get_lora("x").state == "enabled"
+    # No second call to _compute_deltas — prewarm already paid the cost.
+    assert call_count["n"] == 1
+
+
+def test_apply_lora_backward_compat(monkeypatch):
+    """The legacy apply_lora wrapper (register + set_strength + enable)
+    keeps working for callers that haven't migrated."""
+    mgr, refitter = _make_mgr()
+    canned = {"q.weight": torch.ones(8, 16, dtype=torch.float16)}
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: (dict(canned), canned["q.weight"].numel() * 2),
+    )
+
+    lid = mgr.apply_lora("/tmp/foo.safetensors", strength=0.5)
+
+    assert lid == "foo"
+    desc = mgr.get_lora("foo")
+    assert desc.state == "enabled"
+    assert desc.strength == 0.5
+    refitter.refit_cuda_engine.assert_called_once()
+
+
+def test_apply_lora_strength_zero_is_placeholder(monkeypatch):
+    """The placeholder pattern (apply at strength 0, ramp later) still
+    materializes deltas but skips the refit — same as before."""
+    mgr, refitter = _make_mgr()
+    canned = {"q.weight": torch.ones(8, 16, dtype=torch.float16)}
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: (dict(canned), canned["q.weight"].numel() * 2),
+    )
+
+    mgr.apply_lora("/tmp/foo.safetensors", strength=0.0)
+
+    assert mgr.get_lora("foo").state == "enabled"
+    refitter.refit_cuda_engine.assert_not_called()
+
+
+def test_register_library_scans_and_registers(tmp_path, monkeypatch):
+    """register_library should pick up every .safetensors in the dir as
+    a REGISTERED entry (no materialization) and skip non-matching files."""
+    (tmp_path / "a.safetensors").write_bytes(b"")
+    (tmp_path / "b.safetensors").write_bytes(b"")
+    (tmp_path / "ignore.txt").write_text("not a lora")
+
+    mgr, refitter = _make_mgr()
+    ids = mgr.register_library(tmp_path)
+
+    assert sorted(ids) == ["a", "b"]
+    assert all(d.state == "registered" for d in mgr.list_loras())
+    assert mgr.total_materialized_bytes == 0
+    refitter.set_named_weights.assert_not_called()
+
+
+def test_register_library_missing_dir_returns_empty():
+    mgr, _ = _make_mgr()
+    ids = mgr.register_library(Path("/no/such/path/123abc"))
+    assert ids == []
+    assert mgr.list_loras() == []
+
+
+def test_remove_lora_full_lifecycle(monkeypatch):
+    """remove_lora should disable + drop from catalog.  remove_lora(-1)
+    pops the most recently registered entry."""
+    mgr, refitter = _make_mgr()
+    canned = {"q.weight": torch.ones(8, 16, dtype=torch.float16)}
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: (dict(canned), canned["q.weight"].numel() * 2),
+    )
+
+    mgr.register_lora("/tmp/a.safetensors")
+    mgr.register_lora("/tmp/b.safetensors")
+    mgr.enable_lora("a")
+    mgr.set_lora_strength("a", 0.5)
+
+    assert mgr.remove_lora(-1) is True  # pops "b" (most recent)
+    assert {d.id for d in mgr.list_loras()} == {"a"}
+
+    assert mgr.remove_lora("a") is True  # disables (refit) + drops
+    assert mgr.list_loras() == []
+
+    assert mgr.remove_lora("a") is False  # already gone
+    assert mgr.remove_lora(-1) is False  # empty


### PR DESCRIPTION
## What

Adds the `infinite library` foundation to `TRTLoRAManager`: a catalog
of registered LoRAs that costs ~0 RAM until an entry is explicitly
enabled. Resource lifecycle (whether full-rank deltas are materialized
in CPU RAM) is now orthogonal to contribution magnitude (strength).

Before this PR, the only way to have a LoRA "ready to ramp" was to
`apply_trt_lora(path, strength=0.0)` — which paid full-rank delta RAM
(~50 MB-1 GB per LoRA) at startup regardless of strength. With N
placeholders that bill scales linearly. After this PR, the same
workflow is `register + enable when needed`, and N placeholders cost
only the path strings until the operator turns one on.

## API

```python
mgr.register_lora(path, name=None) -> str    # cheap, idempotent
mgr.prewarm_lora(id) -> Future               # async (B@A) on a worker
mgr.enable_lora(id, strength=None)           # sync; awaits prewarm if any
mgr.disable_lora(id)                         # frees deltas, refits
mgr.set_lora_strength(id, strength)          # ENABLED only -> ValueError
mgr.list_loras() -> List[LoRADescriptor]
mgr.register_library(directory=loras_dir())  # scan MODELS_DIR/loras/
```

The `strength` param on `enable_lora` is the fix for the
"first-decode window sounds like the LoRA is missing" glitch on the
streaming pipeline: enabling at 0 and waiting for the next per-tick
`set_strength` to ramp up means the first VAE decode window sees base
weights. Passing `strength=S` makes the REGISTERED -> ENABLED-at-S
transition atomic in one refit, so the very first denoise step
already has the LoRA at the target value.

Lifecycle states: `REGISTERED → MATERIALIZING → MATERIALIZED → ENABLED`.
Strength is preserved across enable/disable cycles. `set_lora_strength`
on a non-enabled LoRA raises `ValueError` rather than silently
auto-enabling — keeps the materialization cost (hundreds of ms) explicit
at the call site.

## Plumbing

- `acestep/paths.py`: `loras_dir()` (defaults to `MODELS_DIR/loras/`)
  and `discover_loras(directory)` helper.
- `acestep/engine/diffusion.py`: pass-through wrappers
  (`register_trt_lora`, `enable_trt_lora`, `disable_trt_lora`,
  `prewarm_trt_lora`, `list_trt_loras`, `get_trt_lora`). The engine
  scans `loras_dir()` automatically when the LoRA manager initializes.
- `acestep/engine/trt/lora_refit.py`: full lifecycle rewrite.
  ThreadPoolExecutor with one worker for prewarm; worker only fills
  the entry's deltas dict, never touches the engine.

## Backward compat

- `apply_lora(path, strength)` is preserved as `register +
  set_strength + enable`. All existing call sites
  (`acestep.nodes.lora_nodes`, `workflows/`, `demos/`) keep working.
- The five strength-0 short-circuit invariants from #3 (b20fba9) are
  preserved verbatim.
- `_ActiveLoRA` alias kept at module level for any external imports.

## Tests

`tests/unit/test_lora_refit.py`:
- 5 existing strength-0 / set_strength tests (unchanged behavior)
- 14 new tests covering: register-doesn't-materialize, register
  idempotence, set_strength-on-non-enabled errors, enable/disable
  refit conditions, strength-0-disable-no-refit,
  re-enable-restores-strength, prewarm-then-enable-skips-recompute,
  apply_lora backward compat, register_library scan, remove_lora full
  lifecycle, enable-with-strength-refits-once-at-target,
  enable-with-strength-zero-still-placeholder.

19 / 19 passing.

## Test plan

- [ ] `pytest tests/unit/test_lora_refit.py -v`
- [ ] Verify auto-scan: drop a `.safetensors` in `MODELS_DIR/loras/`
      and confirm it appears in `engine.list_trt_loras()` with
      `state="registered"` after `Session(...)` loads.
- [ ] Verify the placeholder workflow: register N LoRAs, assert
      `mgr.total_materialized_bytes == 0`.
