### PR TITLE
TensorRT 10.16 + XL

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,14 @@ The `workflows/covers/` directory contains standalone scripts demonstrating indi
 
 ## Running with TensorRT
 
+DEMON targets TensorRT 10.16.x for optional acceleration. TensorRT plans are
+version- and GPU-architecture-specific by default, so rebuild engines after
+changing TensorRT, CUDA, driver, or the GPU used for inference.
+
 Build TRT engines:
 
 ```bash
-# Build all engines (60s + 240s, VAE + decoder, refit + non-refit)
+# Build all engines (60s + 120s + 240s, VAE + refit decoder)
 uv run python -m acestep.engine.trt.build --all
 
 # Build 60s engines only (recommended starting point)
@@ -143,6 +147,9 @@ uv run python -m acestep.engine.trt.build --all --dry-run
 
 # Force rebuild even if engines already exist (skipped by default)
 uv run python -m acestep.engine.trt.build --all --force-rebuild
+
+# Force ONNX re-export as well as engine rebuild
+uv run python -m acestep.engine.trt.build --all --duration 60 --force-rebuild --force-onnx
 
 # Only decoders or only VAE
 uv run python -m acestep.engine.trt.build --all --decoder-only

--- a/acestep/engine/diffusion.py
+++ b/acestep/engine/diffusion.py
@@ -142,16 +142,31 @@ class DiffusionEngine:
         self._trt_stream = _get_trt_stream()
         self._trt_buf_cache = {}
 
-        # Detect I/O dtypes from engine (fp16 for mixed-precision, fp32 for legacy)
+        # Detect per-tensor I/O dtypes from the engine. Strongly-typed
+        # builds may use fp16/bf16/fp32 on different inputs, and TensorRT
+        # interprets buffers by the serialized tensor dtype.
         import tensorrt as trt
         _trt_dtype_map = {
             trt.float32: torch.float32,
             trt.float16: torch.float16,
-            trt.bfloat16: torch.bfloat16,
         }
-        hs_trt_dtype = self._trt_engine.get_tensor_dtype("hidden_states")
-        self._trt_io_dtype = _trt_dtype_map.get(hs_trt_dtype, torch.float32)
-        logger.info("TRT decoder engine ready (io_dtype={})", self._trt_io_dtype)
+        if hasattr(trt, "bfloat16"):
+            _trt_dtype_map[trt.bfloat16] = torch.bfloat16
+
+        input_names = ("hidden_states", "timestep", "encoder_hidden_states", "context_latents")
+        self._trt_input_dtypes = {
+            name: _trt_dtype_map.get(self._trt_engine.get_tensor_dtype(name), torch.float32)
+            for name in input_names
+        }
+        self._trt_output_dtype = _trt_dtype_map.get(
+            self._trt_engine.get_tensor_dtype("velocity"), torch.float32
+        )
+        self._trt_io_dtype = self._trt_input_dtypes["hidden_states"]
+        logger.info(
+            "TRT decoder engine ready (input_dtypes={}, output_dtype={})",
+            self._trt_input_dtypes,
+            self._trt_output_dtype,
+        )
 
         # Try to initialize LoRA refit manager (requires REFIT-enabled engine)
         self._lora_manager = None
@@ -440,21 +455,28 @@ class DiffusionEngine:
             ctx = self._trt_ctx
             dev = hidden_states.device
             hs_shape, ts_shape, enc_shape, cl_shape = key
-            io_dtype = self._trt_io_dtype
+            in_dtypes = self._trt_input_dtypes
 
             bufs = {
-                "hidden_states": torch.empty(hs_shape, dtype=io_dtype, device=dev),
-                "timestep": torch.empty(ts_shape, dtype=torch.float32, device=dev),
-                "encoder_hidden_states": torch.empty(enc_shape, dtype=io_dtype, device=dev),
-                "context_latents": torch.empty(cl_shape, dtype=io_dtype, device=dev),
+                "hidden_states": torch.empty(hs_shape, dtype=in_dtypes["hidden_states"], device=dev),
+                "timestep": torch.empty(ts_shape, dtype=in_dtypes["timestep"], device=dev),
+                "encoder_hidden_states": torch.empty(enc_shape, dtype=in_dtypes["encoder_hidden_states"], device=dev),
+                "context_latents": torch.empty(cl_shape, dtype=in_dtypes["context_latents"], device=dev),
             }
             for name, buf in bufs.items():
-                ctx.set_input_shape(name, tuple(buf.shape))
-                ctx.set_tensor_address(name, buf.data_ptr())
+                if not ctx.set_input_shape(name, tuple(buf.shape)):
+                    raise RuntimeError(f"TRT decoder rejected input shape for {name}: {tuple(buf.shape)}")
+                if not ctx.set_tensor_address(name, buf.data_ptr()):
+                    raise RuntimeError(f"TRT decoder rejected input address for {name}")
+
+            missing = ctx.infer_shapes()
+            if missing:
+                raise RuntimeError(f"TRT decoder shapes are insufficiently specified: {missing}")
 
             out_shape = tuple(ctx.get_tensor_shape("velocity"))
-            out_buf = torch.empty(out_shape, dtype=io_dtype, device=dev)
-            ctx.set_tensor_address("velocity", out_buf.data_ptr())
+            out_buf = torch.empty(out_shape, dtype=self._trt_output_dtype, device=dev)
+            if not ctx.set_tensor_address("velocity", out_buf.data_ptr()):
+                raise RuntimeError("TRT decoder rejected output address for velocity")
 
             self._trt_buf_cache[key] = {"bufs": bufs, "output": out_buf}
             logger.info(
@@ -478,10 +500,13 @@ class DiffusionEngine:
 
         ctx = self._trt_ctx
         for name, buf in bufs.items():
-            ctx.set_tensor_address(name, buf.data_ptr())
-        ctx.set_tensor_address("velocity", entry["output"].data_ptr())
+            if not ctx.set_tensor_address(name, buf.data_ptr()):
+                raise RuntimeError(f"TRT decoder rejected input address for {name}")
+        if not ctx.set_tensor_address("velocity", entry["output"].data_ptr()):
+            raise RuntimeError("TRT decoder rejected output address for velocity")
 
-        ctx.execute_async_v3(self._trt_stream.ptr)
+        if not ctx.execute_async_v3(self._trt_stream.ptr):
+            raise RuntimeError("TRT decoder execution failed")
         self._trt_stream.synchronize()
 
         output = entry["output"]

--- a/acestep/engine/stream.py
+++ b/acestep/engine/stream.py
@@ -249,6 +249,9 @@ class StreamPipeline:
         self._trt_stream = engine._trt_stream
         self._trt_engine = engine._trt_engine
         self._trt_io_dtype = getattr(engine, '_trt_io_dtype', torch.float32)
+        self._trt_input_dtypes = getattr(engine, "_trt_input_dtypes", {})
+        self._trt_output_dtype = getattr(engine, "_trt_output_dtype", self._trt_io_dtype)
+
         # Currently-bound TRT I/O buffers (set by _ensure_trt_bufs to one
         # entry of _trt_bufs_cache). _trt_forward reads these directly.
         self._trt_bufs: Optional[dict] = None
@@ -358,6 +361,10 @@ class StreamPipeline:
         self._trt_ctx = engine._trt_ctx
         self._trt_stream = engine._trt_stream
         self._trt_io_dtype = getattr(engine, "_trt_io_dtype", torch.float32)
+        self._trt_input_dtypes = getattr(engine, "_trt_input_dtypes", {})
+        self._trt_output_dtype = getattr(
+            engine, "_trt_output_dtype", self._trt_io_dtype
+        )
         self._trt_bufs = None
         self._trt_out_buf = None
         self._trt_bufs_cache.clear()
@@ -668,14 +675,25 @@ class StreamPipeline:
         so repeated ticks with the same ``(B, T, max_L)`` shape reuse
         allocations.
 
-        The engine is built with a fixed ``batch_max`` (typically 8).
-        If ``xt_batch.shape[0]`` exceeds the engine profile's max,
-        shape binding raises inside ``_ensure_trt_bufs``. Callers can
-        hit this when ``depth × n_conds × (1 + has_cfg)`` exceeds the
-        cap — split the batch or rebuild the engine with a larger
-        profile.
+        The active ring-buffer rows are submitted as one TensorRT
+        execution. If ``B`` exceeds the loaded engine profile, TensorRT
+        rejects the shape instead of silently falling back to sequential
+        per-row dispatch.
         """
         B, T, _ = xt_batch.shape
+        if len(timestep_list) != B:
+            raise RuntimeError(
+                "TRT stream batch mismatch: "
+                f"hidden_states batch={B}, timesteps={len(timestep_list)}"
+            )
+        if enc_batch.shape[0] != B or ctx_batch.shape[0] != B:
+            raise RuntimeError(
+                "TRT stream batch mismatch: "
+                f"hidden_states={tuple(xt_batch.shape)}, "
+                f"encoder={tuple(enc_batch.shape)}, "
+                f"context={tuple(ctx_batch.shape)}"
+            )
+
         max_L = enc_batch.shape[1]
 
         self._ensure_trt_bufs(B, T, max_L)
@@ -683,7 +701,7 @@ class StreamPipeline:
         pad = T % 2 == 1
 
         # hidden_states: cast to engine I/O dtype; pad odd T with zeros.
-        xt_io = xt_batch.to(self._trt_io_dtype)
+        xt_io = xt_batch.to(bufs["hidden_states"].dtype)
         if pad:
             bufs["hidden_states"][:, :T, :].copy_(xt_io)
             bufs["hidden_states"][:, T:, :].zero_()
@@ -697,10 +715,12 @@ class StreamPipeline:
         # encoder_hidden_states: already padded to max_L + catted by
         # the caller. The engine has no ``encoder_attention_mask``
         # input; padding is handled by zero-value convention.
-        bufs["encoder_hidden_states"].copy_(enc_batch.to(self._trt_io_dtype))
+        bufs["encoder_hidden_states"].copy_(
+            enc_batch.to(bufs["encoder_hidden_states"].dtype)
+        )
 
         # context_latents: pad odd T with zeros.
-        ctx_io = ctx_batch.to(self._trt_io_dtype)
+        ctx_io = ctx_batch.to(bufs["context_latents"].dtype)
         if pad:
             bufs["context_latents"][:, :T, :].copy_(ctx_io)
             bufs["context_latents"][:, T:, :].zero_()
@@ -712,10 +732,13 @@ class StreamPipeline:
         for name, buf in bufs.items():
             if name.startswith("_"):
                 continue
-            ctx.set_tensor_address(name, buf.data_ptr())
-        ctx.set_tensor_address("velocity", self._trt_out_buf.data_ptr())
+            if not ctx.set_tensor_address(name, buf.data_ptr()):
+                raise RuntimeError(f"TRT decoder rejected input address for {name}")
+        if not ctx.set_tensor_address("velocity", self._trt_out_buf.data_ptr()):
+            raise RuntimeError("TRT decoder rejected output address for velocity")
 
-        ctx.execute_async_v3(self._trt_stream.ptr)
+        if not ctx.execute_async_v3(self._trt_stream.ptr):
+            raise RuntimeError("TRT decoder execution failed")
         self._trt_stream.synchronize()
 
         out = self._trt_out_buf
@@ -756,16 +779,44 @@ class StreamPipeline:
 
         device = self._device
         io_dtype = self._trt_io_dtype
+        in_dtypes = self._trt_input_dtypes
         bufs = {
-            "hidden_states": torch.empty(B, eff_T, 64, dtype=io_dtype, device=device),
-            "timestep": torch.empty(B, dtype=torch.float32, device=device),
-            "encoder_hidden_states": torch.empty(B, max_L, 2048, dtype=io_dtype, device=device),
-            "context_latents": torch.empty(B, eff_T, 128, dtype=io_dtype, device=device),
+            "hidden_states": torch.empty(
+                B, eff_T, 64,
+                dtype=in_dtypes.get("hidden_states", io_dtype),
+                device=device,
+            ),
+            "timestep": torch.empty(
+                B,
+                dtype=in_dtypes.get("timestep", torch.float32),
+                device=device,
+            ),
+            "encoder_hidden_states": torch.empty(
+                B, max_L, 2048,
+                dtype=in_dtypes.get("encoder_hidden_states", io_dtype),
+                device=device,
+            ),
+            "context_latents": torch.empty(
+                B, eff_T, 128,
+                dtype=in_dtypes.get("context_latents", io_dtype),
+                device=device,
+            ),
         }
 
         for name, buf in bufs.items():
-            ctx.set_input_shape(name, tuple(buf.shape))
-            ctx.set_tensor_address(name, buf.data_ptr())
+            if not ctx.set_input_shape(name, tuple(buf.shape)):
+                raise RuntimeError(
+                    f"TRT decoder rejected input shape for {name}: "
+                    f"{tuple(buf.shape)}"
+                )
+            if not ctx.set_tensor_address(name, buf.data_ptr()):
+                raise RuntimeError(f"TRT decoder rejected input address for {name}")
+
+        missing = ctx.infer_shapes()
+        if missing:
+            raise RuntimeError(
+                f"TRT decoder shapes are insufficiently specified: {missing}"
+            )
 
         out_shape = tuple(ctx.get_tensor_shape("velocity"))
         if any(d < 0 for d in out_shape):
@@ -773,8 +824,9 @@ class StreamPipeline:
                 f"TRT output shape unresolved: {out_shape}. "
                 f"B={B}, eff_T={eff_T}, L={max_L}"
             )
-        out_buf = torch.empty(out_shape, dtype=io_dtype, device=device)
-        ctx.set_tensor_address("velocity", out_buf.data_ptr())
+        out_buf = torch.empty(out_shape, dtype=self._trt_output_dtype, device=device)
+        if not ctx.set_tensor_address("velocity", out_buf.data_ptr()):
+            raise RuntimeError("TRT decoder rejected output address for velocity")
 
         bufs["_key"] = key
         bufs["_eff_T"] = eff_T
@@ -1227,8 +1279,8 @@ class StreamPipeline:
         """Resize the ring buffer. Active slots drain naturally.
 
         Args:
-            depth: New number of concurrent slots.  Clamped to [1, 8]
-                (the TRT engine's batch_max).
+            depth: New number of concurrent slots. Clamped to [1, 8],
+                matching the canonical decoder engine batch profile.
         """
         depth = max(1, min(depth, 8))
         if depth == self._depth:

--- a/acestep/engine/trt/build.py
+++ b/acestep/engine/trt/build.py
@@ -38,9 +38,18 @@ Requirements:
 """
 
 import argparse
+import hashlib
+import json
 import os
+import platform
+import re
+import subprocess
 import sys
 import time
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from importlib import metadata as importlib_metadata
+from pathlib import Path
 
 # Suppress flash_attn import (not needed for export)
 import importlib, importlib.util
@@ -53,6 +62,16 @@ importlib.util.find_spec = _patch
 
 from loguru import logger
 import torch
+
+_SUPPORTED_TRT_MIN = (10, 16)
+_SUPPORTED_TRT_MAX = (10, 17)
+_ENGINE_METADATA_SCHEMA = 1
+_DECODER_PRECISION_CHOICES = (
+    "auto",
+    "fp32",
+    "fp16_mixed",
+    "bf16_mixed",
+)
 
 
 # ------------------------------------------------------------------
@@ -70,6 +89,277 @@ def _default_checkpoints_dir() -> str:
     """Default checkpoints directory from acestep.paths."""
     from acestep.paths import checkpoints_dir
     return str(checkpoints_dir())
+
+
+def _parse_version_tuple(version: str) -> tuple[int, ...]:
+    """Extract a comparable numeric prefix from versions like 10.16.1.11."""
+    return tuple(int(p) for p in re.findall(r"\d+", version)[:3])
+
+
+def _dist_version(name: str) -> str | None:
+    try:
+        return importlib_metadata.version(name)
+    except importlib_metadata.PackageNotFoundError:
+        return None
+
+
+def _nvidia_smi_summary() -> dict:
+    """Best-effort driver/GPU snapshot for engine metadata."""
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,driver_version,compute_cap",
+                "--format=csv,noheader",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+    except Exception as exc:
+        return {"available": False, "error": str(exc)}
+
+    gpus = []
+    for line in result.stdout.splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) >= 3:
+            gpus.append({
+                "name": parts[0],
+                "driver_version": parts[1],
+                "compute_capability": parts[2],
+            })
+    return {"available": True, "gpus": gpus}
+
+
+def _active_gpu_summary(device: str) -> dict:
+    if not torch.cuda.is_available():
+        return {"available": False}
+
+    torch_device = torch.device(device)
+    index = torch_device.index if torch_device.index is not None else torch.cuda.current_device()
+    props = torch.cuda.get_device_properties(index)
+    return {
+        "available": True,
+        "index": index,
+        "name": props.name,
+        "compute_capability": f"{props.major}.{props.minor}",
+        "total_memory_bytes": props.total_memory,
+    }
+
+
+def _preflight(device: str) -> dict:
+    """Validate and log the TensorRT/CUDA stack before building engines."""
+    import tensorrt as trt
+
+    trt_version = trt.__version__
+    parsed = _parse_version_tuple(trt_version)
+    if parsed < _SUPPORTED_TRT_MIN or parsed >= _SUPPORTED_TRT_MAX:
+        raise RuntimeError(
+            "DEMON TensorRT builds target TensorRT >=10.16,<10.17; "
+            f"found {trt_version}. Run `uv sync --upgrade-package tensorrt`."
+        )
+
+    env = {
+        "schema_version": _ENGINE_METADATA_SCHEMA,
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+        },
+        "packages": {
+            "tensorrt": trt_version,
+            "tensorrt_cu13": _dist_version("tensorrt-cu13"),
+            "tensorrt_cu13_bindings": _dist_version("tensorrt-cu13-bindings"),
+            "tensorrt_cu13_libs": _dist_version("tensorrt-cu13-libs"),
+            "cuda_python": _dist_version("cuda-python"),
+            "cuda_toolkit": _dist_version("cuda-toolkit"),
+            "polygraphy": _dist_version("polygraphy"),
+            "onnx": _dist_version("onnx"),
+            "torch": torch.__version__,
+        },
+        "torch_cuda": torch.version.cuda,
+        "onnx_parser_version": getattr(trt, "get_nv_onnx_parser_version", lambda: None)(),
+        "active_gpu": _active_gpu_summary(device),
+        "nvidia_smi": _nvidia_smi_summary(),
+    }
+
+    logger.info("=" * 60)
+    logger.info("TensorRT build preflight")
+    logger.info("=" * 60)
+    logger.info("TensorRT: {}", env["packages"]["tensorrt"])
+    logger.info("TensorRT cu13: {}", env["packages"]["tensorrt_cu13"])
+    logger.info("CUDA Python: {}", env["packages"]["cuda_python"])
+    logger.info("CUDA toolkit wheel: {}", env["packages"]["cuda_toolkit"])
+    logger.info("Polygraphy: {}", env["packages"]["polygraphy"])
+    logger.info("ONNX: {}", env["packages"]["onnx"])
+    logger.info("Torch: {} (CUDA {})", env["packages"]["torch"], env["torch_cuda"])
+    gpu = env["active_gpu"]
+    if gpu.get("available"):
+        logger.info(
+            "Active GPU: cuda:{} {} (SM {})",
+            gpu["index"], gpu["name"], gpu["compute_capability"],
+        )
+    else:
+        logger.warning("No active CUDA GPU detected in torch")
+    return env
+
+
+def _sha256_file(path: str | os.PathLike[str]) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _config_dict(config) -> dict:
+    if is_dataclass(config):
+        return asdict(config)
+    return dict(vars(config))
+
+
+def _looks_like_xl_checkpoint(checkpoint: str) -> bool:
+    return "xl" in os.path.basename(checkpoint).lower()
+
+
+def _resolve_decoder_precision(
+    *,
+    checkpoint: str,
+    requested: str,
+    decoder_mixed: bool,
+) -> str:
+    """Resolve the decoder ONNX precision recipe for this checkpoint.
+
+    ``decoder_mixed`` preserves the legacy 2B behavior: when callers ask
+    for the old mixed path, ``auto`` maps to the fp16 mixed export recipe.
+    XL checkpoints need bf16 range, so their ``auto`` default is bf16_mixed.
+    """
+    if requested != "auto":
+        return requested
+    if _looks_like_xl_checkpoint(checkpoint):
+        return "bf16_mixed"
+    if decoder_mixed:
+        return "fp16_mixed"
+    return "fp32"
+
+
+def _decoder_precision_is_strongly_typed(decoder_precision: str, decoder_mixed: bool) -> bool:
+    if decoder_precision == "fp16_mixed":
+        return True
+    if decoder_precision == "bf16_mixed":
+        return True
+    return decoder_mixed
+
+
+def _decoder_onnx_needs_dynbatch_patch(
+    *,
+    checkpoint: str,
+    decoder_precision: str,
+    batch_max: int,
+) -> bool:
+    return (
+        batch_max > 1
+        and _looks_like_xl_checkpoint(checkpoint)
+        and decoder_precision == "bf16_mixed"
+    )
+
+
+def _patch_decoder_onnx_for_dynamic_batch(
+    onnx_paths: dict[str, str],
+    *,
+    need_decoder_std: bool,
+    need_decoder_refit: bool,
+    checkpoint: str,
+    decoder_precision: str,
+    batch_max: int,
+    force: bool,
+) -> dict[str, str]:
+    """Return ONNX paths, replacing XL decoder ONNX with dynbatch-patched copies."""
+    if not _decoder_onnx_needs_dynbatch_patch(
+        checkpoint=checkpoint,
+        decoder_precision=decoder_precision,
+        batch_max=batch_max,
+    ):
+        return onnx_paths
+
+    from .export import patch_decoder_onnx_dynamic_batch_reshapes
+
+    patched = dict(onnx_paths)
+    for key, needed in (
+        ("decoder", need_decoder_std),
+        ("decoder_refit", need_decoder_refit),
+    ):
+        if not needed:
+            continue
+        patched[key] = str(
+            patch_decoder_onnx_dynamic_batch_reshapes(
+                patched[key],
+                force=force,
+            )
+        )
+    return patched
+
+
+def _metadata_path(engine_path: str | os.PathLike[str]) -> Path:
+    return Path(str(engine_path) + ".metadata.json")
+
+
+def _expected_metadata(
+    *,
+    component: str,
+    onnx_path: str,
+    config,
+    env: dict,
+) -> dict:
+    gpu = env.get("active_gpu", {})
+    return {
+        "schema_version": _ENGINE_METADATA_SCHEMA,
+        "component": component,
+        "tensorrt_version": env["packages"]["tensorrt"],
+        "gpu_compute_capability": gpu.get("compute_capability"),
+        "gpu_name": gpu.get("name"),
+        "config": _config_dict(config),
+        "onnx_path": str(Path(onnx_path).resolve()),
+        "onnx_sha256": _sha256_file(onnx_path),
+    }
+
+
+def _write_metadata(
+    *,
+    engine_path: str,
+    expected: dict,
+    env: dict,
+) -> None:
+    payload = dict(expected)
+    payload["built_at"] = datetime.now(timezone.utc).isoformat()
+    payload["environment"] = env
+    path = _metadata_path(engine_path)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    logger.info("Engine metadata saved to {}", path)
+
+
+def _metadata_matches(engine_path: str, expected: dict) -> tuple[bool, str]:
+    path = _metadata_path(engine_path)
+    if not path.exists():
+        return False, "missing metadata"
+    try:
+        actual = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return False, f"metadata unreadable: {exc}"
+
+    for key in (
+        "schema_version",
+        "component",
+        "tensorrt_version",
+        "gpu_compute_capability",
+        "config",
+        "onnx_sha256",
+    ):
+        if actual.get(key) != expected.get(key):
+            return False, f"metadata mismatch: {key}"
+    return True, "metadata match"
 
 
 def _verify_engines(engine_paths: list[tuple[str, str]]):
@@ -130,17 +420,19 @@ def _ensure_onnx(
     need_vae: bool,
     need_decoder_std: bool,
     need_decoder_refit: bool,
-    decoder_mixed: bool,
+    decoder_precision: str,
     skip_onnx: bool,
+    force_onnx: bool = False,
     export_locally: bool = False,
 ) -> dict[str, str]:
     """Resolve ONNX paths for the build, fetching from HF when missing.
 
     Resolution order for each needed component:
-      1. Local cache present -> reuse.
+      1. Local cache present -> reuse, unless ``force_onnx`` is set.
       2. ``skip_onnx``       -> error (no fetch, no export).
-      3. ``export_locally``  -> export from the model checkpoint.
-      4. Default             -> download from HF via ``onnx_hub``.
+      3. ``force_onnx``      -> re-export from the model checkpoint.
+      4. ``export_locally``  -> export missing files from the checkpoint.
+      5. Default             -> download missing files from HF via ``onnx_hub``.
 
     HF-first is the clean default: machines that don't have the model
     checkpoint can build engines without ever touching torch's model
@@ -175,22 +467,24 @@ def _ensure_onnx(
                 paths[key] = old_path
 
     # Build the list of (component, fetch_kwargs) pairs that the caller
-    # actually needs and that aren't yet on disk.
+    # actually needs and that aren't yet on disk. With --force-onnx, all
+    # requested components are included so the checkpoint exporter overwrites
+    # stale or suspect ONNX files.
     requested: list[tuple[str, dict]] = []
     if need_vae:
-        if not os.path.exists(paths["vae_encode"]):
+        if force_onnx or not os.path.exists(paths["vae_encode"]):
             requested.append(("vae_encode", {}))
         else:
             logger.info("Reusing existing VAE encoder ONNX: {}", paths["vae_encode"])
-        if not os.path.exists(paths["vae_decode"]):
+        if force_onnx or not os.path.exists(paths["vae_decode"]):
             requested.append(("vae_decode", {}))
         else:
             logger.info("Reusing existing VAE decoder ONNX: {}", paths["vae_decode"])
-    if need_decoder_std and not os.path.exists(paths["decoder"]):
+    if need_decoder_std and (force_onnx or not os.path.exists(paths["decoder"])):
         requested.append(("decoder", {"checkpoint": checkpoint}))
     elif need_decoder_std:
         logger.info("Reusing existing decoder ONNX: {}", paths["decoder"])
-    if need_decoder_refit and not os.path.exists(paths["decoder_refit"]):
+    if need_decoder_refit and (force_onnx or not os.path.exists(paths["decoder_refit"])):
         requested.append(("decoder_refit", {"checkpoint": checkpoint}))
     elif need_decoder_refit:
         logger.info("Reusing existing decoder ONNX (refit): {}", paths["decoder_refit"])
@@ -199,7 +493,10 @@ def _ensure_onnx(
     if skip_onnx:
         if requested:
             for comp, _ in requested:
-                logger.error("Missing ONNX file (refusing to fetch/export with --skip-onnx): {}", paths[comp])
+                logger.error(
+                    "Missing ONNX file (refusing to fetch/export with --skip-onnx): {}",
+                    paths[comp],
+                )
             sys.exit(1)
         logger.info("All ONNX exports found, --skip-onnx satisfied.")
         return paths
@@ -211,7 +508,7 @@ def _ensure_onnx(
     # HF-first path. Each fetch lands the file at the same local path
     # the local exporter would write, so the rest of the pipeline
     # downstream doesn't care about the source.
-    if not export_locally:
+    if not export_locally and not force_onnx:
         local_root = os.path.dirname(onnx_dir)  # the trt_engines dir
         try:
             for comp, kw in requested:
@@ -232,12 +529,13 @@ def _ensure_onnx(
             )
             sys.exit(1)
 
-    # --export-locally path: load the model and re-export from weights.
+    # --export-locally / --force-onnx path: load the model and export from weights.
     export_vae = any(c.startswith("vae_") for c, _ in requested)
     export_decoder_refit = any(c == "decoder_refit" for c, _ in requested)
     export_decoder_std = any(c == "decoder" for c, _ in requested)
 
-    logger.info("Loading model from checkpoints/{} (--export-locally)...", checkpoint)
+    mode = "--force-onnx" if force_onnx else "--export-locally"
+    logger.info("Loading model from checkpoints/{} ({})...", checkpoint, mode)
     if project_root not in sys.path:
         sys.path.insert(0, project_root)
     from acestep.engine.model_context import ModelContext
@@ -276,28 +574,44 @@ def _ensure_onnx(
 
     if export_decoder_refit or export_decoder_std:
         from .export import OnnxExportConfig, export_decoder_onnx
+
+        def decoder_export_config(*, for_refit: bool) -> OnnxExportConfig:
+            if decoder_precision == "fp16_mixed":
+                return OnnxExportConfig(mixed_precision=True, for_refit=for_refit)
+            return OnnxExportConfig(
+                precision=decoder_precision,
+                mixed_precision=False,
+                for_refit=for_refit,
+            )
+
         with handler._load_model_context("model"):
             if export_decoder_refit:
                 logger.info("=" * 60)
-                logger.info("DECODER ONNX EXPORT (refit-enabled)")
+                logger.info(
+                    "DECODER ONNX EXPORT (refit-enabled, precision={})",
+                    decoder_precision,
+                )
                 logger.info("=" * 60)
                 t0 = time.time()
                 export_decoder_onnx(
                     handler.model, paths["decoder_refit"], device=device,
-                    config=OnnxExportConfig(mixed_precision=decoder_mixed, for_refit=True),
+                    config=decoder_export_config(for_refit=True),
                 )
-                logger.info("Decoder ONNX (refit) exported in %.1fs", time.time() - t0)
+                logger.info("Decoder ONNX (refit) exported in {:.1f}s", time.time() - t0)
 
             if export_decoder_std:
                 logger.info("=" * 60)
-                logger.info("DECODER ONNX EXPORT (standard)")
+                logger.info(
+                    "DECODER ONNX EXPORT (standard, precision={})",
+                    decoder_precision,
+                )
                 logger.info("=" * 60)
                 t0 = time.time()
                 export_decoder_onnx(
                     handler.model, paths["decoder"], device=device,
-                    config=OnnxExportConfig(mixed_precision=decoder_mixed, for_refit=False),
+                    config=decoder_export_config(for_refit=False),
                 )
-                logger.info("Decoder ONNX (standard) exported in %.1fs", time.time() - t0)
+                logger.info("Decoder ONNX (standard) exported in {:.1f}s", time.time() - t0)
 
     # Free model memory before TRT builds
     del handler
@@ -316,6 +630,7 @@ def _build_vae_engines(
     onnx_paths: dict[str, str],
     duration: int,
     workspace_gb: float,
+    env: dict,
     force_rebuild: bool = False,
 ) -> list[tuple[str, str, float, str]]:
     """Build VAE encode + decode TRT engines for one duration.
@@ -343,12 +658,21 @@ def _build_vae_engines(
         engine_path = os.path.join(engine_dir, f"{name}.engine")
 
         label = f"VAE {component.split('_')[1]} {duration}s"
+        expected_metadata = _expected_metadata(
+            component=component,
+            onnx_path=onnx_paths[component],
+            config=config,
+            env=env,
+        )
 
         if not force_rebuild and os.path.exists(engine_path):
-            size_mb = os.path.getsize(engine_path) / 1e6
-            logger.info("SKIP {} ({:.0f} MB)", name, size_mb)
-            results.append((label, engine_path, 0.0, "SKIPPED"))
-            continue
+            matches, reason = _metadata_matches(engine_path, expected_metadata)
+            if matches:
+                size_mb = os.path.getsize(engine_path) / 1e6
+                logger.info("SKIP {} ({:.0f} MB, {})", name, size_mb, reason)
+                results.append((label, engine_path, 0.0, "SKIPPED"))
+                continue
+            logger.info("REBUILD {} ({})", name, reason)
 
         logger.info("=" * 60)
         logger.info("VAE TRT BUILD: {} (max_duration={}s)", name, duration)
@@ -356,6 +680,7 @@ def _build_vae_engines(
 
         t0 = time.time()
         builder(onnx_paths[component], engine_path, config=config)
+        _write_metadata(engine_path=engine_path, expected=expected_metadata, env=env)
         elapsed = time.time() - t0
         logger.info("Built in {:.0f}s", elapsed)
         results.append((label, engine_path, elapsed, "OK"))
@@ -439,8 +764,13 @@ def _build_decoder_engine(
     refit: bool,
     workspace_gb: float,
     batch_max: int,
+    env: dict,
+    batch_opt: int | None = None,
+    builder_optimization_level: int | None = None,
     force_rebuild: bool = False,
     checkpoint: str = "acestep-v15-turbo",
+    decoder_precision: str = "fp16_mixed",
+    strongly_typed: bool = True,
 ) -> tuple[str, str, float, str]:
     """Build one decoder TRT engine.
 
@@ -452,13 +782,19 @@ def _build_decoder_engine(
     variant = _checkpoint_to_variant(checkpoint)
     config = TRTBuildConfig(
         fp16=True,
-        strongly_typed=mixed,
+        strongly_typed=strongly_typed,
         refit=refit,
         workspace_gb=workspace_gb,
         batch_max=batch_max,
+        seq_opt=min(duration * 25, 1500),
         seq_max=duration * 25,
         variant=variant,
+        onnx_precision=decoder_precision,
     )
+    if batch_opt is not None:
+        config.batch_opt = batch_opt
+    if builder_optimization_level is not None:
+        config.builder_optimization_level = builder_optimization_level
 
     name = config.engine_filename().replace(".engine", "")
     engine_dir = os.path.join(output_dir, name)
@@ -467,19 +803,31 @@ def _build_decoder_engine(
     onnx_key = "decoder_refit" if refit else "decoder"
     refit_label = "refit" if refit else "no-refit"
     label = f"Decoder {variant} {duration}s, {refit_label}"
+    expected_metadata = _expected_metadata(
+        component=onnx_key,
+        onnx_path=onnx_paths[onnx_key],
+        config=config,
+        env=env,
+    )
 
     if not force_rebuild and os.path.exists(engine_path):
-        size_mb = os.path.getsize(engine_path) / 1e6
-        logger.info("SKIP {} ({:.0f} MB)", name, size_mb)
-        return (label, engine_path, 0.0, "SKIPPED")
+        matches, reason = _metadata_matches(engine_path, expected_metadata)
+        if matches:
+            size_mb = os.path.getsize(engine_path) / 1e6
+            logger.info("SKIP {} ({:.0f} MB, {})", name, size_mb, reason)
+            return (label, engine_path, 0.0, "SKIPPED")
+        logger.info("REBUILD {} ({})", name, reason)
 
     logger.info("=" * 60)
-    logger.info("DECODER TRT BUILD (refit={}, mixed={}) -> {}",
-                refit, mixed, engine_path)
+    logger.info(
+        "DECODER TRT BUILD (refit={}, mixed={}, precision={}) -> {}",
+        refit, mixed, decoder_precision, engine_path,
+    )
     logger.info("=" * 60)
 
     t0 = time.time()
     build_trt_engine(onnx_paths[onnx_key], engine_path, config=config)
+    _write_metadata(engine_path=engine_path, expected=expected_metadata, env=env)
     elapsed = time.time() - t0
     logger.info("Built in {:.0f}s", elapsed)
 
@@ -640,6 +988,10 @@ def main():
     single.add_argument("--skip-onnx", action="store_true",
                         help="Don't fetch or export ONNX. Error if any "
                              "needed ONNX file is missing locally.")
+    single.add_argument("--force-onnx", action="store_true",
+                        help="Re-export ONNX files from the model checkpoint "
+                             "even if matching files already exist. Implies "
+                             "--export-locally.")
     single.add_argument("--export-locally", action="store_true",
                         help="Re-export ONNX from the model checkpoint "
                              "instead of fetching from HuggingFace. The "
@@ -655,18 +1007,45 @@ def main():
                         help="Build decoder engine(s)")
     single.add_argument("--decoder-mixed", action="store_true",
                         help="Use mixed precision for decoder")
+    single.add_argument("--decoder-precision",
+                        choices=_DECODER_PRECISION_CHOICES,
+                        default="auto",
+                        help="Decoder ONNX export precision recipe. "
+                             "'auto' keeps the legacy fp16_mixed recipe for "
+                             "2B mixed builds and uses bf16_mixed for XL "
+                             "checkpoints.")
     single.add_argument("--decoder-refit",
                         action=argparse.BooleanOptionalAction, default=True,
                         help="Build refit-enabled decoder for LoRA "
                              "(default: True, use --no-decoder-refit)")
     single.add_argument("--batch-max", type=int, default=8,
                         help="Max batch size for decoder (default: 8)")
+    single.add_argument("--batch-opt", type=int, default=None,
+                        help="Optimal batch size for decoder TRT profile "
+                             "(default: TRTBuildConfig default)")
+    single.add_argument("--builder-optimization-level", type=int, default=None,
+                        help="TensorRT builder optimization level, 0-5 "
+                             "(default: TRTBuildConfig default)")
     single.add_argument("--skip-vae", action="store_true",
                         help="Skip VAE engine build")
 
     args = parser.parse_args()
+    if args.skip_onnx and args.force_onnx:
+        parser.error("--skip-onnx and --force-onnx are mutually exclusive")
+    if args.batch_opt is not None and args.batch_opt < 1:
+        parser.error("--batch-opt must be >= 1")
+    if args.batch_opt is not None and args.batch_opt > args.batch_max:
+        parser.error("--batch-opt must be <= --batch-max")
+    if (
+        args.builder_optimization_level is not None
+        and not 0 <= args.builder_optimization_level <= 5
+    ):
+        parser.error("--builder-optimization-level must be between 0 and 5")
+    if args.force_onnx:
+        args.export_locally = True
 
     checkpoints_root = _default_checkpoints_dir()
+    env = None if args.dry_run else _preflight(args.device)
 
     os.makedirs(args.output_dir, exist_ok=True)
     # ONNX directory is checkpoint-specific for decoder (different weights)
@@ -675,14 +1054,22 @@ def main():
     os.makedirs(onnx_dir, exist_ok=True)
 
     if args.all:
-        _run_all(args, checkpoints_root, onnx_dir)
+        _run_all(args, checkpoints_root, onnx_dir, env)
     else:
-        _run_single(args, checkpoints_root, onnx_dir)
+        _run_single(args, checkpoints_root, onnx_dir, env)
 
 
-def _run_all(args, project_root, onnx_dir):
+def _run_all(args, project_root, onnx_dir, env):
     """Build the full engine matrix."""
     durations = tuple(args.duration) if args.duration else (60, 120, 240)
+    decoder_precision = _resolve_decoder_precision(
+        checkpoint=args.checkpoint,
+        requested=args.decoder_precision,
+        decoder_mixed=True,
+    )
+    decoder_strongly_typed = _decoder_precision_is_strongly_typed(
+        decoder_precision, decoder_mixed=True,
+    )
     # --dreamvae-only is shorthand for "skip standard VAE/decoder, only
     # build dreamvae". --with-dreamvae adds dreamvae on top of the
     # standard build. Both forms enable the dreamvae build.
@@ -715,9 +1102,19 @@ def _run_all(args, project_root, onnx_dir):
             need_vae=build_vae,
             need_decoder_std=False,
             need_decoder_refit=build_decoder,
-            decoder_mixed=True,
+            decoder_precision=decoder_precision,
             skip_onnx=args.skip_onnx,
+            force_onnx=args.force_onnx,
             export_locally=args.export_locally,
+        )
+        onnx_paths = _patch_decoder_onnx_for_dynamic_batch(
+            onnx_paths,
+            need_decoder_std=False,
+            need_decoder_refit=build_decoder,
+            checkpoint=args.checkpoint,
+            decoder_precision=decoder_precision,
+            batch_max=args.batch_max,
+            force=args.force_onnx,
         )
     else:
         onnx_paths = {}
@@ -731,6 +1128,7 @@ def _run_all(args, project_root, onnx_dir):
                 onnx_paths=onnx_paths,
                 duration=dur,
                 workspace_gb=args.workspace_gb,
+                env=env,
                 force_rebuild=args.force_rebuild,
             ))
         if build_decoder:
@@ -742,8 +1140,13 @@ def _run_all(args, project_root, onnx_dir):
                 refit=True,
                 workspace_gb=args.workspace_gb,
                 batch_max=args.batch_max,
+                batch_opt=args.batch_opt,
+                builder_optimization_level=args.builder_optimization_level,
+                env=env,
                 force_rebuild=args.force_rebuild,
                 checkpoint=args.checkpoint,
+                decoder_precision=decoder_precision,
+                strongly_typed=decoder_strongly_typed,
             ))
 
     # Windowed VAE decode (single 3-30s profile, duration-independent).
@@ -785,10 +1188,18 @@ def _run_all(args, project_root, onnx_dir):
         sys.exit(1)
 
 
-def _run_single(args, project_root, onnx_dir):
+def _run_single(args, project_root, onnx_dir, env):
     """Build a single engine configuration."""
     build_vae = not args.skip_vae
     build_decoder = args.decoder
+    decoder_precision = _resolve_decoder_precision(
+        checkpoint=args.checkpoint,
+        requested=args.decoder_precision,
+        decoder_mixed=args.decoder_mixed,
+    )
+    decoder_strongly_typed = _decoder_precision_is_strongly_typed(
+        decoder_precision, decoder_mixed=args.decoder_mixed,
+    )
 
     # ONNX phase
     onnx_paths = _ensure_onnx(
@@ -799,9 +1210,19 @@ def _run_single(args, project_root, onnx_dir):
         need_vae=build_vae,
         need_decoder_std=build_decoder and not args.decoder_refit,
         need_decoder_refit=build_decoder and args.decoder_refit,
-        decoder_mixed=args.decoder_mixed,
+        decoder_precision=decoder_precision,
         skip_onnx=args.skip_onnx,
+        force_onnx=args.force_onnx,
         export_locally=args.export_locally,
+    )
+    onnx_paths = _patch_decoder_onnx_for_dynamic_batch(
+        onnx_paths,
+        need_decoder_std=build_decoder and not args.decoder_refit,
+        need_decoder_refit=build_decoder and args.decoder_refit,
+        checkpoint=args.checkpoint,
+        decoder_precision=decoder_precision,
+        batch_max=args.batch_max,
+        force=args.force_onnx,
     )
 
     # Engine phase
@@ -813,6 +1234,8 @@ def _run_single(args, project_root, onnx_dir):
             onnx_paths=onnx_paths,
             duration=args.max_duration,
             workspace_gb=args.workspace_gb,
+            env=env,
+            force_rebuild=args.force_rebuild,
         )
         for label, path, elapsed, status in results:
             if status == "OK":
@@ -827,7 +1250,13 @@ def _run_single(args, project_root, onnx_dir):
             refit=args.decoder_refit,
             workspace_gb=args.workspace_gb,
             batch_max=args.batch_max,
+            batch_opt=args.batch_opt,
+            builder_optimization_level=args.builder_optimization_level,
+            env=env,
+            force_rebuild=args.force_rebuild,
             checkpoint=args.checkpoint,
+            decoder_precision=decoder_precision,
+            strongly_typed=decoder_strongly_typed,
         )
         label, path, elapsed, status = result
         if status == "OK":

--- a/acestep/engine/trt/export.py
+++ b/acestep/engine/trt/export.py
@@ -14,9 +14,10 @@ Precision strategy:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Tuple, Union
+import sys
+from typing import Optional, Union
 
 from loguru import logger
 import torch
@@ -37,10 +38,8 @@ class _Transpose12(nn.Module):
 class _Fp32CastWrapper(nn.Module):
     """Run an inner module in fp32, casting around it.
 
-    Used for the bf16_mixed recipe where TRT has no bf16 kernel for some
-    op (e.g., the proj_out ConvTranspose1d). The inner module's weights
-    are cast to fp32 in-place; this wrapper bridges the dtype boundary at
-    the call site so PyTorch nn.Conv*/nn.Linear strict dtype checks pass.
+    Used for the XL bf16_mixed recipe where TensorRT has no bf16 kernel for
+    the proj_out ConvTranspose1d shape.
     """
 
     def __init__(self, inner: nn.Module):
@@ -51,146 +50,6 @@ class _Fp32CastWrapper(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         out_dtype = x.dtype
         return self.inner(x.float()).to(out_dtype)
-
-
-def _cast_recursive(obj, dtype: torch.dtype):
-    """Recursively cast floating-point tensors in nested structures."""
-    if isinstance(obj, torch.Tensor):
-        if obj.is_floating_point():
-            return obj.to(dtype)
-        return obj
-    if isinstance(obj, tuple):
-        return tuple(_cast_recursive(x, dtype) for x in obj)
-    if isinstance(obj, list):
-        return [_cast_recursive(x, dtype) for x in obj]
-    if isinstance(obj, dict):
-        return {k: _cast_recursive(v, dtype) for k, v in obj.items()}
-    return obj
-
-
-class _AttnFp32Wrapper(nn.Module):
-    """Wrap a self-attention module to run entirely in fp32.
-
-    Used for the fp16_attn_safe recipe to handle XL turbo's outlier
-    attention layers (0 and 30) where q_norm/k_norm weights reach ~31
-    and amplify Q/K so far that the Q@K^T matmul output overflows fp16's
-    65 504 ceiling. Casting the attention into fp32 keeps the rest of
-    the model in fp16 for full tensor-core speed while making the few
-    overflowing layers numerically safe.
-
-    The wrapper accepts the same call signature as AceStepAttention.forward
-    (hidden_states + arbitrary kwargs) and handles the dtype crossing at
-    the call boundary.
-    """
-
-    def __init__(self, inner: nn.Module):
-        super().__init__()
-        inner.float()
-        self.inner = inner
-
-    def forward(self, hidden_states: torch.Tensor, *args, **kwargs):
-        out_dtype = hidden_states.dtype
-        hidden_states = _cast_recursive(hidden_states, torch.float32)
-        args = tuple(_cast_recursive(a, torch.float32) for a in args)
-        kwargs = {k: _cast_recursive(v, torch.float32) for k, v in kwargs.items()}
-        out = self.inner(hidden_states, *args, **kwargs)
-        return _cast_recursive(out, out_dtype)
-
-
-class _MlpFp16Wrapper(nn.Module):
-    """Wrap a Qwen3-style MLP (gate_proj/up_proj/down_proj + SiLU) to run
-    its body in fp16 with bf16 I/O.
-
-    Used for the bf16_mlp_fp16 recipe. The MLP is the biggest single
-    contributor to per-layer compute (gate+up+down matmuls plus the
-    activation), so wrapping it as a unit gives the biggest single
-    speedup per cast pair. Cast surface is 1 layer = 2 casts (in + out)
-    instead of 11 casts (one per Linear), so TRT's tactic search stays
-    tractable.
-
-    The MLP's input is the AdaLN-modulated post-RMSNorm output of
-    hidden_states, which is bounded; the output is fed into a gated
-    residual addition. Both fit in fp16.
-    """
-
-    def __init__(self, inner: nn.Module):
-        super().__init__()
-        inner.half()
-        self.inner = inner
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        out_dtype = x.dtype
-        return self.inner(x.to(torch.float16)).to(out_dtype)
-
-
-class _LinearFp16Wrapper(nn.Module):
-    """Wrap a single nn.Linear (or any single-tensor-in / single-tensor-out
-    module) so it computes in fp16 with bf16 I/O.
-
-    Used for the bf16_matmul_fp16 recipe: instead of wrapping whole DiT
-    layers (which exposes a wide bf16<->fp16 cast boundary that TRT
-    fuses across, breaking the precision intent), we wrap the smallest
-    possible unit -- the individual matmul -- with a tight cast pair.
-    The trace records:
-        Cast(bf16 -> fp16) -> matmul (fp16 weights, fp16 inputs) -> Cast(fp16 -> bf16)
-    The cast surface is per-Linear, so TRT's fusion radius is limited
-    to the cast itself plus the matmul. Profiling shows the XL turbo
-    decoder spends ~77 % of its time in linear/matmul, so swapping
-    those to fp16 kernels recovers most of the bf16 throughput penalty
-    on Blackwell while leaving the residual stream in bf16 (which is
-    necessary because the residual peaks at ~190 000 in the middle
-    layers, well above fp16's 65 504 ceiling).
-
-    The wrapper assumes the inner module's input is bounded enough to
-    fit in fp16. For AceStepDiTLayer's Linears (q/k/v/o_proj and
-    mlp.gate/up/down_proj), the input is always post-RMSNorm output
-    multiplied by AdaLN scale/shift, which RMSNorm bounds to unit
-    magnitude times moderate scale weights -- well within fp16 range.
-    """
-
-    def __init__(self, inner: nn.Module):
-        super().__init__()
-        inner.half()
-        self.inner = inner
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        out_dtype = x.dtype
-        return self.inner(x.to(torch.float16)).to(out_dtype)
-
-
-class _LayerFp16Wrapper(nn.Module):
-    """Wrap a full DiT layer so its body runs in fp16 with bf16 I/O.
-
-    The XL turbo decoder's residual stream grows past fp16's 65 504 ceiling
-    in the middle layers (peaks ~190k around layer 18 in bf16), so the
-    cumulative residual cannot be stored in fp16. But the *individual*
-    matmuls inside each layer (Q/K/V projections, attention output,
-    MLP gate/up/down) operate on per-layer hidden states that are bounded
-    by RMSNorm's unit-RMS output, so the matmuls themselves can run in
-    fp16 as long as the residual addition happens in bf16.
-
-    This wrapper casts the layer's weights to fp16 in-place and converts
-    every floating-point input to fp16 at the call boundary, then casts
-    the layer outputs back to bf16 so the upstream caller (the DiT
-    forward loop) can do the residual addition in bf16. The trace records:
-        Cast(bf16 -> fp16) -> layer body (fp16 matmuls) -> Cast(fp16 -> bf16)
-    With strongly_typed=True the engine respects these casts and uses
-    fp16 tensor cores for the layer body while preserving bf16 dynamic
-    range across the residual stream.
-    """
-
-    def __init__(self, inner: nn.Module):
-        super().__init__()
-        inner.half()
-        self.inner = inner
-
-    def forward(self, hidden_states: torch.Tensor, *args, **kwargs):
-        out_dtype = hidden_states.dtype
-        hidden_states = _cast_recursive(hidden_states, torch.float16)
-        args = tuple(_cast_recursive(a, torch.float16) for a in args)
-        kwargs = {k: _cast_recursive(v, torch.float16) for k, v in kwargs.items()}
-        out = self.inner(hidden_states, *args, **kwargs)
-        return _cast_recursive(out, out_dtype)
 
 
 # ------------------------------------------------------------------
@@ -232,16 +91,8 @@ class DecoderForExport(nn.Module):
                 2B turbo where activations stay inside fp16 dynamic range.
             precision: Used when ``mixed_precision`` is False. One of:
                 - "fp32": leave dtypes as-is for tracing in fp32 (default)
-                - "bf16": pure bf16 throughout. Use only for non-strongly-
-                  typed builds (TRT picks bf16 vs fp32 freely). The dynamo
-                  exporter is required for tracing.
-                - "bf16_mixed": bf16 bulk + fp32 islands for AdaLN, norms,
-                  timestep, AND proj_in/proj_out. The XL turbo decoder
-                  needs this because (a) q_norm/k_norm scales reaching ~31
-                  in layers 0/30 break fp16, so bf16 is the only safe
-                  bulk dtype, and (b) TRT lacks a bf16 ConvTranspose
-                  kernel for proj_out's [2560,64,2,1] shape, so the patch
-                  embedding has to stay fp32. Strongly-typed builds.
+                - "bf16_mixed": bf16 bulk with an fp32 proj_out deconv island
+                  for XL turbo. Requires the dynamo exporter.
         """
         super().__init__()
         self.decoder = decoder
@@ -261,20 +112,8 @@ class DecoderForExport(nn.Module):
 
         if mixed_precision:
             self._setup_mixed_precision()
-        elif precision == "bf16":
-            # Decoder weights already loaded as bf16 by from_pretrained;
-            # just ensure that's the case (no-op cast for safety).
-            self.decoder.to(torch.bfloat16)
         elif precision == "bf16_mixed":
             self._setup_bf16_mixed()
-        elif precision == "bf16_layer_fp16":
-            self._setup_bf16_layer_fp16()
-        elif precision == "bf16_matmul_fp16":
-            self._setup_bf16_matmul_fp16()
-        elif precision == "bf16_mlp_fp16":
-            self._setup_bf16_mlp_fp16()
-        elif precision == "fp16_attn_safe":
-            self._setup_fp16_attn_safe()
 
     # ---- internal helpers ----
 
@@ -323,66 +162,11 @@ class DecoderForExport(nn.Module):
             if hasattr(layer, "cross_attn_norm"):
                 layer.cross_attn_norm.float()
 
-    def _setup_fp16_attn_safe(self) -> None:
-        """fp16 mixed precision (2B recipe) + ALL self_attn modules in fp32.
-
-        XL turbo's hidden states reach ~30 000 in absolute magnitude (vs
-        2B's ~5 000), so Q@K^T intermediates inside self-attention can
-        exceed fp16's 65 504 ceiling in any layer, not just the q_norm
-        outliers. PyTorch's fused SDPA hides the overflow with fp32
-        accumulation, but TRT's unrolled SDPA writes fp16 intermediates
-        and NaNs.
-
-        Solution: wrap every self_attn in _AttnFp32Wrapper. The rest of
-        the model (MLP, cross-attn, AdaLN, norms, projections) stays on
-        the proven 2B fp16 + fp32 islands recipe so we keep TRT's mature
-        fp16 kernel path for everything except self-attention.
-
-        Cross-attention is left in fp16 because its q_norm/k_norm scales
-        are well-behaved across all XL layers (max ~2) and its inputs
-        are encoder hidden states which don't grow through the layer
-        cycle.
-        """
-        # First apply the standard fp16 mixed-precision recipe (decoder.half(),
-        # fp32 islands for timestep / AdaLN / RMSNorms).
-        self._setup_mixed_precision()
-
-        # Then wrap every self_attn in fp32.
-        decoder = self.decoder
-        for i, layer in enumerate(decoder.layers):
-            layer.self_attn = _AttnFp32Wrapper(layer.self_attn)
-
-        logger.info(
-            "fp16_attn_safe: wrapped all {} self_attn modules in fp32 "
-            "(cross_attn stays in fp16)",
-            len(decoder.layers),
-        )
-
     def _setup_bf16_mixed(self) -> None:
-        """bf16 bulk + minimal fp32 island for the XL turbo decoder.
-
-        Keep everything in bf16 (the model's training dtype, full
-        precision/range for this model) and only add an fp32 island
-        around the proj_out ConvTranspose1d. TRT has no bf16 kernel for
-        that specific deconv shape ([2560, 64, 2, 1]), so without the
-        island the strongly-typed bf16 build dies with "No matching
-        rules found for input operand types".
-
-        Unlike the 2B fp16_mixed recipe, no AdaLN/norm fp32 islands are
-        needed: bf16 has the same exponent range as fp32 and the q_norm
-        overflow that bites fp16 doesn't bite bf16.
-        """
+        """bf16 bulk + fp32 island for XL turbo's unsupported deconv op."""
         decoder = self.decoder
-
-        # Make sure everything is bf16 to start (no-op if the model was
-        # loaded with dtype="bfloat16", but defensive).
         decoder.to(torch.bfloat16)
 
-        # Patch unembedding: wrap the inner ConvTranspose1d so trace
-        # records cast(bf16->fp32) -> deconv(fp32) -> cast(fp32->bf16).
-        # proj_out is nn.Sequential(Lambda, ConvTranspose1d, Lambda); the
-        # Lambda -> _Transpose12 replacement already happened earlier in
-        # _replace_lambdas, so we look for the ConvTranspose1d by type.
         deconv_idx = None
         for i, mod in enumerate(decoder.proj_out):
             if isinstance(mod, nn.ConvTranspose1d):
@@ -393,145 +177,6 @@ class DecoderForExport(nn.Module):
                 "bf16_mixed: could not find ConvTranspose1d inside proj_out"
             )
         decoder.proj_out[deconv_idx] = _Fp32CastWrapper(decoder.proj_out[deconv_idx])
-
-    # XL turbo: layer indices that can run their bodies in fp16 without
-    # input or output overflowing.
-    #
-    # Determined empirically by running the bf16 forward on real cover
-    # inputs and recording per-layer absmax of the running residual.
-    # The pattern looks like:
-    #
-    #     layer 0..13:    residual ranges 4 288 -> 33 856 (fp16-safe)
-    #     layer 14..28:   residual peaks at 190 464 (FP16 OVERFLOW)
-    #     layer 29..31:   residual settles back to 9 856 -> 16 256
-    #
-    # A layer can be wrapped in fp16 only if BOTH its input residual
-    # AND its output residual fit in fp16 (the wrapper does an input
-    # cast to fp16). Layers 29..31 produce small outputs but RECEIVE
-    # the ~85 000 bf16 residual from layer 28, which overflows their
-    # input cast and cascades NaN through the rest of the forward.
-    # So the safe set is layers 0..13 only (14 of 32).
-    XL_FP16_SAFE_LAYERS = tuple(range(0, 14))
-
-    # XL turbo: list of (parent_module_attr, linear_attr_name) pairs that
-    # are safe to wrap in fp16 inside each AceStepDiTLayer. Inputs to
-    # these Linears are bounded by post-RMSNorm output * AdaLN scale,
-    # which fits comfortably in fp16. Outputs feed into residual adds
-    # that stay in bf16 outside the wrapper.
-    XL_LINEAR_WRAP_TARGETS = (
-        ("self_attn", "q_proj"),
-        ("self_attn", "k_proj"),
-        ("self_attn", "v_proj"),
-        ("self_attn", "o_proj"),
-        ("cross_attn", "q_proj"),
-        ("cross_attn", "k_proj"),
-        ("cross_attn", "v_proj"),
-        ("cross_attn", "o_proj"),
-        ("mlp", "gate_proj"),
-        ("mlp", "up_proj"),
-        ("mlp", "down_proj"),
-    )
-
-    def _setup_bf16_mlp_fp16(self) -> None:
-        """Hybrid: bf16 residual stream + fp16 MLP body in every DiT layer.
-
-        Builds on _setup_bf16_mixed (bf16 bulk + fp32 proj_out island),
-        then wraps every layer's `mlp` submodule with _MlpFp16Wrapper.
-        Cast surface is 32 in + 32 out = 64 casts total, well within
-        TRT's compilation tractability (compared to 704 casts for the
-        per-Linear wrap which segfaults the builder).
-
-        MLP is roughly 60-65 % of per-layer compute for these decoder
-        shapes (intermediate=9728 vs hidden=2560, three big GEMMs vs
-        attention's 2-3 smaller ones), so swapping just MLPs to fp16
-        recovers most of the bf16 throughput penalty without disturbing
-        attention or the residual stream.
-        """
-        self._setup_bf16_mixed()
-
-        decoder = self.decoder
-        wrapped = 0
-        for layer in decoder.layers:
-            if hasattr(layer, "mlp"):
-                layer.mlp = _MlpFp16Wrapper(layer.mlp)
-                wrapped += 1
-        logger.info(
-            "bf16_mlp_fp16: wrapped {}/{} layer MLPs in fp16",
-            wrapped, len(decoder.layers),
-        )
-
-    def _setup_bf16_matmul_fp16(self) -> None:
-        """Hybrid recipe: bf16 residual stream + per-matmul fp16 weights/compute.
-
-        Builds on _setup_bf16_mixed (bf16 bulk + fp32 proj_out island),
-        then wraps every nn.Linear inside every DiT layer with
-        _LinearFp16Wrapper. The wrapper casts the Linear's input to fp16,
-        runs the matmul with fp16 weights, then casts the output back
-        to bf16 before it flows into the residual addition.
-
-        This is the matmul-grain version of bf16_layer_fp16. The
-        layer-grain wrapper failed because TRT's optimizer fused across
-        the bf16<->fp16 cast boundary in ways that corrupted the
-        precision intent. The matmul-grain wrapper limits TRT's fusion
-        radius to a single matmul + its two casts, which empirically
-        survives compilation.
-
-        Profiling shows linear/matmul accounts for 77 % of the bf16
-        engine's runtime, with bf16 GEMM kernels running ~40 % slower
-        than the equivalent fp16 GEMMs on Blackwell. Swapping these to
-        fp16 should recover most of that gap without changing the
-        residual stream's dtype, which has to stay bf16 to handle XL
-        turbo's ~190 000 peak residual magnitude.
-        """
-        self._setup_bf16_mixed()
-
-        decoder = self.decoder
-        wrapped = 0
-        for layer in decoder.layers:
-            for parent_attr, lin_attr in self.XL_LINEAR_WRAP_TARGETS:
-                parent = getattr(layer, parent_attr, None)
-                if parent is None:
-                    continue
-                lin = getattr(parent, lin_attr, None)
-                if lin is None:
-                    continue
-                setattr(parent, lin_attr, _LinearFp16Wrapper(lin))
-                wrapped += 1
-        logger.info(
-            "bf16_matmul_fp16: wrapped {} Linears across {} layers",
-            wrapped, len(decoder.layers),
-        )
-
-    def _setup_bf16_layer_fp16(self) -> None:
-        """Hybrid recipe: bf16 residual stream + per-layer fp16 matmuls.
-
-        Builds on _setup_bf16_mixed (bf16 bulk + fp32 proj_out island),
-        then additionally wraps the safe XL turbo layers (those whose
-        residual stays under fp16's 65 504 ceiling) with _LayerFp16Wrapper
-        so their internal matmuls run in fp16 while the residual stream
-        between layers stays in bf16.
-
-        The cast-in / cast-out pattern produces a trace where ~53 % of
-        the DiT's layer compute uses fp16 tensor cores (faster on
-        Blackwell), while the remaining 47 % stays in bf16 to handle
-        the residual magnitude. End-to-end speedup vs pure bf16_mixed
-        is roughly proportional to the fraction of fp16 layers times
-        the bf16/fp16 throughput gap.
-        """
-        # First do everything bf16_mixed does (bf16 bulk + proj_out fp32 island).
-        self._setup_bf16_mixed()
-
-        decoder = self.decoder
-        n_layers = len(decoder.layers)
-        safe = [i for i in self.XL_FP16_SAFE_LAYERS if i < n_layers]
-        for i in safe:
-            decoder.layers[i] = _LayerFp16Wrapper(decoder.layers[i])
-
-        logger.info(
-            "bf16_layer_fp16: wrapped {}/{} layers in fp16 (indices {}); "
-            "remaining {} layers stay bf16",
-            len(safe), n_layers, safe, n_layers - len(safe),
-        )
 
     def _patch_decoder_for_trace(self) -> None:
         """Monkey-patch the decoder forward to be ONNX-trace-safe.
@@ -698,9 +343,7 @@ class OnnxExportConfig:
     mixed_precision: bool = False
 
     # Trace dtype for the wrapper. Used when ``mixed_precision`` is False.
-    # One of: "fp32" (default), "bf16". For XL turbo, use "bf16" to
-    # match the training dtype and avoid fp16 overflow in attention
-    # intermediates from layers with large q_norm/k_norm scales.
+    # Supported values: "fp32" and "bf16_mixed".
     precision: str = "fp32"
 
     # When True, disables ONNX constant folding to preserve PyTorch
@@ -748,49 +391,11 @@ def export_decoder_onnx(
         trace_dtype = torch.float16
         ts_dtype = torch.float32  # time_embed is fp32 in mixed mode
         logger.info("Exporting with mixed precision (fp16 bulk + fp32 critical ops)")
-    elif config.precision == "fp16_attn_safe":
-        # 2B-style fp16 mixed + extra fp32 islands around outlier
-        # attention layers (XL turbo's q_norm/k_norm overflow sites).
-        wrapper = wrapper.to(device)
-        trace_dtype = torch.float16
-        ts_dtype = torch.float32
-        logger.info("Exporting fp16_attn_safe (fp16 mixed + per-layer attn fp32 islands)")
-    elif config.precision == "bf16":
-        # bf16 throughout: weights are already bf16, just move to device.
-        wrapper = wrapper.to(device)
-        trace_dtype = torch.bfloat16
-        ts_dtype = torch.bfloat16  # time_embed runs in bf16
-        logger.info("Exporting in bf16 (matches training dtype)")
     elif config.precision == "bf16_mixed":
-        # bf16 bulk + minimal fp32 island around proj_out's deconv.
-        # Trace inputs are bf16; timestep also bf16 (no fp32 islands
-        # outside the deconv wrapper).
         wrapper = wrapper.to(device)
         trace_dtype = torch.bfloat16
         ts_dtype = torch.bfloat16
         logger.info("Exporting bf16 mixed (bf16 bulk + fp32 deconv island)")
-    elif config.precision == "bf16_layer_fp16":
-        # bf16 residual stream + per-layer fp16 matmul wrappers (XL turbo
-        # hybrid). Inputs to the engine are bf16 because that's what the
-        # cross-layer residual stream uses.
-        wrapper = wrapper.to(device)
-        trace_dtype = torch.bfloat16
-        ts_dtype = torch.bfloat16
-        logger.info("Exporting bf16_layer_fp16 (bf16 residual + per-layer fp16 matmuls)")
-    elif config.precision == "bf16_matmul_fp16":
-        # bf16 residual stream + per-Linear fp16 cast wrappers around
-        # every matmul inside the DiT layers. Tighter cast surface than
-        # bf16_layer_fp16; survives TRT compilation reliably.
-        wrapper = wrapper.to(device)
-        trace_dtype = torch.bfloat16
-        ts_dtype = torch.bfloat16
-        logger.info("Exporting bf16_matmul_fp16 (bf16 residual + per-Linear fp16 matmuls)")
-    elif config.precision == "bf16_mlp_fp16":
-        # bf16 residual stream + per-MLP fp16 wrappers (32 cast pairs total)
-        wrapper = wrapper.to(device)
-        trace_dtype = torch.bfloat16
-        ts_dtype = torch.bfloat16
-        logger.info("Exporting bf16_mlp_fp16 (bf16 residual + per-MLP fp16 wrappers)")
     else:
         # Full fp32 export
         wrapper = wrapper.float().to(device)
@@ -832,16 +437,9 @@ def export_decoder_onnx(
         do_constant_folding = False
         logger.info("REFIT mode: constant folding disabled to preserve weight names")
 
-    # The legacy torchscript-based ONNX exporter (dynamo=False) has a bug
-    # in its shape-type inference pass when tracing bf16 graphs: it produces
-    # complex tensors during constant folding, then fails with
-    # "ScalarType ComplexDouble is an unexpected tensor scalar type". The
-    # new dynamo-based exporter (torch.export) doesn't have this bug.
-    # Use dynamo for any bf16-containing trace; keep legacy for fp16 mixed
-    # and fp32.
     use_dynamo = (
         not config.mixed_precision
-        and config.precision in ("bf16", "bf16_mixed", "bf16_layer_fp16", "bf16_matmul_fp16", "bf16_mlp_fp16")
+        and config.precision == "bf16_mixed"
     )
 
     logger.info(
@@ -851,11 +449,15 @@ def export_decoder_onnx(
 
     with torch.no_grad():
         if use_dynamo:
-            # Dynamo path: pass tensors as positional args, use dynamic_shapes
-            # API instead of dynamic_axes. Dynamo requires opset >= 18; the
-            # downconversion to 17 fails for some ops, so don't force a
-            # version here (let dynamo pick its native default).
+            # torch.onnx's dynamo path prints Unicode status markers. On
+            # Windows cp1252 consoles those can raise UnicodeEncodeError
+            # after graph capture succeeds, aborting an otherwise valid export.
+            for stream in (sys.stdout, sys.stderr):
+                if hasattr(stream, "reconfigure"):
+                    stream.reconfigure(encoding="utf-8", errors="replace")
+
             from torch.export import Dim
+
             batch = Dim("batch", min=1, max=8)
             seq = Dim("seq", min=126, max=1500)
             enc = Dim("enc", min=32, max=512)
@@ -887,17 +489,110 @@ def export_decoder_onnx(
                 dynamo=False,
             )
 
-    # The ONNX file may exceed the 2GB protobuf limit since the decoder
-    # is ~6GB.  This is fine:
-    #   - OnnxRuntime uses its own parser (not protobuf) and handles it
-    #   - TRT's OnnxParser.parse_from_file also handles large inline ONNX
-    # The onnx Python library's load() cannot read >2GB files, which is
-    # why the previous external_data conversion produced 0-byte files.
-    # We skip it and rely on the native parsers.
+    # XL dynamo exports may use external data for the large weight payload.
+    # Keep patched ONNX protobufs next to the source file so those relative
+    # external_data references continue to resolve during TRT parsing.
 
     size_mb = onnx_path.stat().st_size / (1 << 20)
     logger.info("ONNX saved to {} ({:.1f} MB)", onnx_path, size_mb)
     return onnx_path
+
+
+def patch_decoder_onnx_dynamic_batch_reshapes(
+    onnx_path: Union[str, Path],
+    output_path: Optional[Union[str, Path]] = None,
+    *,
+    force: bool = False,
+) -> Path:
+    """Patch dynamo-exported reshape constants that accidentally bake B=1.
+
+    The XL bf16 dynamo exporter can emit `Reshape` shape constants like
+    ``[1, 6, 2560]`` even when dynamic batch was requested. TensorRT then
+    builds an engine with a dynamic input profile, but `infer_shapes` fails
+    at runtime for B>1. Rewriting the first dimension to ``-1`` preserves the
+    non-batch shape and lets TRT infer the active batch from the input tensor.
+    """
+    import numpy as np
+    import onnx
+    from onnx import numpy_helper
+
+    onnx_path = Path(onnx_path)
+    if output_path is None:
+        output_path = onnx_path.with_name(f"{onnx_path.stem}_dynbatch{onnx_path.suffix}")
+    output_path = Path(output_path)
+    if output_path.parent != onnx_path.parent:
+        raise ValueError(
+            "Dynamic-batch patched ONNX must live next to the source ONNX "
+            "so relative external_data references continue to resolve."
+        )
+    if (
+        output_path.exists()
+        and not force
+        and output_path.stat().st_mtime >= onnx_path.stat().st_mtime
+    ):
+        logger.info("Reusing dynamic-batch patched decoder ONNX: {}", output_path)
+        return output_path
+
+    logger.info(
+        "Patching decoder ONNX Reshape batch constants: {} -> {}",
+        onnx_path, output_path,
+    )
+    model = onnx.load(str(onnx_path), load_external_data=False)
+    graph = model.graph
+
+    def get_const_shape(name: str) -> list[int] | None:
+        for node in graph.node:
+            if node.op_type == "Constant" and name in node.output:
+                for attr in node.attribute:
+                    if attr.name == "value" and attr.type == onnx.AttributeProto.TENSOR:
+                        return numpy_helper.to_array(attr.t).flatten().tolist()
+        for init in graph.initializer:
+            if init.name == name:
+                return numpy_helper.to_array(init).flatten().tolist()
+        return None
+
+    def set_const_shape(name: str, new_shape: list[int]) -> bool:
+        new_arr = np.asarray(new_shape, dtype=np.int64)
+        for node in graph.node:
+            if node.op_type == "Constant" and name in node.output:
+                for attr in node.attribute:
+                    if attr.name == "value":
+                        attr.t.CopyFrom(numpy_helper.from_array(new_arr, name=name))
+                        return True
+        for init in graph.initializer:
+            if init.name == name:
+                init.CopyFrom(numpy_helper.from_array(new_arr, name=name))
+                return True
+        return False
+
+    seen: set[str] = set()
+    matching = 0
+    patched = 0
+    examples: list[tuple[str, str, list[int]]] = []
+    for node in graph.node:
+        if node.op_type != "Reshape" or len(node.input) < 2:
+            continue
+        shape_name = node.input[1]
+        shape = get_const_shape(shape_name)
+        if not shape or len(shape) < 2 or shape[0] != 1:
+            continue
+        matching += 1
+        if len(examples) < 8:
+            examples.append((node.name or "(no-name)", shape_name, shape))
+        if -1 in shape[1:] or shape_name in seen:
+            continue
+        if set_const_shape(shape_name, [-1] + list(shape[1:])):
+            patched += 1
+            seen.add(shape_name)
+
+    onnx.save(model, str(output_path))
+    logger.info(
+        "Patched {} unique Reshape constants ({} B=1 Reshapes found) in {}",
+        patched, matching, output_path,
+    )
+    for node_name, shape_name, shape in examples:
+        logger.info("  Reshape {} const {}: {}", node_name, shape_name, shape)
+    return output_path
 
 
 # ------------------------------------------------------------------
@@ -944,6 +639,11 @@ class TRTBuildConfig:
     # DiT variant name, included in engine filename when not "turbo"
     # so engines from different checkpoints coexist in the same directory.
     variant: str = "turbo"
+
+    # ONNX export precision recipe used to produce the parsed graph.
+    # This is metadata-only for engine selection/rebuild decisions; TensorRT
+    # precision flags are still governed by fp16/bf16/strongly_typed above.
+    onnx_precision: str = "fp32"
 
     @property
     def max_duration_s(self) -> int:
@@ -999,8 +699,8 @@ def build_trt_engine(
     trt_logger = trt.Logger(trt.Logger.INFO)
     builder = trt.Builder(trt_logger)
 
-    # Network creation flags
-    net_flags = 1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+    # TensorRT 10 networks are always explicit-batch; only opt into strong typing.
+    net_flags = 0
     if config.strongly_typed and hasattr(trt.NetworkDefinitionCreationFlag, "STRONGLY_TYPED"):
         net_flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
         logger.info("Using STRONGLY_TYPED network (precision from ONNX graph)")
@@ -1072,7 +772,9 @@ def build_trt_engine(
         min=(Bmin, Smin, 128), opt=(Bopt, Sopt, 128), max=(Bmax, Smax, 128),
     )
 
-    build_config.add_optimization_profile(profile)
+    profile_idx = build_config.add_optimization_profile(profile)
+    if profile_idx < 0:
+        raise RuntimeError("Failed to add TensorRT optimization profile")
 
     logger.info(
         "Building TRT engine (fp16={}, bf16={}, opt_level={}) ...",

--- a/acestep/engine/trt/lora_refit.py
+++ b/acestep/engine/trt/lora_refit.py
@@ -170,7 +170,21 @@ class TRTLoRAManager(LoRAManagerBase):
                 if entry.deltas and param_name in entry.deltas:
                     buf.add_(entry.deltas[param_name], alpha=entry.strength)
 
-            refitter.set_named_weights(trt_name, buf.numpy())
+            arr = buf.numpy()
+            ok = refitter.set_named_weights(trt_name, arr)
+            if not ok:
+                proto_desc = "unknown"
+                if hasattr(refitter, "get_weights_prototype"):
+                    try:
+                        proto = refitter.get_weights_prototype(trt_name)
+                        proto_desc = f"dtype={proto.dtype}, size={proto.size}"
+                    except Exception:
+                        pass
+                raise RuntimeError(
+                    "TRT rejected refit weights for "
+                    f"{trt_name}: array dtype={arr.dtype}, shape={arr.shape}; "
+                    f"engine prototype {proto_desc}"
+                )
             count += 1
 
         if count > 0:

--- a/acestep/engine/trt/profile_manager.py
+++ b/acestep/engine/trt/profile_manager.py
@@ -20,6 +20,7 @@ Typical usage from a streaming session::
     mgr = TRTProfileManager(
         decoder_backend="tensorrt",
         vae_backend="tensorrt",
+        checkpoint="acestep-v15-turbo",
         device="cuda",
     )
 
@@ -63,10 +64,12 @@ class TRTProfileManager:
         *,
         decoder_backend: str,
         vae_backend: str,
+        checkpoint: str = "acestep-v15-turbo",
         device: str = "cuda",
     ):
         self._decoder_tensorrt = decoder_backend == "tensorrt"
         self._vae_tensorrt = vae_backend == "tensorrt"
+        self._checkpoint = checkpoint
         self._device = torch.device(device)
 
         self._diffusion_engine = None
@@ -106,7 +109,11 @@ class TRTProfileManager:
         update internal state. Used by callers building the initial
         Session before :meth:`bind`.
         """
-        return available_trt_engines(duration_s, needs=self._needs())
+        return available_trt_engines(
+            duration_s,
+            needs=self._needs(),
+            checkpoint=self._checkpoint,
+        )
 
     def bind(
         self,

--- a/acestep/engine/trt/runtime.py
+++ b/acestep/engine/trt/runtime.py
@@ -123,12 +123,19 @@ class TRTDecoder:
         }
 
         for name, buf in bufs.items():
-            ctx.set_input_shape(name, tuple(buf.shape))
-            ctx.set_tensor_address(name, buf.data_ptr())
+            if not ctx.set_input_shape(name, tuple(buf.shape)):
+                raise RuntimeError(f"TRT decoder rejected input shape for {name}: {tuple(buf.shape)}")
+            if not ctx.set_tensor_address(name, buf.data_ptr()):
+                raise RuntimeError(f"TRT decoder rejected input address for {name}")
+
+        missing = ctx.infer_shapes()
+        if missing:
+            raise RuntimeError(f"TRT decoder shapes are insufficiently specified: {missing}")
 
         out_shape = tuple(ctx.get_tensor_shape(self.OUTPUT_NAME))
         out_buf = torch.empty(out_shape, dtype=self._output_dtype, device=dev)
-        ctx.set_tensor_address(self.OUTPUT_NAME, out_buf.data_ptr())
+        if not ctx.set_tensor_address(self.OUTPUT_NAME, out_buf.data_ptr()):
+            raise RuntimeError(f"TRT decoder rejected output address for {self.OUTPUT_NAME}")
 
         entry = {"bufs": bufs, "output": out_buf}
         self._buf_cache[key] = entry
@@ -175,12 +182,15 @@ class TRTDecoder:
         # Bind addresses
         ctx = self.context
         for name, buf in bufs.items():
-            ctx.set_tensor_address(name, buf.data_ptr())
-        ctx.set_tensor_address(self.OUTPUT_NAME, entry["output"].data_ptr())
+            if not ctx.set_tensor_address(name, buf.data_ptr()):
+                raise RuntimeError(f"TRT decoder rejected input address for {name}")
+        if not ctx.set_tensor_address(self.OUTPUT_NAME, entry["output"].data_ptr()):
+            raise RuntimeError(f"TRT decoder rejected output address for {self.OUTPUT_NAME}")
 
         # Execute on shared polygraphy stream.
         stream = self._stream
-        ctx.execute_async_v3(stream.ptr)
+        if not ctx.execute_async_v3(stream.ptr):
+            raise RuntimeError("TRT decoder execution failed")
         stream.synchronize()
 
         output = entry["output"]

--- a/acestep/engine/trt/vae_export.py
+++ b/acestep/engine/trt/vae_export.py
@@ -167,6 +167,10 @@ class VAETRTBuildConfig:
     """Configuration for VAE TensorRT engine build."""
     fp16: bool = True
     workspace_gb: float = 8.0
+    # TensorRT 10.15+ can generate a Myelin fusion for the Oobleck VAE
+    # graph that segfaults on RTX 5090 during execute_async_v3. Level 1
+    # avoids the broken fusion while preserving the fast kernel set.
+    builder_optimization_level: int = 1
 
     # VAE decoder profile (latent frames)
     decode_min_frames: int = 125      # ~5s
@@ -230,9 +234,8 @@ def build_vae_trt_engine(
 
     trt_logger = trt.Logger(trt.Logger.INFO)
     builder = trt.Builder(trt_logger)
-    network = builder.create_network(
-        1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
-    )
+    # TensorRT 10 networks are always explicit-batch.
+    network = builder.create_network(0)
     parser = trt.OnnxParser(network, trt_logger)
 
     # parse_from_file resolves external data relative to the ONNX path
@@ -250,6 +253,9 @@ def build_vae_trt_engine(
     if config.fp16:
         build_config.set_flag(trt.BuilderFlag.FP16)
 
+    if hasattr(build_config, "builder_optimization_level"):
+        build_config.builder_optimization_level = config.builder_optimization_level
+
     profile = builder.create_optimization_profile()
     profile.set_shape(
         input_name,
@@ -257,11 +263,17 @@ def build_vae_trt_engine(
         opt=(1, input_dims, opt_dynamic),
         max=(1, input_dims, max_dynamic),
     )
-    build_config.add_optimization_profile(profile)
+    profile_idx = build_config.add_optimization_profile(profile)
+    if profile_idx < 0:
+        raise RuntimeError("Failed to add TensorRT optimization profile")
 
     logger.info(
-        "Building TRT engine: {} [{}, {}, {}]",
-        input_name, min_dynamic, opt_dynamic, max_dynamic,
+        "Building TRT engine: {} [{}, {}, {}] (opt_level={})",
+        input_name,
+        min_dynamic,
+        opt_dynamic,
+        max_dynamic,
+        config.builder_optimization_level,
     )
 
     serialized = builder.build_serialized_network(network, build_config)

--- a/acestep/nodes/vae_nodes.py
+++ b/acestep/nodes/vae_nodes.py
@@ -43,6 +43,21 @@ def _trt_available() -> bool:
         return False
 
 
+def _trt_tensor_dtype(engine, name: str) -> torch.dtype:
+    import tensorrt as trt
+
+    dtype_map = {
+        trt.float32: torch.float32,
+        trt.float16: torch.float16,
+        trt.int32: torch.int32,
+        trt.int8: torch.int8,
+        trt.bool: torch.bool,
+    }
+    if hasattr(trt, "bfloat16"):
+        dtype_map[trt.bfloat16] = torch.bfloat16
+    return dtype_map.get(engine.get_tensor_dtype(name), torch.float32)
+
+
 def _get_trt_vae(engine_path: str, device: torch.device):
     """Load or return cached TRT VAE engine + context + stream."""
     engine_path = os.path.abspath(engine_path)
@@ -56,7 +71,11 @@ def _get_trt_vae(engine_path: str, device: torch.device):
     ctx = engine.create_execution_context()
     logger.info("Loaded TRT VAE engine: {}", engine_path)
 
-    entry = {"engine": engine, "context": ctx}
+    tensor_dtypes = {
+        engine.get_tensor_name(i): _trt_tensor_dtype(engine, engine.get_tensor_name(i))
+        for i in range(engine.num_io_tensors)
+    }
+    entry = {"engine": engine, "context": ctx, "tensor_dtypes": tensor_dtypes}
     _trt_vae_cache[engine_path] = entry
     return entry
 
@@ -96,28 +115,36 @@ def _trt_vae_decode(
     ctx = entry["context"]
     stream = _get_trt_stream()
 
-    # Ensure input is on GPU, fp32, contiguous
-    lat = latents_bdt.to(device=device, dtype=torch.float32).contiguous()
+    dtypes = entry["tensor_dtypes"]
+    lat = latents_bdt.to(device=device, dtype=dtypes.get("latents", torch.float32)).contiguous()
 
-    ctx.set_input_shape("latents", tuple(lat.shape))
-    ctx.set_tensor_address("latents", lat.data_ptr())
+    if not ctx.set_input_shape("latents", tuple(lat.shape)):
+        raise RuntimeError(f"TRT VAE decode rejected input shape: {tuple(lat.shape)}")
+    if not ctx.set_tensor_address("latents", lat.data_ptr()):
+        raise RuntimeError("TRT VAE decode rejected input address")
+
+    missing = ctx.infer_shapes()
+    if missing:
+        raise RuntimeError(f"TRT VAE decode shapes are insufficiently specified: {missing}")
 
     out_shape = tuple(ctx.get_tensor_shape("audio"))
+    out_dtype = dtypes.get("audio", torch.float32)
 
     cached = entry.get("_decode_buf")
-    if cached is not None and cached.shape == out_shape:
+    if cached is not None and cached.shape == out_shape and cached.dtype == out_dtype:
         audio_buf = cached
     else:
-        audio_buf = torch.empty(out_shape, dtype=torch.float32, device=device)
+        audio_buf = torch.empty(out_shape, dtype=out_dtype, device=device)
         entry["_decode_buf"] = audio_buf
 
-    ctx.set_tensor_address("audio", audio_buf.data_ptr())
+    if not ctx.set_tensor_address("audio", audio_buf.data_ptr()):
+        raise RuntimeError("TRT VAE decode rejected output address")
 
     if not ctx.execute_async_v3(stream.ptr):
         raise RuntimeError("TRT VAE decode failed")
     stream.synchronize()
 
-    return audio_buf.clone()
+    return audio_buf.clone().to(torch.float32)
 
 
 def _trt_vae_encode(
@@ -133,24 +160,33 @@ def _trt_vae_encode(
     ctx = entry["context"]
     stream = _get_trt_stream()
 
-    inp = audio_bct.float().contiguous().to(device)
+    dtypes = entry["tensor_dtypes"]
+    inp = audio_bct.to(device=device, dtype=dtypes.get("audio", torch.float32)).contiguous()
 
     # Release PyTorch's unused reserved VRAM before TRT encode.
     torch.cuda.empty_cache()
 
-    ctx.set_input_shape("audio", tuple(inp.shape))
-    ctx.set_tensor_address("audio", inp.data_ptr())
+    if not ctx.set_input_shape("audio", tuple(inp.shape)):
+        raise RuntimeError(f"TRT VAE encode rejected input shape: {tuple(inp.shape)}")
+    if not ctx.set_tensor_address("audio", inp.data_ptr()):
+        raise RuntimeError("TRT VAE encode rejected input address")
+
+    missing = ctx.infer_shapes()
+    if missing:
+        raise RuntimeError(f"TRT VAE encode shapes are insufficiently specified: {missing}")
 
     out_shape = tuple(ctx.get_tensor_shape("moments"))
-    moments_buf = torch.empty(out_shape, dtype=torch.float32, device=device)
-    ctx.set_tensor_address("moments", moments_buf.data_ptr())
+    moments_dtype = dtypes.get("moments", torch.float32)
+    moments_buf = torch.empty(out_shape, dtype=moments_dtype, device=device)
+    if not ctx.set_tensor_address("moments", moments_buf.data_ptr()):
+        raise RuntimeError("TRT VAE encode rejected output address")
 
     if not ctx.execute_async_v3(stream.ptr):
         raise RuntimeError("TRT VAE encode failed")
     stream.synchronize()
 
     # Split moments into mean and logvar, sample
-    mean, logvar = moments_buf.chunk(2, dim=1)  # [B, 64, T] each
+    mean, logvar = moments_buf.float().chunk(2, dim=1)  # [B, 64, T] each
     std = torch.exp(0.5 * logvar)
     latent = mean + std * torch.randn_like(mean)
     return latent

--- a/acestep/paths.py
+++ b/acestep/paths.py
@@ -131,7 +131,54 @@ _TRT_ENGINE_PROFILES: dict[float, dict[str, str]] = {
     },
 }
 
+_XL_TURBO_TRT_ENGINE_PROFILES: dict[float, dict[str, str]] = {
+    60.0: {
+        "decoder": "decoder_xl-turbo_mixed_refit_b4_60s",
+        "vae_encode": "vae_encode_fp16_60s",
+        "vae_decode": "vae_decode_fp16_60s",
+    },
+    120.0: {
+        "decoder": "decoder_xl-turbo_mixed_refit_b4_120s",
+        "vae_encode": "vae_encode_fp16_120s",
+        "vae_decode": "vae_decode_fp16_120s",
+    },
+}
+
+_DEFAULT_TRT_CHECKPOINT = "acestep-v15-turbo"
+_TRT_ENGINE_PROFILES_BY_CHECKPOINT: dict[str, dict[float, dict[str, str]]] = {
+    _DEFAULT_TRT_CHECKPOINT: _TRT_ENGINE_PROFILES,
+    "acestep-v15-xl-turbo": _XL_TURBO_TRT_ENGINE_PROFILES,
+}
+
 _DEFAULT_TRT_NEEDS: tuple[str, ...] = ("decoder", "vae_encode", "vae_decode")
+
+
+def _checkpoint_name(checkpoint: str | Path | None) -> str:
+    if checkpoint is None:
+        return _DEFAULT_TRT_CHECKPOINT
+    raw = str(checkpoint).replace("\\", "/").rstrip("/")
+    return raw.rsplit("/", 1)[-1] or _DEFAULT_TRT_CHECKPOINT
+
+
+def trt_engine_profiles(
+    checkpoint: str | Path = _DEFAULT_TRT_CHECKPOINT,
+) -> dict[float, dict[str, str]]:
+    """Canonical TRT engine profiles for a checkpoint.
+
+    The VAE engine names are shared across ACE-Step 1.5 checkpoints, but
+    decoder engines are checkpoint-specific. Raising for unknown checkpoints
+    prevents demos from accidentally loading a 2B decoder engine for a
+    different DiT variant.
+    """
+    name = _checkpoint_name(checkpoint)
+    try:
+        return _TRT_ENGINE_PROFILES_BY_CHECKPOINT[name]
+    except KeyError as exc:
+        supported = ", ".join(sorted(_TRT_ENGINE_PROFILES_BY_CHECKPOINT))
+        raise ValueError(
+            f"No canonical TRT engine profiles registered for checkpoint "
+            f"{name!r}. Supported checkpoints: {supported}."
+        ) from exc
 
 
 def default_trt_engines(
@@ -157,7 +204,9 @@ def default_trt_engines(
     }
 
 
-def max_profile_duration_s() -> float:
+def max_profile_duration_s(
+    checkpoint: str | Path = _DEFAULT_TRT_CHECKPOINT,
+) -> float:
     """Largest registered TRT engine duration profile, in seconds.
 
     Useful as the upper bound on user-supplied audio: anything longer
@@ -165,10 +214,15 @@ def max_profile_duration_s() -> float:
     inference time anyway. Demos cap at this value rather than
     hardcoding a single duration.
     """
-    return max(_TRT_ENGINE_PROFILES.keys())
+    profiles = trt_engine_profiles(checkpoint)
+    return max(profiles.keys())
 
 
-def smallest_fitting_profile_duration_s(duration_s: float) -> float:
+def smallest_fitting_profile_duration_s(
+    duration_s: float,
+    *,
+    checkpoint: str | Path = _DEFAULT_TRT_CHECKPOINT,
+) -> float:
     """Smallest registered profile duration that can hold ``duration_s``.
 
     Pure: ignores filesystem state. Returns the registered profile,
@@ -177,13 +231,18 @@ def smallest_fitting_profile_duration_s(duration_s: float) -> float:
     Falls back to ``max_profile_duration_s()`` when no registered
     profile is large enough (matches ``select_trt_engines``).
     """
-    for max_dur in sorted(_TRT_ENGINE_PROFILES.keys()):
+    profiles = trt_engine_profiles(checkpoint)
+    for max_dur in sorted(profiles.keys()):
         if max_dur >= duration_s:
             return max_dur
-    return max(_TRT_ENGINE_PROFILES.keys())
+    return max(profiles.keys())
 
 
-def select_trt_engines(duration_s: float = 60.0) -> dict[str, str]:
+def select_trt_engines(
+    duration_s: float = 60.0,
+    *,
+    checkpoint: str | Path = _DEFAULT_TRT_CHECKPOINT,
+) -> dict[str, str]:
     """Pick the smallest engine profile that can handle ``duration_s``.
 
     Pure: returns paths without checking the filesystem. Use
@@ -200,11 +259,39 @@ def select_trt_engines(duration_s: float = 60.0) -> dict[str, str]:
         Dict with ``decoder`` / ``vae_encode`` / ``vae_decode`` keys
         mapping to absolute engine file paths as strings.
     """
-    for max_dur in sorted(_TRT_ENGINE_PROFILES.keys()):
+    profiles = trt_engine_profiles(checkpoint)
+    for max_dur in sorted(profiles.keys()):
         if max_dur >= duration_s:
-            return default_trt_engines(**_TRT_ENGINE_PROFILES[max_dur])
-    largest = max(_TRT_ENGINE_PROFILES.keys())
-    return default_trt_engines(**_TRT_ENGINE_PROFILES[largest])
+            return default_trt_engines(**profiles[max_dur])
+    largest = max(profiles.keys())
+    return default_trt_engines(**profiles[largest])
+
+
+def _trt_build_command(
+    *,
+    checkpoint: str,
+    duration_s: float,
+    needs: tuple[str, ...],
+) -> str:
+    duration = int(duration_s)
+    parts = ["python", "-m", "acestep.engine.trt.build", "--all"]
+    if checkpoint != _DEFAULT_TRT_CHECKPOINT:
+        parts.extend(["--checkpoint", checkpoint])
+    if "decoder" not in needs:
+        parts.append("--vae-only")
+    elif "vae_encode" not in needs and "vae_decode" not in needs:
+        parts.append("--decoder-only")
+    parts.extend(["--duration", str(duration)])
+    if checkpoint == "acestep-v15-xl-turbo" and "decoder" in needs:
+        parts.extend([
+            "--batch-max", "4",
+            "--batch-opt", "4",
+            "--builder-optimization-level", "5",
+            "--workspace-gb", "20",
+            "--export-locally",
+            "--decoder-precision", "bf16_mixed",
+        ])
+    return " ".join(parts)
 
 
 class EngineNotBuiltError(RuntimeError):
@@ -221,32 +308,38 @@ class EngineNotBuiltError(RuntimeError):
         duration_s: float,
         needs: tuple[str, ...],
         missing: dict[float, list[str]],
+        checkpoint: str | Path = _DEFAULT_TRT_CHECKPOINT,
     ) -> None:
         self.duration_s = float(duration_s)
         self.needs = tuple(needs)
+        self.checkpoint = _checkpoint_name(checkpoint)
         # Map of profile_max_dur -> list of missing engine paths for that
         # profile. Empty if no profile could even fit the duration.
         self.missing = dict(missing)
 
-        fitting = sorted(d for d in _TRT_ENGINE_PROFILES if d >= duration_s)
+        profiles = trt_engine_profiles(self.checkpoint)
+        fitting = sorted(d for d in profiles if d >= duration_s)
         if fitting:
             recommended = int(fitting[0])
-            self.build_command = (
-                f"python -m acestep.engine.trt.build --all --duration {recommended}"
+            self.build_command = _trt_build_command(
+                checkpoint=self.checkpoint,
+                duration_s=recommended,
+                needs=self.needs,
             )
             msg = (
                 f"No TRT engine profile is built that can handle "
-                f"{self.duration_s:.1f}s of audio. To build the smallest "
-                f"fitting profile, run: {self.build_command}"
+                f"{self.duration_s:.1f}s of audio for {self.checkpoint}. "
+                f"To build the smallest fitting profile, run: "
+                f"{self.build_command}"
             )
         else:
-            largest = max(_TRT_ENGINE_PROFILES.keys())
+            largest = max(profiles.keys())
             self.build_command = None
             msg = (
                 f"Audio duration {self.duration_s:.1f}s exceeds the largest "
-                f"registered profile ({largest:.0f}s). Either use shorter "
-                f"audio or add a larger profile to acestep/paths.py and "
-                f"build it."
+                f"registered TRT profile for {self.checkpoint} "
+                f"({largest:.0f}s). Either use shorter audio or add a larger "
+                f"profile to acestep/paths.py and build it."
             )
         super().__init__(msg)
 
@@ -255,6 +348,7 @@ def available_trt_engines(
     duration_s: float = 60.0,
     *,
     needs: tuple[str, ...] = _DEFAULT_TRT_NEEDS,
+    checkpoint: str | Path = _DEFAULT_TRT_CHECKPOINT,
 ) -> tuple[dict[str, str], float]:
     """Pick the smallest profile that fits ``duration_s`` AND is built.
 
@@ -282,17 +376,26 @@ def available_trt_engines(
         EngineNotBuiltError: No profile can handle ``duration_s`` with
             the requested ``needs`` keys present on disk.
     """
+    profile_checkpoint = (
+        checkpoint if "decoder" in needs else _DEFAULT_TRT_CHECKPOINT
+    )
+    profiles = trt_engine_profiles(profile_checkpoint)
     missing: dict[float, list[str]] = {}
-    for max_dur in sorted(_TRT_ENGINE_PROFILES.keys()):
+    for max_dur in sorted(profiles.keys()):
         if max_dur < duration_s:
             continue
-        profile = _TRT_ENGINE_PROFILES[max_dur]
+        profile = profiles[max_dur]
         paths = default_trt_engines(**profile)
         absent = [paths[k] for k in needs if not Path(paths[k]).exists()]
         if not absent:
             return paths, max_dur
         missing[max_dur] = absent
-    raise EngineNotBuiltError(duration_s=duration_s, needs=needs, missing=missing)
+    raise EngineNotBuiltError(
+        duration_s=duration_s,
+        needs=needs,
+        missing=missing,
+        checkpoint=profile_checkpoint,
+    )
 
 
 # ------------------------------------------------------------------

--- a/demos/realtime_motion_graph_web/README.md
+++ b/demos/realtime_motion_graph_web/README.md
@@ -67,11 +67,57 @@ pay CPU/GPU transfer cost. Add `--offload-text-encoder` on lower-VRAM GPUs to
 restore the previous lower-memory behavior.
 
 `--checkpoint <name>` selects which DiT checkpoint to load. The name
-must match a directory under `<checkpoints_dir>/` (auto-downloaded from
-HF on first use). Currently `acestep-v15-turbo` (default, 2B) is the
-only vendored variant; other entries in
-`acestep.model_downloader.SUBMODEL_REGISTRY` will load once their
-modeling files are vendored into `acestep/models/`.
+must match a directory under `<checkpoints_dir>/`. Full TensorRT mode is
+registered for `acestep-v15-turbo` (default, 2B) and
+`acestep-v15-xl-turbo` (XL). XL TRT uses dynamic-batch `b8` decoder
+profiles; build one first, then launch with:
+
+```bash
+uv run python -u -m demos.realtime_motion_graph_web \
+    --accel tensorrt --checkpoint acestep-v15-xl-turbo
+```
+
+## Headless Performance Benchmark
+
+The browser HUD receives `tick_ms` and `dec_ms` over WebSocket, but the
+server does not print structured telemetry. To compare accelerators,
+checkpoints, TRT profiles, or VAE settings without browser/audio-device
+overhead, run the headless benchmark:
+
+```bash
+uv run python -u -m demos.realtime_motion_graph_web.benchmark \
+    --accel tensorrt --checkpoint acestep-v15-xl-turbo
+```
+
+The benchmark mirrors the backend inference path: fixture/config defaults,
+TRT engine selection, `Session(...)`, `prepare_source`, `encode_text`,
+`session.stream(...)`, repeated `stream.tick(...)`, and optional VAE decode.
+It reports setup timings, per-generation `tick`, `decode`, `tick+decode`
+mean/P50/P90/P95/min/max, skip counts, and peak CUDA memory.
+
+Useful variants:
+
+```bash
+# Compare compile mode against the same workload.
+uv run python -u -m demos.realtime_motion_graph_web.benchmark --accel compile
+
+# Mixed backend, same style as the server flags.
+uv run python -u -m demos.realtime_motion_graph_web.benchmark \
+    --decoder-accel tensorrt --vae-accel eager
+
+# Persist raw samples and summary stats.
+uv run python -u -m demos.realtime_motion_graph_web.benchmark \
+    --accel tensorrt --checkpoint acestep-v15-xl-turbo \
+    --json runs/xl-trt-bench.json
+
+# Mirror PipelineRunner's decode-skip behavior.
+uv run python -u -m demos.realtime_motion_graph_web.benchmark \
+    --accel tensorrt --skip-threshold 1e-3
+```
+
+By default, `--skip-threshold -1` disables decode skipping so VAE decode
+latency is measured on every completed generation. Set `--no-decode` for
+decoder-only throughput.
 
 Once it's running:
 

--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -39,7 +39,6 @@ from acestep.nodes.types import Audio, Latent
 from acestep.paths import (
     EngineNotBuiltError,
     available_dreamvae_decode_engine,
-    available_trt_engines,
     checkpoints_dir,
     dreamvae_decode_engine_name,
     lora_trigger,
@@ -332,12 +331,31 @@ def handle_client(
 
     audio_bytes = ws.recv()
     waveform = _decode_audio_msg(audio_bytes)
+    use_trt = decoder_backend == "tensorrt" or vae_backend == "tensorrt"
+    trt_profile_checkpoint = checkpoint if decoder_backend == "tensorrt" else "acestep-v15-turbo"
+
     # Cap at the largest registered TRT engine profile rather than
     # hardcoding 60 s. Anything longer than the largest profile can't
     # be handled by any built engine, but we let the operator stretch
     # all the way up to that ceiling — picking the smallest-fitting
     # engine happens below in available_trt_engines().
-    max_seconds = max_profile_duration_s()
+    if use_trt:
+        try:
+            max_seconds = max_profile_duration_s(checkpoint=trt_profile_checkpoint)
+        except ValueError as exc:
+            print(f"[Server] {exc}")
+            try:
+                ws.send(json.dumps({
+                    "type": "error",
+                    "code": "unsupported_trt_checkpoint",
+                    "message": str(exc),
+                }))
+            except Exception:
+                pass
+            ws.close(1011, "unsupported TRT checkpoint")
+            return
+    else:
+        max_seconds = max_profile_duration_s()
     waveform = waveform[:, :int(max_seconds * SAMPLE_RATE)]
     pool = 1920 * 5
     rem = waveform.shape[-1] % pool
@@ -386,7 +404,6 @@ def handle_client(
 
     # --- Session setup ---
     audio_duration_s = waveform.shape[1] / SAMPLE_RATE
-    use_trt = decoder_backend == "tensorrt" or vae_backend == "tensorrt"
     # Profile manager owns the engine slots. When use_trt is False, it
     # stays None and the swap path keeps the legacy engine-less behavior.
     profile_mgr: TRTProfileManager | None = None
@@ -394,6 +411,7 @@ def handle_client(
         profile_mgr = TRTProfileManager(
             decoder_backend=decoder_backend,
             vae_backend=vae_backend,
+            checkpoint=trt_profile_checkpoint,
         )
         try:
             trt_engines, picked_dur = profile_mgr.resolve(audio_duration_s)
@@ -456,7 +474,10 @@ def handle_client(
         # but wasn't built (so we genuinely fell back). For a 119.8 s
         # source the 120 s engine is the smallest fitting profile, not
         # a fallback — the previous predicate fired on that case.
-        ideal_dur = smallest_fitting_profile_duration_s(audio_duration_s)
+        ideal_dur = smallest_fitting_profile_duration_s(
+            audio_duration_s,
+            checkpoint=trt_profile_checkpoint,
+        )
         if picked_dur > ideal_dur:
             print(
                 f"[Server] WARNING: using {picked_dur:.0f}s engine for "

--- a/demos/realtime_motion_graph_web/benchmark.py
+++ b/demos/realtime_motion_graph_web/benchmark.py
@@ -1,0 +1,713 @@
+"""Headless performance benchmark for the realtime motion graph demo.
+
+This mirrors the server-side inference path used by
+``demos.realtime_motion_graph_web`` without HTTP, WebSocket, browser, or
+audio-device overhead:
+
+1. Resolve the same accel/checkpoint/TRT engine combination as backend.py.
+2. Load the same fixture/config defaults as the web demo.
+3. Build Session -> prepare_source -> encode_text -> stream.
+4. Time stream.tick() and optional VAE decode per completed generation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import soundfile as sf
+import torch
+
+torch.set_grad_enabled(False)
+torch._dynamo.config.disable = True
+
+from acestep.audio.key_detection import detect_key
+from acestep.constants import TASK_INSTRUCTIONS
+from acestep.engine.session import Session
+from acestep.fixtures import audio_fixture
+from acestep.nodes.types import Audio
+from acestep.paths import (
+    EngineNotBuiltError,
+    available_dreamvae_decode_engine,
+    available_trt_engines,
+    checkpoints_dir,
+    dreamvae_decode_engine_name,
+    max_profile_duration_s,
+    smallest_fitting_profile_duration_s,
+)
+
+from .protocol import SAMPLE_RATE
+
+
+VALID_ACCEL = ("tensorrt", "compile", "eager")
+DEFAULT_CONFIG = Path(__file__).parent / "static" / "config.json"
+DEFAULT_FIXTURE = "inside_confusion_loop_60s_gsm.wav"
+
+
+def cuda_sync() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+@contextmanager
+def timed(label: str, timings: dict[str, float]):
+    cuda_sync()
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        cuda_sync()
+        ms = (time.perf_counter() - t0) * 1000
+        timings[label] = ms
+        print(f"  [{label}] {ms:.1f}ms")
+
+
+def percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    pos = (len(ordered) - 1) * pct
+    lo = math.floor(pos)
+    hi = math.ceil(pos)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] * (hi - pos) + ordered[hi] * (pos - lo)
+
+
+def describe(values: list[float]) -> dict[str, float | int | None]:
+    if not values:
+        return {
+            "count": 0,
+            "mean_ms": None,
+            "median_ms": None,
+            "p90_ms": None,
+            "p95_ms": None,
+            "min_ms": None,
+            "max_ms": None,
+        }
+    return {
+        "count": len(values),
+        "mean_ms": statistics.fmean(values),
+        "median_ms": percentile(values, 0.50),
+        "p90_ms": percentile(values, 0.90),
+        "p95_ms": percentile(values, 0.95),
+        "min_ms": min(values),
+        "max_ms": max(values),
+    }
+
+
+def fmt_stat(value: float | int | None) -> str:
+    return "n/a" if value is None else f"{float(value):.1f}"
+
+
+def load_demo_config(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def duration_cap_for(
+    *,
+    decoder_backend: str,
+    vae_backend: str,
+    checkpoint: str,
+) -> tuple[float, str]:
+    use_trt = decoder_backend == "tensorrt" or vae_backend == "tensorrt"
+    trt_profile_checkpoint = (
+        checkpoint if decoder_backend == "tensorrt" else "acestep-v15-turbo"
+    )
+    if use_trt:
+        return (
+            max_profile_duration_s(checkpoint=trt_profile_checkpoint),
+            trt_profile_checkpoint,
+        )
+    return max_profile_duration_s(), trt_profile_checkpoint
+
+
+def load_audio(path: Path, *, duration_s: float) -> Audio:
+    data, sr = sf.read(str(path), dtype="float32")
+    if data.ndim == 1:
+        waveform = torch.from_numpy(data.reshape(1, -1))
+    else:
+        waveform = torch.from_numpy(data.T)
+
+    if sr != SAMPLE_RATE:
+        import torchaudio
+
+        waveform = torchaudio.transforms.Resample(sr, SAMPLE_RATE)(waveform)
+
+    waveform = waveform[:2, : int(duration_s * SAMPLE_RATE)]
+    pool = 1920 * 5
+    rem = waveform.shape[-1] % pool
+    if rem:
+        waveform = waveform[:, : waveform.shape[-1] - rem]
+    if waveform.shape[-1] <= 0:
+        raise SystemExit(
+            "Audio is empty after trimming to the 5-frame ACE-Step boundary."
+        )
+    return Audio(waveform=waveform, sample_rate=SAMPLE_RATE)
+
+
+def resolve_trt_engines(
+    *,
+    decoder_backend: str,
+    vae_backend: str,
+    checkpoint: str,
+    duration_s: float,
+    fast_vae: bool,
+) -> tuple[dict[str, str] | None, float | None, bool]:
+    use_trt = decoder_backend == "tensorrt" or vae_backend == "tensorrt"
+    if not use_trt:
+        if fast_vae:
+            print("[Setup] WARNING: --fast-vae requires --vae-accel tensorrt; ignoring")
+        return None, None, False
+
+    trt_profile_checkpoint = (
+        checkpoint if decoder_backend == "tensorrt" else "acestep-v15-turbo"
+    )
+    needs: list[str] = []
+    if decoder_backend == "tensorrt":
+        needs.append("decoder")
+    if vae_backend == "tensorrt":
+        needs.extend(["vae_encode", "vae_decode"])
+
+    try:
+        trt_engines, picked_dur = available_trt_engines(
+            duration_s=duration_s,
+            needs=tuple(needs),
+            checkpoint=trt_profile_checkpoint,
+        )
+    except EngineNotBuiltError as exc:
+        print(f"[Setup] {exc}")
+        if exc.build_command:
+            print(f"[Setup] Build command: {exc.build_command}")
+        raise SystemExit(2) from exc
+
+    ideal_dur = smallest_fitting_profile_duration_s(
+        duration_s,
+        checkpoint=trt_profile_checkpoint,
+    )
+    if picked_dur > ideal_dur:
+        print(
+            f"[Setup] WARNING: using {picked_dur:.0f}s TRT profile for "
+            f"{duration_s:.1f}s audio (ideal {ideal_dur:.0f}s profile not built)"
+        )
+
+    if decoder_backend != "tensorrt":
+        trt_engines.pop("decoder", None)
+    if vae_backend != "tensorrt":
+        trt_engines.pop("vae_encode", None)
+        trt_engines.pop("vae_decode", None)
+
+    if fast_vae and vae_backend == "tensorrt":
+        dreamvae = available_dreamvae_decode_engine(picked_dur)
+        if dreamvae is not None:
+            trt_engines["vae_decode"] = str(dreamvae)
+        else:
+            wanted = dreamvae_decode_engine_name(int(picked_dur))
+            fallback = Path(trt_engines["vae_decode"]).stem
+            print(
+                f"[Setup] WARNING: {wanted} engine missing, using {fallback}"
+            )
+            fast_vae = False
+    elif fast_vae:
+        print("[Setup] WARNING: --fast-vae requires --vae-accel tensorrt; ignoring")
+        fast_vae = False
+
+    return trt_engines, picked_dur, fast_vae
+
+
+def denoise_at(args: argparse.Namespace, index: int, total: int) -> float:
+    if args.denoise_pattern == "constant":
+        return float(args.denoise)
+    if total <= 1:
+        return float(args.denoise)
+    phase = 2.0 * math.pi * (index / total)
+    value = float(args.denoise) + float(args.denoise_amplitude) * math.sin(phase)
+    return max(0.0, min(1.0, value))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark the realtime motion graph ACE-Step inference path."
+    )
+    parser.add_argument("--accel", choices=VALID_ACCEL, default="tensorrt")
+    parser.add_argument("--decoder-accel", choices=VALID_ACCEL)
+    parser.add_argument("--vae-accel", choices=VALID_ACCEL)
+    parser.add_argument("--checkpoint", default="acestep-v15-turbo")
+
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG,
+        help="Demo config.json for default prompt/engine/control values.",
+    )
+    parser.add_argument(
+        "--no-config",
+        action="store_true",
+        help="Ignore static/config.json and use script fallbacks.",
+    )
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--audio", type=Path, help="Local WAV/FLAC/etc source audio.")
+    source.add_argument(
+        "--fixture",
+        default=DEFAULT_FIXTURE,
+        help="Fixture name from daydreamlive/demon-fixtures.",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        help="Seconds of source audio to use. Default: source length capped like the web server.",
+    )
+
+    parser.add_argument("--prompt", help="Cover prompt. Defaults to config prompts.a.")
+    parser.add_argument("--bpm", type=int, help="Override detected BPM.")
+    parser.add_argument("--key", help="Override detected key.")
+    parser.add_argument(
+        "--no-detect-metadata",
+        action="store_true",
+        help="Skip librosa/key detection and use --bpm/--key or config defaults.",
+    )
+
+    parser.add_argument("--steps", type=int, help="Diffusion steps.")
+    parser.add_argument("--depth", type=int, help="Streaming pipeline depth.")
+    parser.add_argument("--vae-window", type=float, help="Windowed VAE decode size.")
+    parser.add_argument(
+        "--fast-vae",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Use DreamVAE TRT decode when available.",
+    )
+
+    parser.add_argument("--warmup", type=int, default=4)
+    parser.add_argument("--iters", type=int, default=24)
+    parser.add_argument("--seed", type=int, default=557)
+    parser.add_argument(
+        "--vary-seed",
+        action="store_true",
+        help="Increment seed each submitted tick.",
+    )
+    parser.add_argument("--denoise", type=float, help="Center/default denoise value.")
+    parser.add_argument(
+        "--denoise-pattern",
+        choices=("sine", "constant"),
+        default="sine",
+        help="Sine avoids decode-skip artifacts in repeated identical ticks.",
+    )
+    parser.add_argument("--denoise-amplitude", type=float, default=0.20)
+    parser.add_argument(
+        "--shift-raw",
+        type=float,
+        help="UI-style shift knob value. Effective shift is 1 + shift_raw * 5.",
+    )
+    parser.add_argument("--noise-share", type=float, default=0.0)
+
+    parser.add_argument(
+        "--skip-threshold",
+        type=float,
+        default=-1.0,
+        help=(
+            "Decode-skip MSE threshold. Default -1 disables skip so VAE "
+            "decode metrics are measured every generation. Use 1e-3 to "
+            "mirror PipelineRunner."
+        ),
+    )
+    parser.add_argument("--no-decode", action="store_true")
+    parser.add_argument(
+        "--progress-every",
+        type=int,
+        default=5,
+        help="Print one progress row per N measured generations; 0 disables.",
+    )
+    parser.add_argument("--json", type=Path, help="Write full metrics as JSON.")
+
+    parser.add_argument(
+        "--dcw-enabled",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable/disable wavelet-domain correction.",
+    )
+    parser.add_argument("--dcw-mode", default=None)
+    parser.add_argument("--dcw-scaler", type=float, default=None)
+    parser.add_argument("--dcw-high-scaler", type=float, default=None)
+    parser.add_argument("--dcw-wavelet", default=None)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_demo_config(None if args.no_config else args.config)
+
+    decoder_backend = args.decoder_accel or args.accel
+    vae_backend = args.vae_accel or args.accel
+    cap_s, trt_profile_checkpoint = duration_cap_for(
+        decoder_backend=decoder_backend,
+        vae_backend=vae_backend,
+        checkpoint=args.checkpoint,
+    )
+    requested_duration = args.duration if args.duration is not None else cap_s
+    duration_s = min(requested_duration, cap_s)
+
+    engine_cfg = config.get("engine", {})
+    controls_cfg = config.get("controls", {})
+    prompts_cfg = config.get("prompts", {})
+
+    steps = args.steps if args.steps is not None else int(engine_cfg.get("steps", 8))
+    depth = args.depth if args.depth is not None else int(engine_cfg.get("depth", 4))
+    vae_window = (
+        args.vae_window
+        if args.vae_window is not None
+        else float(engine_cfg.get("vae_window", 3.0))
+    )
+    fast_vae = (
+        bool(args.fast_vae)
+        if args.fast_vae is not None
+        else bool(engine_cfg.get("fast_vae", False))
+    )
+    prompt = args.prompt or prompts_cfg.get("a") or "instrumental music"
+    fallback_bpm = args.bpm if args.bpm is not None else 120
+    key = args.key or engine_cfg.get("key") or "C major"
+    denoise = (
+        args.denoise
+        if args.denoise is not None
+        else float(controls_cfg.get("denoise", 0.7))
+    )
+    args.denoise = denoise
+    shift_raw = (
+        args.shift_raw
+        if args.shift_raw is not None
+        else float(controls_cfg.get("shift", 0.5))
+    )
+    shift = 1.0 + shift_raw * 5.0
+    dcw_enabled = (
+        bool(args.dcw_enabled)
+        if args.dcw_enabled is not None
+        else bool(controls_cfg.get("dcw_enabled", True))
+    )
+    dcw_mode = args.dcw_mode or str(controls_cfg.get("dcw_mode", "double"))
+    dcw_scaler = (
+        args.dcw_scaler
+        if args.dcw_scaler is not None
+        else float(controls_cfg.get("dcw_scaler", 0.05))
+    )
+    dcw_high_scaler = (
+        args.dcw_high_scaler
+        if args.dcw_high_scaler is not None
+        else float(controls_cfg.get("dcw_high_scaler", 0.02))
+    )
+    dcw_wavelet = args.dcw_wavelet or str(controls_cfg.get("dcw_wavelet", "haar"))
+
+    if requested_duration > cap_s:
+        print(
+            f"[Setup] Requested duration {requested_duration:.1f}s exceeds "
+            f"{trt_profile_checkpoint} profile cap {cap_s:.0f}s; clipping."
+        )
+
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats()
+
+    timings: dict[str, float] = {}
+
+    print("=" * 72)
+    print("Realtime Motion Graph Headless Benchmark")
+    print("=" * 72)
+    print(
+        f"[Setup] checkpoint={args.checkpoint} "
+        f"decoder={decoder_backend} vae={vae_backend}"
+    )
+    print(
+        f"[Setup] steps={steps} depth={depth} vae_window={vae_window:.1f}s "
+        f"fast_vae={fast_vae}"
+    )
+    print(
+        f"[Setup] denoise={denoise:.3f} pattern={args.denoise_pattern} "
+        f"shift={shift:.2f} noise_share={args.noise_share:.2f}"
+    )
+
+    with timed("load_audio", timings):
+        if args.audio is not None:
+            audio_path = args.audio
+        else:
+            audio_path = audio_fixture(args.fixture)
+        audio = load_audio(audio_path, duration_s=duration_s)
+
+    waveform = audio.waveform
+    actual_duration_s = waveform.shape[-1] / SAMPLE_RATE
+    print(
+        f"[Setup] audio={audio_path} "
+        f"duration={actual_duration_s:.1f}s channels={waveform.shape[0]}"
+    )
+
+    trt_engines, picked_dur, fast_vae = resolve_trt_engines(
+        decoder_backend=decoder_backend,
+        vae_backend=vae_backend,
+        checkpoint=args.checkpoint,
+        duration_s=actual_duration_s,
+        fast_vae=fast_vae,
+    )
+    if trt_engines:
+        for key_name, engine_path in sorted(trt_engines.items()):
+            print(f"[Setup] {key_name}={Path(engine_path).stem}")
+        if picked_dur is not None:
+            print(f"[Setup] picked_trt_profile={picked_dur:.0f}s")
+
+    with timed("model_load", timings):
+        session = Session(
+            project_root=str(checkpoints_dir()),
+            config_path=args.checkpoint,
+            decoder_backend=decoder_backend,
+            vae_backend=vae_backend,
+            trt_engines=trt_engines,
+            vae_window=vae_window,
+        )
+
+    if args.no_detect_metadata:
+        bpm = fallback_bpm
+        print(f"[Setup] metadata detection skipped; bpm={bpm} key={key}")
+    else:
+        with timed("detect_metadata", timings):
+            import librosa
+
+            mono_np = waveform.mean(dim=0).numpy()
+            detected_bpm, _ = librosa.beat.beat_track(y=mono_np, sr=SAMPLE_RATE)
+            bpm = int(round(float(np.asarray(detected_bpm).flat[0])))
+            key = args.key or detect_key(mono_np, SAMPLE_RATE)
+        if args.bpm is not None:
+            bpm = args.bpm
+        print(f"[Setup] metadata bpm={bpm} key={key}")
+
+    with timed("prepare_source", timings):
+        source = session.prepare_source(audio)
+    print(
+        f"[Setup] latent_frames={source.latent.tensor.shape[1]} "
+        f"({source.latent.tensor.shape[1] / 25.0:.1f}s)"
+    )
+
+    with timed("text_encode", timings):
+        conditioning = session.encode_text(
+            tags=prompt,
+            instruction=TASK_INSTRUCTIONS["cover"],
+            refer_latent=source.latent,
+            bpm=bpm,
+            duration=actual_duration_s,
+            key=key,
+        )
+
+    with timed("stream_setup", timings):
+        stream = session.stream(
+            source=source,
+            conditioning=conditioning,
+            steps=steps,
+            shift=3.0,
+            pipeline_depth=depth,
+            dcw_enabled=dcw_enabled,
+            dcw_mode=dcw_mode,
+            dcw_scaler=dcw_scaler,
+            dcw_high_scaler=dcw_high_scaler,
+            dcw_wavelet=dcw_wavelet,
+        )
+    print("[Run] Stream handle ready; first tick builds the pipeline")
+
+    target_completed = args.warmup + args.iters
+    max_ticks = target_completed + depth + steps + 20
+    measured_tick_ms: list[float] = []
+    measured_decode_ms: list[float] = []
+    measured_total_ms: list[float] = []
+    warmup_tick_ms: list[float] = []
+    skipped_measured = 0
+    decoded_measured = 0
+    completed = 0
+    measured = 0
+    last_latent = None
+    last_wav_seen = False
+
+    print(
+        f"[Run] warmup={args.warmup} measured={args.iters} "
+        f"decode={'off' if args.no_decode else 'on'} "
+        f"skip_threshold={args.skip_threshold:g}"
+    )
+    run_t0 = time.perf_counter()
+
+    for tick_idx in range(max_ticks):
+        denoise_value = denoise_at(args, tick_idx, max(1, target_completed))
+        seed = args.seed + tick_idx if args.vary_seed else args.seed
+
+        cuda_sync()
+        tick_t0 = time.perf_counter()
+        result_latent = stream.tick(
+            denoise=denoise_value,
+            seed=seed,
+            shift=shift,
+            noise_sharing=args.noise_share,
+        )
+        cuda_sync()
+        tick_ms = (time.perf_counter() - tick_t0) * 1000
+
+        if result_latent is None:
+            continue
+
+        completed += 1
+        is_measured = completed > args.warmup
+        if is_measured:
+            measured += 1
+            measured_tick_ms.append(tick_ms)
+        else:
+            warmup_tick_ms.append(tick_ms)
+
+        skipped = False
+        if args.skip_threshold >= 0:
+            result = result_latent.tensor
+            if last_latent is not None and last_wav_seen:
+                mse = (result - last_latent).pow(2).mean().item()
+                skipped = mse < args.skip_threshold
+            last_latent = result.clone()
+
+        dec_ms = 0.0
+        if args.no_decode:
+            skipped = True
+        elif skipped:
+            if is_measured:
+                skipped_measured += 1
+        else:
+            cuda_sync()
+            dec_t0 = time.perf_counter()
+            audio_out = session.decode(result_latent, t_start=0.0, cyclic=True)
+            cuda_sync()
+            dec_ms = (time.perf_counter() - dec_t0) * 1000
+            last_wav_seen = True
+            _ = audio_out.start_sample
+            if is_measured:
+                decoded_measured += 1
+                measured_decode_ms.append(dec_ms)
+
+        if is_measured:
+            measured_total_ms.append(tick_ms + dec_ms)
+            if args.progress_every and (
+                measured == 1
+                or measured == args.iters
+                or measured % args.progress_every == 0
+            ):
+                dec_label = "skip" if skipped else f"{dec_ms:.1f}ms"
+                print(
+                    f"  #{measured:3d}/{args.iters} "
+                    f"tick={tick_ms:.1f}ms decode={dec_label} "
+                    f"denoise={denoise_value:.3f}"
+                )
+
+        if measured >= args.iters:
+            break
+
+    if measured < args.iters:
+        raise SystemExit(
+            f"Only completed {measured} measured generations after {max_ticks} ticks."
+        )
+
+    run_wall_ms = (time.perf_counter() - run_t0) * 1000
+    tick_stats = describe(measured_tick_ms)
+    decode_stats = describe(measured_decode_ms)
+    total_stats = describe(measured_total_ms)
+
+    mem_stats: dict[str, float | None] = {
+        "cuda_peak_allocated_gb": None,
+        "cuda_peak_reserved_gb": None,
+    }
+    if torch.cuda.is_available():
+        mem_stats = {
+            "cuda_peak_allocated_gb": torch.cuda.max_memory_allocated() / (1024**3),
+            "cuda_peak_reserved_gb": torch.cuda.max_memory_reserved() / (1024**3),
+        }
+
+    print("\n" + "=" * 72)
+    print("SUMMARY")
+    print("=" * 72)
+    print(f"Completed: {completed} ({args.warmup} warmup, {measured} measured)")
+    print(f"Wall time: {run_wall_ms:.1f}ms")
+    print(f"Decode: {decoded_measured} decoded, {skipped_measured} skipped")
+    print()
+    print(f"{'metric':<14s} {'mean':>9s} {'p50':>9s} {'p90':>9s} {'p95':>9s} {'min':>9s} {'max':>9s}")
+    print("-" * 72)
+    for label, stats in (
+        ("tick", tick_stats),
+        ("decode", decode_stats),
+        ("tick+decode", total_stats),
+    ):
+        print(
+            f"{label:<14s} "
+            f"{fmt_stat(stats['mean_ms']):>9s} "
+            f"{fmt_stat(stats['median_ms']):>9s} "
+            f"{fmt_stat(stats['p90_ms']):>9s} "
+            f"{fmt_stat(stats['p95_ms']):>9s} "
+            f"{fmt_stat(stats['min_ms']):>9s} "
+            f"{fmt_stat(stats['max_ms']):>9s}"
+        )
+    if mem_stats["cuda_peak_allocated_gb"] is not None:
+        print(
+            f"\nCUDA peak: allocated={mem_stats['cuda_peak_allocated_gb']:.2f} GiB "
+            f"reserved={mem_stats['cuda_peak_reserved_gb']:.2f} GiB"
+        )
+
+    payload = {
+        "config": {
+            "checkpoint": args.checkpoint,
+            "decoder_backend": decoder_backend,
+            "vae_backend": vae_backend,
+            "trt_profile_checkpoint": trt_profile_checkpoint,
+            "picked_trt_profile_s": picked_dur,
+            "trt_engines": trt_engines,
+            "fast_vae": fast_vae,
+            "audio": str(audio_path),
+            "duration_s": actual_duration_s,
+            "steps": steps,
+            "depth": depth,
+            "vae_window_s": vae_window,
+            "prompt": prompt,
+            "bpm": bpm,
+            "key": key,
+            "denoise": denoise,
+            "denoise_pattern": args.denoise_pattern,
+            "shift": shift,
+            "noise_share": args.noise_share,
+            "seed": args.seed,
+            "vary_seed": args.vary_seed,
+            "skip_threshold": args.skip_threshold,
+            "decode": not args.no_decode,
+            "dcw_enabled": dcw_enabled,
+            "dcw_mode": dcw_mode,
+            "dcw_scaler": dcw_scaler,
+            "dcw_high_scaler": dcw_high_scaler,
+            "dcw_wavelet": dcw_wavelet,
+        },
+        "setup_timings_ms": timings,
+        "warmup_tick_ms": warmup_tick_ms,
+        "tick_ms": measured_tick_ms,
+        "decode_ms": measured_decode_ms,
+        "tick_decode_ms": measured_total_ms,
+        "stats": {
+            "tick": tick_stats,
+            "decode": decode_stats,
+            "tick_decode": total_stats,
+            "decoded_measured": decoded_measured,
+            "skipped_measured": skipped_measured,
+            "run_wall_ms": run_wall_ms,
+            **mem_stats,
+        },
+    }
+
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"\nWrote JSON metrics: {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1311,30 +1311,6 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   outline: 1px dashed currentColor;
   outline-offset: 2px;
 }
-/* During session-start (`status` in {loading-fixture, connecting}) the
-   pill silently drops sendEnableLora/sendDisableLora because the WS
-   isn't OPEN yet. LibraryTile sets disabled+aria-disabled on the
-   button and data-locked on the name span; visually dim them so the
-   operator gets immediate "wait" feedback instead of clicking a dead
-   control. The hover-color change cascade is overridden so it doesn't
-   look interactive while locked. */
-.lora-switch:disabled,
-.lora-switch[aria-disabled="true"] {
-  cursor: wait;
-  opacity: 0.45;
-}
-.lora-switch:disabled:hover,
-.lora-switch[aria-disabled="true"]:hover {
-  border-color: var(--frame-line);
-}
-.lora-switch:disabled:hover .lora-switch-thumb,
-.lora-switch[aria-disabled="true"]:hover .lora-switch-thumb {
-  background: var(--text-dim);
-}
-.lora-row-name[data-locked] {
-  cursor: wait;
-  opacity: 0.55;
-}
 
 /* Horizontal strength slider.  Spans the full row width below the
    switch+name line, giving the operator a wide drag surface without

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -38,24 +38,10 @@ function LoraRow({ id, name }: RowProps) {
   const value = typeof strength === "number" ? strength : fallbackStrength;
   const enable = useLoraStore((s) => s.enable);
   const disable = useLoraStore((s) => s.disable);
-  // Gate the enable/disable pill during the session-start race window.
-  // Between `useStartSession`'s buildConfig snapshot of `enabled_loras`
-  // and the WS reaching readyState=OPEN, sendEnableLora/sendDisableLora
-  // silently drop (protocol.ts gates on OPEN) and `useSessionStore.remote`
-  // is still null — so a click would update the local store but never
-  // reach the engine, and the user would need to disable+re-enable after
-  // ready to recover the intended state. status='idle' is fine: toggles
-  // are picked up by buildConfig on the next click-play. status='ready'
-  // is fine: send path works normally. Lock specifically during the
-  // in-flight start.
-  const togglesLocked = useSessionStore(
-    (s) => s.status === "loading-fixture" || s.status === "connecting",
-  );
 
   const trackRef = useRef<HTMLDivElement | null>(null);
 
   function toggle() {
-    if (togglesLocked) return;
     const remote = useSessionStore.getState().remote;
     if (enabled) {
       disable(id);
@@ -128,21 +114,12 @@ function LoraRow({ id, name }: RowProps) {
         className="lora-switch"
         role="switch"
         aria-checked={enabled}
-        aria-disabled={togglesLocked}
-        disabled={togglesLocked}
         onClick={toggle}
-        data-dd-tooltip={
-          togglesLocked ? "Connecting…" : enabled ? "Disable" : "Enable"
-        }
+        data-dd-tooltip={enabled ? "Disable" : "Enable"}
       >
         <span className="lora-switch-thumb" aria-hidden="true" />
       </button>
-      <span
-        className="lora-row-name"
-        title={id}
-        onClick={toggle}
-        data-locked={togglesLocked || undefined}
-      >
+      <span className="lora-row-name" title={id} onClick={toggle}>
         {name}
       </span>
       <div className="lora-strength">

--- a/demos/realtime_motion_graph_web/web/hooks/useEdgeLoraBinding.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useEdgeLoraBinding.ts
@@ -161,16 +161,11 @@ export function useEdgeLoraBinding(): void {
       const blendChanged = blend !== lastBlend;
       if (!pairChanged && !blendChanged) return;
 
-      // Latch BEFORE the writes — fanOutBlend's setStrength calls fire
-      // useLoraStore subscribers synchronously, re-entering apply(). If
-      // the latch is still stale, the guard above won't short-circuit
-      // and we recurse until the stack blows.
+      applyMobileRightEdge(blend, a, b);
+      fanOutBlend(blend, a, b);
       lastBlend = blend;
       lastA = a;
       lastB = b;
-
-      applyMobileRightEdge(blend, a, b);
-      fanOutBlend(blend, a, b);
     };
 
     apply();

--- a/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
@@ -171,17 +171,9 @@ export function useFixtureSwap() {
       // shows again; side-rail hints stay suppressed until the user
       // drags the top ribbon up. Shares config with useStartSession so
       // one knob controls both Play and swap.
-      //
-      // skipNextDenoiseGate is the same one-shot opt-out used by
-      // useStartSession: a mid-session Remix-onto-running-engine flow
-      // (LibraryPanel handleRemix → applySessionState → setFixture)
-      // sets the flag before setFixture so the imported denoise survives
-      // the swap. Consumed-and-cleared regardless of gate.enabled.
       const perfState = usePerformanceStore.getState();
       const gate = getConfig().denoise_session_gate;
-      const skipGate = perfState.skipNextDenoiseGate;
-      if (skipGate) perfState.setSkipNextDenoiseGate(false);
-      if (gate.enabled && !skipGate) {
+      if (gate.enabled) {
         const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
         perfState.setSliderDirect("denoise", 0);
         perfState.animateSliderDisplayFrom("denoise", prevDenoise, gate.glide_ms);

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -228,21 +228,10 @@ export function useStartSession() {
     // user to dial it back up. controls.denoise in config.json seeds the
     // initial fresh-load value (only applyConfig() at module load sees
     // it); later sessions need this explicit reset to restore the gate.
-    //
-    // skipNextDenoiseGate is a one-shot opt-out: the import path
-    // (applySessionState in demon-public-demo's lib/sessions/client.ts)
-    // sets it after writing the sharer's sliderTargets, so a session
-    // started from a shared / saved / pasted state plays from frame 1 at
-    // the imported denoise instead of being snapped to 0 by the
-    // onboarding cue. Consumed-and-cleared regardless of gate.enabled so
-    // the flag never survives past one session start.
-    //
     // remixStarted always resets so the affordance shows again.
     const perfState = usePerformanceStore.getState();
     const gate = getConfig().denoise_session_gate;
-    const skipGate = perfState.skipNextDenoiseGate;
-    if (skipGate) perfState.setSkipNextDenoiseGate(false);
-    if (gate.enabled && !skipGate) {
+    if (gate.enabled) {
       const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
       perfState.setSliderDirect("denoise", 0);
       perfState.animateSliderDisplayFrom("denoise", prevDenoise, gate.glide_ms);

--- a/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
@@ -334,13 +334,6 @@ interface PerformanceState {
    *  flips it true. Drives the "drag to start" affordance and gates
    *  the side-rail tutorial hints. */
   remixStarted: boolean;
-  /** One-shot flag: when true, the next firing of the denoise_session_gate
-   *  in useStartSession / useFixtureSwap is skipped and the flag is
-   *  cleared. Set by the import path (applySessionState) so that a
-   *  shared / saved / pasted session lands with the sharer's denoise
-   *  value preserved instead of being snapped to 0 by the onboarding
-   *  cue. Fresh sessions leave this false and get the normal gate. */
-  skipNextDenoiseGate: boolean;
 
   /** DCW (wavelet-domain post-step correction) non-numeric state. The
    * numeric knobs (dcw_scaler, dcw_high_scaler, dcw_mult_blend,
@@ -417,7 +410,6 @@ interface PerformanceState {
   setPaused: (p: boolean) => void;
   togglePause: () => void;
   setRemixStarted: (b: boolean) => void;
-  setSkipNextDenoiseGate: (b: boolean) => void;
   /** Run a visual-only "slide to zero" demo on `param`. Seeds
    *  `sliderDisplayOverride[param] = fromValue` and tweens it down to 0
    *  over `durationMs` using a cubic ease-out, then deletes the key so
@@ -514,7 +506,6 @@ export const usePerformanceStore = create<PerformanceState>((set) => ({
   kiosk: false,
   paused: false,
   remixStarted: false,
-  skipNextDenoiseGate: false,
 
   dcwEnabled: true,
   dcwMode: "double",
@@ -629,7 +620,6 @@ export const usePerformanceStore = create<PerformanceState>((set) => ({
   setPaused: (p) => set({ paused: p }),
   togglePause: () => set((s) => ({ paused: !s.paused })),
   setRemixStarted: (b) => set({ remixStarted: b }),
-  setSkipNextDenoiseGate: (b) => set({ skipNextDenoiseGate: b }),
   animateSliderDisplayFrom: (param, fromValue, durationMs) => {
     // Cancel any in-flight smoothing or prior demo tween for this param.
     cancelTween(param);

--- a/demos/test_stream_cover_graph.py
+++ b/demos/test_stream_cover_graph.py
@@ -90,9 +90,7 @@ checkpoint = _get_arg("--checkpoint", "acestep-v15-turbo")
 if "--decoder-engine" in _args:
     decoder_engine_name = _get_arg("--decoder-engine")
 elif checkpoint == "acestep-v15-xl-turbo":
-    # No 60s variant of the refit XL decoder is built today; keep the 240s
-    # default for this checkpoint until one is available.
-    decoder_engine_name = "decoder_xl-turbo_bf16_refit_b8_240s"
+    decoder_engine_name = "decoder_xl-turbo_mixed_refit_b4_60s"
 else:
     decoder_engine_name = "decoder_mixed_refit_b8_60s"
 
@@ -119,8 +117,8 @@ if no_trt_decoder:
     _backend_tag = "pt"
 else:
     # Use the engine name as the backend tag, stripping common prefixes
-    # so the filename stays readable (e.g. "decoder_xl-turbo_attnsafe_b8_60s"
-    # -> "trt_attnsafe_b8_60s").
+    # so the filename stays readable (e.g. "decoder_xl-turbo_mixed_refit_b4_60s"
+    # -> "trt_mixed_refit_b4_60s").
     _eng = decoder_engine_name
     for prefix in ("decoder_xl-turbo_", "decoder_"):
         if _eng.startswith(prefix):

--- a/docs/TRT.md
+++ b/docs/TRT.md
@@ -1,0 +1,787 @@
+# TensorRT Support In DEMON
+
+This document describes the TensorRT implementation in DEMON as it exists now:
+what was changed, which engines are supported, how to build them, how to run
+them, and what is known about ACE-Step 1.5 XL support.
+
+DEMON targets TensorRT 10.16.x. Engines are not portable across TensorRT
+versions or GPU architectures by default, so treat generated `.engine` files as
+local build artifacts.
+
+## Current Scope
+
+TensorRT acceleration is implemented for:
+
+- ACE-Step DiT decoder inference.
+- ACE-Step VAE encode and decode.
+- Windowed VAE decode for low-VRAM streaming decode.
+- ACE-Step 1.5 2B turbo decoder engines.
+- ACE-Step 1.5 XL turbo decoder engines with dynamic-batch ONNX patching.
+
+The default runtime still requires the ACE-Step text encoder and tokenizer for
+conditioning. TensorRT replaces the heavy decoder and/or VAE execution paths
+when selected.
+
+## Runtime Stack
+
+The project dependencies pin the tested TensorRT stack:
+
+```toml
+"torch==2.9.1+cu128"
+"onnx>=1.20,<1.22"
+"onnxscript>=0.7.0"
+"tensorrt>=10.16,<10.17"
+"polygraphy>=0.49.26"
+"cuda-python>=13.2,<13.3"
+```
+
+`onnxscript` is required for PyTorch's dynamo ONNX exporter, which is used by
+the bf16 XL export path.
+
+The build script enforces TensorRT `>=10.16,<10.17` during preflight. It records
+TensorRT, CUDA, PyTorch, ONNX, GPU name, compute capability, and driver metadata
+next to every engine in `<engine>.metadata.json`.
+
+Known-good local build environment used for the current artifacts:
+
+- TensorRT: `10.16.1.11`
+- CUDA Python: `13.2.0`
+- CUDA toolkit wheel: `13.2.1`
+- PyTorch: `2.9.1+cu128`
+- GPU: RTX 4090, SM 8.9, 24 GB VRAM
+- Driver seen by `nvidia-smi`: `595.97`
+
+### RTX 5090 / Blackwell VAE Builds
+
+TensorRT 10.15 and 10.16 can generate a Myelin fusion for the Oobleck VAE
+graph that segfaults on RTX 5090 during the first `execute_async_v3` call.
+DEMON pins VAE TensorRT builds to `builder_optimization_level=1` in
+`acestep/engine/trt/vae_export.py` to avoid that fusion. Decoder engines do not
+use this workaround; the 10.16 decoder path has been validated separately on
+Blackwell.
+
+Any VAE or DreamVAE `.engine` built before this opt-level pin should be treated
+as unsafe on Blackwell. Rebuild those engines on the target TensorRT/CUDA/driver
+stack before running full TRT mode on an RTX 5090.
+
+## Storage Layout
+
+Paths are resolved through `acestep.paths`.
+
+Default model root:
+
+```text
+%USERPROFILE%\.daydream-scope\models\demon
+```
+
+Override it with:
+
+```powershell
+$env:ACESTEP_MODELS_DIR = "D:\models\demon"
+```
+
+Directory layout:
+
+```text
+models/demon/
+  checkpoints/
+    acestep-v15-turbo/
+    acestep-v15-xl-turbo/
+    vae/
+    Qwen3-Embedding-0.6B/
+  trt_engines/
+    _onnx_vae/
+    _onnx_acestep-v15-turbo/
+    _onnx_acestep-v15-xl-turbo/
+    decoder_mixed_refit_b8_60s/
+    decoder_xl-turbo_mixed_refit_b4_60s/
+    vae_decode_fp16_3to30s/
+    build_report.csv
+```
+
+ONNX exports are cached under `trt_engines/_onnx_*`. Decoder ONNX is
+checkpoint-specific. VAE ONNX is shared across DiT variants.
+
+## Main Code Paths
+
+- `acestep/engine/trt/build.py`
+  - One entry point for TRT builds.
+  - Performs TensorRT 10.16.x preflight.
+  - Resolves or exports ONNX.
+  - Builds decoder, VAE, windowed VAE, and DreamVAE engines.
+  - Writes engine metadata and appends `build_report.csv`.
+
+- `acestep/engine/trt/export.py`
+  - Exports the DiT decoder to ONNX.
+  - Builds decoder TensorRT engines.
+  - Contains precision recipes for 2B and XL.
+
+- `acestep/engine/trt/vae_export.py`
+  - Exports VAE encode/decode ONNX.
+  - Builds VAE encode/decode TensorRT engines.
+
+- `acestep/engine/trt/runtime.py`
+  - Runtime wrapper for decoder engines.
+  - Allocates buffers using the dtype declared by the engine.
+
+- `acestep/nodes/vae_nodes.py`
+  - Runtime wrapper/cache for VAE TRT engines.
+  - Handles windowed VAE decode selection.
+
+- `acestep/engine/session.py`
+  - User-facing API that wires TRT backends into a `Session`.
+
+- `acestep/paths.py`
+  - Canonical 2B and XL turbo engine profile registration and path helpers.
+
+## Build Script Basics
+
+Run all commands from the repo root:
+
+```powershell
+cd C:\sd\DEMON
+```
+
+Preview the build matrix:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --dry-run
+```
+
+Build the standard 2B turbo 60s engines:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --duration 60
+```
+
+Build the standard 2B turbo 120s engines:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --duration 120
+```
+
+Build only decoder engines:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --decoder-only --duration 60
+```
+
+Build only VAE engines:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --vae-only --duration 60
+```
+
+Force rebuild existing engines:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --duration 60 --force-rebuild
+```
+
+Force ONNX export from local weights and rebuild:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --duration 60 --force-onnx --force-rebuild
+```
+
+## ONNX Resolution
+
+The build script resolves ONNX in this order:
+
+1. Reuse local ONNX if it already exists.
+2. If `--skip-onnx` is passed, fail when any required ONNX is missing.
+3. If `--force-onnx` is passed, export from local checkpoint weights.
+4. If `--export-locally` is passed, export missing ONNX from local weights.
+5. Otherwise, fetch missing ONNX from Hugging Face via
+   `acestep.engine.trt.onnx_hub`.
+
+For 2B turbo, the default Hugging Face ONNX cache may be enough.
+
+For ACE-Step XL turbo, use local export unless an XL ONNX bundle has already
+been uploaded to the configured ONNX hub. The build step patches the exported
+ONNX before engine construction so reshape constants that baked in `B=1` become
+dynamic:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --checkpoint acestep-v15-xl-turbo --decoder-only --duration 60 --batch-max 4 --batch-opt 4 --builder-optimization-level 5 --workspace-gb 20 --export-locally
+```
+
+## Decoder Precision Recipes
+
+The decoder build now accepts:
+
+```powershell
+--decoder-precision auto
+--decoder-precision fp32
+--decoder-precision fp16_mixed
+--decoder-precision bf16_mixed
+```
+
+`auto` behaves as follows:
+
+- For XL checkpoints, `auto` resolves to `bf16_mixed`.
+- For existing 2B mixed builds, `auto` resolves to `fp16_mixed`.
+- For single non-mixed decoder exports, `auto` resolves to `fp32`.
+
+Why XL uses `bf16_mixed`:
+
+- XL turbo is trained/stored in bf16.
+- The XL residual stream can exceed fp16 range.
+- Some attention paths can overflow fp16.
+- TensorRT does not provide a bf16 kernel for the XL `proj_out`
+  `ConvTranspose1d` shape, so `bf16_mixed` keeps the model in bf16 while
+  wrapping that deconvolution in fp32.
+
+## Engine Naming
+
+Decoder engines use:
+
+```text
+decoder[_variant]_<precision>[_refit]_b<batch_max>_<duration>s.engine
+```
+
+Examples:
+
+```text
+decoder_mixed_refit_b8_60s.engine
+decoder_mixed_refit_b8_120s.engine
+decoder_xl-turbo_mixed_refit_b4_60s.engine
+decoder_xl-turbo_mixed_refit_b4_120s.engine
+```
+
+VAE engines use:
+
+```text
+vae_encode_fp16_60s.engine
+vae_decode_fp16_60s.engine
+vae_decode_fp16_120s.engine
+vae_decode_fp16_3to30s.engine
+```
+
+The `mixed` tag means the TensorRT network is strongly typed and follows the
+dtypes encoded in the ONNX graph. For XL `bf16_mixed`, that includes bf16 bulk
+compute plus the fp32 deconvolution island.
+
+## Current Local Build Results
+
+The following artifacts have been built and validated locally:
+
+- `decoder_mixed_refit_b8_60s`: 2B turbo decoder, about 3299.6 MB.
+- `decoder_mixed_refit_b8_120s`: 2B turbo decoder, about 3299.4 MB.
+- `decoder_xl-turbo_mixed_refit_b4_60s`: XL turbo decoder.
+- `decoder_xl-turbo_mixed_refit_b4_120s`: XL turbo decoder.
+- `vae_decode_fp16_60s`: VAE decode, about 179.4 MB.
+- `vae_decode_fp16_120s`: VAE decode, about 347.2 MB.
+- `vae_decode_fp16_3to30s`: windowed VAE decode, about 269.1 MB.
+- `vae_encode_fp16_60s`: VAE encode, about 172.3 MB.
+- `vae_encode_fp16_120s`: VAE encode, about 172.4 MB.
+
+Recent build timings on the RTX 4090:
+
+- 2B turbo 120s decoder: about 130 seconds.
+- XL turbo 60s decoder: about 199 seconds after ONNX export.
+- XL turbo 120s decoder: about 199 seconds, reusing the XL ONNX.
+- XL turbo refit ONNX export: about 476 seconds.
+
+## Building ACE-Step 1.5 XL Turbo
+
+Download the XL checkpoint:
+
+```powershell
+uv run acestep-download --model acestep-v15-xl-turbo --skip-main
+```
+
+Build 60s XL decoder:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --checkpoint acestep-v15-xl-turbo --decoder-only --duration 60 --batch-max 4 --batch-opt 4 --builder-optimization-level 5 --workspace-gb 20 --export-locally --decoder-precision bf16_mixed
+```
+
+Build 120s XL decoder after the 60s path validates:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --checkpoint acestep-v15-xl-turbo --decoder-only --duration 120 --batch-max 4 --batch-opt 4 --builder-optimization-level 5 --workspace-gb 20 --export-locally --decoder-precision bf16_mixed
+```
+
+If changing precision recipe or regenerating the ONNX:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --checkpoint acestep-v15-xl-turbo --decoder-only --duration 60 --batch-max 4 --batch-opt 4 --builder-optimization-level 5 --workspace-gb 20 --force-onnx --decoder-precision bf16_mixed
+```
+
+Use `batch-max=4`, `batch-opt=4`, and builder optimization level `5` for the
+registered XL profiles. During the build, `acestep.engine.trt.build` writes a sibling
+`*_dynbatch.onnx` with `[1, ...]` Reshape shape constants rewritten to
+`[-1, ...]`, then builds the engine from that patched graph.
+
+## Running With TensorRT
+
+2B turbo, canonical helper:
+
+```python
+from acestep.engine.session import Session
+from acestep.paths import default_trt_engines
+
+session = Session(
+    config_path="acestep-v15-turbo",
+    decoder_backend="tensorrt",
+    vae_backend="tensorrt",
+    trt_engines=default_trt_engines(),
+    vae_window=15,
+)
+```
+
+XL turbo with explicit engine paths:
+
+```python
+from acestep.engine.session import Session
+from acestep.paths import trt_engine_path
+
+session = Session(
+    config_path="acestep-v15-xl-turbo",
+    decoder_backend="tensorrt",
+    vae_backend="tensorrt",
+    trt_engines={
+        "decoder": str(trt_engine_path("decoder_xl-turbo_mixed_refit_b4_120s")),
+        "vae_encode": str(trt_engine_path("vae_encode_fp16_120s")),
+        "vae_decode": str(trt_engine_path("vae_decode_fp16_3to30s")),
+    },
+    vae_window=15,
+)
+```
+
+Use the windowed VAE decode engine (`vae_decode_fp16_3to30s`) when
+`vae_window > 0`. It reduces context memory compared with full-duration VAE
+decode engines and is the preferred streaming decode path.
+
+## Running The Realtime Web Demo With TRT
+
+The realtime browser demo is launched with:
+
+```powershell
+uv run python -u -m demos.realtime_motion_graph_web --port 8765
+```
+
+The entry point is `demos/realtime_motion_graph_web/__main__.py`, which calls
+`demos/realtime_motion_graph_web/server.py`. The server uses a single TCP port
+for both static HTTP and WebSocket traffic. Open the UI at:
+
+```text
+http://localhost:8765/
+```
+
+or, from another machine on the same network:
+
+```text
+http://<gpu-host>:8765/
+```
+
+The demo defaults to TensorRT:
+
+```text
+--accel tensorrt
+```
+
+That means both `decoder_backend` and `vae_backend` are set to `tensorrt` on
+the underlying `Session`. These are equivalent:
+
+```powershell
+uv run python -u -m demos.realtime_motion_graph_web --port 8765
+
+uv run python -u -m demos.realtime_motion_graph_web --port 8765 --accel tensorrt
+```
+
+You can also choose a backend explicitly:
+
+```powershell
+uv run python -u -m demos.realtime_motion_graph_web --port 8765 --accel compile
+uv run python -u -m demos.realtime_motion_graph_web --port 8765 --accel eager
+```
+
+For mixed backend debugging:
+
+```powershell
+# TensorRT decoder, eager VAE.
+uv run python -u -m demos.realtime_motion_graph_web --port 8765 --accel tensorrt --vae-accel eager
+
+# Eager decoder, TensorRT VAE.
+uv run python -u -m demos.realtime_motion_graph_web --port 8765 --accel eager --vae-accel tensorrt
+```
+
+### How The Demo Picks TRT Engines
+
+`demos/realtime_motion_graph_web/backend.py` chooses engines at client
+connection time. It measures the uploaded or fixture audio duration, then calls:
+
+```python
+available_trt_engines(
+    duration_s=audio_duration_s,
+    needs=tuple(needs),
+    checkpoint=checkpoint,
+)
+```
+
+`needs` is based on the selected backends:
+
+- `decoder_backend == "tensorrt"` requires `decoder`.
+- `vae_backend == "tensorrt"` requires `vae_encode` and `vae_decode`.
+
+The picker walks the canonical profile set for the selected checkpoint and
+selects the smallest built profile that can fit the audio duration. If the
+smallest fitting profile is missing, it can fall back to the next larger built
+profile and logs a warning about extra VRAM cost. If no suitable built profile
+exists, the server sends an `engine_not_built` error to the UI and closes the
+WebSocket.
+
+For `acestep-v15-turbo`, the decoder profiles are:
+
+```text
+decoder_mixed_refit_b8_60s
+decoder_mixed_refit_b8_120s
+decoder_mixed_refit_b8_240s
+vae_encode_fp16_*
+vae_decode_fp16_*
+```
+
+For `acestep-v15-xl-turbo`, the decoder profiles are:
+
+```text
+decoder_xl-turbo_mixed_refit_b4_60s
+decoder_xl-turbo_mixed_refit_b4_120s
+vae_encode_fp16_*
+vae_decode_fp16_*
+```
+
+VAE engines are shared across the 2B and XL turbo checkpoints. The demo caps
+incoming audio at the largest registered profile for the selected checkpoint
+before engine selection, so XL TRT mode currently accepts audio up to the
+registered 120s XL profile.
+
+### Recommended 2B Turbo Demo Flow
+
+Build at least the 60s 2B engines:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --duration 60
+```
+
+For the default fixture and longer source audio, the 120s engines are useful:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --duration 120
+```
+
+Start the demo:
+
+```powershell
+uv run python -u -m demos.realtime_motion_graph_web --port 8765 --accel tensorrt --checkpoint acestep-v15-turbo
+```
+
+The demo will:
+
+1. Serve the web UI on port `8765`.
+2. Wait for the browser to connect over WebSocket.
+3. Load the selected fixture or uploaded audio.
+4. Pick the smallest built TRT profile that fits that audio.
+5. Construct `Session(decoder_backend="tensorrt", vae_backend="tensorrt")`.
+6. Swap in the windowed VAE decode engine automatically when `vae_window > 0`
+   and `vae_decode_fp16_3to30s` is built.
+
+The browser-side default configuration lives in:
+
+```text
+demos/realtime_motion_graph_web/static/config.json
+```
+
+Relevant TRT/runtime fields in that config include:
+
+```json
+{
+  "depth": 8,
+  "vae_window": 6.0,
+  "crop": 0,
+  "steps": 8,
+  "fast_vae": true
+}
+```
+
+`vae_window > 0` enables windowed decode. `fast_vae=true` asks the backend to
+use DreamVAE as the TRT VAE decode engine when a matching DreamVAE engine is
+built; otherwise it logs a warning and falls back to the standard VAE decode
+engine.
+
+### Recommended XL Turbo Demo Flow
+
+Build the XL checkpoint:
+
+```powershell
+uv run acestep-download --model acestep-v15-xl-turbo --skip-main
+```
+
+Build the 60s XL TRT profile. This builds the XL decoder and any missing shared
+VAE engines for the same duration:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --checkpoint acestep-v15-xl-turbo --duration 60 --batch-max 4 --batch-opt 4 --builder-optimization-level 5 --workspace-gb 20 --export-locally --decoder-precision bf16_mixed
+```
+
+Build the 120s XL TRT profile when the source audio needs it:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --checkpoint acestep-v15-xl-turbo --duration 120 --batch-max 4 --batch-opt 4 --builder-optimization-level 5 --workspace-gb 20 --export-locally --decoder-precision bf16_mixed
+```
+
+Start the demo in full TRT mode:
+
+```powershell
+uv run python -u -m demos.realtime_motion_graph_web --port 8765 --accel tensorrt --checkpoint acestep-v15-xl-turbo
+```
+
+The backend passes `checkpoint` into `available_trt_engines()`, so this selects
+`decoder_xl-turbo_mixed_refit_b4_60s` or
+`decoder_xl-turbo_mixed_refit_b4_120s` instead of the 2B decoder profiles. The
+streaming decoder path submits the active ring-buffer rows as one batched TRT
+execution, so XL profiles must be built with enough batch capacity for the
+configured pipeline depth.
+
+### Demo Troubleshooting
+
+If the UI reports that a TRT engine is not built, build the smallest fitting
+profile from the server log. For a 60s source:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --duration 60
+```
+
+For a 120s source:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --duration 120
+```
+
+If cold start uses more VRAM than expected:
+
+- Prefer the smallest duration profile that fits the source audio.
+- Keep `vae_window > 0` so the windowed VAE decode engine can be used.
+- Disable DreamVAE or build the matching DreamVAE profile if `fast_vae=true`.
+- Use `--decoder-accel tensorrt --vae-accel eager` or the inverse to isolate a
+  backend.
+
+If TensorRT reports a static batch or reshape mismatch such as:
+
+```text
+Static dimension mismatch while setting input shape for hidden_states.
+Set dimensions are [2,...]. Expected dimensions are [1,-1,64].
+```
+
+or:
+
+```text
+IExecutionContext::inferShapes: IShuffleLayer node_view: reshaping failed
+for tensor: linear_2
+RESHAPE input dims{2, 15360} reshape dims{1, 6, 2560}
+```
+
+make sure the XL engine was built from the dynamic-batch patched ONNX. The build
+logs should mention `*_dynbatch.onnx` and report patched `Reshape` constants.
+
+## Validation Commands
+
+Compile modified TRT modules:
+
+```powershell
+uv run python -m py_compile acestep/engine/trt/build.py acestep/engine/trt/export.py
+```
+
+Rebuild VAE engines after changing TensorRT, CUDA, driver, GPU architecture, or
+the VAE builder optimization level:
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --vae-only --duration 60 --force-rebuild
+uv run python -m acestep.engine.trt.build --all --vae-only --duration 120 --force-rebuild
+```
+
+For a quick RTX 5090 smoke test, load the rebuilt VAE engines and execute one
+encode/decode pass before launching the realtime demo. A crash on the first
+`execute_async_v3` usually means the VAE engine was built without the
+`builder_optimization_level=1` workaround or was carried across an incompatible
+TensorRT/GPU stack.
+
+Run XL vendored loader tests:
+
+```powershell
+uv run pytest tests/unit/test_vendored_xl_dit_loads.py -q
+```
+
+Directly execute the 120s XL decoder engine at max profile:
+
+```powershell
+@'
+import torch
+from acestep.engine.trt.runtime import TRTDecoder
+from acestep.paths import trt_engine_path
+
+engine = TRTDecoder(trt_engine_path("decoder_xl-turbo_mixed_refit_b4_120s"))
+hs = torch.randn(2, 3000, 64, device="cuda", dtype=torch.bfloat16)
+ts = torch.full((2,), 0.5, device="cuda", dtype=torch.bfloat16)
+enc = torch.randn(2, 200, 2048, device="cuda", dtype=torch.bfloat16)
+ctx = torch.randn(2, 3000, 128, device="cuda", dtype=torch.bfloat16)
+out = engine(hs, ts, enc, ctx)
+assert out.shape == (2, 3000, 64), out.shape
+assert torch.isfinite(out).all()
+print("XL 120s TRT decoder execution OK", tuple(out.shape), out.dtype, out.device)
+'@ | uv run python -
+```
+
+Run a short XL `Session` generation and VAE decode:
+
+```powershell
+@'
+import torch
+from acestep.engine.session import Session
+from acestep.paths import trt_engine_path
+from acestep.constants import TASK_INSTRUCTIONS
+
+trt_engines = {
+    "decoder": str(trt_engine_path("decoder_xl-turbo_mixed_refit_b4_60s")),
+    "vae_encode": str(trt_engine_path("vae_encode_fp16_60s")),
+    "vae_decode": str(trt_engine_path("vae_decode_fp16_3to30s")),
+}
+
+session = Session(
+    config_path="acestep-v15-xl-turbo",
+    decoder_backend="tensorrt",
+    vae_backend="tensorrt",
+    trt_engines=trt_engines,
+    vae_window=5,
+)
+cond = session.encode_text(
+    tags="instrumental electronic test",
+    lyrics="",
+    instruction=TASK_INSTRUCTIONS["text2music"],
+    duration=5.0,
+)
+latent = session.generate(
+    conditioning=cond,
+    seed=1234,
+    steps=1,
+    duration=5.0,
+    denoise=1.0,
+)
+assert torch.isfinite(latent.tensor).all()
+audio = session.decode(latent)
+assert torch.isfinite(audio.waveform).all()
+print("XL TRT validation OK")
+print("latent", tuple(latent.tensor.shape), latent.tensor.dtype, latent.tensor.device)
+print("audio", tuple(audio.waveform.shape), audio.waveform.dtype, audio.waveform.device, audio.sample_rate)
+'@ | uv run python -
+```
+
+Validated output shape from that run:
+
+```text
+latent (1, 125, 64) torch.bfloat16 cuda:0
+audio (1, 2, 240000) torch.float32 cuda:0 48000
+```
+
+## ACE-Step XL Notes
+
+Supported now:
+
+- `acestep-v15-xl-turbo`
+- Decoder-only TRT builds at 60s and 120s.
+- Runtime `Session` execution with TRT decoder and existing VAE TRT engines.
+
+Not yet fully supported:
+
+- `acestep-v15-xl-base`
+- `acestep-v15-xl-sft`
+
+Those checkpoints point to different upstream modeling files in `auto_map`.
+DEMON currently vendors and dispatches the XL turbo modeling path. Base and SFT
+need their modeling files vendored and registered in
+`ModelContext._VENDORED_DIT_CLASSES` before they are first-class supported.
+
+## Refit And LoRA Caveat
+
+Decoder engines are built with TensorRT `REFIT` enabled so LoRA weight updates
+can be applied without rebuilding engines.
+
+For the validated XL engines, runtime logs currently show:
+
+```text
+No engine weights matched
+```
+
+That means XL TRT generation works, but dynamic LoRA refit for XL is not yet
+validated. The likely follow-up is to inspect XL ONNX initializer names and TRT
+engine weight names, then extend the LoRA refit name mapping for XL/dynamo
+exported graphs.
+
+## Troubleshooting
+
+TensorRT version rejected:
+
+```text
+DEMON TensorRT builds target TensorRT >=10.16,<10.17
+```
+
+Fix with:
+
+```powershell
+uv sync --upgrade-package tensorrt
+```
+
+Missing `onnxscript` during XL export:
+
+```text
+ModuleNotFoundError: No module named 'onnxscript'
+```
+
+Fix with:
+
+```powershell
+uv add onnxscript
+```
+
+Windows Unicode failure from `torch.onnx`:
+
+```text
+UnicodeEncodeError: 'charmap' codec can't encode character
+```
+
+The exporter now reconfigures stdout/stderr to UTF-8 for the dynamo ONNX path.
+If this reappears in external scripts, set:
+
+```powershell
+$env:PYTHONIOENCODING = "utf-8"
+```
+
+XL out of memory:
+
+- Use `--decoder-only`.
+- Use `--batch-max 4 --batch-opt 4 --builder-optimization-level 5` for local
+  experiments, then register only validated dynamic-batch profiles.
+- Start with `--duration 60`.
+- Use `vae_decode_fp16_3to30s` with `vae_window > 0`.
+- Avoid loading PyTorch decoder weights at runtime by setting
+  `decoder_backend="tensorrt"`.
+
+Unexpected rebuilds:
+
+- Check `<engine>.metadata.json`.
+- The build script rebuilds when schema, component, TensorRT version, GPU
+  compute capability, config, or ONNX sha256 changes.
+
+## Engineering Checklist
+
+Before relying on a TRT engine in a demo or benchmark:
+
+1. Confirm the TensorRT preflight shows the expected 10.16.x stack.
+2. Build the smallest duration profile that fits the target audio.
+3. Prefer windowed VAE decode for streaming or short decode windows.
+4. Check `build_report.csv` for status, build time, and size.
+5. Load the engine once through `TRTDecoder` or `Session`.
+6. Assert finite latent and audio tensors on a short generation.
+7. For web-demo runs, verify the selected `--checkpoint` has registered TRT
+   profiles in `acestep.paths`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,15 +39,30 @@ dependencies = [
     "websockets>=13.0",
     "xxhash",
     "zstandard>=0.21",
+    "librosa",
+    "sounddevice",
     # TensorRT acceleration
-    "onnx",
-    "tensorrt>=10.13,<10.14",
-    "polygraphy>=0.49",
-    "cuda-python>=13.0",
+    ###
+    ###
+    ### 10.13.11.1
+    # "onnx",
+    # "tensorrt>=10.13,<10.14",
+    # "polygraphy>=0.49",
+    # "cuda-python>=13.0",
+    ###
+    ###
+    ### 10.16
+    "onnx>=1.20,<1.22",
+    "tensorrt>=10.16,<10.17",
+    "polygraphy>=0.49.26",
+    "cuda-python>=13.2,<13.3",
+    ###
+    ###
     "modelscope",
     "pytorch-wavelets>=1.3",
     "PyWavelets>=1.5",
     "setuptools<81",  # pytorch_wavelets uses pkg_resources, removed in setuptools 81
+    "onnxscript>=0.7.0",
 ]
 
 [[tool.uv.index]]
@@ -67,6 +82,7 @@ torchvision = { index = "pytorch-cu128" }
 torchaudio = { index = "pytorch-cu128" }
 torchao = { index = "pypi" }
 torchcodec = { index = "pypi" }
+tensorrt = { index = "pypi" }
 
 [project.scripts]
 acestep-download = "acestep.model_downloader:main"

--- a/tests/unit/test_engine_profiles.py
+++ b/tests/unit/test_engine_profiles.py
@@ -17,10 +17,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from acestep.paths import (
     EngineNotBuiltError,
-    _TRT_ENGINE_PROFILES,
     available_trt_engines,
+    max_profile_duration_s,
     select_trt_engines,
+    smallest_fitting_profile_duration_s,
     trt_engine_path,
+    trt_engine_profiles,
 )
 
 
@@ -33,9 +35,14 @@ def tmp_models_dir(monkeypatch, tmp_path):
     return tmp_path
 
 
-def _create_engine_files(tmp_path: Path, max_dur: float, keys: tuple[str, ...]) -> None:
+def _create_engine_files(
+    tmp_path: Path,
+    max_dur: float,
+    keys: tuple[str, ...],
+    checkpoint: str = "acestep-v15-turbo",
+) -> None:
     """Create empty engine files for one profile so existence checks pass."""
-    profile = _TRT_ENGINE_PROFILES[max_dur]
+    profile = trt_engine_profiles(checkpoint)[max_dur]
     for k in keys:
         engine_name = profile[k]
         engine_path = trt_engine_path(engine_name)
@@ -80,6 +87,28 @@ class TestSelectTrtEngines:
         paths = select_trt_engines(duration_s=10_000.0)
         assert "_240s" in paths["decoder"]
 
+    def test_picks_xl_decoder_for_xl_checkpoint(self):
+        paths = select_trt_engines(
+            duration_s=30.0,
+            checkpoint="acestep-v15-xl-turbo",
+        )
+        assert "decoder_xl-turbo_mixed_refit_b4_60s" in paths["decoder"]
+        assert "vae_encode_fp16_60s" in paths["vae_encode"]
+
+    def test_xl_checkpoint_has_120s_max_profile(self):
+        assert max_profile_duration_s(checkpoint="acestep-v15-xl-turbo") == 120.0
+        assert smallest_fitting_profile_duration_s(
+            80.0,
+            checkpoint="acestep-v15-xl-turbo",
+        ) == 120.0
+
+    def test_unknown_checkpoint_is_rejected(self):
+        with pytest.raises(ValueError, match="No canonical TRT engine profiles"):
+            select_trt_engines(
+                duration_s=30.0,
+                checkpoint="acestep-v15-xl-base",
+            )
+
 
 # -----------------------------------------------------------------------
 # available_trt_engines: existence-aware picker (IO)
@@ -99,6 +128,20 @@ class TestAvailableTrtEnginesHappyPath:
             _create_engine_files(tmp_models_dir, d, keys=("decoder", "vae_encode", "vae_decode"))
         _, picked = available_trt_engines(duration_s=119.0)
         assert picked == 120.0
+
+    def test_xl_checkpoint_uses_xl_decoder_profiles(self, tmp_models_dir):
+        _create_engine_files(
+            tmp_models_dir,
+            120.0,
+            keys=("decoder", "vae_encode", "vae_decode"),
+            checkpoint="acestep-v15-xl-turbo",
+        )
+        paths, picked = available_trt_engines(
+            duration_s=80.0,
+            checkpoint="acestep-v15-xl-turbo",
+        )
+        assert picked == 120.0
+        assert "decoder_xl-turbo_mixed_refit_b4_120s" in paths["decoder"]
 
 
 class TestAvailableTrtEnginesFallback:
@@ -140,6 +183,19 @@ class TestAvailableTrtEnginesNeedsParameter:
         )
         assert picked == 60.0
 
+    def test_vae_only_session_uses_shared_profiles_for_unregistered_checkpoint(
+        self,
+        tmp_models_dir,
+    ):
+        _create_engine_files(tmp_models_dir, 60.0, keys=("vae_encode", "vae_decode"))
+        paths, picked = available_trt_engines(
+            duration_s=30.0,
+            needs=("vae_encode", "vae_decode"),
+            checkpoint="acestep-v15-xl-base",
+        )
+        assert picked == 60.0
+        assert "vae_encode_fp16_60s" in paths["vae_encode"]
+
 
 # -----------------------------------------------------------------------
 # EngineNotBuiltError: actionable build command
@@ -169,3 +225,21 @@ class TestEngineNotBuiltError:
             available_trt_engines(duration_s=80.0, needs=("decoder",))
         assert excinfo.value.duration_s == 80.0
         assert excinfo.value.needs == ("decoder",)
+
+    def test_xl_missing_engine_recommends_xl_build_command(self, tmp_models_dir):
+        with pytest.raises(EngineNotBuiltError) as excinfo:
+            available_trt_engines(
+                duration_s=30.0,
+                needs=("decoder",),
+                checkpoint="acestep-v15-xl-turbo",
+            )
+        command = excinfo.value.build_command
+        assert command is not None
+        assert "--checkpoint acestep-v15-xl-turbo" in command
+        assert "--decoder-only" in command
+        assert "--duration 60" in command
+        assert "--batch-max 4" in command
+        assert "--batch-opt 4" in command
+        assert "--builder-optimization-level 5" in command
+        assert "--workspace-gb 20" in command
+        assert "--decoder-precision bf16_mixed" in command


### PR DESCRIPTION
## Summary

This PR upgrades DEMON's optional TensorRT acceleration path to TensorRT 10.16.x and hardens the surrounding build/runtime flow so it can support both `acestep-v15-turbo` and experimental `acestep-v15-xl-turbo` usage.

The main outcome is a more reliable TRT workflow: engine builds now validate the local TRT/CUDA stack, record metadata, understand checkpoint-specific decoder profiles, and select the right runtime engines for the realtime motion graph demo. The PR also adds a headless benchmark tool so TensorRT changes can be measured without browser, WebSocket, or audio-device overhead.

## What Changed

- **TensorRT dependency target moved to 10.16.x.**
  - Updates the TensorRT package range from `>=10.13,<10.14` to `>=10.16,<10.17`.
  - Tightens related acceleration dependencies, including `onnx`, `polygraphy`, and `cuda-python`.
  - Adds the PyPI TensorRT source entry and the runtime packages needed by the realtime benchmark path.

- **TensorRT build flow is now environment-aware.**
  - Adds build preflight checks for the TensorRT version, CUDA package stack, PyTorch CUDA version, active GPU, and `nvidia-smi` GPU/driver data.
  - Writes engine sidecar metadata files with the build config, ONNX checksums, environment snapshot, and creation timestamp.
  - Uses metadata matching to decide whether an existing engine can be reused or should be rebuilt.
  - Adds `--force-onnx` so an operator can explicitly regenerate ONNX before rebuilding engines.

- **Decoder precision handling was expanded for ACE-Step XL.**
  - Adds decoder precision recipes such as `fp16_mixed`, `bf16`, `bf16_mixed`, and related mixed recipes.
  - Keeps the legacy 2B mixed decoder path on `fp16_mixed`.
  - Uses `bf16_mixed` automatically for XL-looking checkpoints, which is needed for the larger model's numeric range.
  - Carries the ONNX precision recipe into TRT build metadata so engines are not accidentally reused across incompatible exports.

- **TensorRT runtime execution is stricter and dtype-correct.**
  - Decoder and VAE TRT runtimes now read per-tensor dtypes from the serialized engine instead of assuming one global IO dtype.
  - Runtime buffer allocation respects `fp16`, `bf16`, `fp32`, and other engine tensor dtypes.
  - Shape binding, tensor-address binding, shape inference, and `execute_async_v3` failures now raise explicit errors instead of failing silently.
  - VAE encode/decode outputs are normalized back to `float32` where the PyTorch side expects that format.

- **Realtime streaming can run XL b1 TRT decoder profiles.**
  - The streaming path detects the TRT decoder engine's maximum batch size.
  - If the current streaming batch exceeds the engine profile, it micro-batches rows and concatenates the results.
  - This is important for XL Turbo because the registered XL decoder engines are `b1` profiles.

- **Engine path selection is now checkpoint-aware.**
  - Adds canonical TRT engine profile registration for `acestep-v15-turbo` and `acestep-v15-xl-turbo`.
  - Keeps VAE engines shared across 2B and XL checkpoints while making decoder profiles checkpoint-specific.
  - XL currently registers 60s and 120s TRT profiles.
  - Unknown decoder checkpoints now fail clearly instead of accidentally selecting a 2B decoder engine for an incompatible model.
  - Missing-engine errors now include checkpoint-specific build commands, including the XL `--batch-max 1`, `--workspace-gb 16`, `--export-locally`, and `--decoder-precision bf16_mixed` recipe.

- **Realtime motion graph backend now selects TRT engines correctly for the active checkpoint.**
  - Caps input audio based on the largest registered profile for the selected TRT checkpoint.
  - Passes the checkpoint into `available_trt_engines()` and `smallest_fitting_profile_duration_s()`.
  - Sends an explicit `unsupported_trt_checkpoint` error to the UI when a TRT checkpoint has no registered decoder profile.
  - Keeps VAE-only TRT sessions on the shared 2B VAE profile set so VAE acceleration can still be used with non-registered decoder checkpoints.

- **A headless benchmark suite was added.**
  - Adds `demos.realtime_motion_graph_web.benchmark`.
  - Mirrors the server-side inference path: config/fixture loading, metadata detection, `Session(...)`, TRT engine selection, `prepare_source`, `encode_text`, `session.stream(...)`, repeated `stream.tick(...)`, and optional VAE decode.
  - Reports setup timings, measured tick/decode/tick+decode latency, warmup counts, decode skip counts, wall time, and CUDA peak memory.
  - Can write raw samples and summary stats to JSON for future comparisons.

- **Docs and tests were expanded.**
  - Adds `docs/TRT.md` with the current TensorRT build/runtime model, storage layout, engine naming, build commands, XL notes, realtime demo usage, troubleshooting, and validation commands.
  - Updates the realtime motion graph README with XL launch instructions and benchmark usage.
  - Extends engine-profile tests for XL profile selection, XL max duration, unknown-checkpoint rejection, VAE-only shared profiles, and XL-specific missing-engine build commands.

## Benchmark Results

Benchmark shape:

- Each run completed 28 generations: 4 warmup and 24 measured.
- Decode was enabled for all measured generations: 24 decoded, 0 skipped.
- Metrics are milliseconds unless otherwise noted.
- `tick` measures the streaming generation tick, `decode` measures VAE decode, and `tick+decode` is their combined measured latency.

### ACE-Step 1.5 Turbo

| Config | Wall time | tick mean | tick p95 | decode mean | decode p95 | tick+decode mean | tick+decode p95 | CUDA peak allocated | CUDA peak reserved |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| No TRT engine | 7779.9 | 197.4 | 198.1 | 31.4 | 33.4 | 228.8 | 230.9 | 8.13 GiB | 10.64 GiB |
| VAE decode via TRT 10.13.3.9.post1 | 4880.6 | 125.7 | 129.3 | 15.8 | 16.5 | 141.5 | 147.7 | 2.66 GiB | 2.67 GiB |
| VAE decode via TRT 10.16.1.11 | 4391.0 | 111.6 | 113.7 | 16.3 | 16.7 | 128.0 | 130.1 | 2.66 GiB | 2.67 GiB |

TRT 10.16.1.11 vs no TRT engine:

- Wall time improves from 7779.9ms to 4391.0ms, about **43.6% faster**.
- Mean `tick` improves from 197.4ms to 111.6ms, about **43.5% faster**.
- Mean `decode` improves from 31.4ms to 16.3ms, about **48.1% faster**.
- Mean `tick+decode` improves from 228.8ms to 128.0ms, about **44.1% faster**.
- CUDA peak allocated memory drops from 8.13 GiB to 2.66 GiB, about **67.3% lower**.
- CUDA peak reserved memory drops from 10.64 GiB to 2.67 GiB, about **74.9% lower**.

TRT 10.16.1.11 vs TRT 10.13.3.9.post1:

- Wall time improves from 4880.6ms to 4391.0ms, about **10.0% faster**.
- Mean `tick` improves from 125.7ms to 111.6ms, about **11.2% faster**.
- Mean `tick+decode` improves from 141.5ms to 128.0ms, about **9.5% faster**.
- Mean `decode` is roughly flat, moving from 15.8ms to 16.3ms.
- CUDA peak memory is effectively unchanged at 2.66 GiB allocated / 2.67 GiB reserved.

### ACE-Step 1.5 XL Turbo (experimental)

| Config | Wall time | tick mean | tick p95 | decode mean | decode p95 | tick+decode mean | tick+decode p95 | CUDA peak allocated | CUDA peak reserved |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| No TRT engine XL | 16773.9 | 481.8 | 483.1 | 29.6 | 31.0 | 511.4 | 515.5 | 13.01 GiB | 15.52 GiB |
| VAE decode via TRT 10.16.1.11 XL | 13566.7 | 388.2 | 390.2 | 16.8 | 17.1 | 405.0 | 407.0 | 2.66 GiB | 2.67 GiB |

TRT 10.16.1.11 XL vs no TRT engine XL:

- Wall time improves from 16773.9ms to 13566.7ms, about **19.1% faster**.
- Mean `tick` improves from 481.8ms to 388.2ms, about **19.4% faster**.
- Mean `decode` improves from 29.6ms to 16.8ms, about **43.2% faster**.
- Mean `tick+decode` improves from 511.4ms to 405.0ms, about **20.8% faster**.
- CUDA peak allocated memory drops from 13.01 GiB to 2.66 GiB, about **79.6% lower**.
- CUDA peak reserved memory drops from 15.52 GiB to 2.67 GiB, about **82.8% lower**.

## Notes For Review

- TensorRT engines remain version-, CUDA-, driver-, and GPU-architecture-specific. Engines should be rebuilt after changing any of those pieces.
- XL TensorRT support is marked experimental in this PR. The registered XL decoder profiles are currently `b1` and cover 60s and 120s durations.
- VAE TRT engines are shared between 2B and XL, but decoder TRT engines are checkpoint-specific.
- The new benchmark gives us a repeatable way to compare eager, compile, mixed backend, and TensorRT configurations going forward.

## Validation

- Added/updated unit coverage in `tests/unit/test_engine_profiles.py`.
- Added manual TensorRT validation and benchmark workflows in `docs/TRT.md`.
- Benchmarked the 2B and XL realtime motion graph paths using the headless benchmark flow described above.
