### PR TITLE
Ryanontheinside/feat/window optimized vae decoder

### DIFF
--- a/acestep/engine/session.py
+++ b/acestep/engine/session.py
@@ -26,6 +26,7 @@ When Daydream Scope integrates, its session management replaces this.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, List, Optional
 
 from acestep.constants import TASK_INSTRUCTIONS
@@ -213,9 +214,54 @@ class Session:
         self.clip = CLIPHandle(handler=ctx)
         self.vae = VAEHandle(handler=ctx)
 
-        # Windowed VAE decode config (seconds; 0 = full decode)
+        # Windowed VAE decode config (seconds; 0 = full decode).
+        # Hard-clamp positive windows to the engine-supported range so
+        # the auto-selected windowed engine is never asked to decode a
+        # chunk longer than its profile max. <= 0 is the disable
+        # sentinel and stays as-is.
+        if vae_window > 0:
+            from acestep.paths import WINDOWED_VAE_WINDOW_RANGE_S
+            lo, hi = WINDOWED_VAE_WINDOW_RANGE_S
+            vae_window = max(lo, min(hi, vae_window))
         self._vae_window = vae_window
         self._vae_overlap = vae_overlap
+
+        # Auto-select the windowed VAE decode engine when windowing is
+        # active. Saves ~7.7 GB of TRT workspace at context-creation
+        # time vs the canonical 240s engine (see
+        # tests/benchmarks/bench_vae_decode_profiles.py). Falls back
+        # silently to whatever the caller passed in when the windowed
+        # engine isn't built yet.
+        if vae_window > 0 and vae_backend == "tensorrt" and "vae_decode" in trt_engines:
+            from acestep.paths import (
+                available_windowed_vae_decode_engine,
+                looks_like_dreamvae_engine,
+            )
+            from loguru import logger as _log
+
+            current = trt_engines["vae_decode"]
+            is_dreamvae = looks_like_dreamvae_engine(current)
+            windowed = available_windowed_vae_decode_engine(dreamvae=is_dreamvae)
+            if windowed is not None and str(windowed) != current:
+                _log.info(
+                    "vae_window={:.1f}s active: swapping vae_decode engine "
+                    "{} -> {}", vae_window,
+                    Path(current).stem, windowed.stem,
+                )
+                # Don't mutate the caller's dict.
+                trt_engines = dict(trt_engines)
+                trt_engines["vae_decode"] = str(windowed)
+            elif windowed is None:
+                _log.warning(
+                    "vae_window={:.1f}s active but windowed engine not "
+                    "built ({}); using {} (will reserve more VRAM than "
+                    "necessary). Build with: python -m "
+                    "acestep.engine.trt.build --all{}",
+                    vae_window,
+                    "dreamvae_decode_fp16_3to30s" if is_dreamvae else "vae_decode_fp16_3to30s",
+                    Path(current).stem,
+                    " --with-dreamvae" if is_dreamvae else "",
+                )
 
         apply_trt_backends(
             ctx,

--- a/acestep/engine/trt/build.py
+++ b/acestep/engine/trt/build.py
@@ -363,6 +363,58 @@ def _build_vae_engines(
     return results
 
 
+def _build_windowed_vae_decode_engine(
+    *,
+    output_dir: str,
+    onnx_paths: dict[str, str],
+    workspace_gb: float,
+    force_rebuild: bool = False,
+) -> tuple[str, str, float, str]:
+    """Build the single windowed (3-30 s) VAE decode engine.
+
+    This profile is shared across all duration tiers — it's selected
+    by the runtime when ``vae_window > 0`` regardless of the song
+    length, because the chunk size fed to the engine is bounded by
+    the user-facing window (5-30 s) plus overlap, never by the full
+    song duration. Building it costs ~75 s and saves ~7.7 GB of TRT
+    workspace at session-creation time vs the canonical 240 s engine.
+    """
+    from .vae_export import build_vae_decode_engine, VAETRTBuildConfig
+    from acestep.paths import (
+        WINDOWED_VAE_DECODE_NAME,
+        WINDOWED_VAE_PROFILE_FRAMES,
+    )
+
+    name = WINDOWED_VAE_DECODE_NAME
+    engine_dir = os.path.join(output_dir, name)
+    engine_path = os.path.join(engine_dir, f"{name}.engine")
+    label = "VAE decode windowed (3-30s)"
+
+    if not force_rebuild and os.path.exists(engine_path):
+        size_mb = os.path.getsize(engine_path) / 1e6
+        logger.info("SKIP %s (%.0f MB)", name, size_mb)
+        return (label, engine_path, 0.0, "SKIPPED")
+
+    min_f, opt_f, max_f = WINDOWED_VAE_PROFILE_FRAMES
+    config = VAETRTBuildConfig(
+        workspace_gb=workspace_gb,
+        decode_min_frames=min_f,
+        decode_opt_frames=opt_f,
+        decode_max_frames=max_f,
+    )
+
+    logger.info("=" * 60)
+    logger.info("VAE TRT BUILD (windowed): %s (min=%d opt=%d max=%d)",
+                name, min_f, opt_f, max_f)
+    logger.info("=" * 60)
+
+    t0 = time.time()
+    build_vae_decode_engine(onnx_paths["vae_decode"], engine_path, config=config)
+    elapsed = time.time() - t0
+    logger.info("Built in %.0fs", elapsed)
+    return (label, engine_path, elapsed, "OK")
+
+
 def _checkpoint_to_variant(checkpoint: str) -> str:
     """Extract short variant name from checkpoint path.
 
@@ -444,6 +496,11 @@ def _print_matrix(durations, build_vae, build_decoder, output_dir, batch_max,
     variant = _checkpoint_to_variant(checkpoint)
     vtag = f"_{variant}" if variant != "turbo" else ""
 
+    from acestep.paths import (
+        WINDOWED_VAE_DECODE_NAME,
+        WINDOWED_DREAMVAE_DECODE_NAME,
+    )
+
     # (label, engine_dir_name) pairs
     jobs = []
     for dur in durations:
@@ -454,6 +511,13 @@ def _print_matrix(durations, build_vae, build_decoder, output_dir, batch_max,
             jobs.append((f"Decoder {variant} {dur}s, refit", f"decoder{vtag}_mixed_refit_b{batch_max}_{dur}s"))
         if build_dreamvae:
             jobs.append((f"DreamVAE decode {dur}s", f"dreamvae_decode_fp16_{dur}s"))
+
+    # Windowed engines are duration-independent (single shared 3-30s
+    # profile) so they're appended once, outside the duration loop.
+    if build_vae:
+        jobs.append(("VAE decode windowed (3-30s)", WINDOWED_VAE_DECODE_NAME))
+    if build_dreamvae:
+        jobs.append(("DreamVAE decode windowed (3-30s)", WINDOWED_DREAMVAE_DECODE_NAME))
 
     to_build = 0
     to_skip = 0
@@ -682,15 +746,33 @@ def _run_all(args, project_root, onnx_dir):
                 checkpoint=args.checkpoint,
             ))
 
+    # Windowed VAE decode (single 3-30s profile, duration-independent).
+    # Auto-selected by Session when vae_window > 0.
+    if build_vae:
+        results.append(_build_windowed_vae_decode_engine(
+            output_dir=args.output_dir,
+            onnx_paths=onnx_paths,
+            workspace_gb=args.workspace_gb,
+            force_rebuild=args.force_rebuild,
+        ))
+
     if build_dreamvae:
         # dreamvae fetches its own ONNX from HF on first use; no shared
         # ONNX state with the loop above. Built last so a missing HF
         # token / network error doesn't tank an otherwise-successful
         # standard build.
-        from .dreamvae_export import build_dreamvae_engines
+        from .dreamvae_export import (
+            build_dreamvae_engines,
+            build_windowed_dreamvae_engine,
+        )
         results.extend(build_dreamvae_engines(
             output_dir=args.output_dir,
             durations=durations,
+            workspace_gb=args.workspace_gb,
+            force_rebuild=args.force_rebuild,
+        ))
+        results.append(build_windowed_dreamvae_engine(
+            output_dir=args.output_dir,
             workspace_gb=args.workspace_gb,
             force_rebuild=args.force_rebuild,
         ))

--- a/acestep/engine/trt/dreamvae_export.py
+++ b/acestep/engine/trt/dreamvae_export.py
@@ -194,6 +194,70 @@ def build_dreamvae_engine(
     return engine_path, "OK"
 
 
+def build_windowed_dreamvae_engine(
+    *,
+    output_dir: Union[str, Path],
+    onnx_path: Optional[Union[str, Path]] = None,
+    workspace_gb: float = 8.0,
+    force_rebuild: bool = False,
+) -> tuple[str, str, float, str]:
+    """Build the single windowed (3-30 s) dreamvae decode engine.
+
+    Mirrors :func:`acestep.engine.trt.build._build_windowed_vae_decode_engine`
+    for the distilled student decoder. The two engines share the same
+    profile shape (75/125/750 frames) so they're interchangeable from
+    the runtime's POV; only the weights differ.
+
+    Returns ``(label, engine_path, elapsed_s, status)`` matching the
+    shape used by the other dreamvae builders so the result can be
+    spliced into the standard build summary.
+    """
+    import time as _time
+
+    from acestep.paths import (
+        WINDOWED_DREAMVAE_DECODE_NAME,
+        WINDOWED_VAE_PROFILE_FRAMES,
+    )
+
+    output_dir = Path(output_dir)
+    name = WINDOWED_DREAMVAE_DECODE_NAME
+    engine_path = output_dir / name / f"{name}.engine"
+    label = "DreamVAE decode windowed (3-30s)"
+
+    if engine_path.exists() and not force_rebuild:
+        size_mb = engine_path.stat().st_size / (1 << 20)
+        logger.info("SKIP %s (%.0f MB)", name, size_mb)
+        return (label, str(engine_path), 0.0, "SKIPPED")
+
+    if onnx_path is None:
+        onnx_path = fetch_dreamvae_onnx(output_dir)
+    onnx_path = Path(onnx_path)
+
+    min_f, opt_f, max_f = WINDOWED_VAE_PROFILE_FRAMES
+    config = VAETRTBuildConfig(
+        workspace_gb=workspace_gb,
+        decode_min_frames=min_f,
+        decode_opt_frames=opt_f,
+        decode_max_frames=max_f,
+    )
+
+    logger.info("=" * 60)
+    logger.info("DREAMVAE TRT BUILD (windowed): %s (min=%d opt=%d max=%d)",
+                name, min_f, opt_f, max_f)
+    logger.info("=" * 60)
+
+    engine_path.parent.mkdir(parents=True, exist_ok=True)
+    t0 = _time.time()
+    try:
+        build_vae_decode_engine(onnx_path, engine_path, config=config)
+        elapsed = _time.time() - t0
+        logger.info("Built in %.0fs", elapsed)
+        return (label, str(engine_path), elapsed, "OK")
+    except Exception as e:
+        logger.error("DreamVAE windowed build failed: %s", e)
+        return (label, "", _time.time() - t0, "FAILED")
+
+
 def build_dreamvae_engines(
     *,
     output_dir: Union[str, Path],

--- a/acestep/nodes/vae_nodes.py
+++ b/acestep/nodes/vae_nodes.py
@@ -159,12 +159,19 @@ def _find_best_vae_engine(component: str) -> Optional[str]:
     `Session(vae_backend="tensorrt", trt_engines={...})`). There is no
     filesystem discovery: TRT is opt-in, never magic.
 
+    Matches both ``vae_<action>_*`` and ``dreamvae_<action>_*`` for the
+    same component, since the distilled DreamVAE engines are drop-in
+    replacements for the standard decoder.
+
     Args:
         component: "vae_decode" or "vae_encode"
     """
+    # component is "vae_decode" or "vae_encode" -> action is "decode"/"encode".
+    action = component.split("_", 1)[-1]
+    accepted = (f"vae_{action}_", f"dreamvae_{action}_")
     for cached_path in _trt_vae_cache:
         basename = os.path.basename(cached_path).lower()
-        if basename.startswith(component):
+        if basename.startswith(accepted):
             return cached_path
     return None
 
@@ -350,9 +357,13 @@ class StreamVAEDecode(BaseNode):
             ),
             params=(
                 NodeParam(
-                    name="vae_window", type="number", default=3.0,
-                    description="Decode window (s); <=0 decodes full latent",
-                    min=0.0, max=60.0, step=0.1,
+                    name="vae_window", type="number", default=5.0,
+                    description=(
+                        "Decode window (s); <=0 decodes full latent. "
+                        "Positive values are clamped to [5, 30] to fit "
+                        "the windowed VAE engine profile."
+                    ),
+                    min=0.0, max=30.0, step=0.1,
                 ),
                 NodeParam(
                     name="vae_overlap", type="number", default=0.5,
@@ -397,10 +408,19 @@ class StreamVAEDecode(BaseNode):
         )
 
     def execute(self, **kwargs: Any) -> dict[str, Any]:
+        from acestep.paths import WINDOWED_VAE_WINDOW_RANGE_S
+
         vae: VAEHandle = kwargs["vae"]
         latent: Latent = kwargs["latent"]
         window_s = float(kwargs.get("vae_window", 0.0))
         overlap_s = float(kwargs.get("vae_overlap", 0.5))
+
+        # Hard-clamp positive windows to the engine-supported range.
+        # ``<= 0`` is the disable sentinel and falls through to a full
+        # decode, so we leave it untouched.
+        if window_s > 0:
+            lo, hi = WINDOWED_VAE_WINDOW_RANGE_S
+            window_s = max(lo, min(hi, window_s))
 
         follow_playhead = bool(kwargs.get("follow_playhead", False))
         playhead_seconds = kwargs.get("playhead_seconds")

--- a/acestep/paths.py
+++ b/acestep/paths.py
@@ -289,6 +289,66 @@ def available_dreamvae_decode_engine(duration_s: float) -> Path | None:
     return None
 
 
+# ------------------------------------------------------------------
+# Windowed VAE decode (single shared profile across both decoder
+# variants). The profile is small enough that it costs ~1.5 GB of
+# workspace at TRT context-creation time vs ~9 GB for the canonical
+# 240 s engine — see tests/benchmarks/bench_vae_decode_profiles.py.
+#
+# Profile shape (in latent frames at 25 fps):
+#     min = 75   (3 s)
+#     opt = 125  (5 s)
+#     max = 750  (30 s)
+#
+# The ``StreamVAEDecode`` window+overlap chunks fit comfortably inside
+# this range for any user-facing window in [5, 30] seconds, which is
+# the range Session enforces when ``vae_window > 0``.
+# ------------------------------------------------------------------
+
+WINDOWED_VAE_DECODE_NAME = "vae_decode_fp16_3to30s"
+WINDOWED_DREAMVAE_DECODE_NAME = "dreamvae_decode_fp16_3to30s"
+WINDOWED_VAE_PROFILE_FRAMES: tuple[int, int, int] = (75, 125, 750)
+WINDOWED_VAE_WINDOW_RANGE_S: tuple[float, float] = (5.0, 30.0)
+
+
+def windowed_vae_decode_engine_name(*, dreamvae: bool = False) -> str:
+    """Engine directory/file stem for the windowed VAE decode engine.
+
+    Args:
+        dreamvae: Pick the distilled student engine instead of the
+            standard teacher engine. The two share the same profile
+            shape so they're interchangeable from the runtime's POV.
+    """
+    return WINDOWED_DREAMVAE_DECODE_NAME if dreamvae else WINDOWED_VAE_DECODE_NAME
+
+
+def windowed_vae_decode_engine_path(*, dreamvae: bool = False) -> Path:
+    """Path to the windowed VAE decode engine. Pure: does not check
+    existence. Use :func:`available_windowed_vae_decode_engine` for
+    existence-aware lookup."""
+    return trt_engine_path(windowed_vae_decode_engine_name(dreamvae=dreamvae))
+
+
+def available_windowed_vae_decode_engine(*, dreamvae: bool = False) -> Path | None:
+    """Return the windowed VAE decode engine path if it is built, else None.
+
+    Callers (Session, demo backends) use this to opportunistically swap
+    in the small-profile engine when ``vae_window > 0``, falling back
+    silently to whatever the caller originally configured.
+    """
+    p = windowed_vae_decode_engine_path(dreamvae=dreamvae)
+    return p if p.exists() else None
+
+
+def looks_like_dreamvae_engine(path: str | Path) -> bool:
+    """True when ``path`` points at a dreamvae (distilled) engine.
+
+    The runtime distinguishes the two variants only by name; both share
+    the same I/O contract (latents [B,64,T] -> audio [B,2,1920*T]).
+    """
+    return Path(path).name.startswith("dreamvae_decode_")
+
+
 def project_root() -> Path:
     """ACEStep source/project root (for non-model resources like test fixtures).
 

--- a/acestep/paths.py
+++ b/acestep/paths.py
@@ -135,6 +135,21 @@ def max_profile_duration_s() -> float:
     return max(_TRT_ENGINE_PROFILES.keys())
 
 
+def smallest_fitting_profile_duration_s(duration_s: float) -> float:
+    """Smallest registered profile duration that can hold ``duration_s``.
+
+    Pure: ignores filesystem state. Returns the registered profile,
+    not whichever was *built* — so callers can compare against the
+    actually-loaded profile to decide whether a fallback happened.
+    Falls back to ``max_profile_duration_s()`` when no registered
+    profile is large enough (matches ``select_trt_engines``).
+    """
+    for max_dur in sorted(_TRT_ENGINE_PROFILES.keys()):
+        if max_dur >= duration_s:
+            return max_dur
+    return max(_TRT_ENGINE_PROFILES.keys())
+
+
 def select_trt_engines(duration_s: float = 60.0) -> dict[str, str]:
     """Pick the smallest engine profile that can handle ``duration_s``.
 

--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -39,6 +39,7 @@ from acestep.paths import (
     dreamvae_decode_engine_name,
     loras_dir,
     max_profile_duration_s,
+    smallest_fitting_profile_duration_s,
     trt_engine_path,
 )
 
@@ -226,14 +227,16 @@ def handle_client(
                 pass
             ws.close(1011, "TRT engine not built")
             return
-        if picked_dur > audio_duration_s and picked_dur > 60.0:
-            # Fell back to a larger profile than strictly needed. Worth
-            # logging because the larger profile reserves noticeably more
-            # VRAM at TRT context-creation time.
+        # Only warn when a *smaller* registered profile would have fit
+        # but wasn't built (so we genuinely fell back). For a 119.8 s
+        # source the 120 s engine is the smallest fitting profile, not
+        # a fallback — the previous predicate fired on that case.
+        ideal_dur = smallest_fitting_profile_duration_s(audio_duration_s)
+        if picked_dur > ideal_dur:
             print(
                 f"[Server] WARNING: using {picked_dur:.0f}s engine for "
-                f"{audio_duration_s:.1f}s audio (fallback; smaller profile "
-                f"not built — extra VRAM cost)"
+                f"{audio_duration_s:.1f}s audio (fallback; {ideal_dur:.0f}s "
+                f"profile not built — extra VRAM cost)"
             )
         # Prune unused keys for the same reason as before:
         # validate_backends() rejects engine entries whose backend isn't

--- a/tests/benchmarks/bench_vae_decode_profiles.json
+++ b/tests/benchmarks/bench_vae_decode_profiles.json
@@ -1,0 +1,321 @@
+{
+  "engine_inspection": {
+    "5s_fixed": {
+      "engine_path": "C:\\Users\\ryanf\\.daydream-scope\\models\\demon\\trt_engines\\vae_decode_fp16_5s_fixed\\vae_decode_fp16_5s_fixed.engine",
+      "on_disk_mb": 279.9,
+      "activation_mb": 338.7,
+      "weight_streaming_mb": 0.0,
+      "profile_shape": {
+        "latents": {
+          "min": [
+            1,
+            64,
+            125
+          ],
+          "opt": [
+            1,
+            64,
+            125
+          ],
+          "max": [
+            1,
+            64,
+            125
+          ]
+        }
+      }
+    },
+    "3to30s": {
+      "engine_path": "C:\\Users\\ryanf\\.daydream-scope\\models\\demon\\trt_engines\\vae_decode_fp16_3to30s\\vae_decode_fp16_3to30s.engine",
+      "on_disk_mb": 216.6,
+      "activation_mb": 1202.3,
+      "weight_streaming_mb": 0.0,
+      "profile_shape": {
+        "latents": {
+          "min": [
+            1,
+            64,
+            75
+          ],
+          "opt": [
+            1,
+            64,
+            125
+          ],
+          "max": [
+            1,
+            64,
+            750
+          ]
+        }
+      }
+    },
+    "240s": {
+      "engine_path": "C:\\Users\\ryanf\\.daydream-scope\\models\\demon\\trt_engines\\vae_decode_fp16_240s\\vae_decode_fp16_240s.engine",
+      "on_disk_mb": 172.7,
+      "activation_mb": 8639.9,
+      "weight_streaming_mb": 0.0,
+      "profile_shape": {
+        "latents": {
+          "min": [
+            1,
+            64,
+            125
+          ],
+          "opt": [
+            1,
+            64,
+            1500
+          ],
+          "max": [
+            1,
+            64,
+            6000
+          ]
+        }
+      }
+    }
+  },
+  "runs": [
+    {
+      "baseline_mb": 1681.6,
+      "baseline_stability_mb": 0.0,
+      "after_deserialize_mb": 1965.6,
+      "after_context_mb": 2309.6,
+      "after_shape_mb": 2309.6,
+      "after_io_mb": 2329.6,
+      "after_first_exec_mb": 2329.6,
+      "peak_mb": 2329.6,
+      "final_mb": 2329.6,
+      "delta_after_deserialize": 284.0,
+      "delta_after_context": 628.0,
+      "delta_after_shape": 628.0,
+      "delta_after_io": 648.0,
+      "delta_after_first_exec": 648.0,
+      "delta_peak": 648.0,
+      "mean_ms": 8.66,
+      "min_ms": 8.29,
+      "max_ms": 9.082,
+      "n_iters": 10,
+      "engine_label": "5s_fixed",
+      "runtime_T": 125,
+      "note": "5 s window \u2014 primary"
+    },
+    {
+      "baseline_mb": 1681.6,
+      "baseline_stability_mb": 0.0,
+      "after_deserialize_mb": 1917.6,
+      "after_context_mb": 3141.6,
+      "after_shape_mb": 3141.6,
+      "after_io_mb": 3161.6,
+      "after_first_exec_mb": 3161.6,
+      "peak_mb": 3161.6,
+      "final_mb": 3161.6,
+      "delta_after_deserialize": 236.0,
+      "delta_after_context": 1460.0,
+      "delta_after_shape": 1460.0,
+      "delta_after_io": 1480.0,
+      "delta_after_first_exec": 1480.0,
+      "delta_peak": 1480.0,
+      "mean_ms": 8.615,
+      "min_ms": 8.286,
+      "max_ms": 9.067,
+      "n_iters": 10,
+      "engine_label": "3to30s",
+      "runtime_T": 125,
+      "note": "5 s window \u2014 primary"
+    },
+    {
+      "baseline_mb": 1681.6,
+      "baseline_stability_mb": 0.0,
+      "after_deserialize_mb": 2003.6,
+      "after_context_mb": 10791.6,
+      "after_shape_mb": 10791.6,
+      "after_io_mb": 10811.6,
+      "after_first_exec_mb": 10811.6,
+      "peak_mb": 10811.6,
+      "final_mb": 10811.6,
+      "delta_after_deserialize": 322.0,
+      "delta_after_context": 9110.0,
+      "delta_after_shape": 9110.0,
+      "delta_after_io": 9130.0,
+      "delta_after_first_exec": 9130.0,
+      "delta_peak": 9130.0,
+      "mean_ms": 10.295,
+      "min_ms": 10.225,
+      "max_ms": 10.357,
+      "n_iters": 10,
+      "engine_label": "240s",
+      "runtime_T": 125,
+      "note": "5 s window \u2014 primary"
+    },
+    {
+      "baseline_mb": 1681.6,
+      "baseline_stability_mb": 0.0,
+      "after_deserialize_mb": 1917.6,
+      "after_context_mb": 3141.6,
+      "after_shape_mb": 3141.6,
+      "after_io_mb": 3161.6,
+      "after_first_exec_mb": 3161.6,
+      "peak_mb": 3161.6,
+      "final_mb": 3161.6,
+      "delta_after_deserialize": 236.0,
+      "delta_after_context": 1460.0,
+      "delta_after_shape": 1460.0,
+      "delta_after_io": 1480.0,
+      "delta_after_first_exec": 1480.0,
+      "delta_peak": 1480.0,
+      "mean_ms": 13.454,
+      "min_ms": 13.375,
+      "max_ms": 13.553,
+      "n_iters": 10,
+      "engine_label": "3to30s",
+      "runtime_T": 250,
+      "note": "10 s \u2014 sweep"
+    },
+    {
+      "baseline_mb": 1681.6,
+      "baseline_stability_mb": 0.0,
+      "after_deserialize_mb": 1917.6,
+      "after_context_mb": 3141.6,
+      "after_shape_mb": 3141.6,
+      "after_io_mb": 3161.6,
+      "after_first_exec_mb": 3161.6,
+      "peak_mb": 3161.6,
+      "final_mb": 3161.6,
+      "delta_after_deserialize": 236.0,
+      "delta_after_context": 1460.0,
+      "delta_after_shape": 1460.0,
+      "delta_after_io": 1480.0,
+      "delta_after_first_exec": 1480.0,
+      "delta_peak": 1480.0,
+      "mean_ms": 24.154,
+      "min_ms": 23.552,
+      "max_ms": 25.873,
+      "n_iters": 10,
+      "engine_label": "3to30s",
+      "runtime_T": 500,
+      "note": "20 s \u2014 sweep"
+    },
+    {
+      "baseline_mb": 1681.6,
+      "baseline_stability_mb": 0.0,
+      "after_deserialize_mb": 1917.6,
+      "after_context_mb": 3141.6,
+      "after_shape_mb": 3141.6,
+      "after_io_mb": 3153.6,
+      "after_first_exec_mb": 3153.6,
+      "peak_mb": 3153.6,
+      "final_mb": 3153.6,
+      "delta_after_deserialize": 236.0,
+      "delta_after_context": 1460.0,
+      "delta_after_shape": 1460.0,
+      "delta_after_io": 1472.0,
+      "delta_after_first_exec": 1472.0,
+      "delta_peak": 1472.0,
+      "mean_ms": 34.494,
+      "min_ms": 34.102,
+      "max_ms": 34.898,
+      "n_iters": 10,
+      "engine_label": "3to30s",
+      "runtime_T": 750,
+      "note": "30 s \u2014 sweep (max)"
+    },
+    {
+      "baseline_mb": 1681.6,
+      "baseline_stability_mb": 0.0,
+      "after_deserialize_mb": 2003.6,
+      "after_context_mb": 10791.6,
+      "after_shape_mb": 10791.6,
+      "after_io_mb": 10803.6,
+      "after_first_exec_mb": 10803.6,
+      "peak_mb": 10803.6,
+      "final_mb": 10803.6,
+      "delta_after_deserialize": 322.0,
+      "delta_after_context": 9110.0,
+      "delta_after_shape": 9110.0,
+      "delta_after_io": 9122.0,
+      "delta_after_first_exec": 9122.0,
+      "delta_peak": 9122.0,
+      "mean_ms": 30.861,
+      "min_ms": 29.687,
+      "max_ms": 32.063,
+      "n_iters": 10,
+      "engine_label": "240s",
+      "runtime_T": 750,
+      "note": "30 s \u2014 sweep"
+    },
+    {
+      "baseline_mb": 1681.6,
+      "baseline_stability_mb": 0.0,
+      "after_deserialize_mb": 2003.6,
+      "after_context_mb": 10791.6,
+      "after_shape_mb": 10791.6,
+      "after_io_mb": 10813.6,
+      "after_first_exec_mb": 10813.6,
+      "peak_mb": 10813.6,
+      "final_mb": 10813.6,
+      "delta_after_deserialize": 322.0,
+      "delta_after_context": 9110.0,
+      "delta_after_shape": 9110.0,
+      "delta_after_io": 9132.0,
+      "delta_after_first_exec": 9132.0,
+      "delta_peak": 9132.0,
+      "mean_ms": 54.727,
+      "min_ms": 53.254,
+      "max_ms": 55.983,
+      "n_iters": 10,
+      "engine_label": "240s",
+      "runtime_T": 1500,
+      "note": "60 s \u2014 sweep (240s opt)"
+    },
+    {
+      "baseline_mb": 1681.6,
+      "baseline_stability_mb": 0.0,
+      "after_deserialize_mb": 2003.6,
+      "after_context_mb": 10791.6,
+      "after_shape_mb": 10791.6,
+      "after_io_mb": 10835.6,
+      "after_first_exec_mb": 10835.6,
+      "peak_mb": 10835.6,
+      "final_mb": 10835.6,
+      "delta_after_deserialize": 322.0,
+      "delta_after_context": 9110.0,
+      "delta_after_shape": 9110.0,
+      "delta_after_io": 9154.0,
+      "delta_after_first_exec": 9154.0,
+      "delta_peak": 9154.0,
+      "mean_ms": 104.233,
+      "min_ms": 103.991,
+      "max_ms": 105.13,
+      "n_iters": 10,
+      "engine_label": "240s",
+      "runtime_T": 3000,
+      "note": "120 s \u2014 sweep"
+    },
+    {
+      "baseline_mb": 1681.6,
+      "baseline_stability_mb": 0.0,
+      "after_deserialize_mb": 2003.6,
+      "after_context_mb": 10791.6,
+      "after_shape_mb": 10791.6,
+      "after_io_mb": 10899.6,
+      "after_first_exec_mb": 10899.6,
+      "peak_mb": 10899.6,
+      "final_mb": 10899.6,
+      "delta_after_deserialize": 322.0,
+      "delta_after_context": 9110.0,
+      "delta_after_shape": 9110.0,
+      "delta_after_io": 9218.0,
+      "delta_after_first_exec": 9218.0,
+      "delta_peak": 9218.0,
+      "mean_ms": 205.098,
+      "min_ms": 204.155,
+      "max_ms": 206.385,
+      "n_iters": 10,
+      "engine_label": "240s",
+      "runtime_T": 6000,
+      "note": "240 s \u2014 sweep (max)"
+    }
+  ]
+}

--- a/tests/benchmarks/bench_vae_decode_profiles.py
+++ b/tests/benchmarks/bench_vae_decode_profiles.py
@@ -1,0 +1,376 @@
+"""VRAM profile across VAE decode TRT engines — accurate edition.
+
+Question: how much VRAM does each VAE decode engine commit, broken down
+by source (weights, TRT activation workspace, runtime overhead), so we
+can decide whether swapping the canonical 240 s VAE decoder for a
+narrow-profile engine while windowed decode is active is worth it.
+
+Three engines are compared (all standard teacher VAE, fp16, same ONNX):
+
+  * vae_decode_fp16_5s_fixed   min=opt=max=125
+  * vae_decode_fp16_3to30s     min=75 opt=125 max=750
+  * vae_decode_fp16_240s       min=125 opt=1500 max=6000   (canonical)
+
+Two complementary measurements:
+
+  1. **TRT-reported, GPU-noise-free.** ``engine.device_memory_size_v2``
+     is the workspace TRT will reserve for the engine, queried from the
+     deserialized engine without ever doing inference. This is the
+     authoritative activation-memory number. Combined with the
+     on-disk engine size (which is dominated by serialised weights),
+     this gives us a per-engine VRAM budget that doesn't depend on what
+     else is on the GPU.
+
+  2. **Subprocess-isolated GPU measurement.** Per (engine, runtime_T)
+     pair we spawn a fresh Python subprocess that initialises CUDA,
+     samples the baseline VRAM 3 times to detect external noise, then
+     loads the engine, creates a context, sets a shape, allocates I/O
+     tensors, and runs warmup + timed iterations. We report driver-
+     level VRAM via ``torch.cuda.mem_get_info()`` at each stage. On
+     Windows WDDM, per-process accounting via NVML returns ``None`` —
+     so this baseline-subtracted delta is the only practical
+     per-process number, and the per-stage breakdown lets us see when
+     each piece commits.
+
+  3. **Shape sweep** for the dynamic-range engines confirms TRT's
+     default ``STATIC`` allocation strategy: workspace is sized for the
+     profile's max shape and committed at context creation, so it
+     doesn't grow when the runtime input grows.
+
+Usage::
+
+    uv run python tests/benchmarks/bench_vae_decode_profiles.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RESULTS_DIR = Path(__file__).resolve().parent
+TRT_ROOT = Path.home() / ".daydream-scope" / "models" / "demon" / "trt_engines"
+
+
+ENGINES: tuple[tuple[str, Path], ...] = (
+    ("5s_fixed", TRT_ROOT / "vae_decode_fp16_5s_fixed" / "vae_decode_fp16_5s_fixed.engine"),
+    ("3to30s",   TRT_ROOT / "vae_decode_fp16_3to30s"   / "vae_decode_fp16_3to30s.engine"),
+    ("240s",     TRT_ROOT / "vae_decode_fp16_240s"     / "vae_decode_fp16_240s.engine"),
+)
+
+
+# (engine_label, runtime_T_frames, comment)
+RUN_PLAN: tuple[tuple[str, int, str], ...] = (
+    ("5s_fixed", 125, "5 s window — primary"),
+    ("3to30s",   125, "5 s window — primary"),
+    ("240s",     125, "5 s window — primary"),
+
+    # Sweep dynamic engines: confirm workspace is shape-invariant.
+    ("3to30s",   250, "10 s — sweep"),
+    ("3to30s",   500, "20 s — sweep"),
+    ("3to30s",   750, "30 s — sweep (max)"),
+    ("240s",     750, "30 s — sweep"),
+    ("240s",    1500, "60 s — sweep (240s opt)"),
+    ("240s",    3000, "120 s — sweep"),
+    ("240s",    6000, "240 s — sweep (max)"),
+)
+
+
+# -----------------------------------------------------------------------
+# 1. TRT-reported authoritative numbers (no GPU work).
+# -----------------------------------------------------------------------
+
+def inspect_engine(engine_path: Path) -> dict:
+    """Return TRT-reported memory numbers for an engine.
+
+    Runs in the parent process; deserialising creates a CUDA context
+    but does not bind a per-engine workspace, so the returned numbers
+    are independent of any subsequent GPU measurement.
+    """
+    import tensorrt as trt
+
+    rt = trt.Runtime(trt.Logger(trt.Logger.WARNING))
+    with open(engine_path, "rb") as f:
+        engine = rt.deserialize_cuda_engine(f.read())
+
+    on_disk = engine_path.stat().st_size
+    # Single profile (idx 0); v2 is the supported API in TRT 10.x.
+    activation = engine.get_device_memory_size_for_profile_v2(0)
+
+    profile_shape = {}
+    for i in range(engine.num_io_tensors):
+        name = engine.get_tensor_name(i)
+        if engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT:
+            mn, op, mx = engine.get_tensor_profile_shape(name, 0)
+            profile_shape[name] = {"min": list(mn), "opt": list(op), "max": list(mx)}
+
+    return {
+        "engine_path": str(engine_path),
+        "on_disk_mb": round(on_disk / (1 << 20), 1),
+        "activation_mb": round(activation / (1 << 20), 1),
+        "weight_streaming_mb": round(engine.streamable_weights_size / (1 << 20), 1),
+        "profile_shape": profile_shape,
+    }
+
+
+# -----------------------------------------------------------------------
+# 2. Subprocess-isolated GPU measurement.
+# -----------------------------------------------------------------------
+
+def parent_main():
+    # ---------- 1. Engine inspection (no GPU pressure yet) ----------
+    print("=" * 96)
+    print("ENGINE INSPECTION  (TRT-reported, independent of GPU state)")
+    print("=" * 96)
+    inspections = {}
+    hdr = f"{'engine':<12}{'on_disk_MB':>13}{'activation_MB':>16}{'profile (T frames)':>30}"
+    print(hdr)
+    print("-" * len(hdr))
+    for label, path in ENGINES:
+        if not path.exists():
+            print(f"{label:<12}  MISSING: {path}")
+            continue
+        info = inspect_engine(path)
+        inspections[label] = info
+        ps = info["profile_shape"].get("latents", {})
+        rng = f"{ps.get('min', ['?'])[-1]} / {ps.get('opt', ['?'])[-1]} / {ps.get('max', ['?'])[-1]}"
+        print(f"{label:<12}{info['on_disk_mb']:>13.1f}{info['activation_mb']:>16.1f}"
+              f"{rng:>30}")
+
+    # ---------- 2. GPU stage-breakdown across (engine, T) pairs ----------
+    print("\n" + "=" * 110)
+    print("GPU STAGE BREAKDOWN  (each row = fresh subprocess; baseline 3x stability check)")
+    print("=" * 110)
+    rows = []
+    engine_paths = dict(ENGINES)
+    for label, T, note in RUN_PLAN:
+        path = engine_paths.get(label)
+        if path is None or not path.exists():
+            print(f"[skip] {label} T={T}: engine missing")
+            continue
+        result = run_child(path, T)
+        if result is None:
+            print(f"[fail] {label} T={T}: subprocess returned no JSON")
+            continue
+        result["engine_label"] = label
+        result["runtime_T"] = T
+        result["note"] = note
+        rows.append(result)
+        print(
+            f"  {label:<10} T={T:>4}  "
+            f"baseline={result['baseline_mb']:>5.0f} "
+            f"(stab+/-{result['baseline_stability_mb']:>4.1f}) | "
+            f"+deserialize={result['delta_after_deserialize']:>+5.0f} "
+            f"+context={result['delta_after_context']:>+5.0f} "
+            f"+shape={result['delta_after_shape']:>+5.0f} "
+            f"+io={result['delta_after_io']:>+5.0f} "
+            f"+exec1={result['delta_after_first_exec']:>+5.0f} | "
+            f"peak_d={result['delta_peak']:>+5.0f}  "
+            f"({result['mean_ms']:>5.2f} ms)"
+        )
+
+    # ---------- 3. Apples-to-apples summary at T=125 ----------
+    print("\n" + "=" * 96)
+    print("PER-PROCESS COST AT T=125  (5 s window — the windowed-decode workload)")
+    print("=" * 96)
+    by_label_125 = {r["engine_label"]: r for r in rows if r["runtime_T"] == 125}
+    if {"5s_fixed", "3to30s", "240s"} <= set(by_label_125):
+        ref = by_label_125["5s_fixed"]
+        hdr = (
+            f"{'engine':<10}{'GPU committed (d)':>22}"
+            f"{'TRT activation':>17}{'TRT on-disk':>14}"
+            f"{'vs 5s_fixed':>14}"
+        )
+        print(hdr)
+        print("-" * len(hdr))
+        for label in ("5s_fixed", "3to30s", "240s"):
+            r = by_label_125[label]
+            inf = inspections.get(label, {})
+            committed = r["delta_peak"]
+            delta_vs_ref = committed - ref["delta_peak"]
+            print(
+                f"{label:<10}{committed:>22.0f}{inf.get('activation_mb', 0):>17.1f}"
+                f"{inf.get('on_disk_mb', 0):>14.1f}{delta_vs_ref:>+14.0f}"
+            )
+
+    # ---------- 4. Shape-invariance check ----------
+    print("\n" + "=" * 96)
+    print("SHAPE INVARIANCE  (does committed VRAM grow when runtime T grows?)")
+    print("=" * 96)
+    for engine_label in ("3to30s", "240s"):
+        related = [r for r in rows if r["engine_label"] == engine_label]
+        if len(related) < 2:
+            continue
+        peaks = [r["delta_peak"] for r in related]
+        rng = max(peaks) - min(peaks)
+        print(f"  {engine_label:<10}: peak-d across {len(related)} shapes = "
+              f"min {min(peaks):.0f} / max {max(peaks):.0f} (spread {rng:.0f} MB)")
+        for r in related:
+            print(f"     T={r['runtime_T']:>4}  peak_d = {r['delta_peak']:>5.0f} MB  "
+                  f"(latency {r['mean_ms']:.2f} ms)")
+
+    out_path = RESULTS_DIR / "bench_vae_decode_profiles.json"
+    out_path.write_text(json.dumps({
+        "engine_inspection": inspections,
+        "runs": rows,
+    }, indent=2))
+    print(f"\nDetailed JSON written to {out_path}")
+
+
+def run_child(engine_path: Path, T: int) -> dict | None:
+    cmd = [
+        sys.executable, str(Path(__file__).resolve()),
+        "--child", "--engine", str(engine_path), "--frames", str(T),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, cwd=str(PROJECT_ROOT))
+    if proc.returncode != 0:
+        print(f"  stderr:\n{proc.stderr}", flush=True)
+        return None
+    last_json = None
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("{") and line.endswith("}"):
+            try:
+                last_json = json.loads(line)
+            except json.JSONDecodeError:
+                pass
+    if last_json is None and proc.stderr:
+        print(f"  stderr:\n{proc.stderr}", flush=True)
+    return last_json
+
+
+# -----------------------------------------------------------------------
+# Child subprocess: own CUDA context, single (engine, T) measurement.
+# -----------------------------------------------------------------------
+
+def child_main(engine_path: Path, T: int):
+    import torch
+    torch.set_grad_enabled(False)
+
+    device = torch.device("cuda")
+    torch.cuda.synchronize()
+    _ = torch.empty(1, device=device)
+    torch.cuda.synchronize()
+
+    def vram_mb() -> float:
+        torch.cuda.synchronize()
+        free, total = torch.cuda.mem_get_info()
+        return (total - free) / (1024 * 1024)
+
+    # 3-sample baseline for noise / external-process detection.
+    baseline_samples = []
+    for _ in range(3):
+        baseline_samples.append(vram_mb())
+        time.sleep(0.05)
+    baseline_mb = statistics.median(baseline_samples)
+    baseline_stability = max(baseline_samples) - min(baseline_samples)
+
+    # ---- Stage 1: deserialize engine (no execution context yet) ----
+    from polygraphy.backend.common import bytes_from_path
+    from polygraphy.backend.trt import engine_from_bytes
+    engine = engine_from_bytes(bytes_from_path(str(engine_path)))
+    after_deserialize_mb = vram_mb()
+
+    # ---- Stage 2: create execution context (TRT default = STATIC reserves now) ----
+    ctx = engine.create_execution_context()
+    after_context_mb = vram_mb()
+
+    # ---- Stage 3: set input shape ----
+    ctx.set_input_shape("latents", (1, 64, T))
+    after_shape_mb = vram_mb()
+
+    # ---- Stage 4: allocate I/O tensors (ours, via torch) ----
+    lat = torch.empty((1, 64, T), dtype=torch.float32, device=device).normal_()
+    ctx.set_tensor_address("latents", lat.data_ptr())
+    out_shape = tuple(ctx.get_tensor_shape("audio"))
+    out = torch.empty(out_shape, dtype=torch.float32, device=device)
+    ctx.set_tensor_address("audio", out.data_ptr())
+    after_io_mb = vram_mb()
+
+    # ---- Stage 5: warmup + timed iterations ----
+    from polygraphy import cuda as pg_cuda
+    stream = pg_cuda.Stream()
+
+    if not ctx.execute_async_v3(stream.ptr):
+        raise RuntimeError("TRT execute_async_v3 failed (warmup #1)")
+    stream.synchronize()
+    after_first_exec_mb = vram_mb()
+
+    peak_mb = max(
+        after_deserialize_mb, after_context_mb, after_shape_mb,
+        after_io_mb, after_first_exec_mb,
+    )
+
+    for _ in range(4):
+        if not ctx.execute_async_v3(stream.ptr):
+            raise RuntimeError("TRT execute_async_v3 failed (warmup)")
+        stream.synchronize()
+        peak_mb = max(peak_mb, vram_mb())
+
+    timings: list[float] = []
+    for _ in range(10):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        if not ctx.execute_async_v3(stream.ptr):
+            raise RuntimeError("TRT execute_async_v3 failed (timed)")
+        stream.synchronize()
+        timings.append((time.perf_counter() - t0) * 1000)
+        peak_mb = max(peak_mb, vram_mb())
+
+    final_mb = vram_mb()
+    keepalive = (engine, ctx, lat, out, stream)
+
+    result = {
+        # Raw (driver-global) VRAM at each stage.
+        "baseline_mb": round(baseline_mb, 1),
+        "baseline_stability_mb": round(baseline_stability, 1),
+        "after_deserialize_mb": round(after_deserialize_mb, 1),
+        "after_context_mb": round(after_context_mb, 1),
+        "after_shape_mb": round(after_shape_mb, 1),
+        "after_io_mb": round(after_io_mb, 1),
+        "after_first_exec_mb": round(after_first_exec_mb, 1),
+        "peak_mb": round(peak_mb, 1),
+        "final_mb": round(final_mb, 1),
+        # Stage deltas (cumulative, baseline-subtracted) — the headline numbers.
+        "delta_after_deserialize": round(after_deserialize_mb - baseline_mb, 1),
+        "delta_after_context": round(after_context_mb - baseline_mb, 1),
+        "delta_after_shape": round(after_shape_mb - baseline_mb, 1),
+        "delta_after_io": round(after_io_mb - baseline_mb, 1),
+        "delta_after_first_exec": round(after_first_exec_mb - baseline_mb, 1),
+        "delta_peak": round(peak_mb - baseline_mb, 1),
+        # Latency, secondary.
+        "mean_ms": round(sum(timings) / len(timings), 3) if timings else -1,
+        "min_ms": round(min(timings), 3) if timings else -1,
+        "max_ms": round(max(timings), 3) if timings else -1,
+        "n_iters": len(timings),
+    }
+    print(json.dumps(result), flush=True)
+    del keepalive
+
+
+# -----------------------------------------------------------------------
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--child", action="store_true",
+                   help="internal: run a single measurement and emit JSON")
+    p.add_argument("--engine", type=Path)
+    p.add_argument("--frames", type=int)
+    args = p.parse_args()
+
+    if args.child:
+        if args.engine is None or args.frames is None:
+            sys.exit("--child requires --engine and --frames")
+        child_main(args.engine, args.frames)
+    else:
+        parent_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/build_vae_decode_test_engines.py
+++ b/tests/benchmarks/build_vae_decode_test_engines.py
@@ -1,0 +1,145 @@
+"""Build small-profile VAE decode TRT engines for windowed-decode experiments.
+
+Two engines are produced from the existing ``vae_decode.onnx``:
+
+  * ``vae_decode_fp16_5s_fixed``  (min=opt=max=125 frames)  — specialised
+    to a single shape; should produce the smallest workspace TRT can
+    plausibly reserve for this graph.
+  * ``vae_decode_fp16_3to30s``    (min=75, opt=125, max=750)  — a small
+    dynamic range that comfortably covers any reasonable streaming
+    window (3-30 s) while staying optimised at the typical 5 s chunk.
+
+Both engines share the standard teacher VAE ONNX, fp16, and the same
+build path as the canonical ``vae_decode_fp16_*`` engines. They land in
+the standard trt_engines directory so the benchmark can discover them
+the same way the runtime would.
+
+Usage::
+
+    uv run python tests/benchmarks/build_vae_decode_test_engines.py
+    uv run python tests/benchmarks/build_vae_decode_test_engines.py --force
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from acestep.engine.trt.vae_export import (
+    VAETRTBuildConfig,
+    build_vae_decode_engine,
+)
+from acestep.paths import trt_engines_dir
+
+
+VAE_DECODE_ONNX_CANDIDATES = (
+    "_onnx_vae/vae_decode/vae_decode.onnx",
+    "_onnx/vae_decode/vae_decode.onnx",
+)
+
+
+def find_vae_decode_onnx(trt_dir: Path) -> Path:
+    for rel in VAE_DECODE_ONNX_CANDIDATES:
+        p = trt_dir / rel
+        if p.exists():
+            return p
+    raise FileNotFoundError(
+        "vae_decode.onnx not found in any known location under "
+        f"{trt_dir}. Run `python -m acestep.engine.trt.build --all "
+        "--vae-only --duration 60` first to produce the ONNX export."
+    )
+
+
+# (engine_dir_name, min_frames, opt_frames, max_frames, description)
+TEST_ENGINES = (
+    (
+        "vae_decode_fp16_5s_fixed",
+        125, 125, 125,
+        "fixed 5s (min=opt=max=125)",
+    ),
+    (
+        "vae_decode_fp16_3to30s",
+        75, 125, 750,
+        "dynamic 3-30s (min=75, opt=125, max=750)",
+    ),
+)
+
+
+def build_one(
+    onnx_path: Path,
+    out_root: Path,
+    name: str,
+    min_f: int,
+    opt_f: int,
+    max_f: int,
+    workspace_gb: float,
+    force: bool,
+) -> tuple[str, Path, float, str]:
+    engine_dir = out_root / name
+    engine_path = engine_dir / f"{name}.engine"
+
+    if engine_path.exists() and not force:
+        size_mb = engine_path.stat().st_size / 1e6
+        print(f"[skip] {name} already exists ({size_mb:.1f} MB)")
+        return (name, engine_path, 0.0, "SKIPPED")
+
+    engine_dir.mkdir(parents=True, exist_ok=True)
+    config = VAETRTBuildConfig(
+        fp16=True,
+        workspace_gb=workspace_gb,
+        decode_min_frames=min_f,
+        decode_opt_frames=opt_f,
+        decode_max_frames=max_f,
+    )
+
+    print(f"[build] {name}: min={min_f} opt={opt_f} max={max_f} frames")
+    t0 = time.time()
+    build_vae_decode_engine(onnx_path, engine_path, config=config)
+    elapsed = time.time() - t0
+    size_mb = engine_path.stat().st_size / 1e6
+    print(f"[done]  {name}: {elapsed:.0f}s, {size_mb:.1f} MB")
+    return (name, engine_path, elapsed, "OK")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--force", action="store_true",
+                   help="Rebuild even if engine already exists.")
+    p.add_argument("--workspace-gb", type=float, default=8.0,
+                   help="TRT builder workspace in GB (default: 8).")
+    args = p.parse_args()
+
+    trt_dir = trt_engines_dir()
+    onnx_path = find_vae_decode_onnx(trt_dir)
+    print(f"ONNX: {onnx_path}")
+    print(f"Output dir: {trt_dir}\n")
+
+    results = []
+    for name, min_f, opt_f, max_f, _desc in TEST_ENGINES:
+        results.append(build_one(
+            onnx_path=onnx_path,
+            out_root=trt_dir,
+            name=name,
+            min_f=min_f,
+            opt_f=opt_f,
+            max_f=max_f,
+            workspace_gb=args.workspace_gb,
+            force=args.force,
+        ))
+
+    print("\n" + "=" * 60)
+    print("BUILD SUMMARY")
+    print("=" * 60)
+    for name, path, elapsed, status in results:
+        size_mb = path.stat().st_size / 1e6 if path.exists() else -1
+        print(f"  {status:7s} {elapsed:6.0f}s  {size_mb:7.1f} MB  {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/smoke_windowed_vae.py
+++ b/tests/benchmarks/smoke_windowed_vae.py
@@ -1,0 +1,203 @@
+"""Smoke test: helpers + clamp + auto-select logic for the windowed
+VAE decode wiring. Avoids loading the model so it runs fast and
+without GPU contention."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def test_helpers():
+    from acestep.paths import (
+        WINDOWED_VAE_DECODE_NAME,
+        WINDOWED_DREAMVAE_DECODE_NAME,
+        WINDOWED_VAE_PROFILE_FRAMES,
+        WINDOWED_VAE_WINDOW_RANGE_S,
+        windowed_vae_decode_engine_name,
+        windowed_vae_decode_engine_path,
+        available_windowed_vae_decode_engine,
+        looks_like_dreamvae_engine,
+    )
+
+    assert WINDOWED_VAE_DECODE_NAME == "vae_decode_fp16_3to30s"
+    assert WINDOWED_DREAMVAE_DECODE_NAME == "dreamvae_decode_fp16_3to30s"
+    assert WINDOWED_VAE_PROFILE_FRAMES == (75, 125, 750)
+    assert WINDOWED_VAE_WINDOW_RANGE_S == (5.0, 30.0)
+
+    assert windowed_vae_decode_engine_name() == "vae_decode_fp16_3to30s"
+    assert windowed_vae_decode_engine_name(dreamvae=True) == "dreamvae_decode_fp16_3to30s"
+
+    std_path = windowed_vae_decode_engine_path()
+    dv_path = windowed_vae_decode_engine_path(dreamvae=True)
+    assert std_path.name.endswith("vae_decode_fp16_3to30s.engine")
+    assert dv_path.name.endswith("dreamvae_decode_fp16_3to30s.engine")
+
+    # Both are built on disk per the previous build steps.
+    assert available_windowed_vae_decode_engine() is not None, \
+        f"std windowed engine missing at {std_path}"
+    assert available_windowed_vae_decode_engine(dreamvae=True) is not None, \
+        f"dreamvae windowed engine missing at {dv_path}"
+
+    # Engine-variant detection by basename. trt_engine_path always
+    # produces .../<name>/<name>.engine so checking the filename is
+    # equivalent to checking the engine variant.
+    assert looks_like_dreamvae_engine("/x/y/dreamvae_decode_fp16_60s/dreamvae_decode_fp16_60s.engine")
+    assert looks_like_dreamvae_engine("dreamvae_decode_fp16_3to30s.engine")
+    assert not looks_like_dreamvae_engine("vae_decode_fp16_60s.engine")
+    assert not looks_like_dreamvae_engine("vae_decode_fp16_3to30s.engine")
+
+    print("[ok] helpers")
+
+
+def test_clamp_window_range():
+    """The clamp applied in StreamVAEDecode.execute and Session.__init__."""
+    from acestep.paths import WINDOWED_VAE_WINDOW_RANGE_S
+    lo, hi = WINDOWED_VAE_WINDOW_RANGE_S
+
+    def clamp(v: float) -> float:
+        if v <= 0:
+            return v   # disable sentinel
+        return max(lo, min(hi, v))
+
+    assert clamp(-1.0) == -1.0     # disable preserved
+    assert clamp(0.0) == 0.0       # disable preserved
+    assert clamp(0.1) == 5.0       # tiny -> floor
+    assert clamp(3.0) == 5.0       # below floor
+    assert clamp(5.0) == 5.0
+    assert clamp(15.0) == 15.0
+    assert clamp(30.0) == 30.0
+    assert clamp(60.0) == 30.0     # above ceiling
+    print("[ok] clamp_window_range")
+
+
+def test_session_imports_clean():
+    """Importing Session must not fail; the new auto-select branch
+    introduces a couple of imports inside the constructor that we want
+    to make sure exist."""
+    from acestep.engine.session import Session  # noqa: F401
+    from acestep.nodes.vae_nodes import StreamVAEDecode  # noqa: F401
+    print("[ok] imports")
+
+
+def test_autoselect_logic_simulation():
+    """Simulate what Session.__init__ does with a fake trt_engines dict
+    so we don't have to load weights. Mirrors the real branch in
+    session.py exactly."""
+    from acestep.paths import (
+        WINDOWED_VAE_WINDOW_RANGE_S,
+        available_windowed_vae_decode_engine,
+        looks_like_dreamvae_engine,
+    )
+
+    def simulate(trt_engines: dict, vae_backend: str, vae_window: float) -> dict:
+        # Clamp.
+        if vae_window > 0:
+            lo, hi = WINDOWED_VAE_WINDOW_RANGE_S
+            vae_window = max(lo, min(hi, vae_window))
+        # Auto-select.
+        if vae_window > 0 and vae_backend == "tensorrt" and "vae_decode" in trt_engines:
+            current = trt_engines["vae_decode"]
+            is_dv = looks_like_dreamvae_engine(current)
+            windowed = available_windowed_vae_decode_engine(dreamvae=is_dv)
+            if windowed is not None and str(windowed) != current:
+                trt_engines = dict(trt_engines)
+                trt_engines["vae_decode"] = str(windowed)
+        return trt_engines, vae_window
+
+    # Case 1: standard 240s + window=15  ->  windowed standard engine.
+    out, w = simulate({"vae_decode": "/x/vae_decode_fp16_240s.engine"},
+                      "tensorrt", 15.0)
+    assert "vae_decode_fp16_3to30s" in out["vae_decode"]
+    assert w == 15.0
+
+    # Case 2: dreamvae 240s + window=8  ->  windowed dreamvae engine.
+    out, w = simulate({"vae_decode": "/x/dreamvae_decode_fp16_240s.engine"},
+                      "tensorrt", 8.0)
+    assert "dreamvae_decode_fp16_3to30s" in out["vae_decode"]
+    assert w == 8.0
+
+    # Case 3: window=0 -> no swap.
+    src = {"vae_decode": "/x/vae_decode_fp16_240s.engine"}
+    out, w = simulate(src, "tensorrt", 0.0)
+    assert out["vae_decode"] == src["vae_decode"]
+    assert w == 0.0
+
+    # Case 4: window=-1 -> no swap (disable sentinel preserved).
+    out, w = simulate({"vae_decode": "/x/vae_decode_fp16_240s.engine"},
+                      "tensorrt", -1.0)
+    assert "fp16_240s" in out["vae_decode"]
+    assert w == -1.0
+
+    # Case 5: vae_backend != tensorrt -> no swap.
+    src = {"vae_decode": "/x/vae_decode_fp16_240s.engine"}
+    out, w = simulate(src, "eager", 10.0)
+    assert out["vae_decode"] == src["vae_decode"]
+
+    # Case 6: window above max -> clamp to 30, swap applied.
+    out, w = simulate({"vae_decode": "/x/vae_decode_fp16_240s.engine"},
+                      "tensorrt", 999.0)
+    assert w == 30.0
+    assert "3to30s" in out["vae_decode"]
+
+    print("[ok] autoselect_logic_simulation")
+
+
+def test_find_best_vae_engine_accepts_dreamvae():
+    """Pre-existing bug: lookup must match both vae_decode_* and
+    dreamvae_decode_* for the same 'vae_decode' component, otherwise
+    sessions with fast_vae or windowed dreamvae crash at runtime when
+    they fall back to PyTorch and the VAE weights were skipped."""
+    from acestep.nodes import vae_nodes
+
+    saved = dict(vae_nodes._trt_vae_cache)
+    try:
+        vae_nodes._trt_vae_cache.clear()
+        vae_nodes._trt_vae_cache["/x/dreamvae_decode_fp16_3to30s/dreamvae_decode_fp16_3to30s.engine"] = object()
+        vae_nodes._trt_vae_cache["/x/vae_encode_fp16_60s/vae_encode_fp16_60s.engine"] = object()
+
+        decode_hit = vae_nodes._find_best_vae_engine("vae_decode")
+        assert decode_hit is not None and "dreamvae_decode" in decode_hit, \
+            f"vae_decode lookup failed to match dreamvae path: {decode_hit!r}"
+
+        encode_hit = vae_nodes._find_best_vae_engine("vae_encode")
+        assert encode_hit is not None and "vae_encode" in encode_hit
+        # Must not return a dreamvae_decode entry under encode lookup.
+        assert "dreamvae_decode" not in encode_hit
+
+        # Also verify the standard (non-dreamvae) decode path still matches.
+        vae_nodes._trt_vae_cache.clear()
+        vae_nodes._trt_vae_cache["/x/vae_decode_fp16_3to30s/vae_decode_fp16_3to30s.engine"] = object()
+        std_hit = vae_nodes._find_best_vae_engine("vae_decode")
+        assert std_hit is not None and "vae_decode_fp16_3to30s" in std_hit
+    finally:
+        vae_nodes._trt_vae_cache.clear()
+        vae_nodes._trt_vae_cache.update(saved)
+    print("[ok] find_best_vae_engine_accepts_dreamvae")
+
+
+def test_streamvae_param_spec():
+    """Param spec in StreamVAEDecode reflects the new bounds."""
+    from acestep.nodes.vae_nodes import StreamVAEDecode
+
+    defn = StreamVAEDecode.get_definition()
+    params = {p.name: p for p in defn.params}
+    win = params["vae_window"]
+    assert win.min == 0.0
+    assert win.max == 30.0
+    assert win.default == 5.0
+    print("[ok] streamvae_param_spec")
+
+
+if __name__ == "__main__":
+    test_helpers()
+    test_clamp_window_range()
+    test_session_imports_clean()
+    test_autoselect_logic_simulation()
+    test_find_best_vae_engine_accepts_dreamvae()
+    test_streamvae_param_spec()
+    print("\nAll smoke tests passed.")


### PR DESCRIPTION
if windowed vae decode is active, we can mix engine profiles for the decoder and the vae and allow for longer songs. Depending on the amount of vram that is actually consumed by the decoder. So conceivably we could have

vae encoder: 240s (seldom runs in this setup)
dit decoder: 240s
vae decoder:  3-30 seconds

3-30 engine is now added to the build profile and automatically selected when caller uses vae-window. 

additionally, 5>= vae windows <= 30 is enforced