### PR TITLE
demo: --accel, audio-primary UI, song switching, kiosk mode

### DIFF
--- a/acestep/engine/stream.py
+++ b/acestep/engine/stream.py
@@ -702,6 +702,26 @@ class StreamPipeline:
         """
         tick_start = time.time()
 
+        # T-coherence: a source swap to a different-length audio leaves
+        # in-flight slots holding xt of the old T while fresh submits
+        # carry the new T. _tick_pt cats xt across slots in dim 0, which
+        # requires the time dim to match — drop stale slots and stale
+        # queued requests so the next batch is uniform. The "target" T
+        # is the most recently submitted request's; older queued ones
+        # from before the swap are filtered out alongside the slots.
+        if self._queue:
+            target_T = self._queue[-1].context_latents.shape[1]
+            if any(
+                r.context_latents.shape[1] != target_T for r in self._queue
+            ):
+                self._queue = [
+                    r for r in self._queue
+                    if r.context_latents.shape[1] == target_T
+                ]
+            for i, slot in enumerate(self._slots):
+                if slot is not None and slot.xt.shape[1] != target_T:
+                    self._slots[i] = None
+
         # Check for finished slot (slot at final step of its schedule)
         finished = None
         for i, slot in enumerate(self._slots):

--- a/demos/realtime_motion_graph/pipeline.py
+++ b/demos/realtime_motion_graph/pipeline.py
@@ -89,15 +89,29 @@ class PipelineRunner:
             on_audio_ready = lambda wav, *_args: audio_eng.swap(wav)
         self.on_audio_ready = on_audio_ready
         # before_tick: optional callable invoked at the top of every loop
-        # iteration on the runner thread. Used by the server to apply
-        # LoRA enable/disable mutations (which trigger refits) on the
-        # GPU-owning thread, serializing them with inference.
+        # iteration on the runner thread.  Used by the web server to
+        # apply cross-thread mutations safely:
+        #   - LoRA enable/disable (which triggers a refit; refit and
+        #     inference are mutually exclusive)
+        #   - source swap (prepare_source / encode_text / replace stream
+        #     fields, which can't race the recv thread that holds the
+        #     WebSocket)
+        # The server's apply_pending() callback drains both queues each
+        # iteration so they share one rendezvous point.
         self.before_tick = before_tick
 
         # Cache silence once; used by the hint-strength blend node.
-        T_frames = stream.source.latent.tensor.shape[1]
+        self._rebuild_silence_latent()
+
+    def _rebuild_silence_latent(self) -> None:
+        """(Re)build the silence latent used by hint-strength blending.
+
+        Tracks the current ``stream.source`` length, so call this after a
+        source swap if the new source has a different latent length.
+        """
+        T_frames = self.stream.source.latent.tensor.shape[1]
         self._silence_latent = EmptyLatent().execute(
-            model=stream.model, duration=T_frames / 25.0,
+            model=self.stream.model, duration=T_frames / 25.0,
         )["latent"]
 
     def _update_hint_strength(self, hint_str: float) -> None:
@@ -152,13 +166,28 @@ class PipelineRunner:
         last_hint_str = 1.0
         last_channel_gains = [1.0] * (len(CHANNEL_GROUPS) + len(KEYSTONE_CHANNELS))
         current_shift = self.stream.base_kwargs["shift"]
+        prev_src_T = self.stream.source.latent.tensor.shape[1]
 
         while self.running[0]:
             if self.before_tick is not None:
-                # Hook for cross-thread mutations (e.g. LoRA enable/disable).
-                # Runs on the runner thread so any refit work the callback
-                # does is serialized with the tick body.
+                # Hook for cross-thread mutations (LoRA enable/disable
+                # AND source swap).  Runs on the runner thread so any
+                # GPU/refit work the callback does is serialized with
+                # the tick body.
                 self.before_tick()
+
+            # If a swap changed the source latent length, the cached
+            # last_latent / last_wav / last_decode_pos are dimensioned
+            # against the old source and would crash both the feedback
+            # blend (source_lat = ... + feedback * last_latent) and the
+            # skip-decode MSE check below. Reset them so the next tick
+            # re-initializes against the new source cleanly.
+            cur_src_T = self.stream.source.latent.tensor.shape[1]
+            if cur_src_T != prev_src_T:
+                last_latent = None
+                last_wav = None
+                last_decode_pos = None
+                prev_src_T = cur_src_T
             if self.use_midi:
                 raw = self.midi_knobs.get_all_values()
             else:

--- a/demos/realtime_motion_graph/server.py
+++ b/demos/realtime_motion_graph/server.py
@@ -326,6 +326,8 @@ def handle_client(ws, *, decoder_backend: str = "tensorrt", vae_backend: str = "
         "lora_dir": str(loras_dir()),
         "lora_catalog": _catalog_payload(),
         "lora_pending_enable": list(initial_enable_ids),
+        "bpm": detected_bpm,
+        "key": detected_key,
     }))
     ws.send(src_np.astype(np.float16).tobytes())
     print(f"[Server] Sent initial buffer ({len(src_np) / SAMPLE_RATE:.1f}s)")
@@ -344,8 +346,27 @@ def handle_client(ws, *, decoder_backend: str = "tensorrt", vae_backend: str = "
     motion_val = [0.0]
     motion_lock = threading.Lock()
 
-    client_mirror = src_np.copy()
+    # Mutable refs so the swap path can replace these in place from the
+    # runner thread without invalidating closures captured by recv_loop /
+    # on_audio_ready. Values are read via the [0] indirection everywhere
+    # that needs the *current* (post-swap) version.
+    source_ref = [source]
+    bpm_ref = [detected_bpm]
+    key_ref = [detected_key]
+    n_channels_ref = [n_channels]
+
+    # Client mirror: tracks what audio the client currently has. Replaced
+    # wholesale on swap so deltas continue to be computed against the
+    # buffer the client just crossfaded into.
+    client_mirror_ref = [src_np.copy()]
     zctx = zstd.ZstdCompressor(level=1)
+
+    # Source-swap rendezvous between the recv thread (sets pending) and
+    # the runner thread (consumes pending in before_tick). The recv loop
+    # only stages audio bytes here; all GPU work happens on the runner
+    # thread so we don't race the streaming pipeline.
+    swap_pending: dict = {"bytes": None, "tags": None}
+    swap_lock = threading.Lock()
 
     # Cross-thread LoRA mutation rendezvous.  The recv thread enqueues
     # ids; the runner thread drains the queues in before_tick so the
@@ -419,6 +440,16 @@ def handle_client(ws, *, decoder_backend: str = "tensorrt", vae_backend: str = "
             ss, se = 0, len(wav_np)
         if se <= ss:
             return
+
+        client_mirror = client_mirror_ref[0]
+        # If the runner emitted a slice that's longer than the freshly
+        # swapped mirror (different source length), clip to the smaller
+        # of the two; the client has no addressable space past mirror.
+        se = min(se, len(client_mirror), len(wav_np))
+        if se <= ss:
+            return
+
+        # Delta = what server has now minus what client has
         region = wav_np[ss:se]
         mirror_region = client_mirror[ss:se]
         delta = (region - mirror_region).astype(np.float16)
@@ -427,7 +458,7 @@ def handle_client(ws, *, decoder_backend: str = "tensorrt", vae_backend: str = "
         hdr = struct.pack(
             SLICE_HDR_FMT,
             SLICE_FLAG_DELTA,
-            ss, se - ss, n_channels,
+            ss, se - ss, n_channels_ref[0],
             params.get("tick_ms", 0), params.get("dec_ms", 0),
             params.get("num_gens", 0),
         )
@@ -453,12 +484,15 @@ def handle_client(ws, *, decoder_backend: str = "tensorrt", vae_backend: str = "
                             latest_raw = data.get("raw", {})
                             latest_pp = data.get("playback_pos", 0.0)
                         elif mtype == "prompt":
+                            # Re-encode on server. Prefer the key sent by the
+                            # client (operator override); fall back to the
+                            # auto-detected key from the loaded source.
                             cond = session.encode_text(
                                 tags=data["tags"],
                                 instruction=TASK_INSTRUCTIONS["cover"],
-                                refer_latent=source.latent,
-                                bpm=detected_bpm, duration=60.0,
-                                key=detected_key,
+                                refer_latent=source_ref[0].latent,
+                                bpm=bpm_ref[0], duration=60.0,
+                                key=data.get("key") or key_ref[0],
                             )
                             stream.conditioning = cond
                             prompt_text[0] = data["tags"]
@@ -490,6 +524,22 @@ def handle_client(ws, *, decoder_backend: str = "tensorrt", vae_backend: str = "
                             if lid:
                                 with pending_lock:
                                     pending_disable.append(str(lid))
+                        elif mtype == "swap_source":
+                            # Followed by a binary audio frame in the same
+                            # format as the init handshake. Block on that
+                            # next message so we don't have to multiplex
+                            # halfway through; the client only sends one
+                            # swap_source at a time.
+                            tags = data.get("tags") or prompt_text[0]
+                            try:
+                                audio_msg = ws.recv()
+                            except ConnectionClosed:
+                                running[0] = False
+                                break
+                            with swap_lock:
+                                swap_pending["bytes"] = audio_msg
+                                swap_pending["tags"] = tags
+                                swap_pending["key"] = data.get("key")
             except TimeoutError:
                 pass
             except ConnectionClosed:
@@ -523,6 +573,110 @@ def handle_client(ws, *, decoder_backend: str = "tensorrt", vae_backend: str = "
                     (lid, lora_strengths_init.get(lid)),
                 )
 
+    # --- Source swap (runs on the runner thread via before_tick) ---
+    # Forward decl so the closure can call runner._rebuild_silence_latent
+    # after replacing stream.source. ``runner`` is assigned just below.
+    runner_holder: list = [None]
+
+    def apply_swap_if_pending():
+        with swap_lock:
+            audio_msg = swap_pending.get("bytes")
+            tags = swap_pending.get("tags")
+            requested_key = swap_pending.get("key")
+            if audio_msg is None:
+                return
+            swap_pending["bytes"] = None
+            swap_pending["tags"] = None
+            swap_pending["key"] = None
+        try:
+            new_channels, new_samples = struct.unpack("<II", audio_msg[:8])
+            new_np = np.frombuffer(audio_msg[8:], dtype=np.float32).reshape(
+                new_samples, new_channels,
+            )
+            new_wf = torch.from_numpy(new_np.T.copy())
+            new_wf = new_wf[:2, :int(60.0 * SAMPLE_RATE)]
+            rem = new_wf.shape[-1] % pool
+            if rem:
+                new_wf = new_wf[:, :new_wf.shape[-1] - rem]
+            print(
+                f"[Server] Swapping source ({new_wf.shape[1] / SAMPLE_RATE:.1f}s, "
+                f"{new_wf.shape[0]}ch)..."
+            )
+
+            # Detect on the new audio. Same code path as init.
+            new_mono = new_wf.mean(dim=0).numpy()
+            new_bpm, _ = librosa.beat.beat_track(y=new_mono, sr=SAMPLE_RATE)
+            new_bpm = int(round(float(np.asarray(new_bpm).flat[0])))
+            new_key = detect_key(new_mono, SAMPLE_RATE)
+            print(f"  new BPM: {new_bpm}  new Key: {new_key}")
+
+            new_audio_in = Audio(waveform=new_wf, sample_rate=SAMPLE_RATE)
+            new_source = session.prepare_source(new_audio_in)
+            new_cond = session.encode_text(
+                tags=tags,
+                instruction=TASK_INSTRUCTIONS["cover"],
+                refer_latent=new_source.latent,
+                bpm=new_bpm, duration=60.0,
+                key=requested_key or new_key,
+            )
+
+            stream.source = new_source
+            stream.conditioning = new_cond
+            stream.context_latent = new_source.context_latent
+            source_ref[0] = new_source
+            bpm_ref[0] = new_bpm
+            key_ref[0] = new_key
+            prompt_text[0] = tags
+            r = runner_holder[0]
+            if r is not None:
+                # Source latent length may have changed; rebuild silence so
+                # _update_hint_strength's blend operands match shapes.
+                r._rebuild_silence_latent()
+
+            new_src_np = new_wf.numpy().T
+            new_n_channels = new_src_np.shape[1] if new_src_np.ndim > 1 else 1
+            n_channels_ref[0] = new_n_channels
+            client_mirror_ref[0] = new_src_np.copy()
+            audio_eng.swap(new_src_np)
+            audio_eng.position = 0
+
+            # Notify the client. swap_ready is the streaming-phase analog
+            # of "ready"; the binary follow-up is the new initial buffer
+            # that the audio worklet swaps in with a 50ms crossfade.
+            with send_lock:
+                ws.send(json.dumps({
+                    "type": "swap_ready",
+                    "duration": len(new_src_np) / SAMPLE_RATE,
+                    "sample_rate": SAMPLE_RATE,
+                    "channels": new_n_channels,
+                    "bpm": new_bpm,
+                    "key": new_key,
+                }))
+                ws.send(new_src_np.astype(np.float16).tobytes())
+            print(f"[Server] Source swap complete ({len(new_src_np) / SAMPLE_RATE:.1f}s)")
+        except ConnectionClosed:
+            running[0] = False
+        except Exception as exc:
+            print(f"[Server] Swap error: {exc}")
+            import traceback
+            traceback.print_exc()
+            try:
+                with send_lock:
+                    ws.send(json.dumps({
+                        "type": "swap_failed",
+                        "error": str(exc),
+                    }))
+            except Exception:
+                pass
+
+    # Combined before_tick callback.  Both kinds of cross-thread
+    # mutation (LoRA enable/disable refits and source swaps) are GPU-
+    # bound and must run on the runner thread between ticks.  Drain
+    # both queues each iteration so they share one rendezvous point.
+    def apply_pending():
+        apply_lora_pending()
+        apply_swap_if_pending()
+
     # --- PipelineRunner: the SAME code as local ---
     runner = PipelineRunner(
         session, stream, audio_eng,
@@ -536,8 +690,9 @@ def handle_client(ws, *, decoder_backend: str = "tensorrt", vae_backend: str = "
         prompt_text=prompt_text, running=running,
         motion_val=motion_val, motion_lock=motion_lock,
         on_audio_ready=on_audio_ready,
-        before_tick=apply_lora_pending,
+        before_tick=apply_pending,
     )
+    runner_holder[0] = runner
 
     try:
         print("[Server] Pipeline running...")

--- a/demos/realtime_motion_graph/server.py
+++ b/demos/realtime_motion_graph/server.py
@@ -124,8 +124,8 @@ class VirtualMidiKnobs:
 # WebSocket handler
 # ---------------------------------------------------------------------------
 
-def handle_client(ws):
-    print("[Server] Client connected")
+def handle_client(ws, *, decoder_backend: str = "tensorrt", vae_backend: str = "tensorrt"):
+    print(f"[Server] Client connected (decoder={decoder_backend}, vae={vae_backend})")
 
     # ---- Phase 1: Init ----
     config = json.loads(ws.recv())
@@ -174,21 +174,36 @@ def handle_client(ws):
 
     # --- Session setup ---
     audio_duration_s = waveform.shape[1] / SAMPLE_RATE
-    trt_engines = select_trt_engines(duration_s=audio_duration_s)
-    if fast_vae:
+    use_trt = decoder_backend == "tensorrt" or vae_backend == "tensorrt"
+    if use_trt:
+        trt_engines = select_trt_engines(duration_s=audio_duration_s)
+        # validate_backends() rejects engine entries whose backend isn't
+        # tensorrt, so prune the unused half on mixed-backend setups.
+        if decoder_backend != "tensorrt":
+            trt_engines.pop("decoder", None)
+        if vae_backend != "tensorrt":
+            trt_engines.pop("vae_encode", None)
+            trt_engines.pop("vae_decode", None)
+    else:
+        trt_engines = None
+    if fast_vae and vae_backend == "tensorrt":
+        # fast_vae uses the dreamvae distilled decoder; profile must match.
         fast_name = "dreamvae_decode_fp16_60s" if audio_duration_s <= 60.0 else "dreamvae_decode_fp16_240s"
         if Path(str(trt_engine_path(fast_name))).exists():
             trt_engines["vae_decode"] = str(trt_engine_path(fast_name))
         else:
             print(f"[Server] WARNING: {fast_name} engine missing, falling back to {Path(trt_engines['vae_decode']).stem}")
             fast_vae = False
+    elif fast_vae:
+        print(f"[Server] WARNING: fast_vae requires vae_backend=tensorrt; ignoring with vae_backend={vae_backend}")
+        fast_vae = False
 
-    print("[Server] Loading model...")
+    print(f"[Server] Loading model... (decoder={decoder_backend}, vae={vae_backend})")
     t0 = time.time()
     session = Session(
         project_root=str(checkpoints_dir()),
-        decoder_backend="tensorrt",
-        vae_backend="tensorrt",
+        decoder_backend=decoder_backend,
+        vae_backend=vae_backend,
         trt_engines=trt_engines,
         vae_window=vae_window,
     )

--- a/demos/realtime_motion_graph_web/README.md
+++ b/demos/realtime_motion_graph_web/README.md
@@ -29,13 +29,19 @@ replacement for the pygame/OpenCV client with the same feature set:
 
 ## Run
 
-From the remote 5090 box (the machine with the GPU):
+First-run only — fetch the bundled audio fixtures:
+
+```bash
+python tests/fixtures/download.py
+```
+
+Then from the remote 5090 box (the machine with the GPU):
 
 ```bash
 uv run python -u -m demos.realtime_motion_graph_web
 # or with explicit binds:
 uv run python -u -m demos.realtime_motion_graph_web \
-    --host 0.0.0.0 --http-port 8080 --ws-port 8765
+    --host 0.0.0.0 --port 8765
 # pick the acceleration mode explicitly (default is tensorrt):
 uv run python -u -m demos.realtime_motion_graph_web --accel tensorrt
 uv run python -u -m demos.realtime_motion_graph_web --accel compile
@@ -47,14 +53,24 @@ uv run python -u -m demos.realtime_motion_graph_web --accel eager
 
 Then from any laptop on the same network:
 
-1. Open `http://<server-host>:8080/`
-2. Paste the WebSocket URL if it's not already pre-filled
-   (`ws://<server-host>:8765`)
-3. Drop in a source audio file (any format the browser can decode;
-   resampled to 48 kHz stereo in-browser before upload)
-4. Tweak the options, click **Connect & start**
-5. Cold start takes ~15 s while the server loads the model + TRT
-   engines; once it's ready the UI switches to the live HUD view
+1. Open `http://<server-host>:8765/`
+2. Click **Play** — the demo loads the default fixture
+   (`new_order_confusion_60seconds.wav`).
+3. Switch fixtures any time using the selector at the top of the
+   Advanced drawer; switching tears down the session and restarts with
+   the new audio.
+4. Cold start takes ~15 s while the server loads the model + TRT
+   engines (or longer on `--accel compile`); once it's ready the UI
+   switches to the live HUD view.
+
+### Audio source vs. video
+
+Audio is the **primary** source: the demo always loads from
+`tests/fixtures/`, served by the web server at `/fixtures/<name>`.
+Video is **optional and secondary** — drop any `.mp4`/`.webm`/`.mov`
+into `static/videos/` to attach the audio-reactive shader pipeline.
+With no videos present the demo runs audio-only (graph mode is the
+default and looks the same).
 
 ## Layout
 

--- a/demos/realtime_motion_graph_web/README.md
+++ b/demos/realtime_motion_graph_web/README.md
@@ -36,7 +36,14 @@ uv run python -u -m demos.realtime_motion_graph_web
 # or with explicit binds:
 uv run python -u -m demos.realtime_motion_graph_web \
     --host 0.0.0.0 --http-port 8080 --ws-port 8765
+# pick the acceleration mode explicitly (default is tensorrt):
+uv run python -u -m demos.realtime_motion_graph_web --accel tensorrt
+uv run python -u -m demos.realtime_motion_graph_web --accel compile
+uv run python -u -m demos.realtime_motion_graph_web --accel eager
 ```
+
+`--accel {tensorrt,compile,eager}` sets BOTH `decoder_backend` and
+`vae_backend` on the underlying `Session`. Default is `tensorrt`.
 
 Then from any laptop on the same network:
 

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -38,6 +38,8 @@ VIDEOS_DIR = STATIC_DIR / "videos"
 # Set in main() based on --no-backend; read by _process_request when the
 # client polls /api/server-info on startup.
 _NO_BACKEND = False
+# Set in main() based on --accel; read by the WS handler wrapper.
+_ACCEL = "tensorrt"
 
 # Keep the wire compact and don't cache anything so the product team
 # always sees the latest JS after a redeploy.
@@ -238,6 +240,7 @@ def _stub_handle_client(ws):
 def main():
     host = "0.0.0.0"
     port = 8765  # single port: serves both HTTP and WebSocket
+    accel = "tensorrt"  # decoder + vae backend; overridden by --accel
 
     args = sys.argv[1:]
     no_backend = "--no-backend" in args or "--ui-only" in args
@@ -254,12 +257,21 @@ def main():
     if "--ws-port" in args and "--http-port" not in args:
         idx = args.index("--ws-port")
         port = int(args[idx + 1])
+    if "--accel" in args:
+        idx = args.index("--accel")
+        accel = args[idx + 1]
+    _VALID_ACCEL = ("tensorrt", "compile", "eager")
+    if accel not in _VALID_ACCEL:
+        raise SystemExit(
+            f"[Server] --accel must be one of {_VALID_ACCEL}, got {accel!r}"
+        )
 
     if not STATIC_DIR.exists():
         raise SystemExit(f"[Server] static dir missing: {STATIC_DIR}")
 
-    global _NO_BACKEND
+    global _NO_BACKEND, _ACCEL
     _NO_BACKEND = no_backend
+    _ACCEL = accel
 
     if no_backend:
         ws_handler = _stub_handle_client
@@ -269,7 +281,9 @@ def main():
         # loads torch + acestep + TRT machinery; in --no-backend we never
         # touch any of it.
         from demos.realtime_motion_graph.server import handle_client
-        ws_handler = handle_client
+
+        def ws_handler(ws):
+            handle_client(ws, decoder_backend=accel, vae_backend=accel)
 
     print(f"[Server] Starting single-port HTTP+WS on :{port}")
     srv = ws_serve(
@@ -283,7 +297,7 @@ def main():
     ws_thread.start()
 
     browsable_host = "localhost" if host in ("0.0.0.0", "::", "") else host
-    mode = "UI-ONLY (no backend)" if no_backend else "WEB APP, single port"
+    mode = "UI-ONLY (no backend)" if no_backend else f"WEB APP, single port, accel={accel}"
     print()
     print("=" * 60)
     print(f"  Real-Time Motion-to-Music  ({mode})")

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -34,6 +34,10 @@ from websockets.sync.server import serve as ws_serve
 
 STATIC_DIR = Path(__file__).parent / "static"
 VIDEOS_DIR = STATIC_DIR / "videos"
+# tests/fixtures lives at the repo root, two levels above this module
+# (demos/realtime_motion_graph_web/ -> repo root -> tests/fixtures).
+FIXTURES_DIR = Path(__file__).resolve().parents[2] / "tests" / "fixtures"
+_AUDIO_EXTS = {".wav", ".mp3", ".flac", ".ogg", ".m4a"}
 
 # Set in main() based on --no-backend; read by _process_request when the
 # client polls /api/server-info on startup.
@@ -188,6 +192,62 @@ def _process_request(connection, request):
             body,
         )
 
+    # API: list audio fixtures from tests/fixtures/
+    if url.split("?", 1)[0] == "/api/fixtures":
+        fixtures = []
+        if FIXTURES_DIR.is_dir():
+            fixtures = sorted(
+                f.name for f in FIXTURES_DIR.iterdir()
+                if f.is_file() and f.suffix.lower() in _AUDIO_EXTS
+            )
+        body = json.dumps(fixtures).encode()
+        _log_http(remote, 200, "GET", url)
+        return Response(
+            200, "OK",
+            Headers([
+                ("Content-Type", "application/json; charset=utf-8"),
+                ("Content-Length", str(len(body))),
+                *_NO_CACHE_HEADERS,
+            ]),
+            body,
+        )
+
+    # Serve files from tests/fixtures/ under /fixtures/<name>.
+    fixture_match = url.split("?", 1)[0].split("#", 1)[0]
+    if fixture_match.startswith("/fixtures/"):
+        rel = fixture_match[len("/fixtures/"):]
+        if rel and "/" not in rel and "\\" not in rel and not rel.startswith("."):
+            candidate = (FIXTURES_DIR / rel).resolve()
+            try:
+                candidate.relative_to(FIXTURES_DIR.resolve())
+            except ValueError:
+                candidate = None  # path escape attempt
+            if candidate and candidate.is_file() and candidate.suffix.lower() in _AUDIO_EXTS:
+                try:
+                    body = candidate.read_bytes()
+                except OSError as e:
+                    msg = f"500 {e}\n".encode()
+                    _log_http(remote, 500, "GET", url)
+                    return Response(
+                        500, "Internal Server Error",
+                        Headers([
+                            ("Content-Type", "text/plain; charset=utf-8"),
+                            ("Content-Length", str(len(msg))),
+                            *_NO_CACHE_HEADERS,
+                        ]),
+                        msg,
+                    )
+                _log_http(remote, 200, "GET", url)
+                return Response(
+                    200, "OK",
+                    Headers([
+                        ("Content-Type", _content_type_for(candidate)),
+                        ("Content-Length", str(len(body))),
+                        *_NO_CACHE_HEADERS,
+                    ]),
+                    body,
+                )
+
     target = _resolve_static(url)
     if target is None:
         body = b"404 not found\n"
@@ -304,6 +364,7 @@ def main():
     print("=" * 60)
     print(f"  Open:      http://{browsable_host}:{port}/")
     print(f"  WebSocket: ws://{browsable_host}:{port}/")
+    print(f"  Fixtures:  {FIXTURES_DIR}")
     print("  Ctrl+C to stop")
     print("=" * 60)
     print()

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -44,6 +44,12 @@ _AUDIO_EXTS = {".wav", ".mp3", ".flac", ".ogg", ".m4a"}
 _NO_BACKEND = False
 # Set in main() based on --accel; read by the WS handler wrapper.
 _ACCEL = "tensorrt"
+# Set in main() based on --kiosk / --mode; surfaced to the client via
+# /api/server-info so installation-only behaviors (cursor auto-hide,
+# idle settings reset) and the initial display mode can be CLI-driven.
+_KIOSK = False
+_DEFAULT_MODE = "graph"
+_VALID_MODES = ("graph", "video")
 
 # Keep the wire compact and don't cache anything so the product team
 # always sees the latest JS after a redeploy.
@@ -126,7 +132,11 @@ def _process_request(connection, request):
     # In --no-backend mode the client takes the video-only path: it plays
     # the source audio directly and skips the WebSocket connection entirely.
     if url.split("?", 1)[0] == "/api/server-info":
-        body = json.dumps({"no_backend": _NO_BACKEND}).encode()
+        body = json.dumps({
+            "no_backend": _NO_BACKEND,
+            "kiosk": _KIOSK,
+            "default_mode": _DEFAULT_MODE,
+        }).encode()
         _log_http(remote, 200, "GET", url)
         return Response(
             200, "OK",
@@ -326,12 +336,24 @@ def main():
             f"[Server] --accel must be one of {_VALID_ACCEL}, got {accel!r}"
         )
 
+    kiosk = "--kiosk" in args
+    default_mode = "graph"
+    if "--mode" in args:
+        idx = args.index("--mode")
+        default_mode = args[idx + 1]
+    if default_mode not in _VALID_MODES:
+        raise SystemExit(
+            f"[Server] --mode must be one of {_VALID_MODES}, got {default_mode!r}"
+        )
+
     if not STATIC_DIR.exists():
         raise SystemExit(f"[Server] static dir missing: {STATIC_DIR}")
 
-    global _NO_BACKEND, _ACCEL
+    global _NO_BACKEND, _ACCEL, _KIOSK, _DEFAULT_MODE
     _NO_BACKEND = no_backend
     _ACCEL = accel
+    _KIOSK = kiosk
+    _DEFAULT_MODE = default_mode
 
     if no_backend:
         ws_handler = _stub_handle_client
@@ -357,7 +379,11 @@ def main():
     ws_thread.start()
 
     browsable_host = "localhost" if host in ("0.0.0.0", "::", "") else host
-    mode = "UI-ONLY (no backend)" if no_backend else f"WEB APP, single port, accel={accel}"
+    extras = [f"mode={default_mode}"]
+    if kiosk:
+        extras.append("kiosk")
+    extra_str = " " + " ".join(f"[{e}]" for e in extras)
+    mode = "UI-ONLY (no backend)" if no_backend else f"WEB APP, single port, accel={accel}{extra_str}"
     print()
     print("=" * 60)
     print(f"  Real-Time Motion-to-Music  ({mode})")

--- a/demos/realtime_motion_graph_web/static/app.js
+++ b/demos/realtime_motion_graph_web/static/app.js
@@ -36,6 +36,7 @@ const pauseBtn = $("pause-btn");
 const modeToggle = $("mode-toggle");
 const graphCanvas = $("graph");
 const effectsCanvas = $("effects-canvas");
+const fixtureSelect = $("fixture-select");
 
 // ── Config ──
 // All initial values come from config.json (next to this file). Edit + refresh
@@ -1176,17 +1177,30 @@ class Session {
   async start() {
     pauseBtn.innerHTML = "&#9646;&#9646;";
 
-    this.videoLayer.setVideos(this.videos);
-    this.videoLayer.play(this.videos[0], "none");
+    // Video is secondary: only attach the VideoLayer when at least one
+    // video file is present. With no video, the audio drives the demo on
+    // its own and the focal canvas falls back to its CSS-only state.
+    this.hasAnyVideo = this.videos.length > 0;
+    if (this.hasAnyVideo) {
+      this.videoLayer.setVideos(this.videos);
+      this.videoLayer.play(this.videos[0], "none");
 
-    // Mirror the playing video into the blurred ambient back layer so
-    // the side gutters fill with motion-matched ambience.
-    const ambient = document.getElementById("install-ambient");
-    if (ambient && this.videos[0]) {
-      ambient.src = `videos/${this.videos[0]}`;
-      ambient.muted = true;
-      ambient.loop = true;
-      ambient.play().catch(() => {});
+      // Mirror the playing video into the blurred ambient back layer so
+      // the side gutters fill with motion-matched ambience.
+      const ambient = document.getElementById("install-ambient");
+      if (ambient) {
+        ambient.src = `videos/${this.videos[0]}`;
+        ambient.muted = true;
+        ambient.loop = true;
+        ambient.play().catch(() => {});
+      }
+    } else {
+      // Hide video DOM so the focal area stays dark instead of showing
+      // a stuck black <video> tile. Effects canvas is also a no-op below.
+      const ambient = document.getElementById("install-ambient");
+      if (ambient) ambient.removeAttribute("src");
+      videoA.removeAttribute("src");
+      videoB.removeAttribute("src");
     }
 
     if (this.remote) {
@@ -1287,7 +1301,10 @@ class Session {
         ? sliderValues[loraStrengthKey(ids[1])] / LORA_SLIDER_MAX : 0;
       this.effects.setDaftPunk(slot0);
       this.effects.setDubstep(slot1);
-      this.effects.tick(this.videoLayer.activeVideo, t, kick);
+      // With no video attached, _uploadVideo() returns false and the
+      // shader clears to transparent — the focal area is empty but the
+      // HUD bars and graph still drive off the audio.
+      this.effects.tick(this.hasAnyVideo ? this.videoLayer.activeVideo : null, t, kick);
     }
     tickRibbons(this.ribbons, t, kick);
 
@@ -1456,23 +1473,87 @@ async function startSession(interleaved, channels, frames, videos) {
 
 // ── Init ──
 
+// Test-fixture audio is the primary source. Videos are best-effort and
+// purely visual: if /api/videos returns at least one file we attach the
+// VideoLayer to the active session, otherwise the audio plays alone.
+let availableFixtures = [];
+let availableVideos = [];
+
+// Pick the file containing "new_order_confusion" if present; fall back to
+// the first fixture. The user requested new_order_confusion as the default
+// audio source.
+function pickDefaultFixture(fixtures) {
+  if (fixtures.length === 0) return null;
+  const m = fixtures.find((f) => f.toLowerCase().includes("new_order_confusion"));
+  return m || fixtures[0];
+}
+
+function populateFixtureSelect(fixtures, selected) {
+  fixtureSelect.innerHTML = "";
+  for (const name of fixtures) {
+    const opt = document.createElement("option");
+    opt.value = name;
+    opt.textContent = name;
+    if (name === selected) opt.selected = true;
+    fixtureSelect.appendChild(opt);
+  }
+}
+
+async function loadFixtureAudio(name) {
+  const resp = await fetch(`/fixtures/${encodeURIComponent(name)}`);
+  if (!resp.ok) throw new Error(`Failed to fetch fixture: ${resp.status}`);
+  const arrayBuf = await resp.arrayBuffer();
+  return decodeAudioBuffer(arrayBuf);
+}
+
+async function startWithFixture(name) {
+  showStatus(`Decoding ${name}...`);
+  const { interleaved, channels, frames } = await loadFixtureAudio(name);
+  await startSession(interleaved, channels, frames, availableVideos);
+}
+
+// Populate the fixture selector on page load so the user can pick a
+// different track before clicking Play. The /api/videos result is also
+// cached here so Play and the fixture-switch handler don't refetch.
+async function preloadCatalog() {
+  try {
+    const [fixturesResp, videosResp] = await Promise.all([
+      fetch("/api/fixtures"),
+      fetch("/api/videos").catch(() => null),
+    ]);
+    if (fixturesResp.ok) availableFixtures = await fixturesResp.json();
+    if (videosResp && videosResp.ok) availableVideos = await videosResp.json();
+    if (availableFixtures.length > 0) {
+      populateFixtureSelect(availableFixtures, pickDefaultFixture(availableFixtures));
+    }
+  } catch (e) {
+    console.warn("Catalog preload failed:", e);
+  }
+}
+preloadCatalog();
+
 playBtn.addEventListener("click", async () => {
   startOverlay.classList.add("hidden");
 
-  showStatus("Loading video...");
+  showStatus("Loading fixtures...");
   try {
-    const resp = await fetch("/api/videos");
-    if (!resp.ok) throw new Error("Could not fetch video list");
-    const videos = await resp.json();
-    if (videos.length === 0) throw new Error("No videos found on server");
+    // If preload succeeded the selector is already populated; if not,
+    // refetch here so a transient startup race doesn't strand the user.
+    if (availableFixtures.length === 0) {
+      await preloadCatalog();
+    }
+    if (availableFixtures.length === 0) {
+      throw new Error(
+        "No audio fixtures found. Run `python tests/fixtures/download.py` to fetch them."
+      );
+    }
 
-    showStatus("Decoding audio from video...");
-    const videoResp = await fetch(`videos/${videos[0]}`);
-    if (!videoResp.ok) throw new Error(`Failed to fetch video: ${videoResp.status}`);
-    const arrayBuf = await videoResp.arrayBuffer();
-    const { interleaved, channels, frames } = await decodeAudioBuffer(arrayBuf);
+    const selected = fixtureSelect.value || pickDefaultFixture(availableFixtures);
+    if (!fixtureSelect.value) {
+      populateFixtureSelect(availableFixtures, selected);
+    }
 
-    await startSession(interleaved, channels, frames, videos);
+    await startWithFixture(selected);
   } catch (e) {
     showStatus(`Error: ${e.message}`);
   }

--- a/demos/realtime_motion_graph_web/static/app.js
+++ b/demos/realtime_motion_graph_web/static/app.js
@@ -37,6 +37,37 @@ const modeToggle = $("mode-toggle");
 const graphCanvas = $("graph");
 const effectsCanvas = $("effects-canvas");
 const fixtureSelect = $("fixture-select");
+const keySelect = $("key-select");
+
+// Full keyscale set, generated the same way Python does in
+// acestep.constants.VALID_KEYSCALES (7 notes × 5 accidentals × 2 modes
+// = 70 entries, including ASCII / Unicode sharp & flat spellings the
+// model accepts verbatim).
+const KEYSCALE_NOTES = ["A", "B", "C", "D", "E", "F", "G"];
+const KEYSCALE_ACCIDENTALS = ["", "#", "b", "♯", "♭"];
+const KEYSCALE_MODES = ["major", "minor"];
+const VALID_KEYSCALES = (() => {
+  const out = [];
+  for (const note of KEYSCALE_NOTES) {
+    for (const acc of KEYSCALE_ACCIDENTALS) {
+      for (const mode of KEYSCALE_MODES) {
+        out.push(`${note}${acc} ${mode}`);
+      }
+    }
+  }
+  return out;
+})();
+
+function populateKeySelect(selected) {
+  keySelect.innerHTML = "";
+  for (const k of VALID_KEYSCALES) {
+    const opt = document.createElement("option");
+    opt.value = k;
+    opt.textContent = k;
+    if (k === selected) opt.selected = true;
+    keySelect.appendChild(opt);
+  }
+}
 
 // ── Config ──
 // All initial values come from config.json (next to this file). Edit + refresh
@@ -1022,6 +1053,27 @@ function sendCurrentPrompt() {
   session?.remote?.sendPrompt(activePrompt, activeKey);
 }
 
+// Single funnel for activeKey edits. ``source`` is "auto" when the server
+// just told us its detected key (no need to re-send — the server already
+// encoded with that key); "user" when the operator picked from the
+// dropdown (re-send so the next generation reflects the override).
+function setActiveKey(key, source) {
+  if (!key) return;
+  activeKey = key;
+  if (keySelect && Array.from(keySelect.options).some((o) => o.value === key)) {
+    keySelect.value = key;
+  }
+  if (source === "user") sendCurrentPrompt();
+}
+
+function initKeySelect() {
+  populateKeySelect(activeKey);
+  keySelect.addEventListener("change", () => {
+    bumpIdleTimer();
+    setActiveKey(keySelect.value, "user");
+  });
+}
+
 function initPrompts() {
   promptAInput.addEventListener("keydown", (e) => e.stopPropagation());
   promptBInput.addEventListener("keydown", (e) => e.stopPropagation());
@@ -1449,6 +1501,7 @@ async function startSession(interleaved, channels, frames, videos) {
     showStatus("Connected. Starting audio...");
     initialBuffer = remote.initialBuffer;
     initialChannels = remote.channels;
+    if (remote.detectedKey) setActiveKey(remote.detectedKey, "auto");
     // Server is now the source of truth.  Reconcile our local catalog
     // with what the server actually loaded (handles cases where the
     // server registered ad-hoc paths or a row in our pre-Play list
@@ -1554,6 +1607,72 @@ playBtn.addEventListener("click", async () => {
     }
 
     await startWithFixture(selected);
+  } catch (e) {
+    showStatus(`Error: ${e.message}`);
+  }
+});
+
+// Switching fixtures: if there's a live session with a backend, swap the
+// source in-place (server keeps the model loaded; the audio worklet
+// crossfades the new buffer in over 50 ms — no cold restart, no audio
+// gap). If there's no live session, or no backend, fall back to a full
+// startSession.
+async function swapToFixture(name) {
+  showStatus(`Decoding ${name}...`);
+  const { interleaved, channels, frames } = await loadFixtureAudio(name);
+
+  const remote = session?.remote;
+  if (!remote || serverInfo.no_backend) {
+    await startSession(interleaved, channels, frames, availableVideos);
+    return;
+  }
+
+  // Race-safe: hook the swap_ready listener BEFORE sending so we never
+  // miss a fast server reply. Server eventually emits exactly one of
+  // swap_ready / swap_failed per request.
+  showStatus(`Swapping to ${name}...`);
+  const swapped = await new Promise((resolve) => {
+    const onReady = (e) => {
+      remote.removeEventListener("swap_ready", onReady);
+      remote.removeEventListener("swap_failed", onFail);
+      session.audio.swap(e.detail.interleaved, e.detail.channels);
+      // Server already encoded with this key; just align the UI/state so
+      // future prompt re-sends carry the right key. "auto" prevents a
+      // redundant prompt re-send (server is already on the new key).
+      if (e.detail.key) setActiveKey(e.detail.key, "auto");
+      resolve(true);
+    };
+    const onFail = (e) => {
+      remote.removeEventListener("swap_ready", onReady);
+      remote.removeEventListener("swap_failed", onFail);
+      console.warn("Server swap_failed:", e.detail);
+      resolve(false);
+    };
+    remote.addEventListener("swap_ready", onReady);
+    remote.addEventListener("swap_failed", onFail);
+    const ok = remote.sendSwapSource(interleaved, channels, activePrompt, activeKey);
+    if (!ok) {
+      remote.removeEventListener("swap_ready", onReady);
+      remote.removeEventListener("swap_failed", onFail);
+      resolve(false);
+    }
+  });
+
+  if (!swapped) {
+    // Server-side swap failed; fall back to a full session restart so
+    // the user still ends up on the requested fixture.
+    await startSession(interleaved, channels, frames, availableVideos);
+    return;
+  }
+  hideStatus();
+}
+
+fixtureSelect.addEventListener("change", async () => {
+  const name = fixtureSelect.value;
+  if (!name) return;
+  bumpIdleTimer();
+  try {
+    await swapToFixture(name);
   } catch (e) {
     showStatus(`Error: ${e.message}`);
   }
@@ -1921,6 +2040,7 @@ try {
 } catch (e) { console.error("applyLoraCatalog(initial) failed:", e); }
 try { initEdgeBars(); } catch (e) { console.error("initEdgeBars failed:", e); }
 try { initPrompts(); } catch (e) { console.error("initPrompts failed:", e); }
+try { initKeySelect(); } catch (e) { console.error("initKeySelect failed:", e); }
 try { initKeyboard(); } catch (e) { console.error("initKeyboard failed:", e); }
 try { initIdleReset(); } catch (e) { console.error("initIdleReset failed:", e); }
 try { initCursorAutoHide(); } catch (e) { console.error("initCursorAutoHide failed:", e); }

--- a/demos/realtime_motion_graph_web/static/app.js
+++ b/demos/realtime_motion_graph_web/static/app.js
@@ -34,6 +34,7 @@ const seedBtn = $("seed-btn");
 const seedValueEl = $("seed-value");
 const pauseBtn = $("pause-btn");
 const modeToggle = $("mode-toggle");
+const kioskToggle = $("kiosk-toggle");
 const graphCanvas = $("graph");
 const effectsCanvas = $("effects-canvas");
 const fixtureSelect = $("fixture-select");
@@ -93,9 +94,11 @@ const userConfig = await fetch(`config.json?t=${Date.now()}`).then((r) => {
 // {no_backend: true} and the Play handler skips the WebSocket path.
 // Best-effort: if the endpoint isn't there (older server) we treat it as
 // backend-present and let WS try as usual.
+// Defaults match the older server (no kiosk, graph mode) so an old server
+// + new client still boots cleanly.
 const serverInfo = await fetch("/api/server-info")
-  .then((r) => (r.ok ? r.json() : { no_backend: false }))
-  .catch(() => ({ no_backend: false }));
+  .then((r) => (r.ok ? r.json() : { no_backend: false, kiosk: false, default_mode: "graph" }))
+  .catch(() => ({ no_backend: false, kiosk: false, default_mode: "graph" }));
 
 // LoRA catalog comes from /api/loras — a cheap filesystem scan of
 // MODELS_DIR/loras/ that runs on the static-file server, so we can
@@ -226,7 +229,7 @@ modeToggle?.addEventListener("click", () => {
   const i = DISPLAY_MODES.indexOf(currentMode);
   setMode(DISPLAY_MODES[(i + 1) % DISPLAY_MODES.length]);
 });
-setMode("graph");
+setMode(DISPLAY_MODES.includes(serverInfo.default_mode) ? serverInfo.default_mode : "graph");
 
 // ── State ──
 
@@ -269,6 +272,13 @@ function applyConfigToDom() {
   blendValueEl.textContent = blendValue.toFixed(2);
   seedValueEl.textContent = seedValue.toFixed(2);
 }
+
+// ── Kiosk runtime state ──
+// Set by setKiosk() (server CLI default + the operator toggle in the
+// Advanced drawer). Consulted by bumpIdleTimer() and showCursor() so they
+// no-op when kiosk is off. Declared here because both functions below
+// reference it.
+let kioskActive = false;
 
 // ── Idle reset ──
 // After `reset_seconds` of no user interaction (pointer, key, MIDI), revert
@@ -318,6 +328,7 @@ function resetToDefaults() {
 }
 
 function bumpIdleTimer() {
+  if (!kioskActive) return;
   const secs = userConfig.reset_seconds ?? 0;
   if (secs <= 0) return;
   clearTimeout(idleTimer);
@@ -344,6 +355,7 @@ let cursorIdleTimer = null;
 function showCursor() {
   document.body.classList.remove("cursor-idle");
   clearTimeout(cursorIdleTimer);
+  if (!kioskActive) return;
   cursorIdleTimer = setTimeout(() => {
     document.body.classList.add("cursor-idle");
   }, CURSOR_IDLE_MS);
@@ -353,6 +365,31 @@ function initCursorAutoHide() {
   document.addEventListener("mousemove", showCursor, { passive: true });
   showCursor();
 }
+
+// Toggle kiosk behaviors at runtime. The CLI flag (--kiosk) seeds the
+// initial state via /api/server-info; the button in the Advanced drawer
+// flips it from there. Turning off cancels in-flight timers and brings
+// the cursor back so the operator isn't left with a half-applied state.
+function setKiosk(on) {
+  kioskActive = !!on;
+  if (kioskToggle) {
+    kioskToggle.textContent = kioskActive ? "EXIT KIOSK" : "KIOSK";
+    kioskToggle.classList.toggle("active", kioskActive);
+    kioskToggle.setAttribute("aria-pressed", kioskActive ? "true" : "false");
+  }
+  if (kioskActive) {
+    // Arm both timers immediately so the operator sees the effect right
+    // after toggling on, without having to first wiggle the mouse.
+    bumpIdleTimer();
+    showCursor();
+  } else {
+    clearTimeout(idleTimer);
+    clearTimeout(cursorIdleTimer);
+    document.body.classList.remove("cursor-idle");
+  }
+}
+
+kioskToggle?.addEventListener("click", () => setKiosk(!kioskActive));
 
 // Global timer state -- persists across reconnects.
 let globalTimerStart = null;
@@ -1726,10 +1763,11 @@ function resolveCcParam(name) {
 // Note actions are looked up by name (the value in midiMap.notes) so
 // localStorage can serialize the binding without holding function refs.
 const NOTE_ACTIONS = {
-  seed:        () => randomizeSeed(),
-  send_prompt: () => sendCurrentPrompt(),
-  mode_toggle: () => modeToggle?.click(),
-  pause:       () => pauseBtn?.click(),
+  seed:         () => randomizeSeed(),
+  send_prompt:  () => sendCurrentPrompt(),
+  mode_toggle:  () => modeToggle?.click(),
+  pause:        () => pauseBtn?.click(),
+  kiosk_toggle: () => kioskToggle?.click(),
 };
 
 const MIDI_STORAGE_KEY = "demon_midi_map_v1";
@@ -2042,7 +2080,13 @@ try { initEdgeBars(); } catch (e) { console.error("initEdgeBars failed:", e); }
 try { initPrompts(); } catch (e) { console.error("initPrompts failed:", e); }
 try { initKeySelect(); } catch (e) { console.error("initKeySelect failed:", e); }
 try { initKeyboard(); } catch (e) { console.error("initKeyboard failed:", e); }
+// Installation features (cursor auto-hide, idle settings reset) are gated
+// by the runtime `kioskActive` flag — see setKiosk() below. The init
+// functions only attach listeners; the bump/showCursor functions early-out
+// when kiosk is off, so a developer running locally isn't fighting an
+// auto-hiding cursor or having their tweaks reverted while they think.
 try { initIdleReset(); } catch (e) { console.error("initIdleReset failed:", e); }
 try { initCursorAutoHide(); } catch (e) { console.error("initCursorAutoHide failed:", e); }
+setKiosk(serverInfo.kiosk === true);
 try { initMidiLearnUI(); } catch (e) { console.error("initMidiLearnUI failed:", e); }
 initMidi();

--- a/demos/realtime_motion_graph_web/static/audio.js
+++ b/demos/realtime_motion_graph_web/static/audio.js
@@ -119,6 +119,28 @@ export class AudioPlayer {
     }
   }
 
+  // Replace the entire loop buffer with a new source. The worklet
+  // crossfades the old and new buffers over CROSSFADE_SECONDS (50 ms by
+  // default), so callers don't hear a click. ScriptProcessor fallback
+  // does an instant swap (the seam-fade still hides the wrap).
+  swap(interleavedBuffer, channels) {
+    this.channels = channels || this.channels;
+    this.frameCount = interleavedBuffer.length / this.channels;
+    this._mirror = interleavedBuffer.slice();
+    this.swapCount++;
+    for (const fn of this._listeners) fn();
+    if (this._useWorklet) {
+      const send = interleavedBuffer.slice();
+      this.node.port.postMessage(
+        { type: "swap", buffer: send, channels: this.channels },
+        [send.buffer],
+      );
+    } else {
+      this._spBuffer = interleavedBuffer.slice();
+      this._spPosition = 0;
+    }
+  }
+
   // Delta-add into a region of the worklet's buffer.
   addDelta(startFrame, deltaInterleaved) {
     this._writeMirror(startFrame, deltaInterleaved, /*add=*/true);

--- a/demos/realtime_motion_graph_web/static/index.html
+++ b/demos/realtime_motion_graph_web/static/index.html
@@ -85,6 +85,7 @@
       <div class="install-section-operator">
         <input type="text" id="ws-url" class="ws-url-input" placeholder="ws://host:port">
         <select id="fixture-select" class="fixture-select" title="Audio source (test fixture)"></select>
+        <select id="key-select" class="fixture-select" title="Musical key — auto-detected; override re-sends prompt"></select>
         <button id="pause-btn" class="pause-btn" data-midi-learn="pause" title="Pause/Resume (right-click to MIDI-learn)">&#9654;</button>
         <button id="mode-toggle" class="pause-btn" data-midi-learn="mode_toggle" title="Switch display mode (right-click to MIDI-learn)">GRAPH</button>
         <!-- MIDI badge + diag are injected here by app.js at startup. -->
@@ -174,6 +175,6 @@
 <div class="cursor-cluster" aria-hidden="true"></div>
 <div class="cursor-dot" aria-hidden="true"></div>
 
-<script type="module" src="app.js?v=36"></script>
+<script type="module" src="app.js?v=39"></script>
 </body>
 </html>

--- a/demos/realtime_motion_graph_web/static/index.html
+++ b/demos/realtime_motion_graph_web/static/index.html
@@ -88,6 +88,7 @@
         <select id="key-select" class="fixture-select" title="Musical key — auto-detected; override re-sends prompt"></select>
         <button id="pause-btn" class="pause-btn" data-midi-learn="pause" title="Pause/Resume (right-click to MIDI-learn)">&#9654;</button>
         <button id="mode-toggle" class="pause-btn" data-midi-learn="mode_toggle" title="Switch display mode (right-click to MIDI-learn)">GRAPH</button>
+        <button id="kiosk-toggle" class="pause-btn" data-midi-learn="kiosk_toggle" title="Toggle kiosk mode — auto-hide cursor + idle reset (right-click to MIDI-learn)">KIOSK</button>
         <!-- MIDI badge + diag are injected here by app.js at startup. -->
         <div id="install-midi-slot"></div>
       </div>

--- a/demos/realtime_motion_graph_web/static/index.html
+++ b/demos/realtime_motion_graph_web/static/index.html
@@ -9,7 +9,7 @@
 <title>Daydream Music</title>
 <link rel="manifest" href="manifest.json">
 <link rel="stylesheet" href="tokens.css?v=10">
-<link rel="stylesheet" href="style.css?v=45">
+<link rel="stylesheet" href="style.css?v=46">
 <script src="lib/fzstd.min.js" onerror="this.onerror=null; var s=document.createElement('script'); s.src='https://cdn.jsdelivr.net/npm/fzstd@0.1.1/umd/index.min.js'; document.head.appendChild(s);"></script>
 </head>
 <body>
@@ -84,6 +84,7 @@
       <!-- Operator strip across the top — connection + transport + MIDI. -->
       <div class="install-section-operator">
         <input type="text" id="ws-url" class="ws-url-input" placeholder="ws://host:port">
+        <select id="fixture-select" class="fixture-select" title="Audio source (test fixture)"></select>
         <button id="pause-btn" class="pause-btn" data-midi-learn="pause" title="Pause/Resume (right-click to MIDI-learn)">&#9654;</button>
         <button id="mode-toggle" class="pause-btn" data-midi-learn="mode_toggle" title="Switch display mode (right-click to MIDI-learn)">GRAPH</button>
         <!-- MIDI badge + diag are injected here by app.js at startup. -->

--- a/demos/realtime_motion_graph_web/static/protocol.js
+++ b/demos/realtime_motion_graph_web/static/protocol.js
@@ -128,6 +128,8 @@ export class RemoteBackend extends EventTarget {
             this.sampleRate = msg.sample_rate;
             this.loraCatalog = msg.lora_catalog || [];
             this.loraDir = msg.lora_dir || "";
+            this.detectedBpm = msg.bpm ?? null;
+            this.detectedKey = msg.key ?? null;
             phase = "initial-buffer";
           } catch (e) { reject(e); }
           return;
@@ -145,6 +147,21 @@ export class RemoteBackend extends EventTarget {
           return;
         }
 
+        // The pending-swap state turns the next binary frame into a full
+        // buffer replacement (sent right after the swap_ready JSON).
+        if (this._pendingSwap && ev.data instanceof ArrayBuffer) {
+          const u16 = new Uint16Array(ev.data);
+          const interleaved = float16ArrayToFloat32(u16);
+          const meta = this._pendingSwap;
+          this._pendingSwap = null;
+          this.duration = meta.duration;
+          this.channels = meta.channels;
+          this.dispatchEvent(new CustomEvent("swap_ready", {
+            detail: { ...meta, interleaved },
+          }));
+          return;
+        }
+
         // --- Streaming phase ---
         if (typeof ev.data === "string") {
           let msg;
@@ -156,6 +173,11 @@ export class RemoteBackend extends EventTarget {
           } else if (msg.type === "lora_catalog") {
             this.loraCatalog = msg.catalog || [];
             this.dispatchEvent(new CustomEvent("lora_catalog", { detail: this.loraCatalog }));
+          } else if (msg.type === "swap_ready") {
+            // Stage the metadata; the next binary frame is the new buffer.
+            this._pendingSwap = msg;
+          } else if (msg.type === "swap_failed") {
+            this.dispatchEvent(new CustomEvent("swap_failed", { detail: msg.error }));
           } else {
             this.dispatchEvent(new CustomEvent("json", { detail: msg }));
           }
@@ -256,6 +278,40 @@ export class RemoteBackend extends EventTarget {
     try {
       this.ws.send(JSON.stringify({ type: "disable_lora", id }));
     } catch {}
+  }
+
+  /**
+   * Replace the source audio in-flight. The server pauses generation,
+   * re-runs prepare_source / encode_text on the new waveform, swaps
+   * stream.source/conditioning, and replies with a swap_ready event +
+   * binary buffer. Caller should hand the buffer to AudioPlayer.swap().
+   * @param {Float32Array} interleaved
+   * @param {number} channels
+   * @param {string} [tags]  current prompt; falls back to server-side
+   * @param {string} [key]   override; otherwise server uses detected key
+   */
+  sendSwapSource(interleaved, channels, tags, key) {
+    if (this.ws?.readyState !== WebSocket.OPEN) return false;
+    try {
+      const msg = { type: "swap_source" };
+      if (tags) msg.tags = tags;
+      if (key) msg.key = key;
+      this.ws.send(JSON.stringify(msg));
+      const samples = interleaved.length / channels;
+      const hdr = new ArrayBuffer(8);
+      const dv = new DataView(hdr);
+      dv.setUint32(0, channels, true);
+      dv.setUint32(4, samples, true);
+      const pcm = new Uint8Array(interleaved.buffer);
+      const combined = new Uint8Array(hdr.byteLength + pcm.byteLength);
+      combined.set(new Uint8Array(hdr), 0);
+      combined.set(pcm, hdr.byteLength);
+      this.ws.send(combined);
+      return true;
+    } catch (e) {
+      console.error("[protocol] sendSwapSource failed:", e);
+      return false;
+    }
   }
 
   close() {

--- a/demos/realtime_motion_graph_web/static/style.css
+++ b/demos/realtime_motion_graph_web/static/style.css
@@ -611,6 +611,11 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   font-size: 0.85em;
   letter-spacing: 0;
 }
+.pause-btn.active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--text);
+}
 
 .seed-btn {
   width: 60px;

--- a/demos/realtime_motion_graph_web/static/style.css
+++ b/demos/realtime_motion_graph_web/static/style.css
@@ -981,6 +981,24 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   width: 100%;
 }
 
+.fixture-select {
+  background: var(--input-bg);
+  border: 1px solid var(--frame-line);
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  min-height: 32px;
+  font-size: 0.7em;
+  max-width: 240px;
+  transition: border-color 120ms, color 120ms;
+}
+.fixture-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  color: var(--text);
+}
+
 .prompt-input {
   padding: 6px 8px;
   font-family: inherit;

--- a/demos/test_stream_cover_graph.py
+++ b/demos/test_stream_cover_graph.py
@@ -38,7 +38,7 @@ from acestep.nodes.types import Audio, Latent
 from acestep.paths import checkpoints_dir, project_root, trt_engine_path, select_trt_engines
 
 PROJECT_ROOT = project_root()
-SOURCE_AUDIO = PROJECT_ROOT / "tests/fixtures" / "new_order_confusion_60seconds.wav"
+DEFAULT_SOURCE_AUDIO = PROJECT_ROOT / "tests/fixtures" / "new_order_confusion_60seconds.wav"
 OUTPUT_DIR = PROJECT_ROOT / "_debug_tests" / "stream_output"
 
 SAMPLE_RATE = 48000
@@ -97,6 +97,17 @@ else:
 
 # Pure-PyTorch decoder mode (skip TRT decoder; VAE engines still used).
 no_trt_decoder = "--no-trt-decoder" in _args
+# Pure-PyTorch everywhere: skip TRT decoder AND TRT VAE engines.
+no_acceleration = "--no-acceleration" in _args
+if no_acceleration:
+    no_trt_decoder = True
+
+source_audio_override = _get_arg("--source-audio", None, str)
+if source_audio_override is not None:
+    _p = Path(source_audio_override)
+    SOURCE_AUDIO = _p if _p.is_absolute() else PROJECT_ROOT / _p
+else:
+    SOURCE_AUDIO = DEFAULT_SOURCE_AUDIO
 
 TRT_ENGINE = trt_engine_path(decoder_engine_name)
 
@@ -189,12 +200,15 @@ print("=" * 60)
 # Setup -- all through Session API
 # ------------------------------------------------------------------
 # load_audio() defaults to 60s, so 60s engines are the right default.
-_base_engines = select_trt_engines(duration_s=60.0)
-trt_engines = {
-    "vae_encode": _base_engines["vae_encode"],
-    "vae_decode": _base_engines["vae_decode"],
-}
-if use_fast_vae:
+if no_acceleration:
+    trt_engines = {}
+else:
+    _base_engines = select_trt_engines(duration_s=60.0)
+    trt_engines = {
+        "vae_encode": _base_engines["vae_encode"],
+        "vae_decode": _base_engines["vae_decode"],
+    }
+if use_fast_vae and not no_acceleration:
     fast_name = "dreamvae_decode_fp16_60s"
     if not Path(str(trt_engine_path(fast_name))).exists():
         print(f"[Setup] WARNING: {fast_name} engine missing, using {Path(trt_engines['vae_decode']).stem}")
@@ -207,7 +221,7 @@ print(f"\n[Setup] checkpoint={checkpoint}")
 print(
     f"[Setup] decoder backend={'PT' if no_trt_decoder else 'TRT (' + decoder_engine_name + ')'}"
 )
-print(f"[Setup] vae backend=TRT  vae_window={vae_window}  depth={depth}")
+print(f"[Setup] vae backend={'PT (eager)' if no_acceleration else 'TRT'}  vae_window={vae_window}  depth={depth}")
 if use_dcw:
     print(
         f"[Setup] DCW=ON  mode={dcw_mode}  scaler={dcw_scaler}  "
@@ -223,7 +237,7 @@ with timed("model_load"):
         project_root=str(checkpoints_dir()),
         config_path=checkpoint,
         decoder_backend="tensorrt" if not no_trt_decoder else "eager",
-        vae_backend="tensorrt",
+        vae_backend="eager" if no_acceleration else "tensorrt",
         trt_engines=trt_engines,
         vae_window=vae_window,
     )


### PR DESCRIPTION
## Summary

Four demo-side changes, in order of commit:

### `--accel` flag for decoder/VAE backend selection
Adds `--accel {tensorrt,compile,eager}` to the demo server. Routes through `decoder_backend` / `vae_backend` and conditionally builds `trt_engines` only when at least one side is `tensorrt`. Lets a developer run the demo without TRT engines built (`--accel eager`) or with `torch.compile` for iteration.

### Audio-primary frontend
Reframes the client around the audio source rather than video. The `default_audio` fixture loads automatically on page load, the WebSocket Play path no longer requires a video, and the effects/video layers gracefully no-op when no video is present. Operator can swap fixtures from a dropdown in the operator strip.

### Mid-session source swap (song switching)
Lets the operator change the source audio without tearing down the WebSocket session. New `swap_source` WS message; server reseeds latents, BPM, and key from the new source and emits `swap_ready` / `swap_failed` so the client can react. Keeps the active prompt and LoRA state intact across the swap.

### Kiosk mode (`--kiosk` + runtime toggle button + `--mode`)
Two new server CLI flags:
- `--kiosk` gates the cursor auto-hide and the idle settings reset. Without the flag, neither feature runs (developers don't fight an auto-hiding cursor or have their tweaks reverted while they think).
- `--mode {graph,video}` selects the initial display mode at startup. Validated server-side with a clear error on bad values.

Both flags are surfaced via `/api/server-info` so the client picks them up on init.

A **kiosk toggle button** lives in the operator strip of the Advanced drawer (next to mode/pause). It flips the runtime kiosk state without restarting the server, so the operator can preview kiosk on a dev workstation. Toggling on arms both timers immediately; toggling off clears them and brings the cursor back so there's no half-applied state. MIDI-learnable via the existing `data-midi-learn` machinery.

Internally, `bumpIdleTimer()` and `showCursor()` now early-out on a runtime `kioskActive` flag, so listeners are always attached but the behavior is gated.

## Test plan

- [x] `pytest tests/unit/` — clean.
- [x] `--mode bogus` rejected at startup with a clear error.
- [x] `/api/server-info` returns `kiosk` and `default_mode` correctly under various flag combinations.
- [ ] Browser smoke: load demo without `--kiosk`, confirm cursor never hides and sliders don't reset. Click the kiosk toggle, confirm both behaviors arm. Toggle off, confirm both stop and cursor reappears.
- [ ] Browser smoke: load demo with `--mode video`, confirm app starts in video mode and the toggle button shows `VIDEO`.
- [ ] Mid-session source swap: switch fixture mid-playback, confirm `swap_ready` arrives and the new source plays without reconnect.
- [ ] `--accel eager` boots without any TRT engine on disk.
