### PR TITLE
fix: lift song limit in demo

### DIFF
--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -337,7 +337,7 @@ def handle_client(
         tags=prompt,
         instruction=TASK_INSTRUCTIONS["cover"],
         refer_latent=source.latent,
-        bpm=detected_bpm, duration=60.0, key=detected_key,
+        bpm=detected_bpm, duration=audio_duration_s, key=detected_key,
     )
 
     print("[Server] Creating stream...")
@@ -419,6 +419,7 @@ def handle_client(
     source_ref = [source]
     bpm_ref = [detected_bpm]
     key_ref = [detected_key]
+    duration_ref = [audio_duration_s]
     n_channels_ref = [n_channels]
 
     # Client mirror: tracks what audio the client currently has. Replaced
@@ -557,7 +558,7 @@ def handle_client(
                                 tags=data["tags"],
                                 instruction=TASK_INSTRUCTIONS["cover"],
                                 refer_latent=source_ref[0].latent,
-                                bpm=bpm_ref[0], duration=60.0,
+                                bpm=bpm_ref[0], duration=duration_ref[0],
                                 key=data.get("key") or key_ref[0],
                             )
                             stream.conditioning = cond
@@ -660,12 +661,16 @@ def handle_client(
                 new_samples, new_channels,
             )
             new_wf = torch.from_numpy(new_np.T.copy())
-            new_wf = new_wf[:2, :int(60.0 * SAMPLE_RATE)]
+            # Cap at the same ceiling the initial upload used so swaps
+            # take advantage of every built engine profile, not a stale
+            # 60 s default.
+            new_wf = new_wf[:2, :int(max_seconds * SAMPLE_RATE)]
             rem = new_wf.shape[-1] % pool
             if rem:
                 new_wf = new_wf[:, :new_wf.shape[-1] - rem]
+            new_audio_duration_s = new_wf.shape[1] / SAMPLE_RATE
             print(
-                f"[Server] Swapping source ({new_wf.shape[1] / SAMPLE_RATE:.1f}s, "
+                f"[Server] Swapping source ({new_audio_duration_s:.1f}s, "
                 f"{new_wf.shape[0]}ch)..."
             )
 
@@ -682,7 +687,7 @@ def handle_client(
                 tags=tags,
                 instruction=TASK_INSTRUCTIONS["cover"],
                 refer_latent=new_source.latent,
-                bpm=new_bpm, duration=60.0,
+                bpm=new_bpm, duration=new_audio_duration_s,
                 key=requested_key or new_key,
             )
 
@@ -692,6 +697,7 @@ def handle_client(
             source_ref[0] = new_source
             bpm_ref[0] = new_bpm
             key_ref[0] = new_key
+            duration_ref[0] = new_audio_duration_s
             prompt_text[0] = tags
             r = runner_holder[0]
             if r is not None:

--- a/demos/realtime_motion_graph_web/pipeline.py
+++ b/demos/realtime_motion_graph_web/pipeline.py
@@ -328,7 +328,16 @@ class PipelineRunner:
 
                 if not skipped:
                     t1 = time.perf_counter()
-                    eff_dur = self.crop_seconds if self.crop_seconds > 0 else 60.0
+                    # eff_dur clamps the windowed-decode playhead so the
+                    # window stays inside the latent. Falling back to a
+                    # hardcoded 60 s would re-introduce the truncation
+                    # bug we're fixing — read it from the live source
+                    # latent (25 fps) so it tracks source swaps and any
+                    # duration the engine matrix actually supports.
+                    eff_dur = (
+                        self.crop_seconds if self.crop_seconds > 0
+                        else self.stream.source.latent.tensor.shape[1] / 25.0
+                    )
                     if self.vae_window > 0:
                         t_pos = self.audio_eng.position / SAMPLE_RATE
                         max_t = max(0.0, eff_dur - self.vae_window)

--- a/demos/realtime_motion_graph_web/static/app.js
+++ b/demos/realtime_motion_graph_web/static/app.js
@@ -420,7 +420,10 @@ async function decodeAudioBuffer(arrayBuf) {
   const rendered = await offline.startRendering();
 
   let frames = rendered.length;
-  frames = Math.min(frames, Math.floor(60.0 * SAMPLE_RATE));
+  // Cap at the largest engine profile the server is built for (240 s).
+  // The server applies the same cap via max_profile_duration_s(); a
+  // client cap shorter than that just truncates uploads needlessly.
+  frames = Math.min(frames, Math.floor(240.0 * SAMPLE_RATE));
   const pool = 1920 * 5;
   frames = frames - (frames % pool);
 


### PR DESCRIPTION
this fixes the demo to handle longer input songs rather than truncate to 60 seconds