### PR TITLE
trt: 120s engine profile + existence-aware picker

### DIFF
--- a/acestep/engine/trt/build.py
+++ b/acestep/engine/trt/build.py
@@ -9,11 +9,15 @@ directory.  Existing ONNX files are auto-detected and reused; the model is
 only loaded when an ONNX export is actually needed.
 
 Usage:
-    # Build all engines (60s + 240s, VAE + decoder, refit + non-refit):
+    # Build the canonical engine matrix (60s + 120s + 240s, VAE + decoder,
+    # refit + non-refit). Matches acestep.paths._TRT_ENGINE_PROFILES.
     python -m acestep.engine.trt.build --all
 
-    # Build 60s engines only:
-    python -m acestep.engine.trt.build --all --duration 60
+    # Build a single duration (e.g. just 120s):
+    python -m acestep.engine.trt.build --all --duration 120
+
+    # Build a custom subset:
+    python -m acestep.engine.trt.build --all --duration 60 240
 
     # Build only decoders (skip VAE):
     python -m acestep.engine.trt.build --all --decoder-only
@@ -512,7 +516,8 @@ def main():
                             "refit + non-refit, across durations)")
     batch.add_argument("--duration", nargs="*", type=int, default=None,
                        help="Duration(s) in seconds for --all mode "
-                            "(default: 60 240)")
+                            "(default: 60 120 240 — the canonical profile set "
+                            "registered in acestep.paths._TRT_ENGINE_PROFILES)")
     batch.add_argument("--force-rebuild", action="store_true",
                        help="Rebuild engines even if they already exist "
                             "(default: skip existing engines)")
@@ -572,7 +577,7 @@ def main():
 
 def _run_all(args, project_root, onnx_dir):
     """Build the full engine matrix."""
-    durations = tuple(args.duration) if args.duration else (240,)
+    durations = tuple(args.duration) if args.duration else (60, 120, 240)
     build_vae = not args.decoder_only
     build_decoder = not args.vae_only
 

--- a/acestep/paths.py
+++ b/acestep/paths.py
@@ -71,11 +71,25 @@ def trt_engine_path(engine_name: str) -> Path:
     return trt_engines_dir() / engine_name / f"{engine_name}.engine"
 
 
+# Canonical engine profiles. Key is the maximum audio duration in seconds
+# the engine context will accept. Engines are named by duration so the
+# build script (`acestep.engine.trt.build --all --duration N`) can drive
+# both halves from a single integer.
+#
+# Larger profiles reserve more workspace at TRT context-creation time and
+# sit on more VRAM regardless of the actual input — see
+# tests/benchmarks/vram_60s_vs_240s_results.md. Pick the smallest profile
+# that fits the audio (see `select_trt_engines` and `available_trt_engines`).
 _TRT_ENGINE_PROFILES: dict[float, dict[str, str]] = {
     60.0: {
         "decoder": "decoder_mixed_refit_b8_60s",
         "vae_encode": "vae_encode_fp16_60s",
         "vae_decode": "vae_decode_fp16_60s",
+    },
+    120.0: {
+        "decoder": "decoder_mixed_refit_b8_120s",
+        "vae_encode": "vae_encode_fp16_120s",
+        "vae_decode": "vae_decode_fp16_120s",
     },
     240.0: {
         "decoder": "decoder_mixed_refit_b8_240s",
@@ -83,6 +97,8 @@ _TRT_ENGINE_PROFILES: dict[float, dict[str, str]] = {
         "vae_decode": "vae_decode_fp16_240s",
     },
 }
+
+_DEFAULT_TRT_NEEDS: tuple[str, ...] = ("decoder", "vae_encode", "vae_decode")
 
 
 def default_trt_engines(
@@ -109,26 +125,115 @@ def default_trt_engines(
 
 
 def select_trt_engines(duration_s: float = 60.0) -> dict[str, str]:
-    """Pick the smallest engine set that can handle ``duration_s`` of audio.
+    """Pick the smallest engine profile that can handle ``duration_s``.
 
-    The 240s engines reserve workspace sized for their max profile at TRT
-    context-creation time, so they sit on ~9 GB more VRAM than the 60s
-    engines even when fed identical 60-second input (decoder +2.4 GB,
-    vae_encode +6.4 GB, vae_decode +0.3 GB; see
-    ``tests/benchmarks/vram_60s_vs_240s_results.md``).
-
-    Default to the 60s set; only escalate to 240s when the requested
-    duration would exceed the 60s engines' max profile (1500 latent
-    frames at 25 fps).
+    Pure: returns paths without checking the filesystem. Use
+    :func:`available_trt_engines` when you want existence-aware picking
+    that falls back to the next-larger profile if the smallest fitting
+    one isn't built. If ``duration_s`` exceeds every registered profile,
+    the largest profile is returned (the caller then fails at engine
+    load with a TRT-side error, same as before).
 
     Args:
         duration_s: Generation duration in seconds.
 
     Returns:
-        Dict suitable for passing to ``Session(trt_engines=...)``.
+        Dict with ``decoder`` / ``vae_encode`` / ``vae_decode`` keys
+        mapping to absolute engine file paths as strings.
     """
-    profile = _TRT_ENGINE_PROFILES[60.0] if duration_s <= 60.0 else _TRT_ENGINE_PROFILES[240.0]
-    return default_trt_engines(**profile)
+    for max_dur in sorted(_TRT_ENGINE_PROFILES.keys()):
+        if max_dur >= duration_s:
+            return default_trt_engines(**_TRT_ENGINE_PROFILES[max_dur])
+    largest = max(_TRT_ENGINE_PROFILES.keys())
+    return default_trt_engines(**_TRT_ENGINE_PROFILES[largest])
+
+
+class EngineNotBuiltError(RuntimeError):
+    """Raised when no built TRT engine profile satisfies a request.
+
+    Carries enough context for callers (the demo server, primarily) to
+    surface an actionable error to the operator: which duration was
+    asked for, which engine keys were needed, what was checked, and the
+    exact build command that would fix it.
+    """
+
+    def __init__(
+        self,
+        duration_s: float,
+        needs: tuple[str, ...],
+        missing: dict[float, list[str]],
+    ) -> None:
+        self.duration_s = float(duration_s)
+        self.needs = tuple(needs)
+        # Map of profile_max_dur -> list of missing engine paths for that
+        # profile. Empty if no profile could even fit the duration.
+        self.missing = dict(missing)
+
+        fitting = sorted(d for d in _TRT_ENGINE_PROFILES if d >= duration_s)
+        if fitting:
+            recommended = int(fitting[0])
+            self.build_command = (
+                f"python -m acestep.engine.trt.build --all --duration {recommended}"
+            )
+            msg = (
+                f"No TRT engine profile is built that can handle "
+                f"{self.duration_s:.1f}s of audio. To build the smallest "
+                f"fitting profile, run: {self.build_command}"
+            )
+        else:
+            largest = max(_TRT_ENGINE_PROFILES.keys())
+            self.build_command = None
+            msg = (
+                f"Audio duration {self.duration_s:.1f}s exceeds the largest "
+                f"registered profile ({largest:.0f}s). Either use shorter "
+                f"audio or add a larger profile to acestep/paths.py and "
+                f"build it."
+            )
+        super().__init__(msg)
+
+
+def available_trt_engines(
+    duration_s: float = 60.0,
+    *,
+    needs: tuple[str, ...] = _DEFAULT_TRT_NEEDS,
+) -> tuple[dict[str, str], float]:
+    """Pick the smallest profile that fits ``duration_s`` AND is built.
+
+    Walks profiles in ascending order. Returns the first one whose
+    requested ``needs`` keys all exist on disk. Falls back to the
+    next-larger profile (with the VRAM cost that implies) when the
+    smallest fitting profile isn't built.
+
+    Args:
+        duration_s: Audio duration the engines must handle.
+        needs: Which engine keys must be present on disk. Pass only the
+            keys the caller will actually use; for a mixed-backend
+            session that runs only the decoder on TRT, pass
+            ``("decoder",)`` so missing VAE engines don't disqualify
+            an otherwise-usable profile.
+
+    Returns:
+        ``(paths, max_dur)`` — ``paths`` is the dict of engine paths
+        (with all keys, not just ``needs``), ``max_dur`` is the chosen
+        profile's max duration. Caller can compare ``max_dur`` against
+        ``duration_s`` to decide whether to log a "using larger profile"
+        warning.
+
+    Raises:
+        EngineNotBuiltError: No profile can handle ``duration_s`` with
+            the requested ``needs`` keys present on disk.
+    """
+    missing: dict[float, list[str]] = {}
+    for max_dur in sorted(_TRT_ENGINE_PROFILES.keys()):
+        if max_dur < duration_s:
+            continue
+        profile = _TRT_ENGINE_PROFILES[max_dur]
+        paths = default_trt_engines(**profile)
+        absent = [paths[k] for k in needs if not Path(paths[k]).exists()]
+        if not absent:
+            return paths, max_dur
+        missing[max_dur] = absent
+    raise EngineNotBuiltError(duration_s=duration_s, needs=needs, missing=missing)
 
 
 def project_root() -> Path:

--- a/demos/realtime_motion_graph/server.py
+++ b/demos/realtime_motion_graph/server.py
@@ -35,7 +35,11 @@ from acestep.constants import TASK_INSTRUCTIONS
 from acestep.engine.session import Session
 from acestep.nodes.types import Audio
 from acestep.paths import (
-    checkpoints_dir, loras_dir, select_trt_engines, trt_engine_path,
+    EngineNotBuiltError,
+    available_trt_engines,
+    checkpoints_dir,
+    loras_dir,
+    trt_engine_path,
 )
 
 from .client.audio_engine import AudioEngine
@@ -176,9 +180,49 @@ def handle_client(ws, *, decoder_backend: str = "tensorrt", vae_backend: str = "
     audio_duration_s = waveform.shape[1] / SAMPLE_RATE
     use_trt = decoder_backend == "tensorrt" or vae_backend == "tensorrt"
     if use_trt:
-        trt_engines = select_trt_engines(duration_s=audio_duration_s)
+        # Tell the picker exactly which engines this session will use, so a
+        # mixed-backend setup (e.g. tensorrt decoder + eager VAE) doesn't
+        # disqualify an otherwise-usable profile because of missing VAE
+        # engines we wouldn't load anyway.
+        needs: list[str] = []
+        if decoder_backend == "tensorrt":
+            needs.append("decoder")
+        if vae_backend == "tensorrt":
+            needs.extend(["vae_encode", "vae_decode"])
+        try:
+            trt_engines, picked_dur = available_trt_engines(
+                duration_s=audio_duration_s, needs=tuple(needs),
+            )
+        except EngineNotBuiltError as exc:
+            # Surface to the operator (server log) AND the client UI.
+            # WebSocket close reason is capped at 123 bytes by the
+            # protocol, so the build command goes in a JSON message
+            # first and the close reason carries a short summary.
+            print(f"[Server] {exc}")
+            try:
+                ws.send(json.dumps({
+                    "type": "error",
+                    "code": "engine_not_built",
+                    "message": str(exc),
+                    "build_command": exc.build_command,
+                    "duration_s": exc.duration_s,
+                }))
+            except Exception:
+                pass
+            ws.close(1011, "TRT engine not built")
+            return
+        if picked_dur > audio_duration_s and picked_dur > 60.0:
+            # Fell back to a larger profile than strictly needed. Worth
+            # logging because the larger profile reserves noticeably more
+            # VRAM at TRT context-creation time.
+            print(
+                f"[Server] WARNING: using {picked_dur:.0f}s engine for "
+                f"{audio_duration_s:.1f}s audio (fallback; smaller profile "
+                f"not built — extra VRAM cost)"
+            )
+        # Prune unused keys for the same reason as before:
         # validate_backends() rejects engine entries whose backend isn't
-        # tensorrt, so prune the unused half on mixed-backend setups.
+        # tensorrt.
         if decoder_backend != "tensorrt":
             trt_engines.pop("decoder", None)
         if vae_backend != "tensorrt":
@@ -187,8 +231,11 @@ def handle_client(ws, *, decoder_backend: str = "tensorrt", vae_backend: str = "
     else:
         trt_engines = None
     if fast_vae and vae_backend == "tensorrt":
-        # fast_vae uses the dreamvae distilled decoder; profile must match.
-        fast_name = "dreamvae_decode_fp16_60s" if audio_duration_s <= 60.0 else "dreamvae_decode_fp16_240s"
+        # fast_vae uses the dreamvae distilled decoder; profile must match
+        # the same duration we picked above. dreamvae engines aren't in
+        # _TRT_ENGINE_PROFILES (different decoder weights), so we resolve
+        # the path by name and check existence directly.
+        fast_name = f"dreamvae_decode_fp16_{int(picked_dur)}s"
         if Path(str(trt_engine_path(fast_name))).exists():
             trt_engines["vae_decode"] = str(trt_engine_path(fast_name))
         else:

--- a/demos/realtime_motion_graph_web/static/protocol.js
+++ b/demos/realtime_motion_graph_web/static/protocol.js
@@ -119,6 +119,14 @@ export class RemoteBackend extends EventTarget {
           // Expect JSON {"type":"ready",...}
           try {
             const msg = JSON.parse(ev.data);
+            if (msg.type === "error") {
+              // Server reported a structured init failure (e.g. no TRT
+              // engine built for this audio duration). Use its full
+              // human-readable message so the connection-failed banner
+              // tells the operator what to do next, not just "closed".
+              reject(new Error(msg.message || `Server error: ${msg.code || "unknown"}`));
+              return;
+            }
             if (msg.type !== "ready") {
               reject(new Error(`Unexpected init message: ${ev.data}`));
               return;

--- a/tests/unit/test_engine_profiles.py
+++ b/tests/unit/test_engine_profiles.py
@@ -1,0 +1,171 @@
+"""Tests for the multi-profile TRT engine picker.
+
+Covers:
+- ``select_trt_engines`` (pure: smallest-that-fits, no IO)
+- ``available_trt_engines`` (existence-aware: smallest fitting profile
+  whose required engines are on disk, falls back to next-larger)
+- ``EngineNotBuiltError`` (carries the build command for the smallest
+  fitting profile)
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from acestep.paths import (
+    EngineNotBuiltError,
+    _TRT_ENGINE_PROFILES,
+    available_trt_engines,
+    select_trt_engines,
+    trt_engine_path,
+)
+
+
+@pytest.fixture
+def tmp_models_dir(monkeypatch, tmp_path):
+    """Point ACESTEP_MODELS_DIR at a clean tmp dir so tests can create
+    engine files without touching the real cache."""
+    monkeypatch.setenv("ACESTEP_MODELS_DIR", str(tmp_path))
+    (tmp_path / "trt_engines").mkdir()
+    return tmp_path
+
+
+def _create_engine_files(tmp_path: Path, max_dur: float, keys: tuple[str, ...]) -> None:
+    """Create empty engine files for one profile so existence checks pass."""
+    profile = _TRT_ENGINE_PROFILES[max_dur]
+    for k in keys:
+        engine_name = profile[k]
+        engine_path = trt_engine_path(engine_name)
+        engine_path.parent.mkdir(parents=True, exist_ok=True)
+        engine_path.write_bytes(b"")
+
+
+# -----------------------------------------------------------------------
+# select_trt_engines: pure picker (no IO)
+# -----------------------------------------------------------------------
+
+class TestSelectTrtEngines:
+    def test_picks_60s_for_short_audio(self):
+        paths = select_trt_engines(duration_s=30.0)
+        assert "_60s" in paths["decoder"]
+        assert "_60s" in paths["vae_encode"]
+        assert "_60s" in paths["vae_decode"]
+
+    def test_picks_60s_at_exact_60s_boundary(self):
+        paths = select_trt_engines(duration_s=60.0)
+        assert "_60s" in paths["decoder"]
+
+    def test_picks_120s_just_over_60s(self):
+        paths = select_trt_engines(duration_s=60.001)
+        assert "_120s" in paths["decoder"]
+
+    def test_picks_120s_at_exact_120s_boundary(self):
+        paths = select_trt_engines(duration_s=120.0)
+        assert "_120s" in paths["decoder"]
+
+    def test_picks_240s_just_over_120s(self):
+        paths = select_trt_engines(duration_s=120.001)
+        assert "_240s" in paths["decoder"]
+
+    def test_picks_240s_for_audio_within_240s(self):
+        paths = select_trt_engines(duration_s=200.0)
+        assert "_240s" in paths["decoder"]
+
+    def test_falls_back_to_largest_when_audio_exceeds_all_profiles(self):
+        """Pure picker has no other option; the largest profile is the
+        last reasonable thing to return. Caller will fail at engine load."""
+        paths = select_trt_engines(duration_s=10_000.0)
+        assert "_240s" in paths["decoder"]
+
+
+# -----------------------------------------------------------------------
+# available_trt_engines: existence-aware picker (IO)
+# -----------------------------------------------------------------------
+
+class TestAvailableTrtEnginesHappyPath:
+    def test_picks_smallest_when_all_built(self, tmp_models_dir):
+        # Build all three profiles; 30s audio should land on 60s.
+        for d in (60.0, 120.0, 240.0):
+            _create_engine_files(tmp_models_dir, d, keys=("decoder", "vae_encode", "vae_decode"))
+        paths, picked = available_trt_engines(duration_s=30.0)
+        assert picked == 60.0
+        assert "_60s" in paths["decoder"]
+
+    def test_returns_picked_duration(self, tmp_models_dir):
+        for d in (60.0, 120.0, 240.0):
+            _create_engine_files(tmp_models_dir, d, keys=("decoder", "vae_encode", "vae_decode"))
+        _, picked = available_trt_engines(duration_s=119.0)
+        assert picked == 120.0
+
+
+class TestAvailableTrtEnginesFallback:
+    def test_falls_back_to_240s_when_60s_missing(self, tmp_models_dir):
+        # 30s audio normally picks 60s, but only 240s is built.
+        _create_engine_files(tmp_models_dir, 240.0, keys=("decoder", "vae_encode", "vae_decode"))
+        paths, picked = available_trt_engines(duration_s=30.0)
+        assert picked == 240.0
+        assert "_240s" in paths["decoder"]
+
+    def test_falls_back_to_240s_when_120s_missing(self, tmp_models_dir):
+        # 80s audio normally picks 120s, but only 240s is built.
+        _create_engine_files(tmp_models_dir, 240.0, keys=("decoder", "vae_encode", "vae_decode"))
+        paths, picked = available_trt_engines(duration_s=80.0)
+        assert picked == 240.0
+
+    def test_does_not_pick_smaller_than_needed(self, tmp_models_dir):
+        # 80s audio cannot use the 60s engine even if it's the only one built.
+        _create_engine_files(tmp_models_dir, 60.0, keys=("decoder", "vae_encode", "vae_decode"))
+        with pytest.raises(EngineNotBuiltError):
+            available_trt_engines(duration_s=80.0)
+
+
+class TestAvailableTrtEnginesNeedsParameter:
+    def test_decoder_only_session_does_not_require_vae_engines(self, tmp_models_dir):
+        # Mixed-backend setup (TRT decoder, eager VAE) only needs the
+        # decoder engine — missing VAE engines should not disqualify.
+        _create_engine_files(tmp_models_dir, 60.0, keys=("decoder",))
+        paths, picked = available_trt_engines(
+            duration_s=30.0, needs=("decoder",),
+        )
+        assert picked == 60.0
+        assert "_60s" in paths["decoder"]
+
+    def test_vae_only_session_does_not_require_decoder_engine(self, tmp_models_dir):
+        _create_engine_files(tmp_models_dir, 60.0, keys=("vae_encode", "vae_decode"))
+        paths, picked = available_trt_engines(
+            duration_s=30.0, needs=("vae_encode", "vae_decode"),
+        )
+        assert picked == 60.0
+
+
+# -----------------------------------------------------------------------
+# EngineNotBuiltError: actionable build command
+# -----------------------------------------------------------------------
+
+class TestEngineNotBuiltError:
+    def test_recommends_smallest_fitting_profile(self, tmp_models_dir):
+        # Nothing built; 30s audio fits in the 60s profile.
+        with pytest.raises(EngineNotBuiltError) as excinfo:
+            available_trt_engines(duration_s=30.0)
+        assert excinfo.value.build_command is not None
+        assert "--duration 60" in excinfo.value.build_command
+
+    def test_recommends_120s_for_audio_in_that_range(self, tmp_models_dir):
+        with pytest.raises(EngineNotBuiltError) as excinfo:
+            available_trt_engines(duration_s=80.0)
+        assert "--duration 120" in excinfo.value.build_command
+
+    def test_no_build_command_when_audio_exceeds_all_profiles(self, tmp_models_dir):
+        with pytest.raises(EngineNotBuiltError) as excinfo:
+            available_trt_engines(duration_s=10_000.0)
+        assert excinfo.value.build_command is None
+        assert "exceeds" in str(excinfo.value).lower()
+
+    def test_carries_duration_and_needs(self, tmp_models_dir):
+        with pytest.raises(EngineNotBuiltError) as excinfo:
+            available_trt_engines(duration_s=80.0, needs=("decoder",))
+        assert excinfo.value.duration_s == 80.0
+        assert excinfo.value.needs == ("decoder",)


### PR DESCRIPTION
## Summary

Audio between 60s and 120s currently jumps to the 240s engine profile, which reserves ~9 GB more VRAM at TRT context-creation time than the 60s engines, even when fed shorter input. Adds a 120s entry to the canonical engine matrix and makes the picker existence-aware so it can fall back to a larger profile when the smallest fitting one isn't built — and surface a clear, actionable error when nothing fits.

## What changes for the operator

- A 60–120s clip can now load on a 120s engine (smaller VRAM footprint than 240s).
- If the smallest fitting profile isn't built, the demo falls back to the next-larger one with a stdout warning about the VRAM cost. No silent crash.
- If no profile fits or none of the candidates are built, the WebSocket sends a structured error message carrying the exact `python -m acestep.engine.trt.build --all --duration N` command for the smallest profile that *would* fit. The browser shows it in the connection-failed banner instead of a "WebSocket closed" mystery.
- `python -m acestep.engine.trt.build --all` now builds the canonical `(60, 120, 240)` set by default. Old behavior was 240 only. Override with `--duration 60` (or any subset) for a faster targeted build.

## Code changes

- **`acestep/paths.py`**
  - Add `120.0` entry to `_TRT_ENGINE_PROFILES`.
  - Generalise `select_trt_engines` to walk profiles ascending. Still pure / no IO — kept for tests, workflows, and scripts that want deterministic behavior.
  - New `EngineNotBuiltError` carrying `duration_s`, `needs`, missing engine paths, and the recommended build command for the smallest fitting profile.
  - New `available_trt_engines(duration_s, *, needs=...)` — existence-aware picker with fallback. The `needs` parameter lets a mixed-backend session (TRT decoder + eager VAE) avoid being disqualified by missing VAE engines it wouldn't load anyway.
- **`acestep/engine/trt/build.py`** — `--all` default bumped from `(240,)` to `(60, 120, 240)`; docstring and `--duration` help reflect the canonical matrix.
- **`demos/realtime_motion_graph/server.py`** — uses `available_trt_engines` with `needs` derived from active backends. Catches `EngineNotBuiltError`, ships the message over the WebSocket, then closes with a short reason. `fast_vae` now resolves `dreamvae_decode_fp16_<picked_dur>s` instead of its own 60/240 split, so it tracks whichever profile we landed on.
- **`demos/realtime_motion_graph_web/static/protocol.js`** — recognises `type:"error"` during the init phase so the structured message reaches the connection-failed banner via the existing `reject(new Error(msg.message))` path.

## Test plan

- [x] `pytest tests/unit/` — 49/49 pass (18 new in `test_engine_profiles.py`):
  - Pure picker boundaries (≤60 / 60.001 / ≤120 / 120.001 / ≤240 / >240).
  - Existence-aware fallback (only-240s-built picks 240s for 30s audio).
  - `needs` parameter (decoder-only and vae-only sessions).
  - `EngineNotBuiltError` recommends the smallest fitting profile, omits the build command when the audio exceeds every registered profile.
- [ ] Browser smoke with no 120s engine built and a 90s clip: confirm fallback to 240s and the warning in the server log.
- [ ] Browser smoke with no engines built at all: confirm the connection-failed banner shows the build command.
- [ ] Build the 120s engines (`python -m acestep.engine.trt.build --all --duration 120`) and load an 80s clip: confirm the 120s engines are picked and the session loads.

## Follow-ups

- Benchmark the actual 120s VRAM footprint (the docstring numbers are extrapolated from the 60s/240s benchmark).
- Vendor or document the `dreamvae_decode_fp16_120s` engine so `fast_vae` covers the 120s profile too.
