### PR TITLE
demo: catalog-driven LoRA library + dynamic web UI

### DIFF
--- a/demos/realtime_motion_graph/assets/loras/README.md
+++ b/demos/realtime_motion_graph/assets/loras/README.md
@@ -1,25 +1,33 @@
-# LoRA weights
+# LoRA weights — moved
 
-Drop `.safetensors` LoRA files here. The realtime motion-to-music
-server reads its default LoRA from this directory via
-`demos/realtime_motion_graph/server.py::LORA_PATH`, which is computed
-relative to the server module so the same relative path works on any
-host (local box, remote 5090, container, etc.).
+LoRAs no longer live in this directory. Drop your `.safetensors` files
+under the project's models directory:
 
-Files in this directory are `.gitignore`-d by default because LoRA
-weights are too large to commit. Sync them out-of-band:
+```
+$ACESTEP_MODELS_DIR/loras/
+# defaults to ~/.daydream-scope/models/demon/loras/ when the env var
+# is unset (see acestep/paths.py::loras_dir).
+```
+
+The realtime demo's TRT engine scans that directory at startup via
+`TRTLoRAManager.register_library()` and publishes the catalog to the
+client. Each `.safetensors` becomes one library entry whose id is the
+filename stem, which is what the operator UI's Library panel toggles
+on/off.
+
+Keep paths layout-portable: the server reads
+`acestep.paths.loras_dir()`, which respects `ACESTEP_MODELS_DIR`. Sync
+LoRAs out-of-band (rsync, container layer, etc.) just like checkpoints
+and TRT engines:
 
 ```bash
 # local -> remote 5090
-rsync -avz demos/realtime_motion_graph/assets/loras/ \
-    user@5090-host:/path/to/ACE-Step-1.5_alt/demos/realtime_motion_graph/assets/loras/
+rsync -avz ~/.daydream-scope/models/demon/loras/ \
+    user@5090-host:/path/to/.daydream-scope/models/demon/loras/
 ```
 
-To change the default LoRA, either:
-- rename your file to `deathsteap_1.safetensors` (no code change), or
-- edit `LORA_PATH` at the top of `demos/realtime_motion_graph/server.py`
-  to point at the new filename.
-
-The server falls back to this path when the client sends
-`lora: true` with no `lora_path`, which both the native thin client
-and the web client do.
+If you have a non-catalog `.safetensors` somewhere else on disk, the
+server also accepts ad-hoc paths via the `lora_paths` field in the
+WebSocket init config (server registers them on the fly). The native
+thin client and the legacy full demo use this path; the web client
+goes through the catalog.

--- a/demos/realtime_motion_graph/client/knobs.py
+++ b/demos/realtime_motion_graph/client/knobs.py
@@ -34,7 +34,23 @@ class KnobBank:
     knobs: dict
 
 
-def build_banks(sde: bool, lora: int = 0) -> list:
+def build_banks(sde: bool, loras=None) -> list:
+    """Build the knob banks driving the streaming pipeline.
+
+    ``loras`` is an iterable of LoRA ids (filename stems).  Each id gets a
+    ``lora_str_<id>`` knob with a freshly allocated CC slot.  Ids replace
+    the old positional ``lora_str_1`` / ``lora_str_2`` naming so toggling
+    catalog entries on and off doesn't shuffle knob identities.
+
+    Backward-compat: an int ``loras`` is accepted and treated as
+    ``[f"slot{i}" for i in range(1, n+1)]`` so callers that haven't
+    migrated still get something usable, with the old-style names.
+    """
+    if isinstance(loras, int):
+        lora_ids = [f"slot{i}" for i in range(1, loras + 1)]
+    else:
+        lora_ids = list(loras or [])
+
     core = {}
     cc = 70
     if sde:
@@ -46,8 +62,11 @@ def build_banks(sde: bool, lora: int = 0) -> list:
     core["shift"] = KnobDef(cc=cc, default=0.5, sensitivity=1.0); cc += 1
     if sde:
         core["periodicity"] = KnobDef(cc=cc, sensitivity=2.0, max_val=12.5); cc += 1
-    for i in range(1, int(lora) + 1):
-        core[f"lora_str_{i}"] = KnobDef(cc=cc, default=0.0, sensitivity=2.0, max_val=2.0); cc += 1
+    for lid in lora_ids:
+        core[f"lora_str_{lid}"] = KnobDef(
+            cc=cc, default=0.0, sensitivity=2.0, max_val=2.0,
+        )
+        cc += 1
     core["hint_strength"] = KnobDef(cc=cc, default=1.0, sensitivity=2.0); cc += 1
     core["noise_share"] = KnobDef(cc=cc, default=0.0, sensitivity=2.0); cc += 1
     core["ode_noise"] = KnobDef(cc=cc, default=0.0, sensitivity=2.0, max_val=0.5); cc += 1

--- a/demos/realtime_motion_graph/pipeline.py
+++ b/demos/realtime_motion_graph/pipeline.py
@@ -58,12 +58,13 @@ class PipelineRunner:
     def __init__(
         self, session, stream, audio_eng, *,
         use_midi, use_sde, use_lora,
-        midi_knobs, lora_ids, engine_obj,
+        midi_knobs, engine_obj,
         vae_window, crop_seconds,
         k1_name, seed, skip_threshold,
         sde_curve_display, params, prompt_text, running,
         motion_val, motion_lock,
         on_audio_ready=None,
+        before_tick=None,
     ):
         self.session = session
         self.stream = stream  # StreamHandle
@@ -72,7 +73,6 @@ class PipelineRunner:
         self.use_sde = use_sde
         self.use_lora = use_lora
         self.midi_knobs = midi_knobs
-        self.lora_ids = lora_ids or []
         self.engine_obj = engine_obj
         self.vae_window = vae_window
         self.crop_seconds = crop_seconds
@@ -88,6 +88,11 @@ class PipelineRunner:
         if on_audio_ready is None:
             on_audio_ready = lambda wav, *_args: audio_eng.swap(wav)
         self.on_audio_ready = on_audio_ready
+        # before_tick: optional callable invoked at the top of every loop
+        # iteration on the runner thread. Used by the server to apply
+        # LoRA enable/disable mutations (which trigger refits) on the
+        # GPU-owning thread, serializing them with inference.
+        self.before_tick = before_tick
 
         # Cache silence once; used by the hint-strength blend node.
         T_frames = stream.source.latent.tensor.shape[1]
@@ -149,6 +154,11 @@ class PipelineRunner:
         current_shift = self.stream.base_kwargs["shift"]
 
         while self.running[0]:
+            if self.before_tick is not None:
+                # Hook for cross-thread mutations (e.g. LoRA enable/disable).
+                # Runs on the runner thread so any refit work the callback
+                # does is serialized with the tick body.
+                self.before_tick()
             if self.use_midi:
                 raw = self.midi_knobs.get_all_values()
             else:
@@ -172,12 +182,20 @@ class PipelineRunner:
             if abs(shift_val - current_shift) > 0.05:
                 current_shift = shift_val
 
-            if self.use_lora and self.lora_ids:
-                for idx, lid in enumerate(self.lora_ids):
-                    key = f"lora_str_{idx + 1}"
-                    lora_str = raw.get(key, 0.0)
+            if self.use_lora and self.engine_obj is not None:
+                # Iterate the catalog so the active set can change at
+                # runtime (enable/disable from the client).  Strength
+                # only flows to the engine for ENABLED LoRAs; sliders
+                # for non-enabled rows are ignored, matching the UI
+                # contract that strength sliders are only interactive
+                # while the LoRA is on.
+                for desc in self.engine_obj.list_trt_loras():
+                    if desc.state != "enabled":
+                        continue
+                    key = f"lora_str_{desc.id}"
+                    lora_str = raw.get(key, desc.strength)
                     if abs(lora_str - self.params.get(key, -1)) > 0.02:
-                        self.engine_obj.set_trt_lora_strength(lid, lora_str)
+                        self.engine_obj.set_trt_lora_strength(desc.id, lora_str)
 
             hint_str = self.midi_knobs.get_param("hint_strength") if self.use_midi else 1.0
             if abs(hint_str - last_hint_str) > 0.02:
@@ -338,10 +356,12 @@ class PipelineRunner:
                 self.params["seed"] = seed
                 self.params["feedback"] = round(feedback, 2)
                 self.params["shift"] = round(shift_val, 2)
-                if self.use_lora:
-                    for idx in range(len(self.lora_ids)):
-                        key = f"lora_str_{idx + 1}"
-                        self.params[key] = round(raw.get(key, 0.0), 2)
+                if self.use_lora and self.engine_obj is not None:
+                    for desc in self.engine_obj.list_trt_loras():
+                        if desc.state != "enabled":
+                            continue
+                        key = f"lora_str_{desc.id}"
+                        self.params[key] = round(raw.get(key, desc.strength), 2)
                 if self.use_sde:
                     self.params["periodicity"] = round(raw.get("periodicity", 0.0), 2)
                 self.params["hint_strength"] = round(hint_str, 2)

--- a/demos/realtime_motion_graph/server.py
+++ b/demos/realtime_motion_graph/server.py
@@ -4,6 +4,9 @@ Remote GPU backend for the realtime motion-to-music demo.
 Runs the SAME PipelineRunner as :mod:`full_demo`, with:
   - VirtualMidiKnobs fed by WebSocket params from the client
   - on_audio_ready callback that sends slices back over WebSocket
+  - Catalog-driven LoRA library (MODELS_DIR/loras): client toggles
+    individual entries on/off via WebSocket messages instead of the
+    server hardcoding which LoRAs to load.
 
 Usage:
     uv run python -u -m demos.realtime_motion_graph.server
@@ -31,7 +34,9 @@ from acestep.audio.key_detection import detect_key
 from acestep.constants import TASK_INSTRUCTIONS
 from acestep.engine.session import Session
 from acestep.nodes.types import Audio
-from acestep.paths import trt_engine_path, checkpoints_dir, select_trt_engines
+from acestep.paths import (
+    checkpoints_dir, loras_dir, select_trt_engines, trt_engine_path,
+)
 
 from .client.audio_engine import AudioEngine
 from .client.knobs import build_banks, CHANNEL_GROUPS, KEYSTONE_CHANNELS
@@ -43,14 +48,6 @@ from .client.protocol import (
     T,
 )
 from .pipeline import PipelineRunner
-
-# Default LoRA lives next to this module so it syncs with the repo /
-# rsync / container layer instead of depending on an absolute user
-# path.  Drop any .safetensors file in demos/realtime_motion_graph/
-# assets/loras/ and point LORA_PATH at it to swap the default.
-LORA_PATHS = [
-    str(Path(__file__).parent / "assets" / "loras" / "deathsteap_1.safetensors"),
-]
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +74,19 @@ class VirtualMidiKnobs:
         """Bulk-update values from a client raw dict."""
         with self._lock:
             self._values.update(raw)
+
+    def add_knob(self, name, knob_def):
+        """Register a new knob after construction (used when the client
+        enables a LoRA at runtime and we need a ``lora_str_<id>`` slot)."""
+        with self._lock:
+            if name not in self._values:
+                self._values[name] = knob_def.default
+            self._all_knobs[name] = knob_def
+
+    def remove_knob(self, name):
+        with self._lock:
+            self._values.pop(name, None)
+            self._all_knobs.pop(name, None)
 
     def get(self, name: str) -> float:
         with self._lock:
@@ -141,19 +151,31 @@ def handle_client(ws):
     depth = config.get("depth", 4)
     steps = config.get("steps", 8)
     prompt = config.get("prompt", "instrumental music")
-    lora_paths = config.get("lora_paths") or (
-        [config["lora_path"]] if config.get("lora_path") else None
-    )
     fast_vae = config.get("fast_vae", False)
 
+    # LoRA selection.  ``enabled_loras`` is the new id-keyed protocol;
+    # ``lora_paths`` / ``lora_path`` are interpreted as filesystem paths
+    # for ad-hoc registration of LoRAs that aren't already in the
+    # MODELS_DIR/loras catalog.  Both can be combined.
+    #
+    # ``lora_strengths`` is a dict {id: strength} — the value passed to
+    # enable_trt_lora at init time.  Setting strength at enable time
+    # (rather than enabling at 0 and waiting for the first per-tick
+    # set_strength) is what keeps the first VAE-decode window from
+    # sounding like the LoRA is missing.
+    enabled_lora_ids = list(config.get("enabled_loras") or [])
+    lora_strengths_init: dict[str, float] = {
+        str(k): float(v) for k, v in (config.get("lora_strengths") or {}).items()
+    }
+    extra_lora_paths = list(
+        config.get("lora_paths")
+        or ([config["lora_path"]] if config.get("lora_path") else [])
+    )
+
     # --- Session setup ---
-    # Audio is clamped to 60s above, so the 60s engine set is what we need.
-    # select_trt_engines() picks 60s by default; pass duration_s explicitly
-    # to make the dependency on the upstream clamp visible.
     audio_duration_s = waveform.shape[1] / SAMPLE_RATE
     trt_engines = select_trt_engines(duration_s=audio_duration_s)
     if fast_vae:
-        # fast_vae uses the dreamvae distilled decoder; profile must match.
         fast_name = "dreamvae_decode_fp16_60s" if audio_duration_s <= 60.0 else "dreamvae_decode_fp16_240s"
         if Path(str(trt_engine_path(fast_name))).exists():
             trt_engines["vae_decode"] = str(trt_engine_path(fast_name))
@@ -172,26 +194,49 @@ def handle_client(ws):
     )
     print(f"  Model loaded in {time.time() - t0:.1f}s")
 
-    lora_ids = []
-    engine_obj = None
+    # --- LoRA library ---
+    # The catalog was populated automatically by DiffusionEngine when it
+    # scanned MODELS_DIR/loras at engine load.  Here we just decide which
+    # subset to enable for this client and prewarm them in the background
+    # so the eventual enable_lora is fast.
+    engine_obj = session.handler._diffusion_engine
+    lora_available = bool(engine_obj and engine_obj.trt_lora_available)
+    if use_lora and not lora_available:
+        print("[Server] WARNING: LoRA engine unavailable on this decoder")
+        use_lora = False
+
+    initial_enable_ids: list[str] = []
     if use_lora:
-        if not lora_paths:
-            lora_paths = list(LORA_PATHS)
-        engine_obj = session.handler._diffusion_engine
-        if engine_obj and engine_obj.trt_lora_available:
-            for lp in lora_paths:
-                if not Path(lp).exists():
-                    print(f"[Server] WARNING: LoRA path missing: {lp}")
-                    continue
-                print(f"[Server] Applying LoRA: {Path(lp).name}")
-                lid = engine_obj.apply_trt_lora(lp, strength=0.0)
-                lora_ids.append(lid)
-            if not lora_ids:
-                print("[Server] WARNING: no valid LoRA files found")
-                use_lora = False
-        else:
-            print("[Server] WARNING: LoRA engine unavailable on this decoder")
-            use_lora = False
+        # Resolve any explicit enable-by-id requests (these must already
+        # be in the catalog from the auto-scan).
+        catalog_ids = {d.id for d in engine_obj.list_trt_loras()}
+        for lid in enabled_lora_ids:
+            if lid in catalog_ids:
+                initial_enable_ids.append(lid)
+            else:
+                print(f"[Server] WARNING: enabled_loras id not in catalog: {lid}")
+        # Resolve ad-hoc paths: register if needed, then enable.
+        for p in extra_lora_paths:
+            pp = Path(p)
+            if not pp.exists():
+                print(f"[Server] WARNING: LoRA path missing: {p}")
+                continue
+            try:
+                lid = engine_obj.register_trt_lora(str(pp))
+                if lid not in initial_enable_ids:
+                    initial_enable_ids.append(lid)
+            except Exception as e:
+                print(f"[Server] WARNING: failed to register {p}: {e}")
+        # Kick off background materialization for everything we plan to
+        # enable. Non-blocking; the eventual enable will block on the
+        # future if the worker hasn't finished yet.
+        for lid in initial_enable_ids:
+            try:
+                engine_obj.prewarm_trt_lora(lid)
+            except Exception as e:
+                print(f"[Server] Prewarm failed for {lid}: {e}")
+        if not initial_enable_ids:
+            print("[Server] No LoRAs enabled at startup (catalog-only)")
 
     audio_in = Audio(waveform=waveform, sample_rate=SAMPLE_RATE)
 
@@ -230,10 +275,6 @@ def handle_client(ws):
         src_np = src_np[:int(crop_seconds * SAMPLE_RATE)]
     n_channels = src_np.shape[1] if src_np.ndim > 1 else 1
 
-    # Pre-blend the buffer's tail with its head so the very first loop
-    # iteration is smooth before any model patches arrive. The client
-    # worklet also crossfades at playback time, so this is belt-and-
-    # suspenders for the initial source audio.
     _seam_fade_samples = int(0.05 * SAMPLE_RATE)
     _seam_fade_samples = min(_seam_fade_samples, len(src_np) // 4)
     if _seam_fade_samples > 0:
@@ -247,10 +288,19 @@ def handle_client(ws):
         _head = src_np[:_seam_fade_samples].copy()
         src_np[-_seam_fade_samples:] = _tail * _fade_out + _head * _fade_in
 
-    # AudioEngine on server (PipelineRunner reads audio_eng.position)
     audio_eng = AudioEngine(src_np, SAMPLE_RATE)
-    # Don't start playback (no speakers on server), but we need position tracking.
-    # We'll update position from the client's playback_pos.
+
+    def _catalog_payload():
+        if not lora_available:
+            return []
+        return [
+            {
+                "id": d.id, "name": d.name, "path": d.path,
+                "state": d.state, "strength": d.strength,
+                "materialized_bytes": d.materialized_bytes,
+            }
+            for d in engine_obj.list_trt_loras()
+        ]
 
     # Send ready + initial buffer
     ws.send(json.dumps({
@@ -258,7 +308,9 @@ def handle_client(ws):
         "duration": len(src_np) / SAMPLE_RATE,
         "sample_rate": SAMPLE_RATE,
         "channels": n_channels,
-        "lora_count": len(lora_ids),
+        "lora_dir": str(loras_dir()),
+        "lora_catalog": _catalog_payload(),
+        "lora_pending_enable": list(initial_enable_ids),
     }))
     ws.send(src_np.astype(np.float16).tobytes())
     print(f"[Server] Sent initial buffer ({len(src_np) / SAMPLE_RATE:.1f}s)")
@@ -268,7 +320,8 @@ def handle_client(ws):
     running = [True]
     send_lock = threading.Lock()
     k1_name = "sde_amp" if use_sde else "denoise"
-    banks = build_banks(use_sde, lora=len(lora_ids) if use_lora else 0)
+    initial_knob_ids = list(initial_enable_ids) if use_lora else []
+    banks = build_banks(use_sde, loras=initial_knob_ids)
     virtual_knobs = VirtualMidiKnobs(banks)
     params = {"num_gens": 0, "tick_ms": 0.0, "dec_ms": 0.0}
     prompt_text = [prompt]
@@ -276,34 +329,86 @@ def handle_client(ws):
     motion_val = [0.0]
     motion_lock = threading.Lock()
 
-    # Client mirror: tracks what audio the client currently has
     client_mirror = src_np.copy()
     zctx = zstd.ZstdCompressor(level=1)
 
+    # Cross-thread LoRA mutation rendezvous.  The recv thread enqueues
+    # ids; the runner thread drains the queues in before_tick so the
+    # refit (which mutates engine state) is serialized with inference.
+    #
+    # pending_enable items are (id, strength_or_None) tuples — strength
+    # is the target the LoRA should be at when the refit fires, applied
+    # in a single transition.  Enabling at 0 and ramping up via the
+    # next per-tick set_strength causes the first decode window to
+    # sound like the LoRA is missing (the streaming pipeline depth
+    # spans several decoded seconds), so callers should always supply
+    # the target strength when they have it.
+    pending_enable: list[tuple[str, float | None]] = []
+    pending_disable: list[str] = []
+    pending_lock = threading.Lock()
+
+    def _send_catalog_update():
+        try:
+            with send_lock:
+                ws.send(json.dumps({
+                    "type": "lora_catalog",
+                    "catalog": _catalog_payload(),
+                }))
+        except ConnectionClosed:
+            running[0] = False
+
+    def apply_lora_pending():
+        if not lora_available:
+            return
+        with pending_lock:
+            local_disable = pending_disable[:]
+            local_enable = pending_enable[:]
+            pending_disable.clear()
+            pending_enable.clear()
+        if not local_disable and not local_enable:
+            return
+        for lid in local_disable:
+            try:
+                engine_obj.disable_trt_lora(lid)
+                virtual_knobs.remove_knob(f"lora_str_{lid}")
+            except Exception as e:
+                print(f"[Server] disable_lora({lid}) failed: {e}")
+        for lid, strength in local_enable:
+            try:
+                engine_obj.enable_trt_lora(lid, strength=strength)
+                # Allocate a knob slot so set_lora_strength can be driven
+                # by the client's params dict.  Default the slot to the
+                # strength we just enabled at, so the runner's slider-
+                # delta check (set_lora_strength only when the new value
+                # differs by > 0.02) doesn't immediately fire a redundant
+                # refit on tick 1.
+                from .client.knobs import KnobDef
+                virtual_knobs.add_knob(
+                    f"lora_str_{lid}",
+                    KnobDef(
+                        cc=0,
+                        default=float(strength) if strength is not None else 0.0,
+                        sensitivity=2.0, max_val=2.0,
+                    ),
+                )
+            except Exception as e:
+                print(f"[Server] enable_lora({lid}) failed: {e}")
+        _send_catalog_update()
+
     # --- on_audio_ready: delta-encode and send to client ---
     def on_audio_ready(wav_np, win_start=None, win_end=None):
-        """Called by PipelineRunner when audio is decoded.
-        Compute delta against client mirror, compress, send."""
-        # Accumulate into server buffer (same as local swap)
         audio_eng.swap(wav_np)
-
         if win_start is not None:
             ss, se = win_start, min(win_end, len(wav_np))
         else:
             ss, se = 0, len(wav_np)
-
         if se <= ss:
             return
-
-        # Delta = what server has now minus what client has
         region = wav_np[ss:se]
         mirror_region = client_mirror[ss:se]
         delta = (region - mirror_region).astype(np.float16)
         compressed = zctx.compress(delta.tobytes())
-
-        # Update mirror to match what client will have after applying delta
         client_mirror[ss:se] = region
-
         hdr = struct.pack(
             SLICE_HDR_FMT,
             SLICE_FLAG_DELTA,
@@ -318,7 +423,7 @@ def handle_client(ws):
         except ConnectionClosed:
             running[0] = False
 
-    # --- recv loop: drain client messages, update virtual knobs ---
+    # --- recv loop: drain client messages ---
     def recv_loop():
         while running[0]:
             latest_raw = None
@@ -328,11 +433,11 @@ def handle_client(ws):
                     msg = ws.recv(timeout=0.005)
                     if isinstance(msg, str):
                         data = json.loads(msg)
-                        if data.get("type") == "params":
+                        mtype = data.get("type")
+                        if mtype == "params":
                             latest_raw = data.get("raw", {})
                             latest_pp = data.get("playback_pos", 0.0)
-                        elif data.get("type") == "prompt":
-                            # Re-encode on server
+                        elif mtype == "prompt":
                             cond = session.encode_text(
                                 tags=data["tags"],
                                 instruction=TASK_INSTRUCTIONS["cover"],
@@ -351,6 +456,25 @@ def handle_client(ws):
                             except ConnectionClosed:
                                 running[0] = False
                                 break
+                        elif mtype == "enable_lora":
+                            lid = data.get("id")
+                            # Optional strength carries the target value
+                            # the client wants the LoRA enabled at, so
+                            # the engine refit lands at that strength in
+                            # one shot instead of going through 0 first.
+                            s = data.get("strength")
+                            try:
+                                strength = float(s) if s is not None else None
+                            except (TypeError, ValueError):
+                                strength = None
+                            if lid:
+                                with pending_lock:
+                                    pending_enable.append((str(lid), strength))
+                        elif mtype == "disable_lora":
+                            lid = data.get("id")
+                            if lid:
+                                with pending_lock:
+                                    pending_disable.append(str(lid))
             except TimeoutError:
                 pass
             except ConnectionClosed:
@@ -364,18 +488,32 @@ def handle_client(ws):
             if latest_raw is not None:
                 virtual_knobs.update(latest_raw)
             if latest_pp is not None:
-                # Sync server's audio_eng position to client's playback
                 audio_eng.position = int(latest_pp * SAMPLE_RATE) % max(1, len(audio_eng.current))
 
     recv_t = threading.Thread(target=recv_loop, daemon=True)
     recv_t.start()
+
+    # Stage the initial enable set so they get applied on the runner
+    # thread before the first tick.  Each entry carries its target
+    # strength (from config.lora_strengths) so the refit lands at the
+    # right value in one shot — without this, the first decoded window
+    # comes out as if the LoRA were missing, because the runner's
+    # set_strength catch-up only kicks in after tick 1.  The prewarm
+    # started at session setup is likely complete by now; any leftover
+    # work is awaited synchronously inside enable_trt_lora.
+    if use_lora and initial_enable_ids:
+        with pending_lock:
+            for lid in initial_enable_ids:
+                pending_enable.append(
+                    (lid, lora_strengths_init.get(lid)),
+                )
 
     # --- PipelineRunner: the SAME code as local ---
     runner = PipelineRunner(
         session, stream, audio_eng,
         use_midi=True,  # always "MIDI" mode; VirtualMidiKnobs provides values
         use_sde=use_sde, use_lora=use_lora,
-        midi_knobs=virtual_knobs, lora_ids=lora_ids,
+        midi_knobs=virtual_knobs,
         engine_obj=engine_obj,
         vae_window=vae_window, crop_seconds=crop_seconds,
         k1_name=k1_name, seed=1528, skip_threshold=1e-3,
@@ -383,11 +521,12 @@ def handle_client(ws):
         prompt_text=prompt_text, running=running,
         motion_val=motion_val, motion_lock=motion_lock,
         on_audio_ready=on_audio_ready,
+        before_tick=apply_lora_pending,
     )
 
     try:
         print("[Server] Pipeline running...")
-        runner.run()  # blocks until running[0] = False
+        runner.run()
     except Exception as exc:
         print(f"[Server] Pipeline error: {exc}")
         import traceback

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -132,6 +132,39 @@ def _process_request(connection, request):
             body,
         )
 
+    # API: list LoRAs in MODELS_DIR/loras/.  Cheap (filesystem glob, no
+    # torch / no engine load), so the browser can render the Library
+    # panel before the user even clicks Play.  Uses the same path
+    # resolution the WebSocket pipeline uses, so everyone agrees on
+    # what's in the catalog.
+    if url.split("?", 1)[0] == "/api/loras":
+        from acestep.paths import discover_loras, loras_dir
+        try:
+            d = loras_dir()
+            entries = [
+                {
+                    "id": p.stem, "name": p.stem, "path": str(p),
+                    "state": "registered", "strength": 0.0,
+                    "materialized_bytes": 0,
+                }
+                for p in discover_loras(d)
+            ]
+        except Exception as e:
+            entries = []
+            sys.stdout.write(f"[HTTP] /api/loras error: {e}\n")
+            sys.stdout.flush()
+        body = json.dumps({"dir": str(loras_dir()), "loras": entries}).encode()
+        _log_http(remote, 200, "GET", url)
+        return Response(
+            200, "OK",
+            Headers([
+                ("Content-Type", "application/json; charset=utf-8"),
+                ("Content-Length", str(len(body))),
+                *_NO_CACHE_HEADERS,
+            ]),
+            body,
+        )
+
     # API: list video files in static/videos/
     if url.split("?", 1)[0] == "/api/videos":
         _VIDEO_EXTS = {".mp4", ".webm", ".mov"}

--- a/demos/realtime_motion_graph_web/static/app.js
+++ b/demos/realtime_motion_graph_web/static/app.js
@@ -41,10 +41,13 @@ const effectsCanvas = $("effects-canvas");
 // All initial values come from config.json (next to this file). Edit + refresh
 // to re-tune the installation; no rebuild needed. The schema is:
 //   ws_url_default — string; takes effect when ?ws= isn't passed.
-//   engine         — passed verbatim to the WebSocket /init handshake.
-//   lora_dir, loras
+//   engine         — passed verbatim to the WebSocket /init handshake;
+//                    notably engine.enabled_loras is the list of LoRA ids
+//                    (filename stems) to auto-enable at session start.
 //   prompts.{a, b, blend}
 //   controls.<param> — initial value for each slider.
+//   controls.lora_default_strength — initial value for any LoRA strength
+//                                    slider (per-id defaults are not used).
 //   seed, video_bpm
 // SLIDER_META below is *behavior* (max range / arrow-key step / pro flag) —
 // not a starting value, so it stays in code.
@@ -62,14 +65,27 @@ const serverInfo = await fetch("/api/server-info")
   .then((r) => (r.ok ? r.json() : { no_backend: false }))
   .catch(() => ({ no_backend: false }));
 
-const LORA_DIR = userConfig.lora_dir;
-const LORAS = userConfig.loras;
+// LoRA catalog comes from /api/loras — a cheap filesystem scan of
+// MODELS_DIR/loras/ that runs on the static-file server, so we can
+// render the Library panel immediately on page load (no Play required,
+// no WebSocket required, no model load required).  When Play kicks
+// off, the WS init config carries `enabled_loras` derived from
+// whatever rows the operator has toggled on, so the pipeline starts
+// with exactly the right LoRAs from the jump.
+const loraInitial = await fetch("/api/loras")
+  .then((r) => (r.ok ? r.json() : { dir: "", loras: [] }))
+  .catch(() => ({ dir: "", loras: [] }));
 
 const CONFIG = {
   ...userConfig.engine,
   prompt: userConfig.prompts.a,
-  lora_paths: LORAS.map((l) => `${LORA_DIR}/${l.file}`),
 };
+
+// LoRA UI defaults.  Per-id slider behavior is uniform; the catalog drives
+// identity, the user names them on disk via the filename stem.
+const LORA_SLIDER_MAX = 2.0;
+const LORA_SLIDER_STEP = 0.2;
+const LORA_DEFAULT_STRENGTH = userConfig.controls?.lora_default_strength ?? 0.0;
 
 const VIDEO_BPM = userConfig.video_bpm;
 
@@ -84,11 +100,11 @@ function resolveDefaultWsUrl() {
 wsUrlInput.value = resolveDefaultWsUrl();
 
 // Slider behavior (max range, arrow-key step, pro-pane membership). Initial
-// values are loaded separately from userConfig.controls below.
+// values are loaded separately from userConfig.controls below.  Per-LoRA
+// `lora_str_<id>` sliders are added dynamically when the server's catalog
+// arrives — they are NOT listed here.
 const SLIDER_META = {
   denoise:       { max: 1.0, step: 0.10 },
-  lora_str_1:    { max: 1.2, step: 0.12 },
-  lora_str_2:    { max: 2.0, step: 0.20 },
   hint_strength: { max: 2.0, step: 0.20 },
 
   feedback:      { max: 1.0, step: 0.10, pro: true },
@@ -132,7 +148,38 @@ const SLIDER_DEFS = Object.fromEntries(
   ])
 );
 
-const SLIDER_KEYS = { a: "denoise", s: "lora_str_1", d: "lora_str_2", g: "hint_strength" };
+// LoRA library state.  Populated from the server's `ready` payload and any
+// later `lora_catalog` updates.  Source of truth for what the UI renders
+// in the Library tile and which entries the perimeter / hotkey / MIDI / FX
+// slots target.  Each entry: {id, name, state, strength}.
+let loraCatalog = [];
+const loraStrengths = {};  // id -> client-side slider value
+
+function enabledLoraIds() {
+  return loraCatalog.filter((d) => d.state === "enabled").map((d) => d.id);
+}
+
+function loraStrengthKey(id) {
+  return `lora_str_${id}`;
+}
+
+// Hotkey (a/s/d/g) -> slider param name.  `s` and `d` are dynamic: they
+// resolve to the first / second currently enabled LoRA at lookup time, so
+// toggling LoRAs in the Library panel doesn't dangle the keyboard
+// shortcuts.  Returns null when no LoRA fills that slot.
+const STATIC_SLIDER_KEYS = { a: "denoise", g: "hint_strength" };
+
+function resolveSliderKey(letter) {
+  if (letter in STATIC_SLIDER_KEYS) return STATIC_SLIDER_KEYS[letter];
+  if (letter === "s" || letter === "d") {
+    const ids = enabledLoraIds();
+    const idx = letter === "s" ? 0 : 1;
+    return ids[idx] ? loraStrengthKey(ids[idx]) : null;
+  }
+  return null;
+}
+
+const SLIDER_KEYS_LETTERS = ["a", "s", "d", "g"];
 
 // Display modes. Graph is the default; the toggle button cycles to the
 // video subtree. CSS swaps visibility based on body[data-mode].
@@ -380,17 +427,25 @@ function bindSlider(group) {
 const DISPLAY_NAMES = {
   noise_share: "nshare",
   ode_noise: "ode",
-  lora_str_1: LORAS[0].label,
-  lora_str_2: LORAS[1].label,
   hint_strength: "structure strength",
   dcw_scaler: "DCW low",
   dcw_high_scaler: "DCW high",
 };
 
+function displayNameFor(param) {
+  if (param in DISPLAY_NAMES) return DISPLAY_NAMES[param];
+  if (param.startsWith("lora_str_")) {
+    const id = param.slice("lora_str_".length);
+    const entry = loraCatalog.find((d) => d.id === id);
+    return entry?.name || id;
+  }
+  return param.replace(/_/g, " ");
+}
+
 function createSliderGroup(param) {
   const def = SLIDER_DEFS[param];
   const frac = (sliderValues[param] / def.max * 100).toFixed(1);
-  const label = DISPLAY_NAMES[param] || param.replace(/_/g, " ");
+  const label = displayNameFor(param);
   const group = document.createElement("div");
   group.className = "slider-group";
   group.dataset.param = param;
@@ -464,6 +519,261 @@ function initSliders() {
   tilesContainer.insertBefore(dcwTile, seedTile);
   bindSlider(dcwLow);
   bindSlider(dcwHigh);
+
+  // Library tile placeholder.  Filled in by applyLoraCatalog() once the
+  // server publishes its catalog.  Inserted after Main so it sits next
+  // to the user-facing faders.
+  const libTile = document.createElement("div");
+  libTile.className = "mixer-tile mixer-tile-library";
+  libTile.dataset.tile = "lora-library";
+  const libLabel = document.createElement("div");
+  libLabel.className = "mixer-tile-label";
+  libLabel.textContent = "LoRA library";
+  const libBody = document.createElement("div");
+  libBody.className = "lora-library-body";
+  libBody.dataset.role = "lora-library-body";
+  libTile.appendChild(libLabel);
+  libTile.appendChild(libBody);
+  const mainTile = tilesContainer.querySelector('[data-tile="main"]');
+  tilesContainer.insertBefore(libTile, mainTile?.nextSibling ?? seedTile);
+}
+
+// ── LoRA library state mgmt ──
+// Source of truth is `loraCatalog`.  Lifecycle:
+//   1. /api/loras at page load -> initial catalog (all REGISTERED).  The
+//      first DEFAULT_AUTO_ENABLE_COUNT entries are flipped to ENABLED in
+//      the local UI by default — that's the demo policy, the server
+//      doesn't impose it.
+//   2. User toggles in the Library panel pre-Play -> mutates
+//      loraCatalog locally (no network).
+//   3. On Play, the WS init config carries `enabled_loras` derived from
+//      whatever is currently ENABLED in loraCatalog.
+//   4. Post-Play, toggling sends enable_lora / disable_lora over the WS;
+//      the server pushes a `lora_catalog` update and we re-render from
+//      that authoritative state.
+const DEFAULT_AUTO_ENABLE_COUNT = 2;
+
+function applyLoraCatalog(newCatalog) {
+  loraCatalog = Array.isArray(newCatalog) ? newCatalog.slice() : [];
+  const seen = new Set();
+  for (const d of loraCatalog) {
+    seen.add(d.id);
+    const key = loraStrengthKey(d.id);
+    if (!(key in SLIDER_DEFS)) {
+      SLIDER_DEFS[key] = {
+        max: LORA_SLIDER_MAX,
+        step: LORA_SLIDER_STEP,
+        default: LORA_DEFAULT_STRENGTH,
+      };
+    }
+    if (!(key in sliderValues)) {
+      // Server sometimes echoes back a non-zero strength (e.g. when a
+      // LoRA was already enabled on a prior connect).  Honor it.
+      sliderValues[key] = typeof d.strength === "number" && d.strength > 0
+        ? d.strength : LORA_DEFAULT_STRENGTH;
+    }
+  }
+  // Drop SLIDER_DEFS / sliderValues entries for ids that left the catalog.
+  for (const k of Object.keys(SLIDER_DEFS)) {
+    if (!k.startsWith("lora_str_")) continue;
+    const id = k.slice("lora_str_".length);
+    if (!seen.has(id)) {
+      delete SLIDER_DEFS[k];
+      delete sliderValues[k];
+    }
+  }
+  rebuildLoraLibraryUI();
+  refreshLoraEdgeBars();
+}
+
+// Local-only mutation: flip a row's enabled state in the catalog without
+// touching the network.  Used pre-Play and as the optimistic update
+// while a WS message is in flight.
+function setLoraEnabledLocal(id, enabled) {
+  const desc = loraCatalog.find((d) => d.id === id);
+  if (!desc) return;
+  desc.state = enabled ? "enabled" : "registered";
+  rebuildLoraLibraryUI();
+  refreshLoraEdgeBars();
+}
+
+function getEnabledLoraIdsForConfig() {
+  return loraCatalog.filter((d) => d.state === "enabled").map((d) => d.id);
+}
+
+// Strength dict keyed by id, for the WS init config.  The server uses
+// this to enable each LoRA at its target strength in one refit, so the
+// first decoded window already has the LoRA contributing — without
+// this, enabling at 0 and waiting for per-tick set_strength to ramp it
+// up produces a "first ~5s sounds like the LoRA is missing" glitch
+// because the streaming pipeline depth covers several decoded seconds.
+function getEnabledLoraStrengthsForConfig() {
+  const out = {};
+  for (const d of loraCatalog) {
+    if (d.state !== "enabled") continue;
+    const v = sliderValues[loraStrengthKey(d.id)];
+    if (typeof v === "number") out[d.id] = v;
+  }
+  return out;
+}
+
+function rebuildLoraLibraryUI() {
+  const body = document.querySelector('[data-role="lora-library-body"]');
+  if (!body) return;
+  body.innerHTML = "";
+  if (loraCatalog.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "lora-library-empty";
+    empty.textContent = "No LoRAs in MODELS_DIR/loras/";
+    body.appendChild(empty);
+    return;
+  }
+  for (const d of loraCatalog) {
+    body.appendChild(buildLoraRow(d));
+  }
+}
+
+// One row per catalog entry.  Layout:
+//   [switch]  name              [horizontal slider]  0.30
+// Switch and slider are interactive in both pre-Play and post-Play; the
+// slider is locked while the LoRA is off so the operator can see the
+// stored value but can't accidentally drag it.
+function buildLoraRow(desc) {
+  const enabled = desc.state === "enabled";
+  const param = loraStrengthKey(desc.id);
+
+  const row = document.createElement("div");
+  row.className = "lora-row";
+  row.dataset.loraId = desc.id;
+  row.dataset.state = enabled ? "enabled" : "disabled";
+  row.dataset.param = param;  // makes the row a MIDI-learn target
+
+  // Toggle switch.  Visual: pill with a sliding thumb.  No text label
+  // (text labels for ON/OFF read as redundant when the thumb position
+  // already says it).  aria-checked carries semantics for screen readers.
+  const sw = document.createElement("button");
+  sw.type = "button";
+  sw.className = "lora-switch";
+  sw.setAttribute("role", "switch");
+  sw.setAttribute("aria-checked", enabled ? "true" : "false");
+  sw.setAttribute("aria-label", `${desc.name || desc.id} — ${enabled ? "enabled" : "disabled"}, click to toggle`);
+  sw.innerHTML = `<span class="lora-switch-thumb" aria-hidden="true"></span>`;
+  sw.addEventListener("click", () => {
+    const wasEnabled = loraCatalog.find((d) => d.id === desc.id)?.state === "enabled";
+    const willEnable = !wasEnabled;
+    // Optimistic local update so the UI feels instant.  Pre-Play this is
+    // the only update; post-Play the server's lora_catalog broadcast
+    // confirms or corrects.
+    setLoraEnabledLocal(desc.id, willEnable);
+    if (session?.remote) {
+      if (willEnable) {
+        // Pass the slider's current value so the server refits at it
+        // in one shot, avoiding the "first decode window sounds like
+        // the LoRA is missing" glitch.
+        const strength = sliderValues[loraStrengthKey(desc.id)];
+        session.remote.sendEnableLora(desc.id, strength);
+      } else {
+        session.remote.sendDisableLora(desc.id);
+      }
+    }
+    bumpIdleTimer();
+  });
+
+  const name = document.createElement("span");
+  name.className = "lora-row-name";
+  name.textContent = desc.name || desc.id;
+  // Click the name to toggle too — bigger hit target than the 32px switch.
+  name.addEventListener("click", () => sw.click());
+
+  // Horizontal strength slider.  Backed by sliderValues[param] so the
+  // rest of the system (sendParams, graph history, MIDI binding,
+  // perimeter bars, FX) reads it like any other slider.
+  const slider = createLoraStrengthSlider(param);
+  row.dataset.strengthSlider = "1";  // marker for findStrengthSlider
+
+  row.appendChild(sw);
+  row.appendChild(name);
+  row.appendChild(slider);
+  return row;
+}
+
+// Horizontal slider tailored for the Library rows.  Doesn't reuse
+// .slider-group because that one is vertical and carries its own label.
+// Registered with sliderEls so updateSliderUI() drives both this and the
+// (hypothetical) vertical slider.
+function createLoraStrengthSlider(param) {
+  const wrap = document.createElement("div");
+  wrap.className = "lora-strength";
+  wrap.dataset.param = param;
+
+  const track = document.createElement("div");
+  track.className = "lora-strength-track";
+  const fill = document.createElement("div");
+  fill.className = "lora-strength-fill";
+  track.appendChild(fill);
+
+  const valEl = document.createElement("div");
+  valEl.className = "lora-strength-value";
+
+  wrap.appendChild(track);
+  wrap.appendChild(valEl);
+
+  // Adapter that exposes the same shape updateSliderUI() expects.
+  // ``thumb`` is null because this slider has no separate thumb element
+  // (the right edge of the fill is the visual position indicator).
+  sliderEls.set(param, {
+    group: wrap, track, fill, thumb: null, valEl,
+    horizontal: true,
+  });
+  updateSliderUI(param);
+
+  bindHorizontalSlider(wrap, param);
+  return wrap;
+}
+
+function bindHorizontalSlider(wrap, param) {
+  const track = wrap.querySelector(".lora-strength-track");
+  const def = SLIDER_DEFS[param];
+  if (!track || !def) return;
+
+  let dragging = false;
+  let lastDownAt = 0;
+  const DBLCLICK_MS = 280;
+
+  const setFromX = (clientX) => {
+    const rect = track.getBoundingClientRect();
+    const frac = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    sliderValues[param] = frac * def.max;
+    updateSliderUI(param);
+    bumpIdleTimer();
+  };
+
+  track.addEventListener("pointerdown", (e) => {
+    // Only respond when the row is enabled.  Reading data-state at
+    // pointerdown time so the lock follows the catalog state without
+    // needing to rebind on toggle.
+    const row = wrap.closest(".lora-row");
+    if (row?.dataset.state !== "enabled") return;
+    if (e.button !== 0) return;
+    const now = performance.now();
+    if (now - lastDownAt < DBLCLICK_MS) {
+      sliderValues[param] = SLIDER_DEFS[param].default;
+      updateSliderUI(param);
+      bumpIdleTimer();
+      lastDownAt = 0;
+      return;
+    }
+    lastDownAt = now;
+    dragging = true;
+    track.setPointerCapture(e.pointerId);
+    setFromX(e.clientX);
+  });
+  track.addEventListener("pointermove", (e) => {
+    if (dragging) setFromX(e.clientX);
+  });
+  const endDrag = () => { dragging = false; };
+  track.addEventListener("pointerup", endDrag);
+  track.addEventListener("pointercancel", endDrag);
 }
 
 // DCW control strip: enable toggle + mode + wavelet selects. Numeric
@@ -520,8 +830,12 @@ function updateSliderUI(param) {
     const def = SLIDER_DEFS[param];
     const frac = Math.max(0, Math.min(1, sliderValues[param] / def.max));
     const pct = (frac * 100).toFixed(1) + "%";
-    el.fill.style.height = pct;
-    el.thumb.style.bottom = pct;
+    if (el.horizontal) {
+      el.fill.style.width = pct;
+    } else {
+      el.fill.style.height = pct;
+      if (el.thumb) el.thumb.style.bottom = pct;
+    }
     el.valEl.textContent = sliderValues[param].toFixed(2);
   }
   updateInstallBar(param);
@@ -534,8 +848,12 @@ function updateSliderUI(param) {
 // through the same updateSliderUI path the sliders + MIDI use, so the
 // Advanced sheet, the bar fill, and any backend sendParams all stay in
 // sync. bumpIdleTimer() keeps the 60s reset clock alive.
+// Edge bar binding.  Top bar is fixed to "denoise"; left/right bars track
+// the first and second currently-enabled LoRA at pointer-time.  The
+// resolver runs on every drag, so toggling the catalog re-aims the bars
+// without rebinding.
 function initEdgeBars() {
-  const bind = (selector, param, axis) => {
+  const bindStatic = (selector, param, axis) => {
     const edge = document.querySelector(selector);
     const def = SLIDER_DEFS[param];
     if (!edge || !def) return;
@@ -560,9 +878,61 @@ function initEdgeBars() {
     edge.addEventListener("pointerup", () => { dragging = false; });
     edge.addEventListener("pointercancel", () => { dragging = false; });
   };
-  bind(".install-edge-top",   "denoise",    "x");
-  bind(".install-edge-left",  "lora_str_1", "y");
-  bind(".install-edge-right", "lora_str_2", "y");
+  const bindLoraSlot = (selector, slotIdx) => {
+    const edge = document.querySelector(selector);
+    if (!edge) return;
+    let dragging = false;
+    const setFromPointer = (clientY) => {
+      const ids = enabledLoraIds();
+      const id = ids[slotIdx];
+      if (!id) return;
+      const param = loraStrengthKey(id);
+      const def = SLIDER_DEFS[param];
+      if (!def) return;
+      const rect = edge.getBoundingClientRect();
+      const frac = 1 - Math.max(0, Math.min(1, (clientY - rect.top) / rect.height));
+      sliderValues[param] = frac * def.max;
+      updateSliderUI(param);
+      bumpIdleTimer();
+    };
+    edge.addEventListener("pointerdown", (e) => {
+      dragging = true;
+      edge.setPointerCapture(e.pointerId);
+      setFromPointer(e.clientY);
+    });
+    edge.addEventListener("pointermove", (e) => {
+      if (dragging) setFromPointer(e.clientY);
+    });
+    edge.addEventListener("pointerup", () => { dragging = false; });
+    edge.addEventListener("pointercancel", () => { dragging = false; });
+  };
+  bindStatic(".install-edge-top", "denoise", "x");
+  bindLoraSlot(".install-edge-left",  0);
+  bindLoraSlot(".install-edge-right", 1);
+}
+
+// Refresh `data-bar` on the left/right perimeter edges so they point at
+// the first/second enabled LoRA's id.  Called whenever the catalog state
+// changes so updateInstallBar's query still hits the right element.
+function refreshLoraEdgeBars() {
+  const ids = enabledLoraIds();
+  const left = document.querySelector(".install-edge-left");
+  const right = document.querySelector(".install-edge-right");
+  const updateEdge = (edge, slotIdx) => {
+    if (!edge) return;
+    const id = ids[slotIdx];
+    edge.dataset.bar = id ? loraStrengthKey(id) : "";
+    edge.classList.toggle("install-edge-empty", !id);
+    const labelEl = edge.querySelector(".install-edge-label");
+    if (labelEl) {
+      const desc = id ? loraCatalog.find((d) => d.id === id) : null;
+      labelEl.textContent = desc ? (desc.name || id) : "";
+    }
+  };
+  updateEdge(left, 0);
+  updateEdge(right, 1);
+  if (ids[0]) updateInstallBar(loraStrengthKey(ids[0]));
+  if (ids[1]) updateInstallBar(loraStrengthKey(ids[1]));
 }
 
 // ── Installation HUD bars ──
@@ -678,10 +1048,13 @@ function initKeyboard() {
 
     const key = e.key.toLowerCase();
 
-    if (key in SLIDER_KEYS) {
-      heldKeys.add(key);
-      const el = sliderEls.get(SLIDER_KEYS[key]);
-      if (el) el.group.classList.add("active");
+    if (SLIDER_KEYS_LETTERS.includes(key)) {
+      const param = resolveSliderKey(key);
+      if (param) {
+        heldKeys.add(key);
+        const el = sliderEls.get(param);
+        if (el) el.group.classList.add("active");
+      }
       return;
     }
 
@@ -689,7 +1062,8 @@ function initKeyboard() {
       e.preventDefault();
       const dir = key === "arrowup" ? 1 : -1;
       for (const k of heldKeys) {
-        if (k in SLIDER_KEYS) adjustSlider(SLIDER_KEYS[k], dir);
+        const param = resolveSliderKey(k);
+        if (param) adjustSlider(param, dir);
       }
       return;
     }
@@ -704,9 +1078,12 @@ function initKeyboard() {
   window.addEventListener("keyup", (e) => {
     const key = e.key.toLowerCase();
     heldKeys.delete(key);
-    if (key in SLIDER_KEYS) {
-      const el = sliderEls.get(SLIDER_KEYS[key]);
-      if (el) el.group.classList.remove("active");
+    if (SLIDER_KEYS_LETTERS.includes(key)) {
+      const param = resolveSliderKey(key);
+      if (param) {
+        const el = sliderEls.get(param);
+        if (el) el.group.classList.remove("active");
+      }
     }
   });
 }
@@ -898,14 +1275,18 @@ class Session {
 
     const t = performance.now() / 1000;
     if (this.effects) {
-      // Knob-driven flavors: lora_str_1 = daft punk (rose bloom tint +
-      // always-on bloom), lora_str_2 = dubstep (chromatic aberration).
-      // Normalize to 0..1 against each slider's max so the shader can
-      // assume a clean range regardless of how SLIDER_META is retuned.
-      const daftN = sliderValues.lora_str_1 / SLIDER_DEFS.lora_str_1.max;
-      const dubN  = sliderValues.lora_str_2 / SLIDER_DEFS.lora_str_2.max;
-      this.effects.setDaftPunk(daftN);
-      this.effects.setDubstep(dubN);
+      // FX flavors slot off the first/second currently-enabled LoRA:
+      // slot 0 -> daft (rose bloom tint), slot 1 -> dubstep (chromatic
+      // aberration).  Decoupled from any specific LoRA id so toggling
+      // the catalog re-aims them.  Both default to 0 when no LoRA fills
+      // the slot.
+      const ids = enabledLoraIds();
+      const slot0 = ids[0]
+        ? sliderValues[loraStrengthKey(ids[0])] / LORA_SLIDER_MAX : 0;
+      const slot1 = ids[1]
+        ? sliderValues[loraStrengthKey(ids[1])] / LORA_SLIDER_MAX : 0;
+      this.effects.setDaftPunk(slot0);
+      this.effects.setDubstep(slot1);
       this.effects.tick(this.videoLayer.activeVideo, t, kick);
     }
     tickRibbons(this.ribbons, t, kick);
@@ -1028,10 +1409,20 @@ async function startSession(interleaved, channels, frames, videos) {
     showStatus(`Loaded ${(frames / SAMPLE_RATE).toFixed(1)}s audio. UI-only mode.`);
     initialBuffer = interleaved;
     initialChannels = channels;
+    applyLoraCatalog([]);
   } else {
     showStatus(`Loaded ${(frames / SAMPLE_RATE).toFixed(1)}s audio. Connecting...`);
     try {
-      const config = { ...CONFIG, prompt: activePrompt, key: activeKey };
+      // Carry the operator's pre-Play LoRA selections through to the
+      // pipeline.  Server enables exactly these ids on first tick — no
+      // mid-stream "now turn it on" round-trip needed.
+      const config = {
+        ...CONFIG,
+        prompt: activePrompt,
+        key: activeKey,
+        enabled_loras: getEnabledLoraIdsForConfig(),
+        lora_strengths: getEnabledLoraStrengthsForConfig(),
+      };
       remote = new RemoteBackend(wsUrlInput.value.trim(), interleaved, channels, config);
       await remote.connect();
     } catch (e) {
@@ -1041,6 +1432,16 @@ async function startSession(interleaved, channels, frames, videos) {
     showStatus("Connected. Starting audio...");
     initialBuffer = remote.initialBuffer;
     initialChannels = remote.channels;
+    // Server is now the source of truth.  Reconcile our local catalog
+    // with what the server actually loaded (handles cases where the
+    // server registered ad-hoc paths or a row in our pre-Play list
+    // was missing from the catalog).
+    if (Array.isArray(remote.loraCatalog) && remote.loraCatalog.length) {
+      applyLoraCatalog(remote.loraCatalog);
+    }
+    remote.addEventListener("lora_catalog", (e) => {
+      applyLoraCatalog(e.detail);
+    });
   }
 
   const player = new AudioPlayer();
@@ -1090,11 +1491,17 @@ pauseBtn.addEventListener("click", () => {
 // last mapping survives a reload. Reset by clearing the entry or via the
 // midi-status badge (shift-click toggles diag, includes a reset hint).
 
+// CC 71/72 use the magic strings "lora_slot_0" / "lora_slot_1"; the
+// handler resolves them at message time to the first / second currently
+// enabled LoRA so toggling the catalog re-aims the knobs without a
+// remap.  All other ccs are static slider names.
+const LORA_SLOT_MARKER = ["lora_slot_0", "lora_slot_1"];
+
 const DEFAULT_MIDI_MAP = {
   cc: {
     70: "denoise",
-    71: "lora_str_1",
-    72: "lora_str_2",
+    71: LORA_SLOT_MARKER[0],
+    72: LORA_SLOT_MARKER[1],
     73: "hint_strength",
     74: "feedback",
     75: "shift",
@@ -1106,6 +1513,15 @@ const DEFAULT_MIDI_MAP = {
     37: "send_prompt",
   },
 };
+
+function resolveCcParam(name) {
+  if (name === LORA_SLOT_MARKER[0] || name === LORA_SLOT_MARKER[1]) {
+    const ids = enabledLoraIds();
+    const idx = name === LORA_SLOT_MARKER[0] ? 0 : 1;
+    return ids[idx] ? loraStrengthKey(ids[idx]) : null;
+  }
+  return name;
+}
 
 // Note actions are looked up by name (the value in midiMap.notes) so
 // localStorage can serialize the binding without holding function refs.
@@ -1190,8 +1606,10 @@ function decodeKnob(cc, value) {
 }
 
 function handleMidiCC(cc, value) {
-  const param = midiMap.cc[cc];
-  if (!param) return;
+  const rawName = midiMap.cc[cc];
+  if (!rawName) return;
+  const param = resolveCcParam(rawName);
+  if (!param) return;  // dynamic slot with no LoRA enabled
   const def = SLIDER_DEFS[param];
   if (!def) return;
   const decoded = decodeKnob(cc, value);
@@ -1251,6 +1669,16 @@ function initMidiLearnUI() {
     if (sliderGroup?.dataset?.param) {
       e.preventDefault();
       startMidiLearn("cc", sliderGroup.dataset.param, sliderGroup);
+      return;
+    }
+    // LoRA library rows are slider-group-equivalent for MIDI learn:
+    // right-click anywhere on the row (switch, name, slider track) to
+    // bind the next CC to that LoRA's strength.  data-param on the row
+    // is set by buildLoraRow to lora_str_<id>.
+    const loraRow = e.target.closest?.(".lora-row");
+    if (loraRow?.dataset?.param) {
+      e.preventDefault();
+      startMidiLearn("cc", loraRow.dataset.param, loraRow);
       return;
     }
     const learnEl = e.target.closest?.("[data-midi-learn]");
@@ -1398,6 +1826,18 @@ midiStatus.addEventListener("click", (e) => {
 // Init UI -- each in try/catch so one failure can't kill the rest.
 try { applyConfigToDom(); } catch (e) { console.error("applyConfigToDom failed:", e); }
 try { initSliders(); } catch (e) { console.error("initSliders failed:", e); }
+// Library tile must be populated AFTER initSliders() (which inserts the
+// tile placeholder) but before initEdgeBars() (which queries the
+// perimeter slot bindings).  Demo policy: pre-toggle the first
+// DEFAULT_AUTO_ENABLE_COUNT rows on so a fresh page-load looks staged
+// and ready; the operator can flip them off before pressing Play.
+try {
+  const initial = (loraInitial.loras || []).map((d, i) => ({
+    ...d,
+    state: i < DEFAULT_AUTO_ENABLE_COUNT ? "enabled" : "registered",
+  }));
+  applyLoraCatalog(initial);
+} catch (e) { console.error("applyLoraCatalog(initial) failed:", e); }
 try { initEdgeBars(); } catch (e) { console.error("initEdgeBars failed:", e); }
 try { initPrompts(); } catch (e) { console.error("initPrompts failed:", e); }
 try { initKeyboard(); } catch (e) { console.error("initKeyboard failed:", e); }

--- a/demos/realtime_motion_graph_web/static/config.json
+++ b/demos/realtime_motion_graph_web/static/config.json
@@ -11,14 +11,10 @@
     "crop": 0,
     "steps": 8,
     "fast_vae": false,
-    "key": "G# minor"
+    "key": "G# minor",
+    "_enabled_loras_help": "List of LoRA ids (filename stems) to auto-enable at session start. Ids must exist in MODELS_DIR/loras. Empty = catalog-only, operator toggles via the Library panel.",
+    "enabled_loras": []
   },
-
-  "lora_dir": "demos/realtime_motion_graph_web/loras",
-  "loras": [
-    { "file": "daftpunkstyle1200.safetensors", "label": "daft" },
-    { "file": "deathsteap_1.safetensors", "label": "death" }
-  ],
 
   "prompts": {
     "a": "heavy dubstep loop, deathstep, afxdump, growl heavy bass distortion",
@@ -28,8 +24,8 @@
 
   "controls": {
     "denoise": 0.7,
-    "lora_str_1": 0.3,
-    "lora_str_2": 0.5,
+    "_lora_default_strength_help": "Initial value for any LoRA strength slider. The first two LoRAs in the catalog auto-enable at page load and start at this value, so a non-zero default lets the demo sound immediately like the LoRAs are doing something.",
+    "lora_default_strength": 0.4,
     "hint_strength": 1.4,
 
     "feedback": 0.0,

--- a/demos/realtime_motion_graph_web/static/graph.js
+++ b/demos/realtime_motion_graph_web/static/graph.js
@@ -5,8 +5,6 @@ const GRAPH_COLORS = {
   denoise:       [0, 255, 0],
   feedback:      [0, 200, 255],
   shift:         [180, 0, 255],
-  lora_str_1:    [255, 50, 200],
-  lora_str_2:    [200, 50, 255],
   hint_strength: [255, 200, 50],
   noise_share:   [120, 120, 255],
   ode_noise:     [200, 200, 200],
@@ -16,6 +14,23 @@ const GRAPH_COLORS = {
   ch13: [255, 100, 100], ch14: [255, 180, 80],  ch19: [220, 255, 80],
   ch23: [80, 255, 180],  ch29: [80, 180, 255],  ch56: [180, 80, 255],
 };
+
+// Hash a LoRA id to a stable hue so per-LoRA history lines stay visually
+// distinct on the graph without requiring config-driven colors.
+const _LORA_HUE_PALETTE = [
+  [255, 50, 200], [200, 50, 255], [50, 200, 255], [255, 150, 50],
+  [120, 255, 80], [255, 80, 120], [180, 255, 200], [255, 200, 100],
+];
+function _loraColor(id) {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) | 0;
+  return _LORA_HUE_PALETTE[Math.abs(h) % _LORA_HUE_PALETTE.length];
+}
+function _colorFor(name) {
+  if (name in GRAPH_COLORS) return GRAPH_COLORS[name];
+  if (name.startsWith("lora_str_")) return _loraColor(name.slice("lora_str_".length));
+  return [255, 255, 255];
+}
 
 const HISTORY_LEN = 600;
 
@@ -86,7 +101,7 @@ export class GraphRenderer {
     ctx.lineWidth = 3 + 2 * pulse;
     const glowAlpha = 0.8 + 0.2 * pulse;
     for (const [name, hist] of this.histories) {
-      this._polyline(ctx, hist, playheadX, GRAPH_COLORS[name] || [255, 255, 255], glowAlpha);
+      this._polyline(ctx, hist, playheadX, _colorFor(name), glowAlpha);
     }
     ctx.restore();
 
@@ -94,7 +109,7 @@ export class GraphRenderer {
     ctx.save();
     ctx.lineWidth = 1;
     for (const [name, hist] of this.histories) {
-      this._polyline(ctx, hist, playheadX, GRAPH_COLORS[name] || [255, 255, 255], 1);
+      this._polyline(ctx, hist, playheadX, _colorFor(name), 1);
     }
     ctx.restore();
 

--- a/demos/realtime_motion_graph_web/static/index.html
+++ b/demos/realtime_motion_graph_web/static/index.html
@@ -55,12 +55,15 @@
       <span class="install-edge-label">Remix Strength</span>
       <div class="install-edge-bar"></div>
     </div>
-    <div class="install-edge install-edge-left" data-bar="lora_str_1">
-      <span class="install-edge-label">Daft Punk Style</span>
+    <!-- Left/right perimeter bars track the first/second currently
+         enabled LoRA.  Their data-bar and label text are written by
+         refreshLoraEdgeBars() whenever the catalog state changes. -->
+    <div class="install-edge install-edge-left">
+      <span class="install-edge-label"></span>
       <div class="install-edge-bar"></div>
     </div>
-    <div class="install-edge install-edge-right" data-bar="lora_str_2">
-      <span class="install-edge-label">Dubstep Style</span>
+    <div class="install-edge install-edge-right">
+      <span class="install-edge-label"></span>
       <div class="install-edge-bar"></div>
     </div>
   </div>
@@ -105,24 +108,10 @@
               <div class="slider-value">0.80</div>
               <kbd class="desktop-only">A + &#9650;&#9660;</kbd>
             </div>
-            <div class="slider-group" data-param="lora_str_1">
-              <div class="slider-label">daft punk style</div>
-              <div class="slider-track">
-                <div class="slider-fill" style="height: 0%"></div>
-                <div class="slider-thumb" style="bottom: 0%"></div>
-              </div>
-              <div class="slider-value">0.00</div>
-              <kbd class="desktop-only">S + &#9650;&#9660;</kbd>
-            </div>
-            <div class="slider-group" data-param="lora_str_2">
-              <div class="slider-label">dubstep style</div>
-              <div class="slider-track">
-                <div class="slider-fill" style="height: 0%"></div>
-                <div class="slider-thumb" style="bottom: 0%"></div>
-              </div>
-              <div class="slider-value">0.00</div>
-              <kbd class="desktop-only">D + &#9650;&#9660;</kbd>
-            </div>
+            <!-- LoRA strength sliders live in the dynamic Library tile
+                 (inserted by app.js when the server's catalog arrives).
+                 Keyboard shortcuts S + arrow / D + arrow drive the
+                 first / second currently-enabled LoRA. -->
             <div class="slider-group" data-param="hint_strength">
               <div class="slider-label">structure strength</div>
               <div class="slider-track">

--- a/demos/realtime_motion_graph_web/static/protocol.js
+++ b/demos/realtime_motion_graph_web/static/protocol.js
@@ -84,6 +84,8 @@ export class RemoteBackend extends EventTarget {
     this.duration = 0;
     this.channels = 0;
     this.sampleRate = SAMPLE_RATE;
+    this.loraCatalog = [];
+    this.loraDir = "";
   }
 
   async connect() {
@@ -124,6 +126,8 @@ export class RemoteBackend extends EventTarget {
             this.duration = msg.duration;
             this.channels = msg.channels;
             this.sampleRate = msg.sample_rate;
+            this.loraCatalog = msg.lora_catalog || [];
+            this.loraDir = msg.lora_dir || "";
             phase = "initial-buffer";
           } catch (e) { reject(e); }
           return;
@@ -149,6 +153,9 @@ export class RemoteBackend extends EventTarget {
             this.dispatchEvent(new CustomEvent("params", { detail: msg.params }));
           } else if (msg.type === "prompt_applied") {
             this.dispatchEvent(new CustomEvent("prompt_applied", { detail: msg.tags }));
+          } else if (msg.type === "lora_catalog") {
+            this.loraCatalog = msg.catalog || [];
+            this.dispatchEvent(new CustomEvent("lora_catalog", { detail: this.loraCatalog }));
           } else {
             this.dispatchEvent(new CustomEvent("json", { detail: msg }));
           }
@@ -228,6 +235,26 @@ export class RemoteBackend extends EventTarget {
       const msg = { type: "prompt", tags };
       if (key) msg.key = key;
       this.ws.send(JSON.stringify(msg));
+    } catch {}
+  }
+
+  sendEnableLora(id, strength) {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    try {
+      const msg = { type: "enable_lora", id };
+      // Pass the target strength so the server refits at it in one
+      // shot — enabling at 0 and waiting for the next params tick to
+      // ramp up produces a one-decode-window glitch where the LoRA
+      // sounds missing.
+      if (typeof strength === "number") msg.strength = strength;
+      this.ws.send(JSON.stringify(msg));
+    } catch {}
+  }
+
+  sendDisableLora(id) {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    try {
+      this.ws.send(JSON.stringify({ type: "disable_lora", id }));
     } catch {}
   }
 

--- a/demos/realtime_motion_graph_web/static/style.css
+++ b/demos/realtime_motion_graph_web/static/style.css
@@ -416,9 +416,157 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
 .install-edge-left  .install-edge-bar { right: 0; transform-origin: right bottom; }
 .install-edge-right .install-edge-bar { left:  0; transform-origin: left  bottom; }
 
+/* When no LoRA is enabled in the corresponding slot, the perimeter bar
+   collapses to a thin static line so it doesn't shout for attention. */
+.install-edge-empty .install-edge-bar { transform: scaleY(0.05); opacity: 0.3; }
+.install-edge-empty .install-edge-label { opacity: 0.4; }
+
 /* The bottom HUD edge has been replaced by the Advanced drawer — the
    drawer's handle bar lives at the bottom of the viewport now and serves
    the same visual role. No `.install-edge-bottom` rule needed. */
+
+/* ============================================================================
+   LoRA Library tile.  One row per catalog entry:
+       [switch]  name              [horizontal slider]  0.30
+   The body scrolls internally — adding LoRAs to the catalog grows the
+   list, not the Advanced drawer's height.  Width is bounded so the
+   tile sits comfortably alongside the other mixer tiles.
+   ============================================================================ */
+.mixer-tile-library {
+  min-width: 280px;
+  max-width: 360px;
+}
+.mixer-tile-library .lora-library-body {
+  display: flex; flex-direction: column;
+  gap: 6px;
+  padding: 4px 8px;
+  /* Internal scroll: the Library tile holds its own height and
+     scrolls when there are too many rows to fit.  The Advanced drawer
+     stays at its natural size. */
+  max-height: 240px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  /* Subtle scrollbar styling (Firefox + WebKit) so it doesn't shout. */
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
+}
+.mixer-tile-library .lora-library-body::-webkit-scrollbar { width: 6px; }
+.mixer-tile-library .lora-library-body::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2); border-radius: 3px;
+}
+.mixer-tile-library .lora-library-body::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.lora-library-empty {
+  font-size: 11px; opacity: 0.55; padding: 14px 6px;
+  text-align: center; font-style: italic;
+}
+
+.lora-row {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  grid-template-rows: auto auto;
+  align-items: center;
+  column-gap: 10px;
+  row-gap: 4px;
+  padding: 4px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+.lora-row:last-child { border-bottom: none; }
+
+.lora-row-name {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  opacity: 0.9;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.lora-row[data-state="disabled"] .lora-row-name { opacity: 0.55; }
+
+/* Toggle switch.  Sliding-pill style so the visual position alone
+   communicates state — no ON/OFF text needed (which would duplicate
+   the row name and confuse scan order). */
+.lora-switch {
+  width: 28px; height: 16px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid currentColor;
+  border-radius: 9px;
+  position: relative;
+  cursor: pointer;
+  opacity: 0.55;
+  transition: opacity 0.12s ease, background 0.18s ease;
+}
+.lora-switch:hover { opacity: 0.85; }
+.lora-switch[aria-checked="true"] {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.06);
+}
+.lora-switch-thumb {
+  position: absolute;
+  top: 1px; left: 1px;
+  width: 12px; height: 12px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.5;
+  transition: transform 0.16s cubic-bezier(.3,1.3,.5,1), opacity 0.12s ease;
+  pointer-events: none;
+}
+.lora-switch[aria-checked="true"] .lora-switch-thumb {
+  transform: translateX(12px);
+  opacity: 1;
+}
+.lora-switch.midi-learning {
+  outline: 1px dashed currentColor;
+  outline-offset: 2px;
+}
+
+/* Horizontal strength slider.  Spans the full row width below the
+   switch+name line, giving the operator a wide drag surface without
+   making each row tall. */
+.lora-strength {
+  grid-column: 1 / -1;
+  display: flex; align-items: center; gap: 8px;
+}
+.lora-strength-track {
+  position: relative;
+  flex: 1;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.lora-strength-track:hover { background: rgba(255, 255, 255, 0.14); }
+.lora-strength-fill {
+  position: absolute;
+  top: 0; bottom: 0; left: 0;
+  width: 0%;
+  background: currentColor;
+  opacity: 0.75;
+  border-radius: 2px;
+  transition: width 0.06s linear;
+}
+.lora-strength-value {
+  font-variant-numeric: tabular-nums;
+  font-size: 10px;
+  min-width: 3ch;
+  text-align: right;
+  opacity: 0.7;
+}
+
+/* Disabled state: lock the slider, dim the name, dim the fill — but
+   leave the switch alone so the operator can re-enable. */
+.lora-row[data-state="disabled"] .lora-strength-track {
+  cursor: not-allowed;
+  background: rgba(255, 255, 255, 0.04);
+}
+.lora-row[data-state="disabled"] .lora-strength-fill { opacity: 0.25; }
+.lora-row[data-state="disabled"] .lora-strength-value { opacity: 0.35; }
 
 /* ============================================================================
    Buttons — single shared "outline + accent on hover" language. The Seed /


### PR DESCRIPTION
## What

End-to-end migration of `demos/realtime_motion_graph` to the dynamic
LoRA library introduced in PR1. The server publishes a catalog
(scanned automatically from `MODELS_DIR/loras/`), the client renders
one row per entry with an enable toggle + strength slider, and all
positional bindings (perimeter bars, hotkeys, MIDI CC, FX slots) now
target the first / second currently-enabled LoRA at lookup time
instead of hardcoded `lora_str_1` / `lora_str_2` ids.

**Stacked on PR1** — needs `trt: dynamic LoRA library` to land first.

## Library card design

```
┌── LoRA library ────────────────┐
│ ●━━○  death                    │
│       ──────●─────────  0.40   │
│ ●━━○  daft                     │
│       ────────●───────  0.40   │
│ ○━━●  another                  │
│       ●───────────────  0.00   │   ← scrolls inside the tile
└────────────────────────────────┘
```

- **Single label per row** — the row name is the LoRA's filename stem.
  No ON/OFF text on the toggle (that would duplicate the row name and
  the visual switch position already communicates state).
- **Sliding-pill switch** with `role="switch"` + `aria-checked` for
  screen-reader semantics. Click the row name as a wider hit target.
- **Horizontal strength slider** below the row header (so each row
  gets a wide drag surface without making the row tall). Double-click
  the track to reset to default; drag to set.
- **Locked when off**: the slider goes `cursor: not-allowed`, fill
  fades, value dims. The switch stays interactive so the operator can
  re-enable.
- **Internal scroll** — `max-height: 240px; overflow-y: auto` on the
  Library body. Catalog can grow without stretching the Advanced
  drawer.

## Catalog at app startup, not pipeline load time

`/api/loras` (added on the static-file server in this PR) scans
`MODELS_DIR/loras/` over plain HTTP — no torch, no engine load, no
WebSocket. The browser renders the Library tile **on page load**,
before the user clicks Play. Demo policy: the first
`DEFAULT_AUTO_ENABLE_COUNT` (2) rows pre-toggle on at startup so a
fresh page-load looks staged and ready. The operator can flip them
off before pressing Play.

When Play fires, the WS init config carries `enabled_loras` plus a
`lora_strengths: {id: value}` dict derived from whatever's currently
toggled in the UI, so the pipeline starts with the right LoRAs at
their target strengths from tick 1 — no mid-stream "now turn it on"
round-trip. Post-Play, toggling sends `enable_lora` (with the current
slider value as `strength`) / `disable_lora` and applies optimistically
until the server broadcasts a confirming catalog.

Without the per-id `lora_strengths` in the init config, the previous
flow enabled each LoRA at strength 0 and waited for the next params
tick to ramp it up — that produced a one-decode-window glitch where
the first ~5s of generated audio sounded like the LoRA was missing
(the streaming pipeline depth covers several decoded seconds, and
that window starts with base weights).

## Server side

`demos/realtime_motion_graph/`:

- **server.py**: drops the hardcoded `LORA_PATHS` constant. Sends
  `lora_catalog` in the `ready` payload. Handles new ws messages
  `enable_lora{id}` / `disable_lora{id}`, staged on the recv thread
  and applied on the runner thread via a `before_tick` hook so refit
  is serialized with inference. Background-prewarms any LoRAs the
  client requests at startup so the first enable is fast.
- **pipeline.py**: drops the `lora_ids` constructor param. Iterates
  `engine.list_trt_loras()` filtered to `state == "enabled"`, keys
  strength by id (`lora_str_<id>`). New `before_tick` callback hook.
- **client/knobs.py**: `build_banks(loras=[id, ...])` takes a list of
  ids and generates `lora_str_<id>` knobs with dynamic CC slots.
- **assets/loras/README.md**: redirects to `MODELS_DIR/loras/` per the
  no-fallback decision.

## Web client

`demos/realtime_motion_graph_web/`:

- **server.py**: new `/api/loras` endpoint (filesystem scan, no
  engine).
- **static/app.js**: drops hardcoded `LORAS` / `LORA_DIR` config.
  `loraCatalog` state populated from `/api/loras` at module init,
  refreshed from `lora_catalog` ws messages after Play. Library tile
  redesigned (see above). `getEnabledLoraIdsForConfig()` feeds the WS
  init config. Hotkeys `s` / `d`, MIDI CC 71/72, perimeter
  left/right bars, and daft/dubstep FX slots all resolve to the
  first/second currently-enabled LoRA at lookup time.
- **static/protocol.js**: captures `lora_catalog` from ready payload,
  dispatches `lora_catalog` events. New `sendEnableLora` /
  `sendDisableLora` helpers.
- **static/index.html**: drops static `lora_str_1` / `lora_str_2`
  slider-groups and the hardcoded `data-bar` values on the perimeter
  edges.
- **static/graph.js**: hashes LoRA id to a color from a small palette
  so per-id history lines stay distinguishable.
- **static/config.json**: drops `loras` and `lora_dir`. Adds
  `engine.enabled_loras` (overrides the demo auto-enable when
  explicitly set) and `controls.lora_default_strength` (default 0.4 so
  auto-enabled rows have audible effect from tick 1).
- **static/style.css**: pill-switch + horizontal-slider styling,
  internal scrolling on the Library tile, disabled-state visuals.

## Test plan

- [ ] Drop two `.safetensors` into `MODELS_DIR/loras/`, start the web
      server, open the page. Library tile renders before clicking
      Play; first two rows are pre-toggled on with strength 0.40.
- [ ] Click Play. Confirm both LoRAs are audibly active from the
      first generation.
- [ ] Toggle a LoRA off, then on a different one. Confirm the
      perimeter / hotkey / FX bindings re-aim without a remap.
- [ ] Drop 50+ LoRAs in the directory. Refresh the page. Library tile
      scrolls internally; the Advanced drawer height is unchanged.
- [ ] Run `pytest tests/unit/test_lora_refit.py -q` — must still be
      17/17.
