### PR TITLE
feat: onnx handling and dreamvae build profiles

### DIFF
--- a/acestep/engine/trt/build.py
+++ b/acestep/engine/trt/build.py
@@ -132,15 +132,28 @@ def _ensure_onnx(
     need_decoder_refit: bool,
     decoder_mixed: bool,
     skip_onnx: bool,
+    export_locally: bool = False,
 ) -> dict[str, str]:
-    """Detect existing ONNX, load model if needed, export missing files.
+    """Resolve ONNX paths for the build, fetching from HF when missing.
 
-    Returns dict mapping component names to ONNX paths.
+    Resolution order for each needed component:
+      1. Local cache present -> reuse.
+      2. ``skip_onnx``       -> error (no fetch, no export).
+      3. ``export_locally``  -> export from the model checkpoint.
+      4. Default             -> download from HF via ``onnx_hub``.
 
-    VAE ONNX exports are stored in a shared ``_onnx_vae/`` directory
-    (sibling to onnx_dir) since all DiT variants share the same VAE.
-    Decoder ONNX exports live in onnx_dir (checkpoint-specific).
+    HF-first is the clean default: machines that don't have the model
+    checkpoint can build engines without ever touching torch's model
+    loader, and CI / cloud runs skip a multi-minute model load. Pass
+    ``--export-locally`` to recover the old behavior, e.g. when iterating
+    on the export code itself.
+
+    VAE ONNX is stored in a shared ``_onnx_vae/`` directory (sibling to
+    ``onnx_dir``) since all DiT variants share the same VAE. Decoder
+    ONNX lives in ``onnx_dir`` (checkpoint-specific).
     """
+    from .onnx_hub import fetch_onnx
+
     # VAE is shared across checkpoints; decoder is checkpoint-specific
     vae_onnx_dir = os.path.join(os.path.dirname(onnx_dir), "_onnx_vae")
     os.makedirs(vae_onnx_dir, exist_ok=True)
@@ -152,7 +165,7 @@ def _ensure_onnx(
         "decoder_refit": os.path.join(onnx_dir, "decoder_refit", "decoder_refit.onnx"),
     }
 
-    # Also check old _onnx/ location for VAE (backward compat)
+    # Also check old _onnx/ location for VAE (backward compat).
     old_onnx_dir = os.path.join(os.path.dirname(onnx_dir), "_onnx")
     for key in ("vae_encode", "vae_decode"):
         if not os.path.exists(paths[key]):
@@ -161,69 +174,84 @@ def _ensure_onnx(
                 logger.info("Found VAE ONNX at old location: %s", old_path)
                 paths[key] = old_path
 
-    # Determine what actually needs exporting
-    export_vae = False
-    export_decoder_std = False
-    export_decoder_refit = False
-
-    if need_vae and not skip_onnx:
-        if not os.path.exists(paths["vae_encode"]) or not os.path.exists(paths["vae_decode"]):
-            export_vae = True
+    # Build the list of (component, fetch_kwargs) pairs that the caller
+    # actually needs and that aren't yet on disk.
+    requested: list[tuple[str, dict]] = []
+    if need_vae:
+        if not os.path.exists(paths["vae_encode"]):
+            requested.append(("vae_encode", {}))
         else:
-            logger.info("Reusing existing VAE ONNX exports in %s", onnx_dir)
-
-    if need_decoder_std and not skip_onnx:
-        if not os.path.exists(paths["decoder"]):
-            export_decoder_std = True
+            logger.info("Reusing existing VAE encoder ONNX: %s", paths["vae_encode"])
+        if not os.path.exists(paths["vae_decode"]):
+            requested.append(("vae_decode", {}))
         else:
-            logger.info("Reusing existing decoder ONNX: %s", paths["decoder"])
+            logger.info("Reusing existing VAE decoder ONNX: %s", paths["vae_decode"])
+    if need_decoder_std and not os.path.exists(paths["decoder"]):
+        requested.append(("decoder", {"checkpoint": checkpoint}))
+    elif need_decoder_std:
+        logger.info("Reusing existing decoder ONNX: %s", paths["decoder"])
+    if need_decoder_refit and not os.path.exists(paths["decoder_refit"]):
+        requested.append(("decoder_refit", {"checkpoint": checkpoint}))
+    elif need_decoder_refit:
+        logger.info("Reusing existing decoder ONNX (refit): %s", paths["decoder_refit"])
 
-    if need_decoder_refit and not skip_onnx:
-        if not os.path.exists(paths["decoder_refit"]):
-            export_decoder_refit = True
-        else:
-            logger.info("Reusing existing decoder ONNX (refit): %s", paths["decoder_refit"])
-
-    # Validate --skip-onnx
+    # --skip-onnx: no resolution path. Error if anything's missing.
     if skip_onnx:
-        missing = []
-        if need_vae:
-            for k in ("vae_encode", "vae_decode"):
-                if not os.path.exists(paths[k]):
-                    missing.append(paths[k])
-        if need_decoder_std and not os.path.exists(paths["decoder"]):
-            missing.append(paths["decoder"])
-        if need_decoder_refit and not os.path.exists(paths["decoder_refit"]):
-            missing.append(paths["decoder_refit"])
-        if missing:
-            for f in missing:
-                logger.error("Missing ONNX file: %s", f)
+        if requested:
+            for comp, _ in requested:
+                logger.error("Missing ONNX file (refusing to fetch/export with --skip-onnx): %s", paths[comp])
             sys.exit(1)
-        logger.info("Skipping ONNX export (--skip-onnx)")
+        logger.info("All ONNX exports found, --skip-onnx satisfied.")
+        return paths
 
-    # Load model only if we need to export something
-    need_model = export_vae or export_decoder_std or export_decoder_refit
+    if not requested:
+        logger.info("All ONNX exports already present, nothing to fetch or export.")
+        return paths
 
-    handler = None
-    if need_model:
-        logger.info("Loading model from checkpoints/%s...", checkpoint)
-        if project_root not in sys.path:
-            sys.path.insert(0, project_root)
-        from acestep.engine.model_context import ModelContext
-        handler = ModelContext(
-            project_root=project_root,
-            config_path=checkpoint,
-            device=device,
-            use_flash_attention=False,
-            compile_decoder=False,
-            compile_vae=False,
-            skip_vae=not need_vae,
-        )
-        logger.info("Model loaded.")
-    else:
-        logger.info("All ONNX exports found, skipping model load.")
+    # HF-first path. Each fetch lands the file at the same local path
+    # the local exporter would write, so the rest of the pipeline
+    # downstream doesn't care about the source.
+    if not export_locally:
+        local_root = os.path.dirname(onnx_dir)  # the trt_engines dir
+        try:
+            for comp, kw in requested:
+                fetched = fetch_onnx(comp, local_root=local_root, **kw)
+                # fetch_onnx returns the canonical local path; the
+                # ``paths`` dict already points at the same location, but
+                # update it in case the registry's local_subdir ever
+                # diverges from this function's hardcoded layout.
+                paths[comp] = str(fetched)
+            return paths
+        except Exception as exc:
+            logger.error(
+                "ONNX fetch from HuggingFace failed: %s. "
+                "Re-run with --export-locally to export from the model "
+                "checkpoint instead, or with --skip-onnx if you have the "
+                "files in a non-standard location.",
+                exc,
+            )
+            sys.exit(1)
 
-    # Export missing ONNX files
+    # --export-locally path: load the model and re-export from weights.
+    export_vae = any(c.startswith("vae_") for c, _ in requested)
+    export_decoder_refit = any(c == "decoder_refit" for c, _ in requested)
+    export_decoder_std = any(c == "decoder" for c, _ in requested)
+
+    logger.info("Loading model from checkpoints/%s (--export-locally)...", checkpoint)
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+    from acestep.engine.model_context import ModelContext
+    handler = ModelContext(
+        project_root=project_root,
+        config_path=checkpoint,
+        device=device,
+        use_flash_attention=False,
+        compile_decoder=False,
+        compile_vae=False,
+        skip_vae=not export_vae,
+    )
+    logger.info("Model loaded.")
+
     if export_vae:
         from .vae_export import (
             export_vae_encoder_onnx, export_vae_decoder_onnx, VAEExportConfig,
@@ -411,7 +439,7 @@ def _build_decoder_engine(
 # ------------------------------------------------------------------
 
 def _print_matrix(durations, build_vae, build_decoder, output_dir, batch_max,
-                   checkpoint="acestep-v15-turbo"):
+                   checkpoint="acestep-v15-turbo", build_dreamvae=False):
     """Print the build matrix for --all mode, showing existing vs new."""
     variant = _checkpoint_to_variant(checkpoint)
     vtag = f"_{variant}" if variant != "turbo" else ""
@@ -424,6 +452,8 @@ def _print_matrix(durations, build_vae, build_decoder, output_dir, batch_max,
             jobs.append((f"VAE encode {dur}s", f"vae_encode_fp16_{dur}s"))
         if build_decoder:
             jobs.append((f"Decoder {variant} {dur}s, refit", f"decoder{vtag}_mixed_refit_b{batch_max}_{dur}s"))
+        if build_dreamvae:
+            jobs.append((f"DreamVAE decode {dur}s", f"dreamvae_decode_fp16_{dur}s"))
 
     to_build = 0
     to_skip = 0
@@ -527,6 +557,13 @@ def main():
                        help="Only build decoder engines (skip VAE)")
     batch.add_argument("--vae-only", action="store_true",
                        help="Only build VAE engines (skip decoder)")
+    batch.add_argument("--with-dreamvae", action="store_true",
+                       help="Also build dreamvae (distilled decoder) engines "
+                            "for each duration. ONNX is fetched from "
+                            "huggingface.co/daydreamlive/DreamVAE on first use.")
+    batch.add_argument("--dreamvae-only", action="store_true",
+                       help="Build ONLY dreamvae engines (skip standard "
+                            "VAE/decoder builds). Implies --with-dreamvae.")
 
     # Shared / single mode
     single = parser.add_argument_group("single mode / shared options")
@@ -537,9 +574,13 @@ def main():
     single.add_argument("--checkpoint", default="acestep-v15-turbo",
                         help="Model checkpoint directory name")
     single.add_argument("--skip-onnx", action="store_true",
-                        help="Force-skip ONNX export (error if files missing). "
-                             "Normally ONNX files in _onnx/ are auto-detected "
-                             "and reused without this flag.")
+                        help="Don't fetch or export ONNX. Error if any "
+                             "needed ONNX file is missing locally.")
+    single.add_argument("--export-locally", action="store_true",
+                        help="Re-export ONNX from the model checkpoint "
+                             "instead of fetching from HuggingFace. The "
+                             "default is HF-first; use this when iterating "
+                             "on the export code or when offline.")
     single.add_argument("--max-duration", type=int, default=240,
                         help="Max audio duration in seconds for single mode "
                              "(default: 240 = 4min)")
@@ -578,29 +619,44 @@ def main():
 def _run_all(args, project_root, onnx_dir):
     """Build the full engine matrix."""
     durations = tuple(args.duration) if args.duration else (60, 120, 240)
-    build_vae = not args.decoder_only
-    build_decoder = not args.vae_only
+    # --dreamvae-only is shorthand for "skip standard VAE/decoder, only
+    # build dreamvae". --with-dreamvae adds dreamvae on top of the
+    # standard build. Both forms enable the dreamvae build.
+    build_dreamvae = args.with_dreamvae or args.dreamvae_only
+    if args.dreamvae_only:
+        build_vae = False
+        build_decoder = False
+    else:
+        build_vae = not args.decoder_only
+        build_decoder = not args.vae_only
 
     # Print matrix
     _print_matrix(durations, build_vae, build_decoder,
-                  args.output_dir, args.batch_max, args.checkpoint)
+                  args.output_dir, args.batch_max, args.checkpoint,
+                  build_dreamvae=build_dreamvae)
 
     if args.dry_run:
         return
 
-    # ONNX phase (once, shared across all durations)
-    # Only refit-enabled decoder ONNX is needed
-    onnx_paths = _ensure_onnx(
-        onnx_dir=onnx_dir,
-        project_root=project_root,
-        checkpoint=args.checkpoint,
-        device=args.device,
-        need_vae=build_vae,
-        need_decoder_std=False,
-        need_decoder_refit=build_decoder,
-        decoder_mixed=True,
-        skip_onnx=args.skip_onnx,
-    )
+    # ONNX phase (once, shared across all durations).  Only refit-enabled
+    # decoder ONNX is needed for the standard build; dreamvae has its
+    # own ONNX, fetched lazily from HF inside _build_dreamvae_engines so
+    # we don't pay network cost when --dreamvae isn't requested.
+    if build_vae or build_decoder:
+        onnx_paths = _ensure_onnx(
+            onnx_dir=onnx_dir,
+            project_root=project_root,
+            checkpoint=args.checkpoint,
+            device=args.device,
+            need_vae=build_vae,
+            need_decoder_std=False,
+            need_decoder_refit=build_decoder,
+            decoder_mixed=True,
+            skip_onnx=args.skip_onnx,
+            export_locally=args.export_locally,
+        )
+    else:
+        onnx_paths = {}
 
     # Engine phase
     results = []
@@ -626,6 +682,19 @@ def _run_all(args, project_root, onnx_dir):
                 checkpoint=args.checkpoint,
             ))
 
+    if build_dreamvae:
+        # dreamvae fetches its own ONNX from HF on first use; no shared
+        # ONNX state with the loop above. Built last so a missing HF
+        # token / network error doesn't tank an otherwise-successful
+        # standard build.
+        from .dreamvae_export import build_dreamvae_engines
+        results.extend(build_dreamvae_engines(
+            output_dir=args.output_dir,
+            durations=durations,
+            workspace_gb=args.workspace_gb,
+            force_rebuild=args.force_rebuild,
+        ))
+
     # Summary
     failures = _print_summary(results, args.output_dir)
     _save_build_report(results, args.output_dir)
@@ -650,6 +719,7 @@ def _run_single(args, project_root, onnx_dir):
         need_decoder_refit=build_decoder and args.decoder_refit,
         decoder_mixed=args.decoder_mixed,
         skip_onnx=args.skip_onnx,
+        export_locally=args.export_locally,
     )
 
     # Engine phase

--- a/acestep/engine/trt/dreamvae_export.py
+++ b/acestep/engine/trt/dreamvae_export.py
@@ -1,0 +1,237 @@
+"""TensorRT engine builds for the DreamVAE distilled decoder.
+
+DreamVAE is a distilled student of the ACE-Step Oobleck VAE decoder. It
+keeps the same I/O contract — ``latents [B, 64, T] -> audio [B, 2,
+1920*T]`` at 48 kHz — so the resulting engines are drop-in replacements
+for ``vae_decode_fp16_*`` whenever the demo's ``fast_vae`` path is
+enabled.
+
+Weights and pre-exported ONNX live on Hugging Face at
+``daydreamlive/DreamVAE``. Engine builds reuse the standard VAE
+optimization-profile knobs from :class:`VAETRTBuildConfig`, so the
+duration sweep matches ``acestep.paths._TRT_ENGINE_PROFILES`` exactly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional, Union
+
+from loguru import logger
+
+from .onnx_hub import fetch_onnx
+from .vae_export import VAETRTBuildConfig, build_vae_decode_engine
+
+
+def dreamvae_engine_filename(duration_s: int) -> str:
+    """Engine filename stem for a given duration. Stable, consumed by
+    the demo via ``acestep.paths.dreamvae_decode_engine_path``.
+    """
+    return f"dreamvae_decode_fp16_{int(duration_s)}s"
+
+
+# ------------------------------------------------------------------
+# ONNX acquisition
+# ------------------------------------------------------------------
+
+def fetch_dreamvae_onnx(
+    output_dir: Union[str, Path],
+    *,
+    force_download: bool = False,
+) -> Path:
+    """Ensure the dreamvae ONNX is present in the local trt_engines tree.
+
+    Thin wrapper over :func:`acestep.engine.trt.onnx_hub.fetch_onnx` so
+    the dreamvae build path uses the same HF-fetch infrastructure as
+    every other ONNX in the build matrix.
+    """
+    return fetch_onnx(
+        "dreamvae", local_root=output_dir, force_download=force_download,
+    )
+
+
+# ------------------------------------------------------------------
+# ONNX export (from weights -> ONNX file on disk)
+# ------------------------------------------------------------------
+#
+# This mirrors the historical export at
+# ``research_program/vae_distillation/hf_upload/scripts/export_trt.py``
+# (commit fa93128) so the source-of-truth for the ONNX export of
+# DreamVAE lives in this repo for posterity. The released
+# ``daydreamlive/DreamVAE/onnx/model.onnx`` file was produced by that
+# same script — re-running this exporter against the released weights
+# should produce a byte-identical file under the same torch / opset.
+
+# Trace shape and opset are pinned to match the released ONNX. Changing
+# either would change the resulting graph and break the byte-identity
+# property: 30 s of audio at 25 latent fps = 750 frames; opset 18 was
+# what the original export used, so we keep it.
+_DREAMVAE_TRACE_LATENT_FRAMES = 750
+_DREAMVAE_ONNX_OPSET = 18
+
+
+def export_dreamvae_onnx(
+    onnx_path: Union[str, Path],
+    *,
+    repo_id: str = "daydreamlive/DreamVAE",
+    device: str = "cuda",
+) -> Path:
+    """Export FastOobleckDecoder weights to ONNX.
+
+    Loads weights from the public ``daydreamlive/DreamVAE`` HF release
+    and runs ``torch.onnx.export`` with the same call shape the
+    historical script used. The result should be byte-identical to
+    ``daydreamlive/DreamVAE/onnx/model.onnx`` on the same torch +
+    opset; the verifier in :func:`verify_dreamvae_onnx_matches_hf`
+    can confirm.
+
+    Returns the path the ONNX was written to.
+    """
+    import torch
+
+    from acestep.models.dreamvae import load_dreamvae_from_hf
+
+    onnx_path = Path(onnx_path)
+    onnx_path.parent.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Loading DreamVAE weights from %s ...", repo_id)
+    model = load_dreamvae_from_hf(repo_id=repo_id, device=device, dtype=torch.float32)
+
+    example = torch.randn(
+        1, 64, _DREAMVAE_TRACE_LATENT_FRAMES,
+        device=device, dtype=torch.float32,
+    )
+
+    logger.info("Exporting DreamVAE to ONNX (opset %d, trace_T=%d) -> %s",
+                _DREAMVAE_ONNX_OPSET, _DREAMVAE_TRACE_LATENT_FRAMES, onnx_path)
+    with torch.no_grad():
+        torch.onnx.export(
+            model,
+            (example,),
+            str(onnx_path),
+            input_names=["latents"],
+            output_names=["audio"],
+            dynamic_axes={
+                "latents": {0: "batch", 2: "latent_frames"},
+                "audio": {0: "batch", 2: "samples"},
+            },
+            opset_version=_DREAMVAE_ONNX_OPSET,
+            do_constant_folding=True,
+            dynamo=False,
+        )
+    size_mb = onnx_path.stat().st_size / (1 << 20)
+    logger.info("DreamVAE ONNX written: %s (%.1f MB)", onnx_path, size_mb)
+    return onnx_path
+
+
+def verify_dreamvae_onnx_matches_hf(local_onnx: Union[str, Path]) -> bool:
+    """SHA-compare a locally-exported ONNX to the public release.
+
+    Returns True when the local file is byte-identical to
+    ``daydreamlive/DreamVAE/onnx/model.onnx``. Logs both hashes either
+    way so the caller can read the divergence if there is one.
+    """
+    import hashlib
+    from huggingface_hub import hf_hub_download
+
+    def sha256(path: Path) -> str:
+        h = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    local_onnx = Path(local_onnx)
+    remote = Path(hf_hub_download("daydreamlive/DreamVAE", "onnx/model.onnx"))
+    a = sha256(local_onnx)
+    b = sha256(remote)
+    logger.info("Local  : %s  %s", local_onnx, a)
+    logger.info("HF     : %s  %s", remote, b)
+    return a == b
+
+
+# ------------------------------------------------------------------
+# Engine build
+# ------------------------------------------------------------------
+
+def build_dreamvae_engine(
+    *,
+    output_dir: Union[str, Path],
+    duration_s: int,
+    onnx_path: Optional[Union[str, Path]] = None,
+    workspace_gb: float = 8.0,
+    force_rebuild: bool = False,
+) -> tuple[Path, str]:
+    """Build a single dreamvae TRT engine for one duration.
+
+    Returns ``(engine_path, status)`` where status is ``"OK"`` if the
+    engine was built this call, or ``"SKIPPED"`` if it already existed.
+    """
+    output_dir = Path(output_dir)
+    name = dreamvae_engine_filename(duration_s)
+    engine_path = output_dir / name / f"{name}.engine"
+
+    if engine_path.exists() and not force_rebuild:
+        size_mb = engine_path.stat().st_size / (1 << 20)
+        logger.info("SKIP %s (%.0f MB)", name, size_mb)
+        return engine_path, "SKIPPED"
+
+    if onnx_path is None:
+        onnx_path = fetch_dreamvae_onnx(output_dir)
+    onnx_path = Path(onnx_path)
+
+    config = VAETRTBuildConfig(
+        workspace_gb=workspace_gb,
+        decode_max_frames=int(duration_s) * 25,  # 25 latent frames/sec
+    )
+
+    logger.info("=" * 60)
+    logger.info("DREAMVAE TRT BUILD: %s (max_duration=%ds)", name, duration_s)
+    logger.info("=" * 60)
+
+    engine_path.parent.mkdir(parents=True, exist_ok=True)
+    build_vae_decode_engine(onnx_path, engine_path, config=config)
+    return engine_path, "OK"
+
+
+def build_dreamvae_engines(
+    *,
+    output_dir: Union[str, Path],
+    durations: Iterable[int] = (60, 120, 240),
+    workspace_gb: float = 8.0,
+    force_rebuild: bool = False,
+) -> list[tuple[str, str, float, str]]:
+    """Build the canonical dreamvae engine matrix.
+
+    Returns a list of ``(label, engine_path, elapsed_seconds, status)``
+    matching the shape used by the standard VAE/decoder builders in
+    :mod:`acestep.engine.trt.build`, so callers can splice the result
+    into the same summary/report path.
+    """
+    import time
+
+    output_dir = Path(output_dir)
+    # Fetch once up front so the per-duration loop doesn't pay HF
+    # network latency three times.
+    onnx_path = fetch_dreamvae_onnx(output_dir)
+
+    results: list[tuple[str, str, float, str]] = []
+    for dur in durations:
+        label = f"DreamVAE decode {dur}s"
+        t0 = time.time()
+        try:
+            engine_path, status = build_dreamvae_engine(
+                output_dir=output_dir,
+                duration_s=dur,
+                onnx_path=onnx_path,
+                workspace_gb=workspace_gb,
+                force_rebuild=force_rebuild,
+            )
+            elapsed = time.time() - t0
+            if status == "OK":
+                logger.info("Built in %.0fs", elapsed)
+            results.append((label, str(engine_path), elapsed, status))
+        except Exception as e:  # build failures shouldn't kill the matrix
+            logger.error("DreamVAE %ds build failed: %s", dur, e)
+            results.append((label, "", time.time() - t0, "FAILED"))
+    return results

--- a/acestep/engine/trt/onnx_hub.py
+++ b/acestep/engine/trt/onnx_hub.py
@@ -1,0 +1,207 @@
+"""Hugging Face source for ONNX exports consumed by the TRT build.
+
+The local ``trt_engines/_onnx_*`` layout is expensive to recreate — the
+decoder export alone takes minutes and pulls a full model load — so we
+mirror it on Hugging Face and let the build pipeline opt into fetching
+instead of re-exporting on machines that don't have the model
+checkpoint or the patience.
+
+Two repos are involved:
+* ``daydreamlive/demon-onnx`` — VAE + decoder ONNX, per-checkpoint
+  subdirectories. Decoder ONNX uses external data (graph + many weight
+  files) so we use :func:`huggingface_hub.snapshot_download` with
+  allow_patterns to grab whole subtrees atomically.
+* ``daydreamlive/DreamVAE`` — distilled student decoder. Single ONNX
+  file; we keep this fetch pointed at the public dreamvae release so
+  end-users using DreamVAE outside this repo see one canonical home.
+
+Local layout produced by this module is identical to what the local
+ONNX exporter writes, so existing :func:`_ensure_onnx` callers don't
+need to know whether the file came from HF or a local export.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Union
+
+from loguru import logger
+
+
+# ------------------------------------------------------------------
+# Repo configuration
+# ------------------------------------------------------------------
+
+DEMON_ONNX_REPO = "daydreamlive/demon-onnx"
+DREAMVAE_ONNX_REPO = "daydreamlive/DreamVAE"
+
+
+@dataclass(frozen=True)
+class _OnnxSource:
+    """How to fetch one ONNX component from HF.
+
+    repo:           HF repo id.
+    hf_glob:        Pattern passed to ``snapshot_download(allow_patterns=...)``.
+                    Supports ``{checkpoint}`` substitution.
+    hf_main_file:   The .onnx file's path inside the repo (also supports
+                    ``{checkpoint}``); used for fetch + upload routing.
+    local_subdir:   Target subdirectory under the local ONNX root, also
+                    supports ``{checkpoint}``. Layout mirrors what the
+                    local exporter would produce.
+    local_filename: Optional override for the local filename. Defaults
+                    to the basename of ``hf_main_file``. Set this when
+                    the HF file name differs from what the local
+                    exporter writes — e.g. dreamvae's ``model.onnx``
+                    on HF maps to ``dreamvae_decode.onnx`` locally to
+                    match the rest of the build pipeline's naming.
+    """
+    repo: str
+    hf_glob: str
+    hf_main_file: str
+    local_subdir: str
+    local_filename: str | None = None
+
+    def local_basename(self, ctx: dict) -> str:
+        if self.local_filename:
+            return self.local_filename.format(**ctx)
+        return Path(self.hf_main_file.format(**ctx)).name
+
+
+# Components map to where their ONNX lives on HF and on disk. ``decoder``
+# and ``decoder_refit`` are checkpoint-specific (the DiT weights differ
+# across acestep-v15-base / sft / turbo / xl-turbo); the VAE and
+# DreamVAE are shared across DiT variants.
+_ONNX_REGISTRY: dict[str, _OnnxSource] = {
+    "vae_encode": _OnnxSource(
+        repo=DEMON_ONNX_REPO,
+        hf_glob="vae/vae_encode/*",
+        hf_main_file="vae/vae_encode/vae_encode.onnx",
+        local_subdir="_onnx_vae/vae_encode",
+    ),
+    "vae_decode": _OnnxSource(
+        repo=DEMON_ONNX_REPO,
+        hf_glob="vae/vae_decode/*",
+        hf_main_file="vae/vae_decode/vae_decode.onnx",
+        local_subdir="_onnx_vae/vae_decode",
+    ),
+    "decoder": _OnnxSource(
+        repo=DEMON_ONNX_REPO,
+        hf_glob="decoders/{checkpoint}/decoder/*",
+        hf_main_file="decoders/{checkpoint}/decoder/decoder.onnx",
+        local_subdir="_onnx_{checkpoint}/decoder",
+    ),
+    "decoder_refit": _OnnxSource(
+        repo=DEMON_ONNX_REPO,
+        hf_glob="decoders/{checkpoint}/decoder_refit/*",
+        hf_main_file="decoders/{checkpoint}/decoder_refit/decoder_refit.onnx",
+        local_subdir="_onnx_{checkpoint}/decoder_refit",
+    ),
+    "dreamvae": _OnnxSource(
+        repo=DREAMVAE_ONNX_REPO,
+        hf_glob="onnx/model.onnx",
+        hf_main_file="onnx/model.onnx",
+        # DreamVAE keeps its own ONNX cache name so the build pipeline's
+        # registry doesn't collide with the standard vae_decode dir.
+        local_subdir="_onnx_dreamvae",
+        # HF's generic ``model.onnx`` is renamed locally to match the
+        # rest of the build pipeline's naming (vae_decode.onnx etc.).
+        local_filename="dreamvae_decode.onnx",
+    ),
+}
+
+
+def known_components() -> tuple[str, ...]:
+    return tuple(_ONNX_REGISTRY.keys())
+
+
+# ------------------------------------------------------------------
+# Fetch
+# ------------------------------------------------------------------
+
+def fetch_onnx(
+    component: str,
+    *,
+    local_root: Union[str, Path],
+    checkpoint: Optional[str] = None,
+    force_download: bool = False,
+) -> Path:
+    """Ensure ``component``'s ONNX is present locally; download from HF if not.
+
+    Args:
+        component: One of :func:`known_components` (e.g. ``"vae_decode"``,
+            ``"decoder_refit"``, ``"dreamvae"``).
+        local_root: TRT engines root (``trt_engines/``) — the ONNX is
+            placed at ``local_root / <component-specific subdir>``.
+        checkpoint: Required for ``decoder*`` components, ignored for
+            shared components (VAE, DreamVAE).
+        force_download: If True, re-fetch even when local files exist.
+
+    Returns the path to the main ``.onnx`` file. External-data files
+    (the decoder's many ``.weight`` / ``.bias`` siblings) are placed
+    next to it so the ONNX parser resolves them without further work.
+    """
+    if component not in _ONNX_REGISTRY:
+        raise ValueError(
+            f"Unknown ONNX component: {component!r}. "
+            f"Known: {known_components()}"
+        )
+    source = _ONNX_REGISTRY[component]
+    if "{checkpoint}" in (source.hf_glob + source.hf_main_file + source.local_subdir):
+        if not checkpoint:
+            raise ValueError(
+                f"component={component!r} is checkpoint-specific; "
+                f"pass checkpoint=..."
+            )
+        ctx = {"checkpoint": checkpoint}
+    else:
+        ctx = {}
+
+    local_root = Path(local_root)
+    target_dir = local_root / source.local_subdir.format(**ctx)
+    main_filename = source.local_basename(ctx)
+    target_main = target_dir / main_filename
+
+    if target_main.exists() and not force_download:
+        logger.info("Reusing local ONNX at %s", target_main)
+        return target_main
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    # Single-file fetches (VAE, DreamVAE) → hf_hub_download is faster
+    # and less chatty than snapshot_download. Multi-file (decoder*) →
+    # snapshot_download with allow_patterns grabs the .onnx + every
+    # external-data sibling in one go.
+    is_single_file = "*" not in source.hf_glob
+    from huggingface_hub import hf_hub_download, snapshot_download
+
+    logger.info(
+        "Fetching ONNX %r from HF: %s/%s",
+        component, source.repo, source.hf_main_file.format(**ctx),
+    )
+    if is_single_file:
+        cached_main = Path(hf_hub_download(
+            repo_id=source.repo,
+            filename=source.hf_main_file.format(**ctx),
+            force_download=force_download,
+        ))
+        shutil.copy2(cached_main, target_main)
+    else:
+        snap_dir = Path(snapshot_download(
+            repo_id=source.repo,
+            allow_patterns=[source.hf_glob.format(**ctx)],
+            force_download=force_download,
+        ))
+        cached_main = snap_dir / source.hf_main_file.format(**ctx)
+        # Copy the entire external-data dir, not just the .onnx — the
+        # ONNX parser resolves external weights relative to the .onnx
+        # path so siblings must travel together.
+        cached_dir = cached_main.parent
+        for f in cached_dir.iterdir():
+            if f.is_file():
+                shutil.copy2(f, target_dir / f.name)
+
+    size_mb = target_main.stat().st_size / (1 << 20)
+    logger.info("ONNX %r ready at %s (%.1f MB)", component, target_main, size_mb)
+    return target_main

--- a/acestep/engine/trt/onnx_upload.py
+++ b/acestep/engine/trt/onnx_upload.py
@@ -1,0 +1,183 @@
+"""Upload locally-exported ONNX trees to Hugging Face.
+
+Companion to :mod:`acestep.engine.trt.onnx_hub` (which fetches): this
+module pushes the local ``trt_engines/_onnx_*`` layout into the HF
+repo(s) the registry points at, so other machines can fetch instead of
+re-exporting.
+
+CLI:
+    # Preview which files would be uploaded for one component
+    python -m acestep.engine.trt.onnx_upload --component vae_decode --dry-run
+
+    # Upload the standard ONNX bundle for a checkpoint
+    python -m acestep.engine.trt.onnx_upload \\
+        --components vae_encode vae_decode decoder decoder_refit \\
+        --checkpoint acestep-v15-turbo
+
+The CLI does NOT default to "upload everything" — every invocation must
+name the components explicitly. Uploads are public-facing and slow
+(the decoder ONNX is ~3 GB across hundreds of files), and we don't want
+a stray invocation pushing a half-baked export.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from loguru import logger
+
+from .onnx_hub import _ONNX_REGISTRY, known_components
+
+
+def upload_onnx(
+    component: str,
+    *,
+    local_root: Path,
+    checkpoint: str | None = None,
+    repo_id: str | None = None,
+    commit_message: str | None = None,
+    dry_run: bool = False,
+) -> None:
+    """Upload one component's ONNX dir to HF.
+
+    Args:
+        component: One of :func:`known_components`.
+        local_root: TRT engines root (``trt_engines/``) — same root the
+            local exporter writes to.
+        checkpoint: Required for ``decoder*`` components.
+        repo_id: Override the registry's repo for this upload (rare;
+            useful for staging to a fork before the public repo exists).
+        commit_message: HF commit message; auto-generated if omitted.
+        dry_run: Print the plan, don't actually upload.
+    """
+    if component not in _ONNX_REGISTRY:
+        raise ValueError(
+            f"Unknown component: {component!r}. Known: {known_components()}"
+        )
+    source = _ONNX_REGISTRY[component]
+    needs_checkpoint = "{checkpoint}" in (
+        source.local_subdir + source.hf_main_file + source.hf_glob
+    )
+    if needs_checkpoint and not checkpoint:
+        raise ValueError(
+            f"component={component!r} is checkpoint-specific; pass checkpoint=..."
+        )
+    ctx = {"checkpoint": checkpoint} if needs_checkpoint else {}
+
+    repo = repo_id or source.repo
+    local_dir = Path(local_root) / source.local_subdir.format(**ctx)
+    main_file = local_dir / source.local_basename(ctx)
+    if not main_file.exists():
+        raise FileNotFoundError(
+            f"Missing local ONNX for {component!r}: {main_file}"
+        )
+
+    hf_main = source.hf_main_file.format(**ctx)
+    is_single_file = "*" not in source.hf_glob
+
+    if is_single_file:
+        # One file, possibly renamed across local/HF (e.g. dreamvae's
+        # local `dreamvae_decode.onnx` -> HF `onnx/model.onnx`). Use
+        # upload_file with explicit path_in_repo so the rename sticks.
+        size_mb = main_file.stat().st_size / (1 << 20)
+        logger.info(
+            "Upload plan: {} -> {}/{} ({:.1f} MB)",
+            component, repo, hf_main, size_mb,
+        )
+        logger.info("  {} -> {}", main_file.name, Path(hf_main).name)
+        if dry_run:
+            logger.info("--dry-run: not uploading")
+            return
+        from huggingface_hub import HfApi
+        api = HfApi()
+        msg = commit_message or f"Upload {component} ONNX ({size_mb:.0f} MB)"
+        api.upload_file(
+            repo_id=repo,
+            path_or_fileobj=str(main_file),
+            path_in_repo=hf_main,
+            commit_message=msg,
+        )
+    else:
+        # External-data layout: graph + many sibling weight files. The
+        # local dir's contents mirror the HF subtree 1:1, so upload_folder
+        # is the right call. ``path_in_repo`` is the parent of hf_main.
+        repo_dir = str(Path(hf_main).parent).replace("\\", "/")
+        files = sorted(local_dir.iterdir())
+        total_mb = sum(f.stat().st_size for f in files if f.is_file()) / (1 << 20)
+        logger.info(
+            "Upload plan: {} -> {}/{} ({} files, {:.1f} MB)",
+            component, repo, repo_dir, len(files), total_mb,
+        )
+        for f in files[:10]:
+            logger.info("  {}", f.name)
+        if len(files) > 10:
+            logger.info("  ... {} more", len(files) - 10)
+        if dry_run:
+            logger.info("--dry-run: not uploading")
+            return
+        from huggingface_hub import HfApi
+        api = HfApi()
+        msg = commit_message or f"Upload {component} ONNX ({len(files)} files, {total_mb:.0f} MB)"
+        api.upload_folder(
+            repo_id=repo,
+            folder_path=str(local_dir),
+            path_in_repo=repo_dir,
+            commit_message=msg,
+        )
+
+    logger.info("Uploaded {} to {}", component, repo)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Upload local ONNX exports to Hugging Face",
+    )
+    parser.add_argument(
+        "--components", nargs="+", required=True,
+        choices=list(known_components()),
+        help="Which components to upload.",
+    )
+    parser.add_argument(
+        "--checkpoint", default=None,
+        help="Required for decoder/decoder_refit (ignored for shared "
+             "components like vae_encode / vae_decode / dreamvae).",
+    )
+    parser.add_argument(
+        "--local-root", default=None,
+        help="TRT engines directory (default: from acestep.paths.trt_engines_dir()).",
+    )
+    parser.add_argument(
+        "--repo", default=None,
+        help="Override the registry repo (rare; for staging).",
+    )
+    parser.add_argument(
+        "--commit-message", default=None,
+        help="HF commit message (auto-generated if omitted).",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the plan without uploading.",
+    )
+    args = parser.parse_args()
+
+    if args.local_root is None:
+        from acestep.paths import trt_engines_dir
+        local_root = trt_engines_dir()
+    else:
+        local_root = Path(args.local_root)
+
+    for component in args.components:
+        upload_onnx(
+            component,
+            local_root=local_root,
+            checkpoint=args.checkpoint,
+            repo_id=args.repo,
+            commit_message=args.commit_message,
+            dry_run=args.dry_run,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/acestep/models/dreamvae.py
+++ b/acestep/models/dreamvae.py
@@ -1,0 +1,173 @@
+"""FastOobleckDecoder — the model backing DreamVAE.
+
+DreamVAE is a distilled student of the ACE-Step 1.5 Oobleck VAE
+decoder, released at ``daydreamlive/DreamVAE``. Same I/O contract as
+the teacher: ``[B, 64, T]`` latents at 25 fps -> ``[B, 2, 1920*T]``
+audio at 48 kHz, so the resulting weights / ONNX / TRT engine are a
+drop-in replacement wherever the teacher decoder runs.
+
+This file is the canonical source-of-truth for the architecture inside
+this repo. The HF release ships an identical ``modeling.py`` so users
+loading DreamVAE via ``transformers``' ``trust_remote_code`` get the
+same class definition.
+
+Default config matches the released checkpoint:
+    channels=128, input_channels=64, audio_channels=2,
+    upsampling_ratios=[10, 6, 4, 4, 2],
+    channel_multiples=[1, 2, 4, 8, 8].
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional
+
+import torch
+import torch.nn as nn
+from torch.nn.utils import weight_norm
+
+
+class Snake1d(nn.Module):
+    """Snake activation (DAC, NeurIPS 2023)."""
+
+    def __init__(self, hidden_dim: int, logscale: bool = True) -> None:
+        super().__init__()
+        self.alpha = nn.Parameter(torch.zeros(1, hidden_dim, 1))
+        self.beta = nn.Parameter(torch.zeros(1, hidden_dim, 1))
+        self.logscale = logscale
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        shape = hidden_states.shape
+        alpha = torch.exp(self.alpha) if self.logscale else self.alpha
+        beta = torch.exp(self.beta) if self.logscale else self.beta
+        hidden_states = hidden_states.reshape(shape[0], shape[1], -1)
+        hidden_states = hidden_states + (beta + 1e-9).reciprocal() * torch.sin(alpha * hidden_states).pow(2)
+        return hidden_states.reshape(shape)
+
+
+class FastResidualUnit(nn.Module):
+    def __init__(self, dim: int, dilation: int = 1) -> None:
+        super().__init__()
+        pad = ((7 - 1) * dilation) // 2
+        self.snake1 = Snake1d(dim)
+        self.conv1 = weight_norm(nn.Conv1d(dim, dim, kernel_size=7, dilation=dilation, padding=pad))
+        self.snake2 = Snake1d(dim)
+        self.conv2 = weight_norm(nn.Conv1d(dim, dim, kernel_size=1))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.conv1(self.snake1(x))
+        h = self.conv2(self.snake2(h))
+        pad = (x.shape[-1] - h.shape[-1]) // 2
+        if pad > 0:
+            x = x[..., pad:-pad]
+        return x + h
+
+
+class FastDecoderBlock(nn.Module):
+    def __init__(self, in_dim: int, out_dim: int, stride: int = 1) -> None:
+        super().__init__()
+        self.snake1 = Snake1d(in_dim)
+        self.conv_t = weight_norm(
+            nn.ConvTranspose1d(
+                in_dim,
+                out_dim,
+                kernel_size=2 * stride,
+                stride=stride,
+                padding=math.ceil(stride / 2),
+            )
+        )
+        self.res1 = FastResidualUnit(out_dim, dilation=1)
+        self.res2 = FastResidualUnit(out_dim, dilation=3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.snake1(x)
+        x = self.conv_t(x)
+        x = self.res1(x)
+        x = self.res2(x)
+        return x
+
+
+class FastOobleckDecoder(nn.Module):
+    """Distilled ACE-Step 1.5 VAE decoder (51.7M params).
+
+    Drop-in replacement for diffusers' OobleckDecoder with identical
+    input/output shapes. Accepts ``[B, 64, T]`` latents at 25 fps and
+    produces ``[B, 2, 1920*T]`` audio at 48 kHz.
+    """
+
+    def __init__(
+        self,
+        channels: int = 128,
+        input_channels: int = 64,
+        audio_channels: int = 2,
+        upsampling_ratios: Optional[List[int]] = None,
+        channel_multiples: Optional[List[int]] = None,
+    ) -> None:
+        super().__init__()
+        if upsampling_ratios is None:
+            upsampling_ratios = [10, 6, 4, 4, 2]
+        if channel_multiples is None:
+            channel_multiples = [1, 2, 4, 8, 8]
+
+        strides = upsampling_ratios
+        cm = [1] + channel_multiples
+
+        self.conv1 = weight_norm(
+            nn.Conv1d(input_channels, channels * cm[-1], kernel_size=7, padding=3)
+        )
+
+        blocks = []
+        for i, stride in enumerate(strides):
+            in_dim = channels * cm[len(strides) - i]
+            out_dim = channels * cm[len(strides) - i - 1]
+            blocks.append(FastDecoderBlock(in_dim, out_dim, stride=stride))
+        self.blocks = nn.ModuleList(blocks)
+
+        self.final_snake = Snake1d(channels)
+        self.conv2 = weight_norm(
+            nn.Conv1d(channels, audio_channels, kernel_size=7, padding=3, bias=False)
+        )
+
+    def forward(self, latents: torch.Tensor) -> torch.Tensor:
+        x = self.conv1(latents)
+        for block in self.blocks:
+            x = block(x)
+        x = self.final_snake(x)
+        x = self.conv2(x)
+        return x
+
+
+# ------------------------------------------------------------------
+# Loaders
+# ------------------------------------------------------------------
+
+def load_dreamvae_from_hf(
+    repo_id: str = "daydreamlive/DreamVAE",
+    *,
+    device: str | torch.device = "cuda",
+    dtype: torch.dtype = torch.float32,
+) -> FastOobleckDecoder:
+    """Load a FastOobleckDecoder from the public DreamVAE HF release.
+
+    Pulls ``config.json`` + ``model.safetensors`` from ``repo_id``,
+    instantiates the model with the exact released config, and loads
+    weights. Returns the model in ``eval()`` mode on ``device``.
+    """
+    import json
+    from huggingface_hub import hf_hub_download
+    from safetensors.torch import load_file
+
+    cfg_path = hf_hub_download(repo_id, "config.json")
+    weights_path = hf_hub_download(repo_id, "model.safetensors")
+    with open(cfg_path) as f:
+        cfg = json.load(f)
+    model = FastOobleckDecoder(
+        channels=cfg["channels"],
+        input_channels=cfg["input_channels"],
+        audio_channels=cfg["audio_channels"],
+        upsampling_ratios=cfg["upsampling_ratios"],
+        channel_multiples=cfg["channel_multiples"],
+    )
+    state = load_file(weights_path)
+    model.load_state_dict(state)
+    return model.to(device=device, dtype=dtype).eval()

--- a/acestep/paths.py
+++ b/acestep/paths.py
@@ -124,6 +124,17 @@ def default_trt_engines(
     }
 
 
+def max_profile_duration_s() -> float:
+    """Largest registered TRT engine duration profile, in seconds.
+
+    Useful as the upper bound on user-supplied audio: anything longer
+    than this can't be handled by any built engine and would fail at
+    inference time anyway. Demos cap at this value rather than
+    hardcoding a single duration.
+    """
+    return max(_TRT_ENGINE_PROFILES.keys())
+
+
 def select_trt_engines(duration_s: float = 60.0) -> dict[str, str]:
     """Pick the smallest engine profile that can handle ``duration_s``.
 
@@ -234,6 +245,48 @@ def available_trt_engines(
             return paths, max_dur
         missing[max_dur] = absent
     raise EngineNotBuiltError(duration_s=duration_s, needs=needs, missing=missing)
+
+
+# ------------------------------------------------------------------
+# DreamVAE (distilled student decoder, drop-in for vae_decode)
+# ------------------------------------------------------------------
+#
+# The dreamvae engines are NOT in ``_TRT_ENGINE_PROFILES`` because they
+# don't replace the standard profile triple — they ride alongside it,
+# selected per-session by the demo's ``fast_vae`` flag. Naming follows
+# the same ``<component>_fp16_<dur>s`` convention as the teacher
+# engines so the duration sweep stays consistent.
+
+def dreamvae_decode_engine_name(duration_s: int) -> str:
+    """Engine directory/file stem for a dreamvae decoder at duration_s."""
+    return f"dreamvae_decode_fp16_{int(duration_s)}s"
+
+
+def dreamvae_decode_engine_path(duration_s: int) -> Path:
+    """Path to a dreamvae decode engine for a specific duration.
+
+    Pure: does not check existence. Use
+    :func:`available_dreamvae_decode_engine` for existence-aware lookup
+    that mirrors the standard ``available_trt_engines`` fallback.
+    """
+    return trt_engine_path(dreamvae_decode_engine_name(duration_s))
+
+
+def available_dreamvae_decode_engine(duration_s: float) -> Path | None:
+    """Pick the smallest *built* dreamvae engine that fits ``duration_s``.
+
+    Returns ``None`` if no fitting dreamvae engine is built, so callers
+    (the demo's ``fast_vae`` path) can fall back to the teacher decoder
+    without raising.
+    """
+    candidates = sorted(d for d in _TRT_ENGINE_PROFILES if d >= duration_s)
+    if not candidates:
+        candidates = [max(_TRT_ENGINE_PROFILES.keys())]
+    for dur in candidates:
+        path = dreamvae_decode_engine_path(int(dur))
+        if path.exists():
+            return path
+    return None
 
 
 def project_root() -> Path:

--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -33,9 +33,12 @@ from acestep.engine.session import Session
 from acestep.nodes.types import Audio
 from acestep.paths import (
     EngineNotBuiltError,
+    available_dreamvae_decode_engine,
     available_trt_engines,
     checkpoints_dir,
+    dreamvae_decode_engine_name,
     loras_dir,
+    max_profile_duration_s,
     trt_engine_path,
 )
 
@@ -147,7 +150,13 @@ def handle_client(
         num_samples, channels,
     )
     waveform = torch.from_numpy(audio_np.T.copy())
-    waveform = waveform[:2, :int(60.0 * SAMPLE_RATE)]
+    # Cap at the largest registered TRT engine profile rather than
+    # hardcoding 60 s. Anything longer than the largest profile can't
+    # be handled by any built engine, but we let the operator stretch
+    # all the way up to that ceiling — picking the smallest-fitting
+    # engine happens below in available_trt_engines().
+    max_seconds = max_profile_duration_s()
+    waveform = waveform[:2, :int(max_seconds * SAMPLE_RATE)]
     pool = 1920 * 5
     rem = waveform.shape[-1] % pool
     if rem:
@@ -239,13 +248,16 @@ def handle_client(
     if fast_vae and vae_backend == "tensorrt":
         # fast_vae uses the dreamvae distilled decoder; profile must match
         # the same duration we picked above. dreamvae engines aren't in
-        # _TRT_ENGINE_PROFILES (different decoder weights), so we resolve
-        # the path by name and check existence directly.
-        fast_name = f"dreamvae_decode_fp16_{int(picked_dur)}s"
-        if Path(str(trt_engine_path(fast_name))).exists():
-            trt_engines["vae_decode"] = str(trt_engine_path(fast_name))
+        # _TRT_ENGINE_PROFILES (different decoder weights), so we look
+        # them up via the dedicated helper which knows the naming
+        # convention and falls back to a larger fitting profile when the
+        # exact one isn't built (same logic as available_trt_engines).
+        dv_path = available_dreamvae_decode_engine(picked_dur)
+        if dv_path is not None:
+            trt_engines["vae_decode"] = str(dv_path)
         else:
-            print(f"[Server] WARNING: {fast_name} engine missing, falling back to {Path(trt_engines['vae_decode']).stem}")
+            wanted = dreamvae_decode_engine_name(int(picked_dur))
+            print(f"[Server] WARNING: {wanted} engine missing, falling back to {Path(trt_engines['vae_decode']).stem}")
             fast_vae = False
     elif fast_vae:
         print(f"[Server] WARNING: fast_vae requires vae_backend=tensorrt; ignoring with vae_backend={vae_backend}")


### PR DESCRIPTION
This unifies onnx handling, preferring download of pre-exported onnx from HF, falling back to exporting locally. Additionally, adds dreamvae to the build profiles.