### PR TITLE
lora: unify backend across TRT and PyTorch decoders

### DIFF
--- a/acestep/engine/diffusion.py
+++ b/acestep/engine/diffusion.py
@@ -93,12 +93,16 @@ class DiffusionEngine:
         self._trt_stream = None
         self._trt_buf_cache: dict[tuple, dict] = {}
 
-        # Dynamic LoRA via TRT weight refitting (initialized in load_trt_engine
-        # when the engine supports REFIT).
+        # Dynamic LoRA manager. TRT path constructs TRTLoRAManager inside
+        # load_trt_engine (after the engine is up and refit support is
+        # confirmed). Eager path constructs EagerLoRAManager up-front so
+        # the LoRA library is usable from tick 0 with no prerequisites.
         self._lora_manager = None
 
         if trt_engine_path is not None:
             self.load_trt_engine(trt_engine_path)
+        else:
+            self._init_eager_lora_manager()
 
     # ------------------------------------------------------------------
     # TRT engine management
@@ -165,7 +169,7 @@ class DiffusionEngine:
             # Pre-register the on-disk library (MODELS_DIR/loras).  This
             # is the catalog backing the "infinite library" workflow:
             # register every .safetensors as REGISTERED (zero RAM cost),
-            # callers materialize on demand via enable_trt_lora.
+            # callers materialize on demand via enable_lora.
             try:
                 self._lora_manager.register_library()
             except Exception as e:
@@ -177,115 +181,112 @@ class DiffusionEngine:
             logger.warning("Failed to init TRT LoRA manager: %s", e)
 
     # ------------------------------------------------------------------
-    # TRT LoRA management (delegates to TRTLoRAManager)
+    # LoRA management (backend-agnostic)
+    #
+    # Delegates to the active manager (TRTLoRAManager when a TRT engine
+    # is loaded with REFIT support, EagerLoRAManager otherwise). All
+    # public methods here are stable across backends; the manager
+    # subclass differs only in *where* the weight writeback lands.
     # ------------------------------------------------------------------
 
-    def apply_trt_lora(self, lora_path: str, strength: float = 1.0) -> int:
-        """Apply a LoRA to the TRT engine via weight refitting.
+    def _init_eager_lora_manager(self) -> None:
+        """Construct an EagerLoRAManager around the live decoder.
 
-        Args:
-            lora_path: Path to .safetensors LoRA file.
-            strength: LoRA strength (0.0 = no effect, 1.0 = full).
+        Skipped silently when the decoder has no parameters (e.g. the
+        skip_decoder TRT path before load_trt_engine has run, or a
+        pure-VAE/text-encoder ModelContext).
+        """
+        from acestep.engine.lora import EagerLoRAManager
 
-        Returns:
-            LoRA ID for later removal or strength adjustment.
+        try:
+            self._lora_manager = EagerLoRAManager(decoder=self.decoder)
+        except (RuntimeError, ValueError) as e:
+            logger.info("Eager LoRA manager not available: %s", e)
+            self._lora_manager = None
+            return
+
+        try:
+            self._lora_manager.register_library()
+        except Exception as e:
+            logger.warning("Failed to scan LoRA library: %s", e)
+
+    def apply_lora(self, lora_path: str, strength: float = 1.0) -> str:
+        """Register + enable a LoRA in one call. Returns the LoRA id.
 
         Raises:
-            RuntimeError: If TRT engine doesn't support refit.
+            RuntimeError: If no LoRA backend is available.
         """
-        if self._lora_manager is None:
-            raise RuntimeError(
-                "TRT LoRA refit not available. Rebuild the decoder engine "
-                "with refit=True (OnnxExportConfig.for_refit=True + "
-                "TRTBuildConfig.refit=True)."
-            )
+        self._require_lora_manager()
         return self._lora_manager.apply_lora(lora_path, strength)
 
-    def remove_trt_lora(self, lora_id: int = -1) -> bool:
-        """Remove a LoRA from the TRT engine. Default: most recent."""
+    def remove_lora(self, lora_id=-1) -> bool:
+        """Remove a LoRA (default: most recently registered)."""
         if self._lora_manager is None:
             return False
         return self._lora_manager.remove_lora(lora_id)
 
-    def set_trt_lora_strength(self, lora_id: int, strength: float) -> None:
-        """Adjust strength of an active TRT LoRA."""
-        if self._lora_manager is None:
-            raise RuntimeError("TRT LoRA refit not available")
+    def set_lora_strength(self, lora_id: str, strength: float) -> None:
+        """Adjust the strength of an ENABLED LoRA."""
+        self._require_lora_manager()
         self._lora_manager.set_lora_strength(lora_id, strength)
 
-    def remove_all_trt_loras(self) -> None:
-        """Remove all LoRAs and restore the TRT engine to base weights."""
+    def remove_all_loras(self) -> None:
+        """Remove all LoRAs and restore the decoder to base weights."""
         if self._lora_manager is not None:
             self._lora_manager.remove_all()
 
-    # ------------------------------------------------------------------
-    # Lifecycle API: register / enable / disable / prewarm
-    # ------------------------------------------------------------------
-
-    def register_trt_lora(self, lora_path: str, name: str | None = None) -> str:
-        """Add a LoRA to the catalog without materializing deltas.
-
-        Returns the (filename-stem) id used for subsequent enable/disable
-        calls.  Idempotent on path.
-        """
-        if self._lora_manager is None:
-            raise RuntimeError("TRT LoRA refit not available")
+    def register_lora(self, lora_path: str, name: str | None = None) -> str:
+        """Add a LoRA to the catalog without materializing deltas."""
+        self._require_lora_manager()
         return self._lora_manager.register_lora(lora_path, name=name)
 
-    def enable_trt_lora(
+    def enable_lora(
         self, lora_id: str, strength: float | None = None,
     ) -> None:
         """Promote a registered LoRA to ENABLED (materialize + refit).
 
         ``strength``, when provided, sets the entry's strength BEFORE the
-        refit so the streaming pipeline's first decode window already
-        sees the LoRA at its target strength — avoids the "first ~5s
-        sounds like the LoRA is missing" glitch caused by enabling at
-        strength 0 and waiting for the next per-tick set_strength call
-        to ramp it up.
-
-        Synchronous; if a prewarm is in flight, blocks on it.  Refit only
-        fires when the resulting strength is non-zero.
+        refit so the first decode window already sees the LoRA at its
+        target strength — avoids the "first ~5s sounds like the LoRA is
+        missing" glitch caused by enabling at strength 0 and waiting for
+        the next per-tick set_strength call to ramp it up.
         """
-        if self._lora_manager is None:
-            raise RuntimeError("TRT LoRA refit not available")
+        self._require_lora_manager()
         self._lora_manager.enable_lora(lora_id, strength=strength)
 
-    def disable_trt_lora(self, lora_id: str) -> None:
-        """Drop a LoRA's deltas from CPU RAM.  Strength is preserved."""
-        if self._lora_manager is None:
-            raise RuntimeError("TRT LoRA refit not available")
+    def disable_lora(self, lora_id: str) -> None:
+        """Drop a LoRA's deltas. Strength is preserved on the entry."""
+        self._require_lora_manager()
         self._lora_manager.disable_lora(lora_id)
 
-    def prewarm_trt_lora(self, lora_id: str):
-        """Kick off background materialization.  Returns a Future.
-
-        Use this when the catalog is large but only some LoRAs will
-        actually be enabled — call ``prewarm_trt_lora`` for the
-        likely-enabled subset at session start so the eventual
-        ``enable_trt_lora`` call is fast.
-        """
-        if self._lora_manager is None:
-            raise RuntimeError("TRT LoRA refit not available")
+    def prewarm_lora(self, lora_id: str):
+        """Kick off background delta materialization. Returns a Future."""
+        self._require_lora_manager()
         return self._lora_manager.prewarm_lora(lora_id)
 
-    def list_trt_loras(self):
-        """Return a list of :class:`LoRADescriptor` for every entry in
-        the catalog.  Empty list if the manager is unavailable."""
+    def list_loras(self):
+        """Return descriptors for every entry. Empty list when no manager."""
         if self._lora_manager is None:
             return []
         return self._lora_manager.list_loras()
 
-    def get_trt_lora(self, lora_id: str):
-        """Return the current :class:`LoRADescriptor` for ``lora_id``."""
-        if self._lora_manager is None:
-            raise RuntimeError("TRT LoRA refit not available")
+    def get_lora(self, lora_id: str):
+        """Return the current descriptor for ``lora_id``."""
+        self._require_lora_manager()
         return self._lora_manager.get_lora(lora_id)
 
     @property
-    def trt_lora_available(self) -> bool:
-        """True if the TRT engine supports dynamic LoRA via refit."""
+    def lora_available(self) -> bool:
+        """True if a LoRA backend is initialized for this engine."""
         return self._lora_manager is not None
+
+    def _require_lora_manager(self) -> None:
+        if self._lora_manager is None:
+            raise RuntimeError(
+                "LoRA manager not available. For the TRT path, rebuild "
+                "the decoder engine with refit=True. For the PyTorch "
+                "path, the decoder must have parameters loaded."
+            )
 
     def _trt_decoder_step(
         self,

--- a/acestep/engine/lora.py
+++ b/acestep/engine/lora.py
@@ -1,0 +1,689 @@
+"""Backend-agnostic LoRA manager.
+
+Owns the catalog, lifecycle (REGISTERED -> MATERIALIZING -> MATERIALIZED
+-> ENABLED), background prewarm, and delta math (B @ A) for dynamic LoRA
+application. Subclasses plug in *where the live weights live*: a TRT
+engine via IRefitter, or a PyTorch decoder's parameters directly.
+
+Library:
+  ``register_library(directory)`` discovers ``*.safetensors`` in a flat
+  directory and registers each as a REGISTERED entry whose id is the
+  filename stem. The catalog backs an "infinite library" workflow where
+  hundreds of LoRAs cost nothing until enabled.
+
+Threading:
+  - register / enable / disable / set_strength / refit run on the
+    inference-owning thread; refit and inference are mutually exclusive.
+  - prewarm runs on a background ThreadPoolExecutor; the worker only
+    fills the entry's deltas dict and never touches the engine.
+"""
+
+from __future__ import annotations
+
+import abc
+import concurrent.futures
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from loguru import logger
+import torch
+from safetensors.torch import load_file
+
+
+class LoRAState(Enum):
+    REGISTERED = "registered"
+    MATERIALIZING = "materializing"
+    MATERIALIZED = "materialized"
+    ENABLED = "enabled"
+
+
+@dataclass
+class LoRADescriptor:
+    """Read-only public view of a LoRA in the library."""
+    id: str
+    path: str
+    name: str
+    state: str
+    strength: float
+    materialized_bytes: int
+
+
+@dataclass
+class _LoRAEntry:
+    """Internal mutable state for one library entry.
+
+    ``strength`` is preserved across enable/disable cycles so flipping a
+    UI toggle off and back on doesn't reset the slider.
+    """
+    lora_id: str
+    path: str
+    name: str = ""
+    state: LoRAState = LoRAState.REGISTERED
+    strength: float = 0.0
+    deltas: Optional[Dict[str, torch.Tensor]] = None
+    future: Optional[concurrent.futures.Future] = None
+    materialized_bytes: int = 0
+
+
+class LoRAManagerBase(abc.ABC):
+    """Catalog + lifecycle + delta math; subclasses do the engine writeback.
+
+    Subclasses must:
+
+    - Populate ``self._base_weights`` (dict: param_name -> CPU/GPU tensor in
+      the live weight's native dtype) and ``self._param_dtype`` (dict:
+      param_name -> torch.dtype) during __init__, then call
+      ``super().__init__()`` to set up the lifecycle bookkeeping.
+    - Implement :meth:`_apply_to_engine`, which writes
+      ``base + sum_over_enabled(strength * delta)`` to the live weights
+      for the supplied ``param_names``.
+
+    Param naming is decoder-relative (matches ``decoder.named_parameters()``).
+    The TRT subclass adds the ``decoder.`` prefix only at the refitter
+    boundary.
+    """
+
+    def __init__(self) -> None:
+        # Subclasses set _base_weights and _param_dtype before super().__init__.
+        if not hasattr(self, "_base_weights"):
+            self._base_weights: Dict[str, torch.Tensor] = {}
+        if not hasattr(self, "_param_dtype"):
+            self._param_dtype: Dict[str, torch.dtype] = {}
+
+        # Library + lifecycle state.  Insertion order is preserved so
+        # ``remove_lora(-1)`` can pop the most-recently-registered entry,
+        # matching the legacy stack-style API.
+        self._loras: Dict[str, _LoRAEntry] = {}
+        self._ever_dirty: Set[str] = set()
+        self._executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+
+    # ------------------------------------------------------------------
+    # Subclass hook
+    # ------------------------------------------------------------------
+
+    @abc.abstractmethod
+    def _apply_to_engine(self, param_names: Set[str]) -> None:
+        """Write ``base + Σ strength·delta`` to the live weights.
+
+        ``param_names`` is the set of decoder-relative param names that
+        need updating. Subclasses iterate, accumulate enabled-LoRA
+        contributions in a buffer, and push to the live weights.
+        """
+
+    # ------------------------------------------------------------------
+    # Lifecycle transition hooks (default: no-ops)
+    #
+    # The base lifecycle (enable_lora / disable_lora) calls these around
+    # state transitions so subclasses can attach side effects without
+    # overriding the lifecycle proper. The motivating case is the eager
+    # backend's "promote materialized deltas to GPU on enable, drop the
+    # GPU mirror on disable" pattern: deltas live cheaply in CPU RAM
+    # while merely MATERIALIZED, but the active set lives in VRAM so
+    # slider-driven refits stay zero-copy on the device.
+    # ------------------------------------------------------------------
+
+    def _on_enabled(self, entry: "_LoRAEntry") -> None:
+        """Hook: ``entry`` just transitioned to ENABLED. Called BEFORE
+        the contributing-strength refit fires so subclasses can stage
+        runtime data the refit will read."""
+
+    def _on_disabled(self, entry: "_LoRAEntry") -> None:
+        """Hook: ``entry`` just transitioned away from ENABLED. Called
+        AFTER ``entry.deltas`` is cleared but BEFORE the rollback refit
+        fires (so subclasses can drop their mirrors first)."""
+
+    # ------------------------------------------------------------------
+    # Library: catalog without RAM cost
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_id(path: str) -> str:
+        """Filename-stem id. Two files with the same stem collide; the
+        registrar treats this as identity, so that's fine for a flat
+        library directory but means a caller can't register two distinct
+        LoRAs that happen to share a stem."""
+        return Path(path).stem
+
+    def register_lora(
+        self, path: str, name: Optional[str] = None,
+    ) -> str:
+        """Add a LoRA to the catalog without materializing deltas.
+
+        Idempotent: re-registering the same id (filename stem) returns
+        the existing id and leaves any in-flight prewarm / enabled
+        state alone.  The existing entry's name is NOT overwritten on
+        re-register; pass an explicit ``name`` only on first registration.
+        """
+        lora_id = self._make_id(path)
+        if lora_id in self._loras:
+            existing = self._loras[lora_id]
+            if existing.path != str(path):
+                logger.warning(
+                    "LoRA id %r already registered to %s; ignoring re-register from %s",
+                    lora_id, existing.path, path,
+                )
+            return lora_id
+        self._loras[lora_id] = _LoRAEntry(
+            lora_id=lora_id, path=str(path),
+            name=name if name is not None else lora_id,
+        )
+        logger.info("Registered LoRA: %s (path=%s)", lora_id, path)
+        return lora_id
+
+    def register_library(
+        self, directory: Optional[Path] = None,
+    ) -> List[str]:
+        """Discover and register every ``*.safetensors`` in ``directory``.
+
+        Defaults to :func:`acestep.paths.loras_dir`.  Returns the list
+        of registered ids in directory order (sorted by filename).
+        Missing directory returns an empty list.
+        """
+        from acestep.paths import discover_loras, loras_dir
+        d = directory if directory is not None else loras_dir()
+        files = discover_loras(d)
+        ids: List[str] = []
+        for p in files:
+            try:
+                ids.append(self.register_lora(str(p)))
+            except Exception as e:
+                logger.warning("Failed to register %s: %s", p, e)
+        if files:
+            logger.info(
+                "Registered library: %d LoRAs from %s", len(ids), d,
+            )
+        return ids
+
+    # ------------------------------------------------------------------
+    # Lifecycle: REGISTERED <-> MATERIALIZING <-> MATERIALIZED <-> ENABLED
+    # ------------------------------------------------------------------
+
+    def _get_executor(self) -> concurrent.futures.ThreadPoolExecutor:
+        """Lazy-init single-worker pool for prewarm.  Single worker
+        because the materialization runs (B @ A) on the same CUDA device
+        as inference; oversubscribing would just block on the GPU."""
+        if self._executor is None:
+            self._executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="lora_prewarm",
+            )
+        return self._executor
+
+    def prewarm_lora(self, lora_id: str) -> concurrent.futures.Future:
+        """Kick off background materialization of ``lora_id``.
+
+        Returns a Future that resolves to ``None`` once deltas are in
+        CPU RAM.  Subsequent ``enable_lora`` will skip the materialization
+        step.  Calling on a MATERIALIZED / ENABLED entry returns an
+        already-completed future; calling on a MATERIALIZING entry
+        returns the in-flight future.
+        """
+        entry = self._require_entry(lora_id)
+        if entry.state in (LoRAState.MATERIALIZED, LoRAState.ENABLED):
+            f: concurrent.futures.Future = concurrent.futures.Future()
+            f.set_result(None)
+            return f
+        if entry.state == LoRAState.MATERIALIZING:
+            assert entry.future is not None
+            return entry.future
+        entry.state = LoRAState.MATERIALIZING
+        entry.future = self._get_executor().submit(
+            self._materialize_worker, entry,
+        )
+        logger.info("Prewarming LoRA: %s", lora_id)
+        return entry.future
+
+    def _materialize_worker(self, entry: _LoRAEntry) -> None:
+        """Worker-thread body.  Loads safetensors, computes deltas,
+        writes them to the entry.  Engine state untouched.
+
+        If the entry was concurrently disabled (state changed away from
+        MATERIALIZING), the result is dropped to avoid resurrecting the
+        deltas after disable cleared them.
+        """
+        t0 = time.perf_counter()
+        try:
+            deltas, bytes_ = self._compute_deltas(entry.path)
+        except Exception:
+            if entry.state == LoRAState.MATERIALIZING:
+                entry.state = LoRAState.REGISTERED
+                entry.future = None
+            raise
+        if entry.state == LoRAState.MATERIALIZING:
+            entry.deltas = deltas
+            entry.materialized_bytes = bytes_
+            entry.state = LoRAState.MATERIALIZED
+            elapsed = (time.perf_counter() - t0) * 1000
+            logger.info(
+                "Materialized LoRA %s (%d params, %.1f MB) in %.1fms",
+                entry.lora_id, len(deltas), bytes_ / 1e6, elapsed,
+            )
+
+    def _compute_deltas(
+        self, lora_path: str,
+    ) -> Tuple[Dict[str, torch.Tensor], int]:
+        """Load LoRA from disk and compute full-rank deltas (B @ A).
+
+        Pure compute; safe to call from a worker thread.  Returns
+        (deltas_dict, total_bytes_in_cpu_ram). Each delta is stored in
+        the live weight's native dtype on CPU. Subclasses pull deltas
+        through to whatever device they need.
+        """
+        raw = load_file(lora_path)
+        pairs: Dict[str, Dict[str, torch.Tensor]] = {}
+        for key, tensor in raw.items():
+            parts = key.replace("base_model.model.", "")
+            if ".lora_A.weight" in parts:
+                param_name = parts.replace(".lora_A.weight", ".weight")
+                pairs.setdefault(param_name, {})["A"] = tensor
+            elif ".lora_B.weight" in parts:
+                param_name = parts.replace(".lora_B.weight", ".weight")
+                pairs.setdefault(param_name, {})["B"] = tensor
+
+        device = self._delta_compute_device()
+        deltas: Dict[str, torch.Tensor] = {}
+        total_bytes = 0
+        skipped = 0
+        for param_name, ab in pairs.items():
+            if "A" not in ab or "B" not in ab:
+                continue
+            if param_name not in self._param_dtype:
+                skipped += 1
+                continue
+            A = ab["A"].to(device=device, dtype=torch.float32)
+            B = ab["B"].to(device=device, dtype=torch.float32)
+            target_dt = self._param_dtype[param_name]
+            d = (B @ A).to(dtype=target_dt).to(
+                device=self._delta_storage_device(),
+            ).contiguous()
+            deltas[param_name] = d
+            total_bytes += d.numel() * d.element_size()
+        if skipped:
+            logger.debug(
+                "_compute_deltas(%s): %d params skipped (not in engine)",
+                Path(lora_path).name, skipped,
+            )
+        return deltas, total_bytes
+
+    def _delta_compute_device(self) -> torch.device:
+        """Where the (B @ A) matmul runs. GPU when available."""
+        return torch.device(
+            "cuda" if torch.cuda.is_available() else "cpu"
+        )
+
+    def _delta_storage_device(self) -> torch.device:
+        """Where deltas live in RAM after materialization.
+
+        TRT keeps them on CPU because refit buffers and numpy views are
+        CPU. Eager keeps them on the decoder's device so refits don't
+        pay an H2D transfer per slider tick.
+        """
+        return torch.device("cpu")
+
+    def enable_lora(
+        self, lora_id: str, strength: Optional[float] = None,
+    ) -> None:
+        """Promote a LoRA to ENABLED.  Synchronous; materializes if needed.
+
+        ``strength``, when provided, overrides the entry's stored strength
+        BEFORE the refit fires.  Pass it whenever you know the target
+        strength up-front: it lets a one-shot caller atomically transition
+        REGISTERED -> ENABLED-at-S without an intermediate refit at 0
+        followed by a second refit at S, which the streaming pipeline can
+        observe as a one-tick "missing LoRA" glitch in the first decode
+        window.
+
+        Refits the engine weights iff the resulting strength is non-zero
+        (a strength-0 enable is a placeholder for a slider that hasn't
+        ramped yet, and the refit would be a no-op).
+        """
+        entry = self._require_entry(lora_id)
+        if strength is not None:
+            entry.strength = float(strength)
+        if entry.state == LoRAState.ENABLED:
+            return
+        if entry.state == LoRAState.MATERIALIZING:
+            assert entry.future is not None
+            entry.future.result()
+        if entry.state == LoRAState.REGISTERED:
+            t0 = time.perf_counter()
+            deltas, bytes_ = self._compute_deltas(entry.path)
+            entry.deltas = deltas
+            entry.materialized_bytes = bytes_
+            entry.state = LoRAState.MATERIALIZED
+            elapsed = (time.perf_counter() - t0) * 1000
+            logger.info(
+                "Materialized LoRA %s inline (%d params, %.1f MB) in %.1fms",
+                lora_id, len(deltas), bytes_ / 1e6, elapsed,
+            )
+        entry.state = LoRAState.ENABLED
+        entry.future = None
+        # Subclass hook: stage backend-specific runtime state (e.g. the
+        # eager backend's CPU->GPU delta promotion) BEFORE the refit so
+        # the refit can read it.
+        self._on_enabled(entry)
+        if entry.strength != 0.0 and entry.deltas:
+            self._refit_weights(set(entry.deltas.keys()))
+        logger.info(
+            "Enabled LoRA %s (%d params, %.1f MB, strength=%.2f)",
+            lora_id, len(entry.deltas or {}),
+            entry.materialized_bytes / 1e6, entry.strength,
+        )
+
+    def disable_lora(self, lora_id: str) -> None:
+        """Drop deltas from CPU RAM and refit if the LoRA was contributing.
+
+        Strength is preserved on the entry so re-enable returns to the
+        same slider position.
+        """
+        entry = self._require_entry(lora_id)
+        if entry.state == LoRAState.REGISTERED:
+            return
+
+        if entry.state == LoRAState.MATERIALIZING and entry.future is not None:
+            try:
+                entry.future.result()
+            except Exception:
+                pass
+
+        was_contributing = (
+            entry.state == LoRAState.ENABLED and entry.strength != 0.0
+        )
+        affected_params: Set[str] = (
+            set(entry.deltas.keys()) if entry.deltas else set()
+        )
+
+        entry.state = LoRAState.REGISTERED
+        entry.deltas = None
+        entry.materialized_bytes = 0
+        entry.future = None
+
+        # Subclass hook: drop backend-specific runtime state (e.g. the
+        # eager backend's GPU delta mirror). Runs before the rollback
+        # refit so the composing code never sees a stale mirror.
+        self._on_disabled(entry)
+
+        if was_contributing:
+            self._refit_weights(affected_params)
+        logger.info(
+            "Disabled LoRA %s (was_contributing=%s)",
+            lora_id, was_contributing,
+        )
+
+    def set_lora_strength(self, lora_id: str, strength: float) -> None:
+        """Adjust the strength of an ENABLED LoRA.
+
+        Raises ValueError if the LoRA is not enabled.  Auto-enable was
+        considered and rejected: it would hide materialization cost
+        (hundreds of ms) behind a slider event.  The UI is responsible
+        for calling ``enable_lora`` before a slider becomes interactive.
+        """
+        entry = self._require_entry(lora_id)
+        if entry.state != LoRAState.ENABLED:
+            raise ValueError(
+                f"LoRA {lora_id!r} is not enabled (state={entry.state.value}). "
+                "Call enable_lora() first."
+            )
+        if entry.strength == strength:
+            return
+        old = entry.strength
+        entry.strength = strength
+        if entry.deltas:
+            self._refit_weights(set(entry.deltas.keys()))
+        logger.info(
+            "LoRA %s strength: %.3f -> %.3f (%d params)",
+            lora_id, old, strength, len(entry.deltas or {}),
+        )
+
+    def remove_lora(self, lora_id=-1) -> bool:
+        """Drop a LoRA from the catalog entirely.
+
+        Disables first if enabled.  Default ``-1`` removes the most
+        recently registered entry, preserving the legacy stack-pop API.
+        """
+        if lora_id == -1:
+            if not self._loras:
+                return False
+            lora_id = next(reversed(self._loras))
+        if lora_id not in self._loras:
+            return False
+        self.disable_lora(lora_id)
+        del self._loras[lora_id]
+        logger.info("Removed LoRA %s from catalog", lora_id)
+        return True
+
+    def remove_all(self) -> None:
+        """Remove every LoRA from the catalog and restore engine to base."""
+        for lid in list(self._loras.keys()):
+            self.remove_lora(lid)
+
+    # ------------------------------------------------------------------
+    # Backward-compat one-shot API
+    # ------------------------------------------------------------------
+
+    def apply_lora(self, lora_path: str, strength: float = 1.0) -> str:
+        """Register, set strength, and enable a LoRA in one call.
+
+        Idempotent on path: calling twice is the same as registering
+        once and setting the second-call's strength.
+        """
+        lora_id = self.register_lora(lora_path)
+        self._loras[lora_id].strength = float(strength)
+        self.enable_lora(lora_id)
+        return lora_id
+
+    # ------------------------------------------------------------------
+    # Inspection
+    # ------------------------------------------------------------------
+
+    def list_loras(self) -> List[LoRADescriptor]:
+        return [
+            LoRADescriptor(
+                id=e.lora_id, path=e.path, name=e.name,
+                state=e.state.value, strength=e.strength,
+                materialized_bytes=e.materialized_bytes,
+            )
+            for e in self._loras.values()
+        ]
+
+    def get_lora(self, lora_id: str) -> LoRADescriptor:
+        e = self._require_entry(lora_id)
+        return LoRADescriptor(
+            id=e.lora_id, path=e.path, name=e.name,
+            state=e.state.value, strength=e.strength,
+            materialized_bytes=e.materialized_bytes,
+        )
+
+    def _require_entry(self, lora_id: str) -> _LoRAEntry:
+        if lora_id not in self._loras:
+            raise ValueError(f"LoRA {lora_id!r} not registered")
+        return self._loras[lora_id]
+
+    @property
+    def has_active_loras(self) -> bool:
+        return any(e.state == LoRAState.ENABLED for e in self._loras.values())
+
+    @property
+    def active_lora_count(self) -> int:
+        return sum(
+            1 for e in self._loras.values() if e.state == LoRAState.ENABLED
+        )
+
+    @property
+    def active_lora_ids(self) -> List[str]:
+        return [
+            e.lora_id for e in self._loras.values()
+            if e.state == LoRAState.ENABLED
+        ]
+
+    @property
+    def total_materialized_bytes(self) -> int:
+        return sum(e.materialized_bytes for e in self._loras.values())
+
+    @property
+    def refittable_param_count(self) -> int:
+        return len(self._param_dtype)
+
+    # ------------------------------------------------------------------
+    # Refit driver (subclass writeback)
+    # ------------------------------------------------------------------
+
+    def _refit_weights(self, param_names: Set[str]) -> None:
+        """Time + log the engine writeback. Subclass does the actual work.
+
+        Splitting time/log out of ``_apply_to_engine`` keeps the subclass
+        method narrow and lets the TRT path reuse pre-allocated refit
+        buffers without bookkeeping noise.
+        """
+        if not param_names:
+            return
+        t0 = time.perf_counter()
+        self._apply_to_engine(param_names)
+        for name in param_names:
+            self._ever_dirty.add(name)
+        elapsed = (time.perf_counter() - t0) * 1000
+        logger.info(
+            "Refitted %d weights in %.1fms", len(param_names), elapsed,
+        )
+
+
+class EagerLoRAManager(LoRAManagerBase):
+    """LoRA writeback into a PyTorch decoder's parameters in place.
+
+    Storage strategy ("hybrid"):
+
+    - ``MATERIALIZED`` deltas live on **CPU**, matching the TRT backend.
+      A library workflow that prewarms dozens of LoRAs costs system
+      RAM, not VRAM.
+    - On the ENABLED transition, the entry's deltas are mirrored into a
+      per-id **GPU** buffer (``self._gpu_deltas[id]``). Refits read from
+      that mirror, so slider-driven strength updates run zero-copy on
+      the device. The mirror is freed on disable.
+    - The base-weight snapshot is also lazy: nothing is cloned at
+      construction. The first refit clones the live params it's about
+      to overwrite into ``self._base_weights``, so a session that never
+      enables a LoRA pays no extra VRAM.
+
+    All writes use ``param.data.copy_`` / ``.add_`` so the live
+    ``nn.Parameter`` identity stays the same — required for safety
+    under ``torch.compile``: the compiled graph reads params as tensor
+    inputs (not constants), and storage-level mutations are visible to
+    the next forward without retracing.
+    """
+
+    def __init__(
+        self,
+        decoder: torch.nn.Module,
+        device: Optional[torch.device] = None,
+    ):
+        if decoder is None:
+            raise ValueError("EagerLoRAManager requires a decoder module")
+
+        # If the decoder has been wrapped by ``torch.compile``, the live
+        # parameters live on the original module; named_parameters()
+        # routes through the OptimizedModule wrapper transparently, so
+        # this works for both compiled and eager decoders.
+        named = list(decoder.named_parameters())
+        if not named:
+            raise RuntimeError(
+                "Decoder has no parameters; cannot init EagerLoRAManager. "
+                "(If running with skip_decoder=True, use the TRT path.)"
+            )
+
+        # Resolve device: caller-provided wins, else infer from the first
+        # parameter. We tolerate a meta-device decoder by deferring to CPU.
+        first_param = named[0][1]
+        inferred = first_param.device
+        self._device = device if device is not None else (
+            inferred if inferred.type != "meta" else torch.device("cpu")
+        )
+
+        self._decoder_params: Dict[str, torch.nn.Parameter] = {}
+        # Populated lazily on first refit (see _ensure_base_snapshot).
+        self._base_weights: Dict[str, torch.Tensor] = {}
+        self._param_dtype: Dict[str, torch.dtype] = {}
+        # Per-id GPU mirror of MATERIALIZED CPU deltas, populated on
+        # _on_enabled and dropped on _on_disabled.
+        self._gpu_deltas: Dict[str, Dict[str, torch.Tensor]] = {}
+
+        for name, param in named:
+            self._decoder_params[name] = param
+            self._param_dtype[name] = param.dtype
+
+        logger.info(
+            "Eager LoRA manager ready: %d decoder params indexed on %s "
+            "(base snapshot deferred until first enable)",
+            len(self._param_dtype), self._device,
+        )
+
+        super().__init__()
+
+    def _delta_compute_device(self) -> torch.device:
+        return self._device
+
+    # _delta_storage_device falls back to base default (CPU): MATERIALIZED
+    # deltas live in system RAM. The hot, GPU-resident mirror is only
+    # populated for ENABLED entries via _on_enabled.
+
+    def _on_enabled(self, entry: "_LoRAEntry") -> None:
+        """Promote CPU deltas to a GPU mirror so refits stay zero-copy.
+
+        Pays one H2D transfer at enable time; subsequent refits (slider
+        ticks, disable rollbacks) read straight from the device mirror.
+        """
+        if not entry.deltas:
+            return
+        self._gpu_deltas[entry.lora_id] = {
+            name: d.to(device=self._device, non_blocking=True).contiguous()
+            for name, d in entry.deltas.items()
+        }
+
+    def _on_disabled(self, entry: "_LoRAEntry") -> None:
+        """Drop the GPU mirror; the CPU MATERIALIZED copy was already
+        cleared by the lifecycle. Frees VRAM equal to the LoRA's delta
+        footprint."""
+        self._gpu_deltas.pop(entry.lora_id, None)
+
+    def _ensure_base_snapshot(self, param_names: Set[str]) -> None:
+        """Lazily clone live params into ``_base_weights`` for the
+        requested set.
+
+        Called on the refit hot path. The clone happens at most once
+        per param: after first capture, subsequent refits reuse the
+        snapshot to recompose ``base + Σ s·d``. A session that only
+        ever sits at strength 0 (placeholder pattern) never triggers a
+        snapshot because no refit fires.
+        """
+        for name in param_names:
+            if name in self._base_weights:
+                continue
+            param = self._decoder_params.get(name)
+            if param is None:
+                continue
+            self._base_weights[name] = param.data.detach().clone()
+
+    def _apply_to_engine(self, param_names: Set[str]) -> None:
+        """Compose ``base + Σ strength·delta`` directly into param.data.
+
+        Reads deltas from ``self._gpu_deltas`` (the on-device mirror),
+        not from ``entry.deltas`` (which live on CPU). The mirror is
+        guaranteed populated for every ENABLED entry by ``_on_enabled``.
+        """
+        self._ensure_base_snapshot(param_names)
+
+        for param_name in param_names:
+            param = self._decoder_params.get(param_name)
+            if param is None:
+                continue
+            param.data.copy_(self._base_weights[param_name])
+
+            for entry in self._loras.values():
+                if entry.state != LoRAState.ENABLED:
+                    continue
+                if entry.strength == 0.0:
+                    continue
+                gpu = self._gpu_deltas.get(entry.lora_id)
+                if gpu and param_name in gpu:
+                    param.data.add_(gpu[param_name], alpha=entry.strength)

--- a/acestep/engine/model_context.py
+++ b/acestep/engine/model_context.py
@@ -78,7 +78,6 @@ class ModelContext:
         self._compile_vae = compile_vae
         self._offload_text_encoder = False
         self._diffusion_engine = None
-        self._active_lora_deltas: list = []
 
         self._load_models(
             project_root=project_root,

--- a/acestep/engine/runtime_init.py
+++ b/acestep/engine/runtime_init.py
@@ -64,19 +64,39 @@ def apply_trt_backends(
 ) -> None:
     """Wire TRT engines into a freshly constructed ModelContext.
 
+    Also constructs the ``DiffusionEngine`` Python wrapper for every
+    decoder backend (not just tensorrt). The wrapper is a cheap state
+    holder — it does not compile or allocate anything beyond its own
+    fields — and owning it eagerly lets the LoRA manager hosted inside
+    be queried at startup (e.g. to populate a UI dropdown) instead of
+    being lazy-built on the first ``StreamDenoise.execute``.
+
     Assumes ``ctx`` was built with ``skip_decoder``/``skip_vae`` set to match
     the tensorrt flags — PyTorch weights for those components are absent and
     TRT engines take over.
     """
     import torch
+    from acestep.engine.diffusion import DiffusionEngine
 
     if decoder_backend == "tensorrt":
-        from acestep.engine.diffusion import DiffusionEngine
-
         ctx._diffusion_engine = DiffusionEngine(
             ctx.model,
             trt_engine_path=trt_engines["decoder"],
             compile_loops=False,  # TRT decoder, no need to compile loops
+        )
+    elif ctx.model is not None:
+        # Eager / compile: same wrapper, no TRT engine path. The
+        # ``compile_loops`` flag governs the ODE/SDE inner-step
+        # primitives (orthogonal to whether the decoder itself was
+        # torch.compile'd), and matches what StreamDenoise would have
+        # passed in if it lazy-built the engine.
+        #
+        # The ``model is not None`` guard preserves the validation-only
+        # test path that stubs ModelContext with ``model=None`` — those
+        # tests never load a real DiT and shouldn't try to wrap one.
+        ctx._diffusion_engine = DiffusionEngine(
+            ctx.model,
+            compile_loops=(decoder_backend == "compile"),
         )
 
     if vae_backend == "tensorrt":

--- a/acestep/engine/session.py
+++ b/acestep/engine/session.py
@@ -473,34 +473,30 @@ class Session:
             latent_a=a, latent_b=b, alpha=alpha,
         )["latent"]
 
-    def apply_lora(self, path: str, scale: float = 1.0) -> None:
-        """Load and apply a LoRA. Stackable (call multiple times)."""
-        from acestep.nodes.lora_nodes import LoadLoRA, ApplyLoRA
+    def apply_lora(self, path: str, scale: float = 1.0) -> str:
+        """Load and apply a LoRA. Stackable (call multiple times).
 
-        lora = LoadLoRA().execute(path=path, scale=scale)["lora"]
-        ApplyLoRA().execute(model=self.model, lora=lora)
+        Returns the LoRA id (filename stem) for selective removal.
+        """
+        engine = self.model.handler._diffusion_engine
+        lora_id = engine.apply_lora(path, strength=scale)
         if not hasattr(self, '_lora_stack'):
             self._lora_stack = []
-        self._lora_stack.append(lora)
+        self._lora_stack.append(lora_id)
+        return lora_id
 
     def remove_loras(self) -> None:
         """Remove all applied LoRAs in reverse order."""
-        from acestep.nodes.lora_nodes import RemoveLoRA
-
+        engine = self.model.handler._diffusion_engine
         if hasattr(self, '_lora_stack'):
             while self._lora_stack:
-                RemoveLoRA().execute(
-                    model=self.model, lora=self._lora_stack.pop(),
-                )
+                engine.remove_lora(self._lora_stack.pop())
 
     def remove_last_lora(self) -> None:
         """Remove the most recently applied LoRA."""
-        from acestep.nodes.lora_nodes import RemoveLoRA
-
+        engine = self.model.handler._diffusion_engine
         if hasattr(self, '_lora_stack') and self._lora_stack:
-            RemoveLoRA().execute(
-                model=self.model, lora=self._lora_stack.pop(),
-            )
+            engine.remove_lora(self._lora_stack.pop())
 
     # ------------------------------------------------------------------
     # Streaming

--- a/acestep/engine/trt/lora_refit.py
+++ b/acestep/engine/trt/lora_refit.py
@@ -1,87 +1,31 @@
-"""Dynamic LoRA application to TRT engines via weight refitting.
+"""TRT subclass of :class:`LoRAManagerBase`: writeback via IRefitter.
 
-Uses TensorRT's IRefitter API to modify engine weights at runtime,
-enabling LoRA application/removal without rebuilding the engine.
-
-Lifecycle (per LoRA):
-  REGISTERED   - in the library catalog, no CPU RAM cost (only path + label)
-  MATERIALIZING - background prewarm in flight (worker computing B@A)
-  MATERIALIZED - deltas in CPU RAM, NOT yet contributing to engine state
-  ENABLED      - deltas applied to the engine; contributes at current strength
-
-Strength is orthogonal to the lifecycle: an ENABLED LoRA can sit at
-strength 0 indefinitely (placeholder pattern for slider-driven UIs).
-``set_lora_strength`` is rejected on non-ENABLED LoRAs to keep the
-materialization cost explicit at the call site rather than buried under
-a slider event.
-
-Library:
-  ``register_library(directory)`` discovers ``*.safetensors`` in a flat
-  directory and registers each as a REGISTERED entry whose id is the
-  filename stem. The catalog backs an "infinite library" workflow where
-  hundreds of LoRAs cost nothing until enabled.
-
-Threading:
-  - register / enable / disable / set_strength / refit run on the
-    inference-owning thread; refit and inference are mutually exclusive.
-  - prewarm runs on a background ThreadPoolExecutor; the worker only
-    fills the entry's deltas dict and never touches the engine.
+The base class owns catalog, lifecycle, prewarm, and delta math. This
+file is just the TRT-specific writeback path: pre-allocated CPU
+buffers per refittable weight, named in the engine's ``decoder.``
+prefix space.
 """
 
 from __future__ import annotations
 
-import concurrent.futures
-import time
-from dataclasses import dataclass, field
-from enum import Enum
-from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, Optional, Set
 
 from loguru import logger
 import numpy as np
 import torch
-from safetensors.torch import load_file
+
+from acestep.engine.lora import (
+    LoRAManagerBase,
+    LoRAState,           # re-exported for back-compat
+    LoRADescriptor,      # re-exported for back-compat
+    _LoRAEntry,          # re-exported for tests
+)
 
 # numpy dtype -> torch dtype
 _NP_TO_TORCH = {
     np.float32: torch.float32,
     np.float16: torch.float16,
 }
-
-
-class LoRAState(Enum):
-    REGISTERED = "registered"
-    MATERIALIZING = "materializing"
-    MATERIALIZED = "materialized"
-    ENABLED = "enabled"
-
-
-@dataclass
-class LoRADescriptor:
-    """Read-only public view of a LoRA in the library."""
-    id: str
-    path: str
-    name: str
-    state: str
-    strength: float
-    materialized_bytes: int
-
-
-@dataclass
-class _LoRAEntry:
-    """Internal mutable state for one library entry.
-
-    ``strength`` is preserved across enable/disable cycles so flipping a
-    UI toggle off and back on doesn't reset the slider.
-    """
-    lora_id: str
-    path: str
-    name: str = ""
-    state: LoRAState = LoRAState.REGISTERED
-    strength: float = 0.0
-    deltas: Optional[Dict[str, torch.Tensor]] = None
-    future: Optional[concurrent.futures.Future] = None
-    materialized_bytes: int = 0
 
 
 # Backward-compat alias for tests / external code that imported the old
@@ -91,8 +35,8 @@ class _LoRAEntry:
 _ActiveLoRA = _LoRAEntry
 
 
-class TRTLoRAManager:
-    """Manages dynamic LoRA application to a TRT engine via weight refitting."""
+class TRTLoRAManager(LoRAManagerBase):
+    """LoRA writeback into a TRT engine via IRefitter."""
 
     def __init__(
         self,
@@ -115,7 +59,6 @@ class TRTLoRAManager:
         if hasattr(trt, "bfloat16"):
             _trt_to_np[trt.bfloat16] = np.float32
 
-        # Query refittable weight names
         refitter = trt.Refitter(engine, self._trt_logger)
         if not hasattr(refitter, "get_all_weights"):
             raise RuntimeError("TRT engine refitting requires TensorRT 10.0+")
@@ -126,10 +69,8 @@ class TRTLoRAManager:
                 "Engine has no refittable weights. Rebuild with refit=True."
             )
 
-        # Cache refitter for reuse
         self._refitter = refitter
 
-        # Resolve base weight source
         decoder_params = dict(decoder.named_parameters()) if decoder is not None else {}
         checkpoint_file = None
         if not decoder_params and checkpoint_path:
@@ -139,11 +80,13 @@ class TRTLoRAManager:
 
         has_prototype = hasattr(refitter, "get_weights_prototype")
 
-        # Build mapping and cache base weights + refit buffers
+        # Mapping + per-weight buffers/dtypes. _base_weights and
+        # _param_dtype are what LoRAManagerBase looks at.
         self._param_to_trt: Dict[str, str] = {}
-        self._base_weights: Dict[str, torch.Tensor] = {}  # native dtype, CPU
-        self._refit_bufs: Dict[str, torch.Tensor] = {}    # pre-alloc output
+        self._base_weights: Dict[str, torch.Tensor] = {}   # native dtype, CPU
+        self._refit_bufs: Dict[str, torch.Tensor] = {}     # pre-alloc output
         self._np_dtype: Dict[str, np.dtype] = {}
+        self._param_dtype: Dict[str, torch.dtype] = {}
 
         matched = 0
         for trt_name in all_trt_names:
@@ -151,7 +94,6 @@ class TRTLoRAManager:
                 continue
             param_name = trt_name[len(trt_weight_prefix):]
 
-            # Detect engine dtype for this weight
             np_dt = np.float32
             if has_prototype:
                 try:
@@ -161,7 +103,6 @@ class TRTLoRAManager:
                     pass
             torch_dt = _NP_TO_TORCH.get(np_dt, torch.float32)
 
-            # Load base weight
             raw_w = None
             if param_name in decoder_params:
                 raw_w = decoder_params[param_name].data
@@ -174,12 +115,12 @@ class TRTLoRAManager:
             if raw_w is None:
                 continue
 
-            # Store base weight in engine's native dtype (e.g., fp16)
             base = raw_w.to(dtype=torch_dt).cpu().contiguous()
             self._param_to_trt[param_name] = trt_name
             self._base_weights[param_name] = base
             self._refit_bufs[param_name] = torch.empty_like(base)
             self._np_dtype[param_name] = np_dt
+            self._param_dtype[param_name] = torch_dt
             matched += 1
 
         logger.info(
@@ -192,400 +133,24 @@ class TRTLoRAManager:
                 all_trt_names[:5],
             )
 
-        # Library + lifecycle state.  Insertion order is preserved so
-        # ``remove_lora(-1)`` can pop the most-recently-registered entry,
-        # matching the legacy stack-style API.
-        self._loras: Dict[str, _LoRAEntry] = {}
-        self._ever_dirty: Set[str] = set()
-        self._executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+        super().__init__()
+
+    def _delta_compute_device(self) -> torch.device:
+        return self._device
 
     # ------------------------------------------------------------------
-    # Library: catalog without RAM cost
+    # Engine writeback (IRefitter)
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _make_id(path: str) -> str:
-        """Filename-stem id. Two files with the same stem collide; the
-        registrar treats this as identity, so that's fine for a flat
-        library directory but means a caller can't register two distinct
-        LoRAs that happen to share a stem."""
-        return Path(path).stem
+    def _apply_to_engine(self, param_names: Set[str]) -> None:
+        """Refit engine weights using pre-allocated buffers + in-place ops.
 
-    def register_lora(
-        self, path: str, name: Optional[str] = None,
-    ) -> str:
-        """Add a LoRA to the catalog without materializing deltas.
-
-        Idempotent: re-registering the same id (filename stem) returns
-        the existing id and leaves any in-flight prewarm / enabled
-        state alone.  The existing entry's name is NOT overwritten on
-        re-register; pass an explicit ``name`` only on first registration.
+        All math runs in the engine's native dtype (typically fp16) so
+        the numpy view fed to ``set_named_weights`` is zero-copy. A
+        strength-0 ENABLED entry is skipped explicitly: the add_ would
+        be a math-no-op but still walks the full weight, wasting cycles
+        for slider-driven UIs that leave placeholders at 0.
         """
-        lora_id = self._make_id(path)
-        if lora_id in self._loras:
-            existing = self._loras[lora_id]
-            if existing.path != str(path):
-                logger.warning(
-                    "LoRA id %r already registered to %s; ignoring re-register from %s",
-                    lora_id, existing.path, path,
-                )
-            return lora_id
-        self._loras[lora_id] = _LoRAEntry(
-            lora_id=lora_id, path=str(path),
-            name=name if name is not None else lora_id,
-        )
-        logger.info("Registered TRT LoRA: %s (path=%s)", lora_id, path)
-        return lora_id
-
-    def register_library(
-        self, directory: Optional[Path] = None,
-    ) -> List[str]:
-        """Discover and register every ``*.safetensors`` in ``directory``.
-
-        Defaults to :func:`acestep.paths.loras_dir`.  Returns the list
-        of registered ids in directory order (sorted by filename).
-        Missing directory returns an empty list.
-        """
-        from acestep.paths import discover_loras, loras_dir
-        d = directory if directory is not None else loras_dir()
-        files = discover_loras(d)
-        ids: List[str] = []
-        for p in files:
-            try:
-                ids.append(self.register_lora(str(p)))
-            except Exception as e:
-                logger.warning("Failed to register %s: %s", p, e)
-        if files:
-            logger.info(
-                "Registered library: %d LoRAs from %s", len(ids), d,
-            )
-        return ids
-
-    # ------------------------------------------------------------------
-    # Lifecycle: REGISTERED <-> MATERIALIZING <-> MATERIALIZED <-> ENABLED
-    # ------------------------------------------------------------------
-
-    def _get_executor(self) -> concurrent.futures.ThreadPoolExecutor:
-        """Lazy-init single-worker pool for prewarm.  Single worker
-        because the materialization runs (B @ A) on the same CUDA device
-        as inference; oversubscribing would just block on the GPU."""
-        if self._executor is None:
-            self._executor = concurrent.futures.ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix="lora_prewarm",
-            )
-        return self._executor
-
-    def prewarm_lora(self, lora_id: str) -> concurrent.futures.Future:
-        """Kick off background materialization of ``lora_id``.
-
-        Returns a Future that resolves to ``None`` once deltas are in
-        CPU RAM.  Subsequent ``enable_lora`` will skip the materialization
-        step.  Calling on a MATERIALIZED / ENABLED entry returns an
-        already-completed future; calling on a MATERIALIZING entry
-        returns the in-flight future.
-        """
-        entry = self._require_entry(lora_id)
-        if entry.state in (LoRAState.MATERIALIZED, LoRAState.ENABLED):
-            f: concurrent.futures.Future = concurrent.futures.Future()
-            f.set_result(None)
-            return f
-        if entry.state == LoRAState.MATERIALIZING:
-            assert entry.future is not None
-            return entry.future
-        # REGISTERED -> MATERIALIZING
-        entry.state = LoRAState.MATERIALIZING
-        entry.future = self._get_executor().submit(
-            self._materialize_worker, entry,
-        )
-        logger.info("Prewarming TRT LoRA: %s", lora_id)
-        return entry.future
-
-    def _materialize_worker(self, entry: _LoRAEntry) -> None:
-        """Worker-thread body.  Loads safetensors, computes deltas,
-        writes them to the entry.  Engine state untouched.
-
-        If the entry was concurrently disabled (state changed away from
-        MATERIALIZING), the result is dropped to avoid resurrecting the
-        deltas after disable cleared them.
-        """
-        t0 = time.perf_counter()
-        try:
-            deltas, bytes_ = self._compute_deltas(entry.path)
-        except Exception:
-            if entry.state == LoRAState.MATERIALIZING:
-                entry.state = LoRAState.REGISTERED
-                entry.future = None
-            raise
-        if entry.state == LoRAState.MATERIALIZING:
-            entry.deltas = deltas
-            entry.materialized_bytes = bytes_
-            entry.state = LoRAState.MATERIALIZED
-            elapsed = (time.perf_counter() - t0) * 1000
-            logger.info(
-                "Materialized TRT LoRA %s (%d params, %.1f MB) in %.1fms",
-                entry.lora_id, len(deltas), bytes_ / 1e6, elapsed,
-            )
-        # else: entry was disabled mid-prewarm; drop the deltas silently.
-
-    def _compute_deltas(
-        self, lora_path: str,
-    ) -> Tuple[Dict[str, torch.Tensor], int]:
-        """Load LoRA from disk and compute full-rank deltas (B @ A).
-
-        Pure compute; safe to call from a worker thread.  Returns
-        (deltas_dict, total_bytes_in_cpu_ram).
-        """
-        raw = load_file(lora_path)
-        pairs: Dict[str, Dict[str, torch.Tensor]] = {}
-        for key, tensor in raw.items():
-            parts = key.replace("base_model.model.", "")
-            if ".lora_A.weight" in parts:
-                param_name = parts.replace(".lora_A.weight", ".weight")
-                pairs.setdefault(param_name, {})["A"] = tensor
-            elif ".lora_B.weight" in parts:
-                param_name = parts.replace(".lora_B.weight", ".weight")
-                pairs.setdefault(param_name, {})["B"] = tensor
-
-        deltas: Dict[str, torch.Tensor] = {}
-        total_bytes = 0
-        skipped = 0
-        for param_name, ab in pairs.items():
-            if "A" not in ab or "B" not in ab:
-                continue
-            if param_name not in self._param_to_trt:
-                skipped += 1
-                continue
-            A = ab["A"].to(device=self._device, dtype=torch.float32)
-            B = ab["B"].to(device=self._device, dtype=torch.float32)
-            target_dt = self._base_weights[param_name].dtype
-            d = (B @ A).to(dtype=target_dt).cpu().contiguous()
-            deltas[param_name] = d
-            total_bytes += d.numel() * d.element_size()
-        if skipped:
-            logger.debug(
-                "_compute_deltas(%s): %d params skipped (not in engine)",
-                Path(lora_path).name, skipped,
-            )
-        return deltas, total_bytes
-
-    def enable_lora(
-        self, lora_id: str, strength: Optional[float] = None,
-    ) -> None:
-        """Promote a LoRA to ENABLED.  Synchronous; materializes if needed.
-
-        ``strength``, when provided, overrides the entry's stored strength
-        BEFORE the refit fires.  Pass it whenever you know the target
-        strength up-front: it lets a one-shot caller atomically transition
-        REGISTERED -> ENABLED-at-S without an intermediate refit at 0
-        followed by a second refit at S, which the streaming pipeline can
-        observe as a one-tick "missing LoRA" glitch in the first decode
-        window.
-
-        Refits the engine weights iff the resulting strength is non-zero
-        (a strength-0 enable is a placeholder for a slider that hasn't
-        ramped yet, and the refit would be a no-op).
-        """
-        entry = self._require_entry(lora_id)
-        if strength is not None:
-            entry.strength = float(strength)
-        if entry.state == LoRAState.ENABLED:
-            return
-        if entry.state == LoRAState.MATERIALIZING:
-            assert entry.future is not None
-            entry.future.result()
-            # state should now be MATERIALIZED (or REGISTERED on failure)
-        if entry.state == LoRAState.REGISTERED:
-            t0 = time.perf_counter()
-            deltas, bytes_ = self._compute_deltas(entry.path)
-            entry.deltas = deltas
-            entry.materialized_bytes = bytes_
-            entry.state = LoRAState.MATERIALIZED
-            elapsed = (time.perf_counter() - t0) * 1000
-            logger.info(
-                "Materialized TRT LoRA %s inline (%d params, %.1f MB) in %.1fms",
-                lora_id, len(deltas), bytes_ / 1e6, elapsed,
-            )
-        # MATERIALIZED -> ENABLED
-        entry.state = LoRAState.ENABLED
-        entry.future = None
-        if entry.strength != 0.0 and entry.deltas:
-            self._refit_weights(set(entry.deltas.keys()))
-        logger.info(
-            "Enabled TRT LoRA %s (%d params, %.1f MB, strength=%.2f)",
-            lora_id, len(entry.deltas or {}),
-            entry.materialized_bytes / 1e6, entry.strength,
-        )
-
-    def disable_lora(self, lora_id: str) -> None:
-        """Drop deltas from CPU RAM and refit if the LoRA was contributing.
-
-        Strength is preserved on the entry so re-enable returns to the
-        same slider position.
-        """
-        entry = self._require_entry(lora_id)
-        if entry.state == LoRAState.REGISTERED:
-            return
-
-        # If a prewarm is in flight, wait it out so the worker can't
-        # later resurrect the deltas we're about to drop.  Worker checks
-        # state before assigning, so transitions during the wait are
-        # benign.
-        if entry.state == LoRAState.MATERIALIZING and entry.future is not None:
-            try:
-                entry.future.result()
-            except Exception:
-                pass
-
-        was_contributing = (
-            entry.state == LoRAState.ENABLED and entry.strength != 0.0
-        )
-        affected_params: Set[str] = (
-            set(entry.deltas.keys()) if entry.deltas else set()
-        )
-
-        entry.state = LoRAState.REGISTERED
-        entry.deltas = None
-        entry.materialized_bytes = 0
-        entry.future = None
-
-        if was_contributing:
-            self._refit_weights(affected_params)
-        logger.info(
-            "Disabled TRT LoRA %s (was_contributing=%s)",
-            lora_id, was_contributing,
-        )
-
-    def set_lora_strength(self, lora_id: str, strength: float) -> None:
-        """Adjust the strength of an ENABLED LoRA.
-
-        Raises ValueError if the LoRA is not enabled.  Auto-enable was
-        considered and rejected: it would hide materialization cost
-        (hundreds of ms) behind a slider event.  The UI is responsible
-        for calling ``enable_lora`` before a slider becomes interactive.
-        """
-        entry = self._require_entry(lora_id)
-        if entry.state != LoRAState.ENABLED:
-            raise ValueError(
-                f"LoRA {lora_id!r} is not enabled (state={entry.state.value}). "
-                "Call enable_lora() first."
-            )
-        if entry.strength == strength:
-            # Slider sometimes lands back on the previous value;
-            # skip the full refit + GPU re-upload in that case.
-            return
-        old = entry.strength
-        entry.strength = strength
-        if entry.deltas:
-            self._refit_weights(set(entry.deltas.keys()))
-        logger.info(
-            "TRT LoRA %s strength: %.3f -> %.3f (%d params)",
-            lora_id, old, strength, len(entry.deltas or {}),
-        )
-
-    def remove_lora(self, lora_id=-1) -> bool:
-        """Drop a LoRA from the catalog entirely.
-
-        Disables first if enabled.  Default ``-1`` removes the most
-        recently registered entry, preserving the legacy stack-pop API
-        used by ``acestep.nodes.lora_nodes.RemoveLoRA``.
-        """
-        if lora_id == -1:
-            if not self._loras:
-                return False
-            lora_id = next(reversed(self._loras))
-        if lora_id not in self._loras:
-            return False
-        self.disable_lora(lora_id)
-        del self._loras[lora_id]
-        logger.info("Removed TRT LoRA %s from catalog", lora_id)
-        return True
-
-    def remove_all(self) -> None:
-        """Remove every LoRA from the catalog and restore engine to base."""
-        for lid in list(self._loras.keys()):
-            self.remove_lora(lid)
-
-    # ------------------------------------------------------------------
-    # Backward-compat one-shot API
-    # ------------------------------------------------------------------
-
-    def apply_lora(self, lora_path: str, strength: float = 1.0) -> str:
-        """Register, set strength, and enable a LoRA in one call.
-
-        Idempotent on path: calling twice is the same as registering
-        once and setting the second-call's strength.  Kept for
-        ``workflows/``, ``acestep.nodes.lora_nodes``, and demo bootstrap
-        paths that haven't migrated to explicit register/enable.
-        """
-        lora_id = self.register_lora(lora_path)
-        self._loras[lora_id].strength = float(strength)
-        self.enable_lora(lora_id)
-        return lora_id
-
-    # ------------------------------------------------------------------
-    # Inspection
-    # ------------------------------------------------------------------
-
-    def list_loras(self) -> List[LoRADescriptor]:
-        return [
-            LoRADescriptor(
-                id=e.lora_id, path=e.path, name=e.name,
-                state=e.state.value, strength=e.strength,
-                materialized_bytes=e.materialized_bytes,
-            )
-            for e in self._loras.values()
-        ]
-
-    def get_lora(self, lora_id: str) -> LoRADescriptor:
-        e = self._require_entry(lora_id)
-        return LoRADescriptor(
-            id=e.lora_id, path=e.path, name=e.name,
-            state=e.state.value, strength=e.strength,
-            materialized_bytes=e.materialized_bytes,
-        )
-
-    def _require_entry(self, lora_id: str) -> _LoRAEntry:
-        if lora_id not in self._loras:
-            raise ValueError(f"LoRA {lora_id!r} not registered")
-        return self._loras[lora_id]
-
-    @property
-    def has_active_loras(self) -> bool:
-        return any(e.state == LoRAState.ENABLED for e in self._loras.values())
-
-    @property
-    def active_lora_count(self) -> int:
-        return sum(
-            1 for e in self._loras.values() if e.state == LoRAState.ENABLED
-        )
-
-    @property
-    def active_lora_ids(self) -> List[str]:
-        return [
-            e.lora_id for e in self._loras.values()
-            if e.state == LoRAState.ENABLED
-        ]
-
-    @property
-    def total_materialized_bytes(self) -> int:
-        return sum(e.materialized_bytes for e in self._loras.values())
-
-    @property
-    def refittable_param_count(self) -> int:
-        return len(self._param_to_trt)
-
-    # ------------------------------------------------------------------
-    # Internal refit
-    # ------------------------------------------------------------------
-
-    def _refit_weights(self, param_names: Set[str]) -> None:
-        """Refit engine weights. Uses pre-allocated buffers and in-place
-        ops to avoid memory allocation. All math is in the engine's
-        native dtype (typically fp16) for zero-copy numpy handoff."""
-        if not param_names:
-            return
-
-        t0 = time.perf_counter()
         refitter = self._refitter
         count = 0
 
@@ -594,14 +159,9 @@ class TRTLoRAManager:
             if trt_name is None:
                 continue
 
-            # Copy base into pre-allocated buffer (no allocation)
             buf = self._refit_bufs[param_name]
             buf.copy_(self._base_weights[param_name])
 
-            # Accumulate ENABLED LoRA contributions in-place (native
-            # dtype). Skip strength-0 contributions; they're a no-op
-            # but the add_ traverses the full weight, which is wasteful
-            # for slider-driven UIs that leave placeholders at 0.
             for entry in self._loras.values():
                 if entry.state != LoRAState.ENABLED:
                     continue
@@ -610,10 +170,8 @@ class TRTLoRAManager:
                 if entry.deltas and param_name in entry.deltas:
                     buf.add_(entry.deltas[param_name], alpha=entry.strength)
 
-            # Zero-copy numpy view (contiguous CPU tensor, matching dtype)
             refitter.set_named_weights(trt_name, buf.numpy())
             count += 1
-            self._ever_dirty.add(param_name)
 
         if count > 0:
             ok = refitter.refit_cuda_engine()
@@ -623,5 +181,14 @@ class TRTLoRAManager:
                     f"TRT refit failed. Missing weights: {missing}"
                 )
 
-        elapsed = (time.perf_counter() - t0) * 1000
-        logger.info("Refitted %d weights in %.1fms", count, elapsed)
+
+# Re-export the lifecycle public symbols so existing imports
+# (`from acestep.engine.trt.lora_refit import TRTLoRAManager, LoRAState, ...`)
+# keep working without churn.
+__all__ = [
+    "TRTLoRAManager",
+    "LoRAState",
+    "LoRADescriptor",
+    "_LoRAEntry",
+    "_ActiveLoRA",
+]

--- a/acestep/nodes/lora_nodes.py
+++ b/acestep/nodes/lora_nodes.py
@@ -1,10 +1,9 @@
 """LoRA loading and application nodes.
 
-Supports two paths:
-  - PyTorch path: modifies decoder parameters directly (original behavior).
-  - TRT refit path: when a REFIT-enabled TRT engine is loaded, applies
-    LoRA via weight refitting without touching PyTorch parameters.
-    Detected automatically; no user configuration needed.
+Both nodes route through the unified ``DiffusionEngine`` LoRA API,
+which dispatches internally to the eager (PyTorch in-place writeback)
+or TRT (IRefitter) backend depending on what's loaded. Callers don't
+need to branch.
 """
 
 from __future__ import annotations
@@ -12,31 +11,17 @@ from __future__ import annotations
 from typing import Any, ClassVar
 
 from loguru import logger
-import torch
-from safetensors.torch import load_file
 
 from .base import BaseNode, NodeDefinition, NodeParam, NodePort, NodeRegistry
 from .types import LoRA, ModelHandle
-
-
-def _has_trt_lora(handler) -> bool:
-    """Check if handler has a TRT engine with LoRA refit support."""
-    engine = getattr(handler, "_diffusion_engine", None)
-    if engine is None:
-        return False
-    return getattr(engine, "trt_lora_available", False)
 
 
 @NodeRegistry.register
 class LoadLoRA(BaseNode):
     """Load a LoRA adapter from a safetensors file.
 
-    Pre-computes the weight deltas (B @ A * scale) so they can be
-    quickly applied/removed from the decoder.
-
-    Node parameters:
-        path: Path to the .safetensors LoRA file.
-        scale: LoRA strength multiplier (default 1.0).
+    Returns a wire payload carrying the path + scale; the actual
+    materialization happens in :class:`ApplyLoRA`.
     """
 
     node_type_id: ClassVar[str] = "acestep.LoadLoRA"
@@ -73,12 +58,7 @@ class LoadLoRA(BaseNode):
 
 @NodeRegistry.register
 class ApplyLoRA(BaseNode):
-    """Apply a LoRA adapter to the model and return the modified handle.
-
-    Automatically uses TRT weight refitting when a REFIT-enabled TRT
-    engine is loaded, otherwise falls back to direct PyTorch parameter
-    modification.
-    """
+    """Apply a LoRA adapter to the model and return the modified handle."""
 
     node_type_id: ClassVar[str] = "acestep.ApplyLoRA"
 
@@ -103,43 +83,26 @@ class ApplyLoRA(BaseNode):
         lora: LoRA = kwargs["lora"]
         handler = model_handle.handler
 
-        # TRT refit path: apply LoRA to the TRT engine directly
-        if _has_trt_lora(handler):
-            lora_id = handler._diffusion_engine.apply_trt_lora(
-                lora.path, lora.scale,
+        engine = getattr(handler, "_diffusion_engine", None)
+        if engine is None or not engine.lora_available:
+            logger.warning(
+                "ApplyLoRA: no LoRA backend available on this model; "
+                "skipping %s", lora.path,
             )
-            # Store lora_id for RemoveLoRA
-            if not hasattr(handler, '_active_trt_lora_ids'):
-                handler._active_trt_lora_ids = []
-            handler._active_trt_lora_ids.append(lora_id)
             return {"model": model_handle}
 
-        # PyTorch path: modify decoder parameters directly
-        deltas = _precompute_lora_deltas(
-            lora.path, lora.scale,
-            handler.device, handler.dtype,
-        )
-
-        with handler._load_model_context("model"):
-            _apply_lora_deltas(handler.model.decoder, deltas, sign=1.0)
-        logger.info(
-            "Applied LoRA: %s (%d params, scale=%.2f)",
-            lora.path, len(deltas), lora.scale,
-        )
-
-        if not hasattr(handler, '_active_lora_deltas'):
-            handler._active_lora_deltas = []
-        handler._active_lora_deltas.append(deltas)
-
+        lora_id = engine.apply_lora(lora.path, lora.scale)
+        # Stack of ids so RemoveLoRA can pop the most recent.  Same
+        # contract the old per-backend stacks honored, just unified.
+        if not hasattr(handler, "_active_lora_ids"):
+            handler._active_lora_ids = []
+        handler._active_lora_ids.append(lora_id)
         return {"model": model_handle}
 
 
 @NodeRegistry.register
 class RemoveLoRA(BaseNode):
-    """Remove the most recently applied LoRA from the model.
-
-    Handles both TRT refit and PyTorch parameter paths.
-    """
+    """Remove the most recently applied LoRA from the model."""
 
     node_type_id: ClassVar[str] = "acestep.RemoveLoRA"
 
@@ -161,68 +124,11 @@ class RemoveLoRA(BaseNode):
     def execute(self, **kwargs: Any) -> dict[str, Any]:
         model_handle: ModelHandle = kwargs["model"]
         handler = model_handle.handler
-
-        # TRT refit path
-        if _has_trt_lora(handler):
-            ids = getattr(handler, '_active_trt_lora_ids', [])
-            if ids:
-                lora_id = ids.pop()
-                handler._diffusion_engine.remove_trt_lora(lora_id)
+        engine = getattr(handler, "_diffusion_engine", None)
+        if engine is None:
             return {"model": model_handle}
 
-        # PyTorch path
-        if hasattr(handler, '_active_lora_deltas') and handler._active_lora_deltas:
-            deltas = handler._active_lora_deltas.pop()
-            with handler._load_model_context("model"):
-                _apply_lora_deltas(handler.model.decoder, deltas, sign=-1.0)
-            logger.info("Removed LoRA (%d params)", len(deltas))
-
+        ids = getattr(handler, "_active_lora_ids", [])
+        if ids:
+            engine.remove_lora(ids.pop())
         return {"model": model_handle}
-
-
-# -----------------------------------------------------------------------
-# Helpers (PyTorch path)
-# -----------------------------------------------------------------------
-
-def _precompute_lora_deltas(
-    lora_path: str,
-    strength: float,
-    device: torch.device,
-    dtype: torch.dtype,
-) -> dict[str, torch.Tensor]:
-    """Load LoRA weights and compute full-rank deltas: strength * (B @ A)."""
-    raw = load_file(lora_path)
-    pairs: dict[str, dict[str, torch.Tensor]] = {}
-    for key, tensor in raw.items():
-        parts = key.replace("base_model.model.", "")
-        if ".lora_A.weight" in parts:
-            param_name = parts.replace(".lora_A.weight", ".weight")
-            pairs.setdefault(param_name, {})["A"] = tensor
-        elif ".lora_B.weight" in parts:
-            param_name = parts.replace(".lora_B.weight", ".weight")
-            pairs.setdefault(param_name, {})["B"] = tensor
-
-    deltas = {}
-    for param_name, ab in pairs.items():
-        if "A" not in ab or "B" not in ab:
-            continue
-        A = ab["A"].to(device=device, dtype=dtype)
-        B = ab["B"].to(device=device, dtype=dtype)
-        deltas[param_name] = strength * (B @ A)
-
-    return deltas
-
-
-def _apply_lora_deltas(
-    decoder: torch.nn.Module,
-    deltas: dict[str, torch.Tensor],
-    sign: float = 1.0,
-) -> None:
-    """Add (sign=1) or remove (sign=-1) precomputed deltas from decoder params."""
-    decoder_params = dict(decoder.named_parameters())
-    applied = 0
-    for param_name, delta in deltas.items():
-        if param_name in decoder_params:
-            decoder_params[param_name].data.add_(delta, alpha=sign)
-            applied += 1
-    logger.info("LoRA delta %s: %d/%d params", "applied" if sign > 0 else "removed", applied, len(deltas))

--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -169,7 +169,7 @@ def handle_client(
     # MODELS_DIR/loras catalog.  Both can be combined.
     #
     # ``lora_strengths`` is a dict {id: strength} — the value passed to
-    # enable_trt_lora at init time.  Setting strength at enable time
+    # enable_lora at init time.  Setting strength at enable time
     # (rather than enabling at 0 and waiting for the first per-tick
     # set_strength) is what keeps the first VAE-decode window from
     # sounding like the LoRA is missing.
@@ -269,7 +269,7 @@ def handle_client(
     # subset to enable for this client and prewarm them in the background
     # so the eventual enable_lora is fast.
     engine_obj = session.handler._diffusion_engine
-    lora_available = bool(engine_obj and engine_obj.trt_lora_available)
+    lora_available = bool(engine_obj and engine_obj.lora_available)
     if use_lora and not lora_available:
         print("[Server] WARNING: LoRA engine unavailable on this decoder")
         use_lora = False
@@ -278,7 +278,7 @@ def handle_client(
     if use_lora:
         # Resolve any explicit enable-by-id requests (these must already
         # be in the catalog from the auto-scan).
-        catalog_ids = {d.id for d in engine_obj.list_trt_loras()}
+        catalog_ids = {d.id for d in engine_obj.list_loras()}
         for lid in enabled_lora_ids:
             if lid in catalog_ids:
                 initial_enable_ids.append(lid)
@@ -291,7 +291,7 @@ def handle_client(
                 print(f"[Server] WARNING: LoRA path missing: {p}")
                 continue
             try:
-                lid = engine_obj.register_trt_lora(str(pp))
+                lid = engine_obj.register_lora(str(pp))
                 if lid not in initial_enable_ids:
                     initial_enable_ids.append(lid)
             except Exception as e:
@@ -301,7 +301,7 @@ def handle_client(
         # future if the worker hasn't finished yet.
         for lid in initial_enable_ids:
             try:
-                engine_obj.prewarm_trt_lora(lid)
+                engine_obj.prewarm_lora(lid)
             except Exception as e:
                 print(f"[Server] Prewarm failed for {lid}: {e}")
         if not initial_enable_ids:
@@ -368,7 +368,7 @@ def handle_client(
                 "state": d.state, "strength": d.strength,
                 "materialized_bytes": d.materialized_bytes,
             }
-            for d in engine_obj.list_trt_loras()
+            for d in engine_obj.list_loras()
         ]
 
     # Send ready + initial buffer
@@ -459,13 +459,13 @@ def handle_client(
             return
         for lid in local_disable:
             try:
-                engine_obj.disable_trt_lora(lid)
+                engine_obj.disable_lora(lid)
                 virtual_knobs.remove_knob(f"lora_str_{lid}")
             except Exception as e:
                 print(f"[Server] disable_lora({lid}) failed: {e}")
         for lid, strength in local_enable:
             try:
-                engine_obj.enable_trt_lora(lid, strength=strength)
+                engine_obj.enable_lora(lid, strength=strength)
                 # Allocate a knob slot so set_lora_strength can be driven
                 # by the client's params dict.  Default the slot to the
                 # strength we just enabled at, so the runner's slider-
@@ -619,7 +619,7 @@ def handle_client(
     # comes out as if the LoRA were missing, because the runner's
     # set_strength catch-up only kicks in after tick 1.  The prewarm
     # started at session setup is likely complete by now; any leftover
-    # work is awaited synchronously inside enable_trt_lora.
+    # work is awaited synchronously inside enable_lora.
     if use_lora and initial_enable_ids:
         with pending_lock:
             for lid in initial_enable_ids:

--- a/demos/realtime_motion_graph_web/pipeline.py
+++ b/demos/realtime_motion_graph_web/pipeline.py
@@ -212,13 +212,13 @@ class PipelineRunner:
                 # for non-enabled rows are ignored, matching the UI
                 # contract that strength sliders are only interactive
                 # while the LoRA is on.
-                for desc in self.engine_obj.list_trt_loras():
+                for desc in self.engine_obj.list_loras():
                     if desc.state != "enabled":
                         continue
                     key = f"lora_str_{desc.id}"
                     lora_str = raw.get(key, desc.strength)
                     if abs(lora_str - self.params.get(key, -1)) > 0.02:
-                        self.engine_obj.set_trt_lora_strength(desc.id, lora_str)
+                        self.engine_obj.set_lora_strength(desc.id, lora_str)
 
             hint_str = self.midi_knobs.get_param("hint_strength") if self.use_midi else 1.0
             if abs(hint_str - last_hint_str) > 0.02:
@@ -380,7 +380,7 @@ class PipelineRunner:
                 self.params["feedback"] = round(feedback, 2)
                 self.params["shift"] = round(shift_val, 2)
                 if self.use_lora and self.engine_obj is not None:
-                    for desc in self.engine_obj.list_trt_loras():
+                    for desc in self.engine_obj.list_loras():
                         if desc.state != "enabled":
                             continue
                         key = f"lora_str_{desc.id}"

--- a/demos/test_stream_cover_graph.py
+++ b/demos/test_stream_cover_graph.py
@@ -245,14 +245,14 @@ with timed("model_load"):
 
 if use_lora:
     engine_obj = session.handler._diffusion_engine
-    if engine_obj is not None and engine_obj.trt_lora_available:
+    if engine_obj is not None and engine_obj.lora_available:
         with timed("apply_lora"):
             print(
                 f"[Setup] Applying LoRA: {Path(LORA_PATH).name} (strength={LORA_STRENGTH})"
             )
-            engine_obj.apply_trt_lora(LORA_PATH, strength=LORA_STRENGTH)
+            engine_obj.apply_lora(LORA_PATH, strength=LORA_STRENGTH)
     else:
-        print("[Setup] WARNING: --lora requested but TRT LoRA refit not available")
+        print("[Setup] WARNING: --lora requested but LoRA backend unavailable")
 
 with timed("load_audio"):
     print("[Setup] Loading source audio...")

--- a/tests/unit/test_lora_eager.py
+++ b/tests/unit/test_lora_eager.py
@@ -1,0 +1,302 @@
+"""Unit tests for ``EagerLoRAManager``.
+
+Builds a tiny ``nn.Module`` decoder, wires the manager onto it, and
+asserts that enable / disable / set_strength push the right deltas
+straight into ``param.data``. No TRT, no safetensors on disk — every
+test stubs ``_compute_deltas`` with hand-built deltas the same way the
+TRT tests do.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn as nn
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from acestep.engine.lora import EagerLoRAManager, LoRAState
+
+
+def _make_decoder() -> nn.Module:
+    """Decoder with two named params (``q.weight``, ``k.weight``),
+    both 8x16 fp32 zeros so identity-base assertions are simple."""
+    decoder = nn.Module()
+    decoder.q = nn.Linear(16, 8, bias=False)
+    decoder.k = nn.Linear(16, 8, bias=False)
+    with torch.no_grad():
+        decoder.q.weight.zero_()
+        decoder.k.weight.zero_()
+    return decoder
+
+
+def _make_mgr():
+    decoder = _make_decoder()
+    mgr = EagerLoRAManager(decoder=decoder, device=torch.device("cpu"))
+    return mgr, decoder
+
+
+def test_init_indexes_params_without_snapshotting():
+    """Construction records dtypes + param refs but does NOT clone weights.
+
+    The whole point of the lazy snapshot is that a session that never
+    enables a LoRA pays no extra VRAM. So _base_weights stays empty
+    until the first refit hits.
+    """
+    mgr, decoder = _make_mgr()
+    assert mgr.refittable_param_count == 2
+    assert mgr._param_dtype == {
+        "q.weight": torch.float32, "k.weight": torch.float32,
+    }
+    assert mgr._base_weights == {}
+
+
+def test_first_enable_triggers_lazy_snapshot(monkeypatch):
+    """The first refit clones the affected param into _base_weights."""
+    mgr, decoder = _make_mgr()
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: ({"q.weight": torch.full((8, 16), 4.0)}, 8 * 16 * 4),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    assert mgr._base_weights == {}  # still empty
+
+    mgr.enable_lora("x", strength=0.5)
+
+    # Snapshot of q.weight captured (k.weight not touched: not in delta set).
+    assert "q.weight" in mgr._base_weights
+    assert torch.equal(mgr._base_weights["q.weight"], torch.zeros(8, 16))
+    assert "k.weight" not in mgr._base_weights
+
+
+def test_strength_zero_enable_does_not_snapshot(monkeypatch):
+    """Placeholder enable (strength=0) doesn't trigger a refit, so the
+    base snapshot must NOT be populated. The whole point of the
+    placeholder pattern is "zero VRAM cost until you actually move the
+    slider"."""
+    mgr, decoder = _make_mgr()
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: ({"q.weight": torch.full((8, 16), 4.0)}, 8 * 16 * 4),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    mgr.enable_lora("x", strength=0.0)
+
+    assert mgr.get_lora("x").state == "enabled"
+    assert mgr._base_weights == {}  # no refit fired -> no snapshot
+
+
+def test_enable_promotes_deltas_to_gpu_mirror(monkeypatch):
+    """On enable, the manager keeps a GPU-resident mirror of the deltas
+    so subsequent refits don't H2D-copy per slider tick.
+
+    This test runs on CPU (no CUDA needed) because EagerLoRAManager
+    promotes to ``self._device`` which is CPU here — the SHAPE of the
+    promotion (mirror exists, holds the right tensors) is what the
+    test asserts; the device transfer itself is a no-op cast on CPU.
+    """
+    mgr, decoder = _make_mgr()
+    delta = torch.full((8, 16), 4.0)
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: ({"q.weight": delta.clone()}, delta.numel() * 4),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    assert "x" not in mgr._gpu_deltas
+
+    mgr.enable_lora("x", strength=0.5)
+
+    assert "x" in mgr._gpu_deltas
+    assert torch.equal(mgr._gpu_deltas["x"]["q.weight"], delta)
+
+
+def test_disable_drops_gpu_mirror(monkeypatch):
+    """The whole reason for the hybrid is that disable frees VRAM."""
+    mgr, decoder = _make_mgr()
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: ({"q.weight": torch.full((8, 16), 4.0)}, 8 * 16 * 4),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    mgr.enable_lora("x", strength=0.5)
+    assert "x" in mgr._gpu_deltas
+
+    mgr.disable_lora("x")
+    assert "x" not in mgr._gpu_deltas
+
+
+def test_prewarm_does_not_allocate_gpu_mirror(monkeypatch):
+    """Prewarm pre-computes deltas in CPU RAM (the MATERIALIZED state),
+    but must NOT reserve VRAM until the LoRA is actually enabled. This
+    is the property that makes the library workflow ("register 100,
+    prewarm 20, enable 3") translate cleanly to the eager backend."""
+    mgr, decoder = _make_mgr()
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: ({"q.weight": torch.full((8, 16), 4.0)}, 8 * 16 * 4),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    f = mgr.prewarm_lora("x")
+    f.result(timeout=5)
+
+    assert mgr.get_lora("x").state == "materialized"
+    assert mgr._gpu_deltas == {}  # nothing on GPU yet
+    assert mgr._base_weights == {}  # snapshot still deferred
+
+
+def test_enable_with_strength_writes_into_param_data(monkeypatch):
+    """enable_lora(s=0.5) must end with param.data == base + 0.5 * delta.
+
+    The point of the eager path: writeback lands directly in the live
+    parameter, not in a side buffer.
+    """
+    mgr, decoder = _make_mgr()
+    delta = torch.full((8, 16), 4.0)
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: ({"q.weight": delta.clone()}, delta.numel() * 4),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    mgr.enable_lora("x", strength=0.5)
+
+    expected = torch.full((8, 16), 2.0)
+    assert torch.allclose(decoder.q.weight.data, expected)
+    # Untouched param stays at base.
+    assert torch.allclose(decoder.k.weight.data, torch.zeros(8, 16))
+
+
+def test_disable_restores_base_weights(monkeypatch):
+    """disable_lora must reset param.data back to the snapshot."""
+    mgr, decoder = _make_mgr()
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: ({"q.weight": torch.full((8, 16), 4.0)}, 8 * 16 * 4),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    mgr.enable_lora("x", strength=0.5)
+    assert decoder.q.weight.data.abs().sum() > 0  # non-zero now
+
+    mgr.disable_lora("x")
+    assert torch.allclose(decoder.q.weight.data, torch.zeros(8, 16))
+
+
+def test_strength_change_updates_param_data(monkeypatch):
+    """set_lora_strength must move the live weight to base + new_s * delta."""
+    mgr, decoder = _make_mgr()
+    delta = torch.full((8, 16), 4.0)
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: ({"q.weight": delta.clone()}, delta.numel() * 4),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    mgr.enable_lora("x", strength=0.5)
+    mgr.set_lora_strength("x", 0.25)
+
+    expected = torch.full((8, 16), 1.0)  # 0.25 * 4.0
+    assert torch.allclose(decoder.q.weight.data, expected)
+
+
+def test_two_loras_compose_additively(monkeypatch):
+    """Two ENABLED entries on the same param compose: param == base + Σ s·d."""
+    mgr, decoder = _make_mgr()
+
+    deltas = {
+        "a": {"q.weight": torch.full((8, 16), 2.0)},
+        "b": {"q.weight": torch.full((8, 16), 3.0)},
+    }
+    paths = {"/tmp/a.safetensors": "a", "/tmp/b.safetensors": "b"}
+
+    def fake_compute(p):
+        d = deltas[paths[p]]
+        return {k: v.clone() for k, v in d.items()}, sum(
+            v.numel() * 4 for v in d.values()
+        )
+
+    monkeypatch.setattr(mgr, "_compute_deltas", fake_compute)
+
+    mgr.register_lora("/tmp/a.safetensors")
+    mgr.register_lora("/tmp/b.safetensors")
+    mgr.enable_lora("a", strength=0.5)
+    mgr.enable_lora("b", strength=0.5)
+
+    # 0.5 * 2.0 + 0.5 * 3.0 == 2.5
+    expected = torch.full((8, 16), 2.5)
+    assert torch.allclose(decoder.q.weight.data, expected)
+
+    # Disabling one rolls back its contribution but leaves the other.
+    mgr.disable_lora("a")
+    expected = torch.full((8, 16), 1.5)  # only b at 0.5 * 3.0
+    assert torch.allclose(decoder.q.weight.data, expected)
+
+
+def test_enable_strength_zero_does_not_mutate_param(monkeypatch):
+    """Strength-0 ENABLED placeholder must leave param.data at base.
+
+    Same invariant as the TRT path's b20fba9 short-circuit: a slider
+    parked at zero shouldn't pay the writeback cost.
+    """
+    mgr, decoder = _make_mgr()
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: ({"q.weight": torch.full((8, 16), 99.0)}, 8 * 16 * 4),
+    )
+
+    mgr.register_lora("/tmp/x.safetensors")
+    mgr.enable_lora("x", strength=0.0)
+
+    assert mgr.get_lora("x").state == "enabled"
+    # Live param untouched.
+    assert torch.allclose(decoder.q.weight.data, torch.zeros(8, 16))
+
+
+def test_decoder_with_no_params_raises():
+    decoder = nn.Module()
+    with pytest.raises(RuntimeError, match="has no parameters"):
+        EagerLoRAManager(decoder=decoder)
+
+
+def test_apply_lora_one_shot_lifecycle(monkeypatch):
+    """apply_lora is the legacy register+enable shorthand."""
+    mgr, decoder = _make_mgr()
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: ({"q.weight": torch.full((8, 16), 2.0)}, 8 * 16 * 4),
+    )
+
+    lid = mgr.apply_lora("/tmp/foo.safetensors", strength=0.5)
+    assert lid == "foo"
+    assert mgr.get_lora(lid).state == "enabled"
+    assert torch.allclose(decoder.q.weight.data, torch.full((8, 16), 1.0))
+
+    assert mgr.remove_lora(lid)
+    assert torch.allclose(decoder.q.weight.data, torch.zeros(8, 16))
+
+
+def test_param_dtype_preserved(monkeypatch):
+    """Writeback must not silently upcast a fp16 param to fp32."""
+    decoder = nn.Module()
+    decoder.q = nn.Linear(16, 8, bias=False)
+    with torch.no_grad():
+        decoder.q.weight.data = decoder.q.weight.data.to(torch.float16).zero_()
+
+    mgr = EagerLoRAManager(decoder=decoder, device=torch.device("cpu"))
+    assert mgr._param_dtype["q.weight"] == torch.float16
+
+    monkeypatch.setattr(
+        mgr, "_compute_deltas",
+        lambda p: (
+            {"q.weight": torch.full((8, 16), 2.0, dtype=torch.float16)},
+            8 * 16 * 2,
+        ),
+    )
+    mgr.apply_lora("/tmp/foo.safetensors", strength=0.5)
+    assert decoder.q.weight.data.dtype == torch.float16

--- a/tests/unit/test_lora_refit.py
+++ b/tests/unit/test_lora_refit.py
@@ -43,6 +43,7 @@ def _make_mgr():
         "k.weight": torch.empty_like(base_k),
     }
     mgr._np_dtype = {"q.weight": np.float16, "k.weight": np.float16}
+    mgr._param_dtype = {"q.weight": torch.float16, "k.weight": torch.float16}
     mgr._loras = {}
     mgr._ever_dirty = set()
     mgr._executor = None


### PR DESCRIPTION
Extract LoRAManagerBase from TRTLoRAManager (catalog + lifecycle +
prewarm + delta math) and add EagerLoRAManager that writes directly
into decoder.named_parameters() in place. Both backends now share one
state machine and one public API on DiffusionEngine.

Eager storage is hybrid: MATERIALIZED deltas live in CPU RAM (matching
TRT, so the "register N, prewarm M" library workflow generalizes), and
the ENABLED transition mirrors them onto the decoder's device so
slider-driven refits stay zero-copy. The base-weight snapshot is also
lazy: a session that never enables a LoRA pays no extra VRAM.

DiffusionEngine.apply_trt_lora / register_trt_lora / etc. are renamed
without the _trt_ prefix (apply_lora, register_lora, ...). The wrapper
is now constructed for every decoder backend in apply_trt_backends, not
just tensorrt, so the LoRA library is reachable at startup instead of
being lazy-built on the first StreamDenoise.execute.

The existing LoadLoRA / ApplyLoRA / RemoveLoRA nodes keep working but
collapse to a single dispatch path (engine.apply_lora / engine.remove_lora).
The PyTorch-specific _precompute_lora_deltas / _apply_lora_deltas helpers
and ModelContext._active_lora_deltas state are gone.

Tests: 19 existing TRT tests preserved; 14 new tests in test_lora_eager.py
covering the lazy snapshot, GPU-mirror promotion on enable/disable, and
the prewarm-without-VRAM property.
