### PR TITLE
demos/realtime_motion_graph_web: Next.js app with inlined React UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,11 @@ eggs/
 .eggs/
 lib/
 lib64/
+# The Python "lib/" rule above is from the cookiecutter Python .gitignore;
+# whitelist the realtime_motion_graph_web Next.js demo's lib/ tree (audio
+# encoders, etc.) so the React UI source tracks normally.
+!demos/realtime_motion_graph_web/web/lib/
+!demos/realtime_motion_graph_web/web/lib/**
 parts/
 sdist/
 var/

--- a/demos/realtime_motion_graph_web/README.md
+++ b/demos/realtime_motion_graph_web/README.md
@@ -24,7 +24,32 @@ WebSocket server runs the GPU pipeline alongside the browser client:
   support are optional. HTTPS is *not* required because the server
   binds on the same origin as the WebSocket endpoint.
 
-## Run
+## Run (Next.js front-end)
+
+The recommended layout runs the Python backend on `:8765` and a Next.js
+dev server on `:3000`. A single launcher starts both with combined output:
+
+```bash
+uv run python -u -m demos.realtime_motion_graph_web.run
+# forward backend args after `--`:
+uv run python -u -m demos.realtime_motion_graph_web.run -- --accel eager
+```
+
+First run installs `web/node_modules` automatically (Node.js 20+ required).
+Open `http://localhost:3000`. Next.js rewrites `/api/*`, `/fixtures/*`,
+`/loras/*`, and `/videos/*` to the backend at `:8765`; the WebSocket
+URL comes from `NEXT_PUBLIC_POD_BASE_URL` (set by the launcher).
+
+The full UI lives under `web/` (React + zustand, mirrored from the
+internal `daydreamlive/demon-react` package). See `web/components/`,
+`web/engine/`, `web/hooks/`, and `web/store/` for the source.
+
+## Run (legacy single-port server)
+
+The original `python -m demos.realtime_motion_graph_web` entry still
+works and serves the older vanilla-JS client out of `static/` on the
+same port as the WebSocket. Useful for Vast.ai-style single-port
+deploys where binding two ports isn't an option.
 
 From the remote 5090 box (the machine with the GPU):
 

--- a/demos/realtime_motion_graph_web/run.py
+++ b/demos/realtime_motion_graph_web/run.py
@@ -60,19 +60,26 @@ def _tee(stream: IO[bytes], label: str) -> None:
         print(f"{prefix} {line}", flush=True)
 
 
-def _ensure_node_modules() -> None:
-    if (WEB_DIR / "node_modules").is_dir():
-        return
-    if shutil.which("npm") is None:
+def _resolve_npm() -> str:
+    # On Windows `npm` is `npm.cmd`; subprocess without shell=True only
+    # resolves `.exe` via CreateProcess, so we look it up explicitly.
+    npm = shutil.which("npm")
+    if npm is None:
         sys.exit(
             "npm not found on PATH. Install Node.js 20+ "
             "(https://nodejs.org) and re-run."
         )
+    return npm
+
+
+def _ensure_node_modules(npm: str) -> None:
+    if (WEB_DIR / "node_modules").is_dir():
+        return
     print(
         f"{_PREFIXES['web']} node_modules missing — running `npm install`...",
         flush=True,
     )
-    rc = subprocess.call(["npm", "install"], cwd=WEB_DIR)
+    rc = subprocess.call([npm, "install"], cwd=WEB_DIR)
     if rc != 0:
         sys.exit(f"npm install exited with {rc}")
 
@@ -107,8 +114,9 @@ def main() -> int:
     if backend_extras and backend_extras[0] == "--":
         backend_extras = backend_extras[1:]
 
+    npm = _resolve_npm()
     if not args.no_install:
-        _ensure_node_modules()
+        _ensure_node_modules(npm)
 
     backend_cmd = [
         sys.executable,
@@ -121,7 +129,7 @@ def main() -> int:
         str(args.port),
         *backend_extras,
     ]
-    web_cmd = ["npm", "run", "dev", "--", "-p", str(args.web_port)]
+    web_cmd = [npm, "run", "dev", "--", "-p", str(args.web_port)]
 
     web_env = os.environ.copy()
     web_env["NEXT_PUBLIC_POD_BASE_URL"] = f"http://{args.host}:{args.port}"
@@ -129,6 +137,12 @@ def main() -> int:
     print(f"{_PREFIXES['backend']} {' '.join(backend_cmd)}", flush=True)
     print(
         f"{_PREFIXES['web']} (cwd={WEB_DIR}) {' '.join(web_cmd)}",
+        flush=True,
+    )
+    banner = _color("\x1b[1;32m")
+    print(
+        f"\n{banner}>>> Open http://localhost:{args.web_port}/ "
+        f"(NOT :{args.port} — that's the legacy static UI){_RESET}\n",
         flush=True,
     )
 

--- a/demos/realtime_motion_graph_web/run.py
+++ b/demos/realtime_motion_graph_web/run.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Launch the realtime motion-graph demo: Python backend + Next.js frontend.
+
+Spawns two child processes and tees their output with a `[backend]` /
+`[web]` prefix so a single terminal shows both. Ctrl-C cleanly tears
+both down.
+
+Backend defaults to ``--host 127.0.0.1 --port 8765``. The Next.js dev
+server uses ``next dev`` on the default port (3000); the rewrites in
+``web/next.config.ts`` proxy ``/api/*``, ``/fixtures/*``, ``/loras/*``,
+and ``/videos/*`` to the backend on 8765.
+
+Run from the repo root::
+
+    python -u -m demos.realtime_motion_graph_web.run
+
+or directly::
+
+    python -u demos/realtime_motion_graph_web/run.py
+
+Pass any backend args after ``--``::
+
+    python -u -m demos.realtime_motion_graph_web.run -- --accel eager
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import IO
+
+
+WEB_DIR = Path(__file__).parent / "web"
+ROOT_DIR = Path(__file__).resolve().parents[2]
+
+
+# ANSI dim/colour helpers for prefixing combined output. Falls back to no
+# colour if stdout isn't a TTY (CI logs, redirected output).
+def _color(code: str) -> str:
+    return code if sys.stdout.isatty() else ""
+
+
+_RESET = _color("\x1b[0m")
+_PREFIXES = {
+    "backend": _color("\x1b[36m") + "[backend]" + _RESET,
+    "web": _color("\x1b[35m") + "[web]    " + _RESET,
+}
+
+
+def _tee(stream: IO[bytes], label: str) -> None:
+    prefix = _PREFIXES[label]
+    for raw in iter(stream.readline, b""):
+        line = raw.decode("utf-8", errors="replace").rstrip("\n")
+        print(f"{prefix} {line}", flush=True)
+
+
+def _ensure_node_modules() -> None:
+    if (WEB_DIR / "node_modules").is_dir():
+        return
+    if shutil.which("npm") is None:
+        sys.exit(
+            "npm not found on PATH. Install Node.js 20+ "
+            "(https://nodejs.org) and re-run."
+        )
+    print(
+        f"{_PREFIXES['web']} node_modules missing — running `npm install`...",
+        flush=True,
+    )
+    rc = subprocess.call(["npm", "install"], cwd=WEB_DIR)
+    if rc != 0:
+        sys.exit(f"npm install exited with {rc}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the demo backend + Next.js frontend together.",
+        epilog=(
+            "Anything after `--` is forwarded to the backend "
+            "(e.g. `-- --accel eager`)."
+        ),
+    )
+    parser.add_argument("--port", type=int, default=8765, help="Backend port.")
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Backend bind host (default 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--web-port",
+        type=int,
+        default=3000,
+        help="Next.js dev port (default 3000).",
+    )
+    parser.add_argument(
+        "--no-install",
+        action="store_true",
+        help="Skip the `npm install` check.",
+    )
+    args, backend_extras = parser.parse_known_args()
+    # `--` separator is preserved by parse_known_args; strip it if present.
+    if backend_extras and backend_extras[0] == "--":
+        backend_extras = backend_extras[1:]
+
+    if not args.no_install:
+        _ensure_node_modules()
+
+    backend_cmd = [
+        sys.executable,
+        "-u",
+        "-m",
+        "demos.realtime_motion_graph_web",
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        *backend_extras,
+    ]
+    web_cmd = ["npm", "run", "dev", "--", "-p", str(args.web_port)]
+
+    web_env = os.environ.copy()
+    web_env["NEXT_PUBLIC_POD_BASE_URL"] = f"http://{args.host}:{args.port}"
+
+    print(f"{_PREFIXES['backend']} {' '.join(backend_cmd)}", flush=True)
+    print(
+        f"{_PREFIXES['web']} (cwd={WEB_DIR}) {' '.join(web_cmd)}",
+        flush=True,
+    )
+
+    backend = subprocess.Popen(
+        backend_cmd,
+        cwd=ROOT_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    web = subprocess.Popen(
+        web_cmd,
+        cwd=WEB_DIR,
+        env=web_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    threads = [
+        threading.Thread(
+            target=_tee, args=(backend.stdout, "backend"), daemon=True
+        ),
+        threading.Thread(target=_tee, args=(web.stdout, "web"), daemon=True),
+    ]
+    for t in threads:
+        t.start()
+
+    # Forward SIGINT/SIGTERM to children, then wait. The first child to
+    # die brings the other down too — keeps the terminal honest about
+    # whether either side crashed.
+    def _shutdown(_signum=None, _frame=None) -> None:
+        for proc in (web, backend):
+            if proc.poll() is None:
+                try:
+                    proc.terminate()
+                except ProcessLookupError:
+                    pass
+
+    signal.signal(signal.SIGINT, _shutdown)
+    signal.signal(signal.SIGTERM, _shutdown)
+
+    rc = 0
+    try:
+        while True:
+            be = backend.poll()
+            we = web.poll()
+            if be is not None or we is not None:
+                rc = (be if be is not None else we) or 0
+                break
+            try:
+                backend.wait(timeout=0.5)
+            except subprocess.TimeoutExpired:
+                continue
+    finally:
+        _shutdown()
+        for proc in (backend, web):
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos/realtime_motion_graph_web/web/.env.development
+++ b/demos/realtime_motion_graph_web/web/.env.development
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_POD_BASE_URL=http://localhost:8765

--- a/demos/realtime_motion_graph_web/web/.env.local.example
+++ b/demos/realtime_motion_graph_web/web/.env.local.example
@@ -1,0 +1,4 @@
+# Engine WebSocket base URL. The HTTP routes (/api/*, /fixtures/*, /loras/*,
+# /videos/*) are proxied by next.config.ts rewrites so they don't need an env
+# var, but the WebSocket connection bypasses Next.js entirely.
+NEXT_PUBLIC_POD_BASE_URL=http://localhost:8765

--- a/demos/realtime_motion_graph_web/web/.gitignore
+++ b/demos/realtime_motion_graph_web/web/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.next/
+out/
+*.tsbuildinfo
+next-env.d.ts
+.env.local
+.DS_Store
+*.log

--- a/demos/realtime_motion_graph_web/web/app/RTMGBoot.tsx
+++ b/demos/realtime_motion_graph_web/web/app/RTMGBoot.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { setEngineUrlBuilder } from "@/engine/rtmgConfig";
+
+// Same-origin URL builder. The engine's HTTP routes (/api/*, /fixtures/*,
+// /loras/*, /videos/*) are proxied to the Python backend at :8765 by the
+// Next.js rewrites in next.config.ts. The WebSocket URL goes through
+// `defaultWsUrl()` which reads NEXT_PUBLIC_POD_BASE_URL — set in .env.local.
+//
+// Configured at module load (top-level, not in useEffect) so it's ready
+// before any child component's mount-time fetch fires.
+setEngineUrlBuilder((path) => (path.startsWith("/") ? path : `/${path}`));
+
+export function RTMGBoot() {
+  return null;
+}

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1,0 +1,3765 @@
+/* ============================================================================
+   tokens.css — design tokens for the Daydream Music installation.
+
+   Single source of truth for the look-and-feel. Change a value here and the
+   whole UI re-themes; nothing in style.css should hardcode a color or radius
+   that has a token below.
+
+   Loaded before style.css in index.html so every rule downstream can resolve
+   var(--*) references.
+   ============================================================================ */
+:root {
+
+  /* ── Surfaces ─────────────────────────────────────────────────────── */
+  --bg:            #000000;   /* page background, behind the HUD frame */
+  --frame:         #0d0d14;   /* HUD edge bars + opaque dark surfaces  */
+  --frame-line:    #20202c;   /* dividers between frame and content    */
+  --sheet-bg:      #0a0a12;   /* advanced sheet background             */
+  --input-bg:      #06060b;   /* text inputs, ws-url field             */
+  --overlay-bg:    rgba(6, 6, 12, 0.85);   /* play-button overlay      */
+
+  /* ── Text ─────────────────────────────────────────────────────────── */
+  --text:          #d6d6e0;   /* primary text                          */
+  --text-strong:   #e6e6ee;   /* headings, slider thumbs               */
+  --text-dim:      #6e6e7c;   /* labels, secondary info                */
+
+  /* ── Daydream gradient (sampled from icon_1024x1024.png) ───────────────
+     Four-stop palette: teal → mustard → orange → coral. Used by ribbons,
+     slider fills, the topnav avatar, and the modal accent line. The
+     orange stop (--dd-3) is promoted to --accent so every existing rule
+     re-themes from one place. */
+  --dd-1:           #3db6be;   /* teal       (top stop)        */
+  --dd-2:           #c7b566;   /* mustard    (35%)             */
+  --dd-3:           #f08a48;   /* orange     (70%, accent)     */
+  --dd-4:           #e84f3d;   /* coral red  (bottom)          */
+  --dd-gradient:    linear-gradient(180deg,
+                      var(--dd-1) 0%,
+                      var(--dd-2) 35%,
+                      var(--dd-3) 70%,
+                      var(--dd-4) 100%);
+
+  /* Accent role mappings — orange. Touch every slider, button, focus
+     ring, MIDI badge, and the cursor by re-tinting these six tokens. */
+  --accent:         #f08a48;
+  --accent-hover:   #f4a56a;
+  --accent-soft:    rgba(240, 138, 72, 0.08);   /* hover backgrounds   */
+  --accent-medium:  rgba(240, 138, 72, 0.18);   /* active backgrounds  */
+  --accent-glow:    rgba(240, 138, 72, 0.45);   /* shadow halos        */
+  --accent-line:    rgba(240, 138, 72, 0.35);   /* gradient endpoints  */
+
+  /* ── Status (distinct from accent so warnings stay legible) ───────── */
+  --warn:          #ffcc00;
+  --critical:      #ff5050;
+
+  /* ── Geometry ─────────────────────────────────────────────────────── */
+  --hud-thickness: clamp(56px, 6vmin, 90px);
+  --radius-sm:     4px;
+  --radius-md:     6px;
+  --radius-lg:     8px;
+
+  /* ── HUD tint ─────────────────────────────────────────────────────────
+     Viewport-edge darkening that anchors the bar zones without drawing a
+     hard line. Applied as a single inset shadow on the stage (in style.css)
+     so there are no seams between bars. Heavier alpha = more "framed";
+     lighter = the whole stage dissolves into the ambient. */
+  --hud-tint-strong: rgba(4, 4, 8, 0.85);
+
+  /* ── Source aspect ────────────────────────────────────────────────────
+     Aspect ratio (W:H) of the centerpiece source video. The focal wrapper
+     is height-bound to the viewport; this token drives its width. The
+     current source (combined.mp4) is 1920×1080 outpainted from a 1440²
+     original, so 16:9. If the source is replaced again, update here.
+     Wrapper extends beyond viewport at very wide values; #install-video-
+     area's overflow:hidden clips it, so extreme ratios just lose the
+     outermost (most-outpainted, most-feathered) side content. */
+  --source-aspect: 1.7778;
+
+  /* ── Focal feather (vertical only) ────────────────────────────────────
+     Soft fade at the focal's top/bottom edges, blending into the bar
+     zones. Horizontal sides are handled by --side-blur-* below, not
+     by this feather, so outpainted pixels are blurred *in place*
+     rather than faded out. */
+  --focal-feather-y: 6%;
+
+  /* ── Side blur (covers up outpainted sides) ────────────────────────────
+     Two backdrop-filter overlays sit on the focal's left and right edges
+     and blur the outpainted pixels in place. Width matches the outpaint
+     extent: with --source-aspect 1.7778 the central 1:1 region is 56% of
+     the wrapper, so each side is (100% - 56%) / 2 ≈ 22%. Each overlay
+     fades to transparent at its inner edge so the blur ramps smoothly to
+     zero at the boundary of the central square. */
+  --side-blur-amount: 60px;
+  --side-blur-width:  22%;
+
+  /* ── Type ─────────────────────────────────────────────────────────── */
+  --font-mono:     "SF Mono", "Monaco", "Consolas", monospace;
+  --tracking-wide: 0.3em;
+  --tracking-bar:  0.4em;
+}
+/* ============================================================================
+   style.css — Daydream Music installation.
+
+   All colors, radii, and spacing tokens come from tokens.css. Nothing in this
+   file should hardcode a brand color or a magic radius — if a value isn't
+   semantic to the rule (e.g. a thumb's pixel size), it stays inline; if it's
+   part of the design language, it goes through a token. Change tokens.css to
+   re-theme.
+
+   Layout: full-bleed video framed by four HUD edge bars + a slide-in Advanced
+   sheet on the right. No timer, no expiry — runs indefinitely.
+   ============================================================================ */
+
+/* ── Reset + base ────────────────────────────────────────────────────────── */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+               "Helvetica Neue", Arial, sans-serif;
+  overflow: hidden;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.hidden { display: none !important; }
+
+/* Hide the OS cursor only inside the Performance surface — useCursor
+   adds `body.cursor-hidden` while it's mounted, and removes it on
+   unmount. Admin pages, 404, and any non-Performance shell keep the
+   normal pointer. Modals ([role="dialog"]) override below so users
+   inside config/mobile-sheet/upload prompts can see their cursor. */
+body.cursor-hidden,
+body.cursor-hidden * {
+  cursor: none !important;
+}
+body.cursor-hidden [role="dialog"],
+body.cursor-hidden [role="dialog"] *,
+/* Next.js dev overlay (compile errors, build issues panel) lives inside
+   a custom <nextjs-portal> element with no [role="dialog"] — without an
+   explicit exception the OS cursor disappears the moment the dev panel
+   opens. Production has no <nextjs-portal>, so this rule is dev-only by
+   construction. */
+body.cursor-hidden nextjs-portal,
+body.cursor-hidden nextjs-portal * {
+  cursor: auto !important;
+}
+
+/* Custom cursor — palette-colored particle constellation + precise white
+   centre dot, all rendered into a single 2D canvas so the entire effect
+   is one composited GPU layer. Previous implementation stacked DOM divs
+   with box-shadow + mix-blend-mode: plus-lighter, which Gecko fell back
+   on software for during slider drags. cursor.ts drives drawImage from
+   pre-rasterised radial-gradient sprites + globalCompositeOperation =
+   "lighter" — both engines hardware-composite that path.
+
+   body.cursor-idle fades the canvas via opacity (HW-accelerated) on the
+   existing 2s idle timer. */
+.cursor-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  /* Above any full-screen overlay (QueueScene, PaywallSignedIn at z 100)
+     so the orbit + confetti remain visible while those scenes are up. */
+  z-index: 111;
+  opacity: 1;
+  transition: opacity 280ms cubic-bezier(.2, .8, .2, 1);
+}
+
+body.cursor-idle .cursor-canvas { opacity: 0; }
+
+/* ── Performance screen + Play overlay ───────────────────────────────────── */
+#performance {
+  position: fixed;
+  inset: 0;
+}
+
+#start-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--overlay-bg);
+  z-index: 20;
+}
+
+/* The brand mark IS the play button. No separate CTA on the title screen —
+   the icon halo and the "click/tap to begin" whisper sit inside ONE
+   <button> so anywhere on either is a hit target (testers kept clicking
+   the copy itself). The button is a flex column, button chrome reset, the
+   halo on top, the whisper beneath. */
+.start-cta {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  padding: 18px 40px 24px;
+  margin: 0;
+  background: transparent;
+  border: none;
+  border-radius: 24px;
+  cursor: pointer;
+  user-select: none;
+  appearance: none;
+  -webkit-appearance: none;
+  transition: transform 220ms cubic-bezier(.2, .8, .2, 1),
+              filter 220ms;
+}
+.start-cta:hover:not(:disabled) {
+  transform: translate(-50%, -50%) scale(1.05);
+  filter: brightness(1.18) saturate(1.1);
+}
+.start-cta:active:not(:disabled) {
+  transform: translate(-50%, -50%) scale(0.97);
+}
+.start-cta:focus-visible {
+  outline: none;
+  filter: brightness(1.2) saturate(1.1)
+          drop-shadow(0 0 12px rgba(255, 255, 255, 0.5));
+}
+.start-cta:disabled {
+  cursor: default;
+}
+
+/* Halo container — holds the SVG ribbons + the daydream icon. Sized to
+   give the writhing ribbons room to bloom outside their nominal radius. */
+.start-cta-halo {
+  position: relative;
+  display: block;
+  width: clamp(180px, 22vmin, 260px);
+  height: clamp(180px, 22vmin, 260px);
+  pointer-events: none;
+}
+.start-mark {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: clamp(48px, 6vmin, 72px);
+  height: auto;
+  opacity: 0.95;
+  z-index: 1;
+  pointer-events: none;
+  transition: opacity 200ms;
+}
+.start-cta:hover .start-mark { opacity: 1; }
+.start-mark-ribbons {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: visible;
+  /* Soft white bloom to lift the ribbons off the dark overlay without
+     overpowering the calm title-screen mood. */
+  filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.42));
+  z-index: 0;
+  transition: filter 220ms;
+}
+.start-cta:hover .start-mark-ribbons {
+  filter: drop-shadow(0 0 14px rgba(255, 255, 255, 0.65));
+}
+.start-mark-ribbons path {
+  fill: none;
+  stroke-width: 2.6px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.88;
+  vector-effect: non-scaling-stroke;
+}
+
+/* Whisper line beneath the icon — quiet mono caps. Lives inside the same
+   <button> as the halo, so a click on the copy fires onPlay too. */
+.start-whisper {
+  font-family: var(--font-mono);
+  font-size: 0.72em;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.4);
+  white-space: nowrap;
+  animation: start-whisper-breathe 2.6s ease-in-out infinite;
+}
+@keyframes start-whisper-breathe {
+  0%, 100% { opacity: 0.45; }
+  50%      { opacity: 0.85; }
+}
+
+/* ── Launch transition ─────────────────────────────────────────────────────
+   Keep this aligned with LAUNCH_DURATION_MS in StartOverlay.tsx (700ms).
+   On click: a brief anticipation squash, then the ribbons spin + scale
+   outward dramatically while the icon zooms forward and everything fades
+   to black. Each layer uses just two segments (anticipation → release)
+   with a single smooth cubic-bezier so the easing curve doesn't have to
+   thread through a mid-flight keyframe stop — that's what was producing
+   the visible stutter at the 60% mark in the previous version. */
+.start-cta.start-cta--launching {
+  animation: start-cta-launch 700ms cubic-bezier(.4, 0, .65, .25) forwards;
+  pointer-events: none;
+}
+.start-cta.start-cta--launching .start-mark-ribbons {
+  animation: start-ribbons-explode 700ms cubic-bezier(.4, 0, .65, .25) forwards;
+}
+.start-cta.start-cta--launching .start-mark {
+  animation: start-mark-zoom 700ms cubic-bezier(.4, 0, .65, .25) forwards;
+}
+.start-cta.start-cta--launching .start-whisper {
+  animation: start-whisper-vanish 240ms ease forwards;
+}
+
+@keyframes start-cta-launch {
+  0%   { transform: translate(-50%, -50%) scale(1)    rotate(0deg);  opacity: 1; }
+  20%  { transform: translate(-50%, -50%) scale(0.94) rotate(-8deg); opacity: 1; }
+  100% { transform: translate(-50%, -50%) scale(1.06) rotate(8deg);  opacity: 0; }
+}
+@keyframes start-ribbons-explode {
+  0%   { transform: scale(1)    rotate(0deg);   opacity: 0.88; }
+  20%  { transform: scale(0.92) rotate(-25deg); opacity: 1; }
+  100% { transform: scale(4)    rotate(680deg); opacity: 0; }
+}
+@keyframes start-mark-zoom {
+  0%   { transform: translate(-50%, -50%) scale(1);    opacity: 0.95; }
+  20%  { transform: translate(-50%, -50%) scale(0.88); opacity: 1; }
+  100% { transform: translate(-50%, -50%) scale(2.4);  opacity: 0; }
+}
+@keyframes start-whisper-vanish {
+  to { opacity: 0; transform: translateY(8px); }
+}
+
+
+/* ── Queue scene status strip ──────────────────────────────────────────
+   Bottom-of-screen status during the queued spotlight. Matches the
+   .start-whisper design language so the title→queue→stage arc reads as
+   one continuous typography system. */
+.qs-status-text,
+.qs-status-link,
+.qs-status-cta {
+  font-family: var(--font-mono);
+  font-size: 0.72em;
+  letter-spacing: 0.32em;
+  font-weight: 500;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.qs-status-text {
+  color: rgba(255, 255, 255, 0.42);
+  animation: start-whisper-breathe 2.6s ease-in-out infinite;
+}
+.qs-status-dot {
+  color: rgba(255, 255, 255, 0.22);
+  font-size: 0.72em;
+}
+.qs-status-link {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.55);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  transition: color 180ms cubic-bezier(.2, .8, .2, 1);
+}
+.qs-status-link:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+.qs-status-cta {
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  padding: 7px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  color: var(--accent-hover);
+  box-shadow: 0 0 14px var(--accent-glow);
+  transition:
+    background-color 180ms cubic-bezier(.2, .8, .2, 1),
+    color 180ms cubic-bezier(.2, .8, .2, 1),
+    box-shadow 180ms cubic-bezier(.2, .8, .2, 1),
+    transform 140ms cubic-bezier(.2, .8, .2, 1);
+}
+.qs-status-cta:hover {
+  background: var(--accent-medium);
+  color: #ffe6cf;
+  box-shadow: 0 0 22px var(--accent-glow);
+  transform: scale(1.04);
+}
+.qs-status-cta:active {
+  transform: scale(0.99);
+}
+
+
+/* ============================================================================
+   Stage — full-bleed video framed by four HUD edge bars. In graph mode,
+   when the Advanced drawer is open, the stage's bottom is pushed up so the
+   entire interface (HUD edges, graph, everything) shrinks above the drawer
+   instead of being overlaid by it. The transition matches the drawer slide
+   so the resize lands at the same time the drawer arrives. In video mode
+   (or when the drawer is closed) the stage stays full-bleed.
+   ============================================================================ */
+#install-stage {
+  position: fixed;
+  inset: 0;
+  transition: bottom 320ms cubic-bezier(.2, .7, .2, 1);
+}
+body[data-mode="graph"].drawer-open #install-stage {
+  bottom: var(--drawer-h);
+}
+
+/* Single inset shadow that darkens the viewport perimeter. Reach equals
+   the bar thickness so the focal well stays untouched; corners stack the
+   x and y components and read naturally darker than the midpoints. This
+   replaces per-bar background fills, so there are no seams where bars
+   meet at the corners. */
+#install-stage::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 5;
+  box-shadow: inset 0 0 var(--hud-thickness) 0 var(--hud-tint-strong);
+}
+
+/* Full-bleed video area — covers the whole stage. z-index 7 puts the
+   whole video subtree (canvas + side-blurs) above the perimeter HUD
+   bars at z-index 6, so the alpha-keyed canvas can paint the subject
+   (and its bloom halo) over the bars. Transparent regions of the
+   canvas (pure black in the source) leave the bars visible behind. */
+#install-video-area {
+  position: absolute;
+  inset: 0;
+  background: transparent;
+  overflow: hidden;
+}
+
+/* Ambient backdrop hidden — background is pure black so the focal
+   square is the only thing the eye locks onto. */
+#install-ambient { display: none; }
+
+/* Focal video wrapper — height-bound, centered horizontally, width
+   driven by --source-aspect so we use as much of the (possibly out-
+   painted) source as the source actually contains. Vertical feather
+   blends top/bottom into the bar zones; horizontal sides are handled
+   by .focal-side-blur below — the outpainted pixels stay visible but
+   are progressively blurred in place. */
+#install-video-area #video-wrap {
+  position: absolute;
+  top: 0; bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  height: 100%;
+  width: auto;
+  aspect-ratio: var(--source-aspect);
+  z-index: 1;
+  -webkit-mask-image:
+    linear-gradient(to bottom, transparent 0%, black var(--focal-feather-y),
+                    black calc(100% - var(--focal-feather-y)), transparent 100%);
+          mask-image:
+    linear-gradient(to bottom, transparent 0%, black var(--focal-feather-y),
+                    black calc(100% - var(--focal-feather-y)), transparent 100%);
+}
+
+/* Side blur overlays — two strips on the focal's left and right edges
+   that backdrop-blur the outpainted pixels behind them. Each is
+   --side-blur-width wide; the inner edge fades to transparent so the
+   blur ramps smoothly to zero at the boundary of the original 1:1
+   square in the centre. Two separate elements (rather than one with a
+   centre-cut mask) avoids known Chromium issues with combining
+   mask-image and backdrop-filter on a single element. */
+.focal-side-blur {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: var(--side-blur-width);
+  pointer-events: none;
+  -webkit-backdrop-filter: blur(var(--side-blur-amount));
+          backdrop-filter: blur(var(--side-blur-amount));
+}
+/* Non-linear mask: opaque (full blur) for the outer 70% of the overlay,
+   then a quick non-linear falloff in the inner 30% so the outpainted
+   regions are fully obscured rather than fading gradually inward. The
+   curve uses approximated ease-out stops to avoid a visible linear ramp. */
+.focal-side-blur-left {
+  left: 0;
+  -webkit-mask-image: linear-gradient(to right,
+    black 0%,
+    black 70%,
+    rgba(0,0,0,0.85) 80%,
+    rgba(0,0,0,0.55) 88%,
+    rgba(0,0,0,0.20) 95%,
+    transparent 100%);
+          mask-image: linear-gradient(to right,
+    black 0%,
+    black 70%,
+    rgba(0,0,0,0.85) 80%,
+    rgba(0,0,0,0.55) 88%,
+    rgba(0,0,0,0.20) 95%,
+    transparent 100%);
+}
+.focal-side-blur-right {
+  right: 0;
+  -webkit-mask-image: linear-gradient(to right,
+    transparent 0%,
+    rgba(0,0,0,0.20) 5%,
+    rgba(0,0,0,0.55) 12%,
+    rgba(0,0,0,0.85) 20%,
+    black 30%,
+    black 100%);
+          mask-image: linear-gradient(to right,
+    transparent 0%,
+    rgba(0,0,0,0.20) 5%,
+    rgba(0,0,0,0.55) 12%,
+    rgba(0,0,0,0.85) 20%,
+    black 30%,
+    black 100%);
+}
+
+/* Crossfade between video-a and video-b layers (driven by VideoLayer).
+   Source aspect matches the wrapper, so cover/contain are equivalent —
+   cover is kept for resilience if a future video has a different aspect. */
+#video-a, #video-b {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 1.5s ease-in-out;
+}
+
+/* Shader output canvas. Sits above the <video> siblings so the WebGL
+   pipeline's rendered frame is what the audience sees; opaque, so the
+   videos beneath are completely covered while it's up. No z-index on
+   purpose — DOM order is canvas → focal-side-blur, so the backdrop-
+   filter blur strips still sit above the canvas and feather the
+   outpainted gutters of the shader output. Starts at opacity 0 so the
+   raw <video> shows through until the shader pipeline produces its
+   first frame; effects.js adds .effects-ready on the first successful
+   render and the CSS transition crossfades the shader output in,
+   covering the cold-load gap. If effects fail to initialise (no
+   WebGL2, etc.) app.js sets display:none here and the underlying
+   video elements become the permanent fallback. */
+#effects-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  opacity: 0;
+  transition: opacity 500ms ease-out;
+}
+#effects-canvas.effects-ready { opacity: 1; }
+
+/* Legacy HUD canvas always hidden. The graph swaps with the video subtree
+   based on body[data-mode]; default is "graph". */
+#install-video-area #hud { display: none; }
+/* Graph wrap reserves a generous gap past the ribbon canvas + its bloom
+   drop-shadow halo (which can extend ~11 px past the canvas at peak
+   --bloom-amount). Using --hud-thickness as the gap scales the breathing
+   room with the rest of the HUD. */
+#install-video-area #graph-wrap { position: absolute; inset: calc(var(--hud-thickness) * 2 + var(--ribbon-bleed)); z-index: 2; }
+#install-video-area #graph {
+  width: 100%; height: 100%; display: block;
+  /* Stronger feathering: the centered playhead exposes both edges, and
+     the user wants old samples to fade out aggressively as they drift
+     left, plus a softer right-edge entry. Tuned to the canvas width
+     bands (clamps so the feather reads on small + huge viewports). */
+  --graph-feather-x: clamp(80px, 14vw, 220px);
+  --graph-feather-y: 36px;
+  -webkit-mask-image:
+    linear-gradient(to right,  transparent 0, black var(--graph-feather-x), black calc(100% - var(--graph-feather-x)), transparent 100%),
+    linear-gradient(to bottom, transparent 0, black var(--graph-feather-y), black calc(100% - var(--graph-feather-y)), transparent 100%);
+          mask-image:
+    linear-gradient(to right,  transparent 0, black var(--graph-feather-x), black calc(100% - var(--graph-feather-x)), transparent 100%),
+    linear-gradient(to bottom, transparent 0, black var(--graph-feather-y), black calc(100% - var(--graph-feather-y)), transparent 100%);
+  -webkit-mask-composite: source-in;
+          mask-composite: intersect;
+}
+body:not([data-mode="graph"]) #install-video-area #graph-wrap { display: none; }
+/* Title-screen guard: before the user clicks Play, session is idle and
+   the graph + playhead would draw through the start overlay. Hide the
+   whole subtree so the canvas isn't painting under a black screen. */
+body[data-session="idle"] #install-video-area #graph-wrap { display: none; }
+body[data-mode="graph"] #install-video-area #video-wrap,
+body[data-mode="graph"] #install-video-area #effects-canvas,
+body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
+
+/* ── Graph click-to-pause overlay ────────────────────────────────────────
+   Full-bleed transparent button on top of the graph canvas; makes the
+   whole graph area a click target. The centered glyph fades in/out as a
+   transient confirmation when toggled (and once on first ready as a
+   discovery hint — see GraphPauseOverlay.tsx). */
+#install-video-area #graph-wrap .graph-pause-overlay {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  z-index: 3;
+  -webkit-appearance: none;
+  appearance: none;
+}
+#install-video-area #graph-wrap .graph-pause-overlay:focus-visible {
+  outline: none;
+}
+.graph-pause-overlay__glyph {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 96px;
+  height: 96px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--overlay-bg);
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 40px;
+  line-height: 1;
+  letter-spacing: 0;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  pointer-events: none;
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.92);
+  transition:
+    opacity 240ms cubic-bezier(.2, .8, .2, 1),
+    transform 240ms cubic-bezier(.2, .8, .2, 1);
+}
+.graph-pause-overlay.is-flashing .graph-pause-overlay__glyph {
+  opacity: 0.95;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+/* ── Schedule Curves overlay ─────────────────────────────────────────────
+   Full-bleed semi-transparent pane over the graph canvas. The user draws
+   per-param automation curves here against the live track waveform. Sits
+   above .graph-pause-overlay (z=3) — when both could be visible the
+   curves overlay wins. Mounted in #graph-wrap by InstallStage; gated on
+   useCurveStore.overlayOpen.
+
+   Vocabulary: same frosted-glass palette as .halo-menu / .status-bar.
+   The two stacked <canvas>es (waveform underlay + curves) are absolutely
+   positioned and stretch to fill the drawing area; the tab strip pins to
+   the bottom and reserves its own 44px row. */
+.schedule-curves-overlay {
+  /* Viewport-fixed so it claims a full chunk of the screen regardless
+     of where the moving-lines graph (#graph-wrap) sits, and regardless
+     of whether the AdvancedDrawer is open underneath. Z-index above
+     the drawer (z=50) so it covers the drawer when both would overlap.
+     Insets leave room for the top HaloBadge + ribbon bleed; the
+     drawing area below extends as far down as the bottom HUD. */
+  position: fixed;
+  top: 70px;
+  left: 24px;
+  right: 24px;
+  bottom: 24px;
+  z-index: 51;
+  display: flex;
+  flex-direction: column;
+  /* Semi-transparent dark wash, NO backdrop blur — the user wants the
+     moving lines beneath visible at all times. No border / border-radius
+     either; this is a layer over the graph, not a card. */
+  background: rgba(6, 6, 12, 0.32);
+  overflow: hidden;
+}
+
+/* Stacked canvases share the same drawing region (everything above the
+   tabs). The bg canvas paints the waveform silhouette; the foreground
+   canvas paints the curve, control points, and playhead. */
+.schedule-curves-bg,
+.schedule-curves-canvas {
+  position: absolute;
+  inset: 0 0 44px 0;
+  width: 100%;
+  pointer-events: none;
+}
+.schedule-curves-canvas {
+  pointer-events: auto;
+  cursor: crosshair;
+  z-index: 1;
+}
+
+.schedule-curves-tabs {
+  margin-top: auto;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  padding: 6px 8px;
+  background: rgba(6, 6, 12, 0.7);
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  z-index: 2;
+  position: relative;
+}
+
+.schedule-curves-tab {
+  font-family: var(--font-mono);
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  font-size: 0.66em;
+  padding: 6px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.55);
+  border-radius: 3px;
+  cursor: pointer;
+  transition:
+    color 140ms ease,
+    border-color 140ms ease,
+    box-shadow 200ms ease;
+}
+.schedule-curves-tab:hover {
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+.schedule-curves-tab--enabled::after {
+  /* A small dot to the right of the label signals "this curve is
+     actually driving the param right now" — different from "active"
+     (= currently being edited in the canvas). */
+  content: "";
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  margin-left: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 6px rgba(240, 138, 72, 0.6);
+  vertical-align: middle;
+}
+.schedule-curves-tab--active {
+  color: var(--accent);
+  border-color: rgba(240, 138, 72, 0.45);
+  box-shadow: 0 0 12px -4px rgba(240, 138, 72, 0.45);
+}
+
+/* LoRA tabs — same shape as standard tabs but with a subtle violet
+   accent at the start so users can tell them apart from the fixed
+   six. Matches the LoRA-side ribbon palette in the rest of the UI. */
+.schedule-curves-tab--lora {
+  border-left: 2px solid rgba(176, 140, 232, 0.55);
+}
+.schedule-curves-tab--lora.schedule-curves-tab--active {
+  border-left-color: rgba(176, 140, 232, 0.95);
+}
+
+/* Master ON/OFF — kill-switch for ALL curves. Pinned right of the
+   tabs, before the close button. Visually distinct so users notice
+   it: green when active (curves driving), dim grey when paused. */
+.schedule-curves-master {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  font-size: 0.62em;
+  padding: 6px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.55);
+  border-radius: 3px;
+  cursor: pointer;
+  transition:
+    color 140ms ease,
+    border-color 140ms ease,
+    box-shadow 200ms ease;
+}
+.schedule-curves-master:hover {
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+.schedule-curves-master--on {
+  color: rgba(150, 220, 160, 1);
+  border-color: rgba(120, 200, 130, 0.55);
+  box-shadow: 0 0 12px -4px rgba(120, 200, 130, 0.45);
+}
+.schedule-curves-master--on:hover {
+  color: rgba(180, 240, 190, 1);
+}
+
+.schedule-curves-close {
+  /* margin-left: auto used to push us to the right; .schedule-curves-master
+     now owns that auto-margin, so we just sit right of the master toggle. */
+  font-family: var(--font-mono);
+  font-size: 1em;
+  width: 28px;
+  height: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 3px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.schedule-curves-close:hover {
+  color: rgba(255, 255, 255, 0.95);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+/* Preset menu — opens on tab right-click. Frosted-glass card with
+   Enable/Disable + Reset + a list of musical presets. Positioned
+   absolutely relative to the overlay (the component sets x/y inline). */
+.schedule-curves-preset-menu {
+  position: absolute;
+  z-index: 5;
+  min-width: 180px;
+  padding: 6px;
+  background: rgba(6, 6, 12, 0.92);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 4px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.55);
+  /* Cap the height so a tall menu doesn't extend off the top of the
+     overlay. The component anchors the menu at the tab's top edge and
+     grows upward; on narrow viewports the available height shrinks. */
+  max-height: calc(100% - 60px);
+  overflow-y: auto;
+}
+
+.schedule-curves-preset-header {
+  font-family: var(--font-mono);
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  font-size: 0.62em;
+  color: rgba(255, 255, 255, 0.55);
+  padding: 6px 10px 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  margin-bottom: 4px;
+}
+
+.schedule-curves-preset-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  font-family: var(--font-mono);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.66em;
+  padding: 7px 10px;
+  border: 0;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.78);
+  cursor: pointer;
+  border-radius: 3px;
+}
+.schedule-curves-preset-item:hover {
+  background: rgba(240, 138, 72, 0.18);
+  color: rgba(255, 255, 255, 0.98);
+}
+
+.schedule-curves-preset-divider {
+  height: 1px;
+  margin: 4px 6px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* ── HUD edges ───────────────────────────────────────────────────────────── */
+/* Bars are transparent containers for labels + level meters. The viewport
+   edge darkening lives on #install-stage::before instead, so the same
+   ambient image runs continuously through the bar zones. z-index sits
+   above the stage darkening overlay so meters and labels paint cleanly. */
+.install-edge {
+  position: absolute;
+  color: var(--text-dim);
+  font-size: 22px;
+  letter-spacing: var(--tracking-bar);
+  text-transform: uppercase;
+  user-select: none;
+  z-index: 6;
+  --fill: 0;
+}
+.install-edge .install-edge-label {
+  position: absolute;
+  z-index: 2;
+  text-shadow: 0 1px 2px #000;
+}
+/* Thin colored ribbons along each slider edge — see ribbons.js. Sized
+   close to the original 2 px line so they read as a quiet perimeter
+   signal, not a focal element. SVG fills the bar zone and is allowed
+   to bleed slightly into the video gutter for the writhing.
+   vector-effect:non-scaling-stroke so stroke widths are real CSS
+   pixels regardless of viewBox aspect. Stroke-width, opacity, and a
+   soft white halo all grow with --bloom-amount so the perimeter
+   pulses with the shader bloom on the video without drawing
+   attention. White (not amber) — chosen for neutrality so the halo
+   reads as luminance rather than a UI accent color. */
+.install-ribbons {
+  position: absolute;
+  pointer-events: none;
+  overflow: visible;
+  filter: drop-shadow(0 0 calc(1px + var(--bloom-amount, 0) * 10px) rgba(255, 255, 255, 0.55));
+  /* Canvas-rendered (was SVG). Strokes/opacity that used to live in CSS
+     are applied in tickRibbons to mirror the same contract. The canvas
+     extends past the host on the inward edge so the writhing curls that
+     bleed into the central gutter don't get clipped — SVG used overflow:
+     visible to bleed; canvas needs the bitmap to actually extend. The
+     bleed amount is set per-edge below. No will-change: it would clip
+     the canvas to its layer surface and chop the bleed. */
+}
+/* Inward bleed so the writhing curls (which can reach ~30% past the
+   viewBox boundary, plus the arrowhead curl on top of that) don't get
+   clipped by the canvas bitmap. Tied to --hud-thickness so it scales
+   with viewport: 56px host → 28px bleed, 90px host → 45px bleed,
+   which leaves clear headroom for the writhe peak + curl tip. */
+:root {
+  --ribbon-bleed: calc(var(--hud-thickness) * 0.5);
+}
+/* `<canvas>` is a replaced element with an intrinsic 300x150 box; CSS
+   anchor positioning (top/left/right/bottom) won't stretch it like a
+   block. Set explicit width/height so the canvas fills the host PLUS
+   the inward bleed where the writhing curls land. */
+/* Trailing-end fade on the along axis. The writhe path has a hard endpoint
+   at along=0 — without a taper the strokes terminate flush, which reads as
+   a clip. Mask the canvas so the trailing end fades to transparent over
+   --ribbon-tail-fade, with the 0% point landing exactly at the writhe
+   path's endpoint (16 px inside the canvas, matching ALONG_END_INSET_PX
+   in ribbons.ts). The leading end (with the arrowhead curl) stays fully
+   opaque. Per-bar direction:
+     - top   : fade the LEFT  end (leading edge / curl is at the right)
+     - left  : fade the BOTTOM end (leading edge / curl is at the top)
+     - right : fade the BOTTOM end (same flipAlong as left bar) */
+:root {
+  --ribbon-tail-fade: 80px;
+  --ribbon-along-inset: 16px; /* mirrors ALONG_END_INSET_PX in ribbons.ts */
+}
+.install-edge-top .install-ribbons {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: calc(100% + var(--ribbon-bleed));
+  -webkit-mask-image: linear-gradient(to right, transparent var(--ribbon-along-inset), black calc(var(--ribbon-along-inset) + var(--ribbon-tail-fade)), black 100%);
+          mask-image: linear-gradient(to right, transparent var(--ribbon-along-inset), black calc(var(--ribbon-along-inset) + var(--ribbon-tail-fade)), black 100%);
+}
+.install-edge-left .install-ribbons {
+  top: 0;
+  left: 0;
+  width: calc(100% + var(--ribbon-bleed));
+  height: 100%;
+  -webkit-mask-image: linear-gradient(to bottom, black 0, black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
+          mask-image: linear-gradient(to bottom, black 0, black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
+}
+.install-edge-right .install-ribbons {
+  top: 0;
+  /* bleed sits to the LEFT of the host; shift the canvas left by that
+     amount so its right edge stays aligned with the host's right edge
+     (= screen edge). */
+  left: calc(-1 * var(--ribbon-bleed));
+  width: calc(100% + var(--ribbon-bleed));
+  height: 100%;
+  -webkit-mask-image: linear-gradient(to bottom, black 0, black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
+          mask-image: linear-gradient(to bottom, black 0, black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
+}
+.install-edge.install-edge-pulse .install-edge-bar { opacity: 1; }
+.install-edge.install-edge-pulse .install-edge-label {
+  color: var(--text);
+  transition: color 200ms;
+}
+
+/* TOP — fills left → right. Indented by --hud-thickness on each side
+   so the top-left and top-right corners are bare, matching the way
+   the left/right bars stop short of the top/bottom corners. */
+.install-edge-top {
+  top: 0;
+  left: var(--hud-thickness);
+  /* Stop short of the halo badge (which sits at right: hud + 24, width 44 →
+     left edge at hud + 68). 12px gap so the ribbon at fill=1 reads as
+     terminating at the halo without crowding it. */
+  right: calc(var(--hud-thickness) + 80px);
+  height: var(--hud-thickness);
+}
+/* Bias the label down ~5px from the bar's vertical mid-line so it (and
+   the mirrored halo badge) get more breathing room from the very top
+   screen edge. The halo offsets by the same amount via --top-bias below. */
+.install-edge-top .install-edge-label {
+  top: calc(50% + var(--top-bias, 5px));
+  left: 24px;
+  transform: translateY(-50%);
+}
+.install-edge-top .install-edge-bar {
+  bottom: 0; left: 0; height: 2px; width: 100%;
+  transform-origin: left bottom;
+  /* scaleY pulses the bar's thickness with bloom so it visibly fattens on
+     kick rather than just acquiring a halo. */
+  transform: scaleX(var(--fill)) scaleY(calc(1 + var(--bloom-amount, 0) * 3));
+}
+
+/* LEFT + RIGHT — fill bottom → top. The vertical extent is constrained
+   so the side ribbons sit between the corner anchors: HaloBadge (top-right)
+   and Turntable (bottom-right above the bottom HUD bar). The left bar
+   mirrors the same bounds for visual symmetry even though it has no
+   anchored elements on desktop. Math for the bottom inset: turntable bottom
+   is (hud + 24) from viewport bottom, height 70 → bbox top at (hud + 94),
+   plus a ~25px disc drop-shadow + bloom-glow halo above the bbox → visible
+   top at ~(hud + 119), plus 25px breathing room → bar bottom at (hud + 144). */
+.install-edge-left,
+.install-edge-right {
+  top: var(--hud-thickness);
+  bottom: calc(var(--hud-thickness) + 144px);
+  width: var(--hud-thickness);
+}
+.install-edge-left  { left: 0;  }
+.install-edge-right { right: 0; }
+
+.install-edge-left  .install-edge-label,
+.install-edge-right .install-edge-label {
+  bottom: 24px; left: 50%; transform: translateX(-50%);
+  writing-mode: vertical-rl; text-orientation: mixed;
+}
+.install-edge-left  .install-edge-bar,
+.install-edge-right .install-edge-bar {
+  bottom: 0; width: 2px; height: 100%;
+  /* scaleX pulses bar thickness on bloom (same idea as the top bar). */
+  transform: scaleY(var(--fill)) scaleX(calc(1 + var(--bloom-amount, 0) * 3));
+}
+.install-edge-left  .install-edge-bar { right: 0; transform-origin: right bottom; }
+.install-edge-right .install-edge-bar { left:  0; transform-origin: left  bottom; }
+
+/* When no LoRA is enabled in the corresponding slot, the perimeter bar
+   collapses to a thin static line so it doesn't shout for attention. */
+.install-edge-empty .install-edge-bar { transform: scaleY(0.05); opacity: 0.3; }
+.install-edge-empty .install-edge-label { opacity: 0.4; }
+
+/* First-run microcopy that teaches new users the Remix Strength strings
+   are draggable. Lives inside .desktop-edge-drag[data-side="top"], follows
+   the cursor's x-position via `left: <pct>%`, vertically centred via
+   `transform: translate(-50%, …)`. The transform's translateY carries the
+   tiny idle bob; horizontal positioning is parent-relative on `left` so
+   the percentage resolves against the wrapper, not the element.
+   `top: calc(100% + 6px)` puts the hint just *below* the slider's bar so
+   it appears under the ribbons (not over them). Dismissed forever after
+   the first successful drag (localStorage key: remix-strength:dismissed). */
+.remix-hint {
+  position: absolute;
+  top: calc(100% + 6px);
+  pointer-events: none;
+  font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.55);
+  white-space: nowrap;
+  text-transform: lowercase;
+  transition: opacity 180ms ease;
+  z-index: 8;
+}
+
+/* Desktop drag overlays — transparent click targets sized to each HUD
+   edge bar. Pointer-events fall through the SVG ribbons (which set
+   pointer-events: none) so dragging anywhere along the bar updates the
+   bound parameter. data-empty="true" disables the overlay when there's
+   no LoRA bound to that slot. */
+.desktop-edge-drag {
+  position: fixed;
+  touch-action: none;
+  z-index: 7; /* above .install-edge */
+}
+/* Click target spans the host AND the inward ribbon bleed so a user can
+   grab anywhere on the visible ribbon — including the writhing curls
+   that extend past the host into the central gutter. */
+.desktop-edge-drag[data-side="top"] {
+  top: 0;
+  left: var(--hud-thickness);
+  /* Match .install-edge-top's shortened right inset so the drag rect
+     ends 12px before the halo badge — fraction=1 maps to "just before
+     the halo" instead of "under the halo". */
+  right: calc(var(--hud-thickness) + 80px);
+  height: calc(var(--hud-thickness) + var(--ribbon-bleed));
+  cursor: ew-resize;
+}
+/* Match .install-edge-left/.install-edge-right's bottom inset (hud + 144px,
+   leaving room for the turntable) so the drag rect's bottom aligns with the
+   visible ribbon's bottom — cursor at the ribbon's bottom = fraction 0 = value
+   0, instead of being ~24% up the rect because the drag extended into invisible
+   space below the ribbon.
+
+   Width extends past the ribbon (hud + bleed) into the gutter by
+   --remix-hint-extend so the RemixHint can sit visibly inward — far
+   enough from the screen edge that the ← / → arrow has room to "point
+   at" the ribbon — while still inside the click area, so accidental
+   clicks on the hint area register as a slider drag (not as clicks on
+   whatever sits in the central gutter). */
+:root {
+  --remix-hint-extend: 60px;
+}
+.desktop-edge-drag[data-side="left"] {
+  left: 0;
+  top: var(--hud-thickness);
+  bottom: calc(var(--hud-thickness) + 144px);
+  width: calc(
+    var(--hud-thickness) + var(--ribbon-bleed) + var(--remix-hint-extend)
+  );
+  cursor: ns-resize;
+}
+.desktop-edge-drag[data-side="right"] {
+  right: 0;
+  top: var(--hud-thickness);
+  bottom: calc(var(--hud-thickness) + 144px);
+  width: calc(
+    var(--hud-thickness) + var(--ribbon-bleed) + var(--remix-hint-extend)
+  );
+  cursor: ns-resize;
+}
+/* Empty LoRA slot — keep the overlay on the page so the RemixHint stays
+   visible at the head position, but signal non-interactivity with the
+   default cursor. Pointer events stay enabled so hover-state still tracks;
+   the pointerdown handler in DesktopEdgeDrag early-returns on
+   data-empty="true", and commitValue no-ops without a bound LoRA id. */
+.desktop-edge-drag[data-empty="true"] {
+  cursor: default;
+}
+
+/* The bottom HUD edge has been replaced by the Advanced drawer — the
+   drawer's handle bar lives at the bottom of the viewport now and serves
+   the same visual role. No `.install-edge-bottom` rule needed. */
+
+/* ============================================================================
+   LoRA Library tile.  One row per catalog entry:
+       [switch]  name              [horizontal slider]  0.30
+   The body scrolls internally — adding LoRAs to the catalog grows the
+   list, not the Advanced drawer's height.  Width is bounded so the
+   tile sits comfortably alongside the other mixer tiles.
+   ============================================================================ */
+.mixer-tile-library {
+  min-width: 280px;
+  max-width: 360px;
+}
+.mixer-tile-library .lora-library-body {
+  display: flex; flex-direction: column;
+  gap: 6px;
+  padding: 4px 8px;
+  /* Internal scroll: the Library tile holds its own height and
+     scrolls when there are too many rows to fit.  The Advanced drawer
+     stays at its natural size. */
+  max-height: 240px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  /* Subtle scrollbar styling (Firefox + WebKit) so it doesn't shout. */
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
+}
+.mixer-tile-library .lora-library-body::-webkit-scrollbar { width: 6px; }
+.mixer-tile-library .lora-library-body::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2); border-radius: 3px;
+}
+.mixer-tile-library .lora-library-body::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.lora-library-empty {
+  font-size: 11px; opacity: 0.55; padding: 14px 6px;
+  text-align: center; font-style: italic;
+}
+
+.lora-row {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  grid-template-rows: auto auto;
+  align-items: center;
+  column-gap: 10px;
+  row-gap: 4px;
+  padding: 4px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+.lora-row:last-child { border-bottom: none; }
+
+.lora-row-name {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  opacity: 0.9;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.lora-row[data-state="disabled"] .lora-row-name { opacity: 0.55; }
+
+/* Toggle switch.  Sliding-pill style so the visual position alone
+   communicates state — no ON/OFF text needed (which would duplicate
+   the row name and confuse scan order). */
+.lora-switch {
+  width: 28px; height: 16px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid currentColor;
+  border-radius: 9px;
+  position: relative;
+  cursor: pointer;
+  opacity: 0.55;
+  transition: opacity 0.12s ease, background 0.18s ease;
+}
+.lora-switch:hover { opacity: 0.85; }
+.lora-switch[aria-checked="true"] {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.06);
+}
+.lora-switch-thumb {
+  position: absolute;
+  top: 1px; left: 1px;
+  width: 12px; height: 12px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.5;
+  transition: transform 0.16s cubic-bezier(.3,1.3,.5,1), opacity 0.12s ease;
+  pointer-events: none;
+}
+.lora-switch[aria-checked="true"] .lora-switch-thumb {
+  transform: translateX(12px);
+  opacity: 1;
+}
+.lora-switch.midi-learning {
+  outline: 1px dashed currentColor;
+  outline-offset: 2px;
+}
+
+/* Horizontal strength slider.  Spans the full row width below the
+   switch+name line, giving the operator a wide drag surface without
+   making each row tall. */
+.lora-strength {
+  grid-column: 1 / -1;
+  display: flex; align-items: center; gap: 8px;
+}
+.lora-strength-track {
+  position: relative;
+  flex: 1;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.lora-strength-track:hover { background: rgba(255, 255, 255, 0.14); }
+.lora-strength-fill {
+  position: absolute;
+  top: 0; bottom: 0; left: 0;
+  width: 0%;
+  background: currentColor;
+  opacity: 0.75;
+  border-radius: 2px;
+  transition: width 0.06s linear;
+}
+.lora-strength-value {
+  font-variant-numeric: tabular-nums;
+  font-size: 10px;
+  min-width: 3ch;
+  text-align: right;
+  opacity: 0.7;
+}
+
+/* Disabled state: lock the slider, dim the name, dim the fill — but
+   leave the switch alone so the operator can re-enable. */
+.lora-row[data-state="disabled"] .lora-strength-track {
+  cursor: not-allowed;
+  background: rgba(255, 255, 255, 0.04);
+}
+.lora-row[data-state="disabled"] .lora-strength-fill { opacity: 0.25; }
+.lora-row[data-state="disabled"] .lora-strength-value { opacity: 0.35; }
+
+/* ============================================================================
+   Buttons — single shared "outline + accent on hover" language. The Seed /
+   Pause / Send buttons inside the drawer all share this look so the whole
+   UI reads as one piece. The drawer handle is its own variant (see below).
+   ============================================================================ */
+.seed-btn,
+.pause-btn,
+.send-prompt-btn {
+  background: transparent;
+  color: var(--text-dim);
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 120ms, border-color 120ms, background 120ms;
+}
+.seed-btn:hover,
+.pause-btn:hover,
+.send-prompt-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.seed-btn:active,
+.send-prompt-btn:active,
+.pause-btn:active {
+  background: var(--accent-medium);
+  border-color: var(--accent);
+}
+
+.pause-btn {
+  min-width: 36px;
+  min-height: 32px;
+  padding: 0 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85em;
+  letter-spacing: 0;
+}
+.pause-btn.active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.seed-btn {
+  width: 60px;
+  height: 90px;
+  font-size: 1.3em;
+  letter-spacing: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Inline SVG dice replaces the OS-rendered emoji 🎲 — sized to feel
+   commensurate with the button (~28px) and inherits color from the
+   button so hover/active states tint the icon. Used in both SeedTile
+   (advanced drawer) and LiteControls (mobile/lite). */
+.seed-dice {
+  width: 28px;
+  height: 28px;
+  color: var(--text);
+}
+.lite-seed-icon .seed-dice {
+  width: 22px;
+  height: 22px;
+}
+
+.send-prompt-btn {
+  padding: 8px 16px;
+  min-height: 36px;
+  font-size: 0.72em;
+  letter-spacing: 0.06em;
+}
+
+/* ============================================================================
+   Advanced drawer — pulls up from the bottom of the viewport, mixer-board
+   layout. The drawer is always present in the DOM; in the closed state a
+   transform pushes the body off the viewport so only the handle bar peeks
+   above the bottom edge. Clicking the handle (or Esc / `o`) toggles open.
+   ============================================================================ */
+:root {
+  --drawer-handle-h: 28px;
+  --drawer-h: clamp(380px, 50vh, 540px);
+}
+
+.install-sheet {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  height: var(--drawer-h);
+  background: var(--sheet-bg);
+  border-top: 1px solid var(--frame-line);
+  /* Closed: only the handle (top --drawer-handle-h px) is on-screen. */
+  transform: translateY(calc(100% - var(--drawer-handle-h)));
+  transition: transform 320ms cubic-bezier(.2, .7, .2, 1);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+}
+.install-sheet.open { transform: translateY(0); }
+
+/* Drawer handle — full-width bar at the top of the drawer. The only
+   on-screen close affordance, so it's deliberately bigger and more
+   discoverable than the old corner button. Two rounded "grip"
+   indicators flank a small label so the bar reads as a draggable
+   surface even on first sight. */
+.install-drawer-handle {
+  flex-shrink: 0;
+  height: var(--drawer-handle-h);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 0 18px;
+  background: var(--frame);
+  border: none;
+  border-bottom: 1px solid var(--frame-line);
+  color: var(--text-dim);
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: 0.7em;
+  letter-spacing: var(--tracking-bar);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 120ms, background 120ms;
+}
+.install-drawer-handle:hover {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.install-drawer-handle-grip {
+  width: 56px;
+  height: 4px;
+  background: var(--frame-line);
+  border-radius: 2px;
+  transition: background 120ms;
+}
+.install-drawer-handle:hover .install-drawer-handle-grip {
+  background: var(--accent);
+}
+.install-drawer-handle-label {
+  white-space: nowrap;
+}
+.install-drawer-handle--disabled,
+.install-drawer-handle--disabled:hover {
+  opacity: 0.35;
+  pointer-events: none;
+  background: var(--frame);
+  color: var(--text-dim);
+  cursor: not-allowed;
+}
+.install-drawer-handle--disabled .install-drawer-handle-grip {
+  background: var(--frame-line);
+}
+
+/* Drawer body — vertical stack: operator strip across the top, then a
+   wrap-flex grid of mixer tiles below. Tiles wrap to the next row before
+   anything overflows horizontally — no sideways scrolling. */
+.install-sheet-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 14px 14px;
+  min-height: 0;
+}
+
+.install-section-operator {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--frame-line);
+}
+.install-section-operator .ws-url-input { width: 220px; }
+/* Density toggle anchors the right cluster — its margin-left: auto pushes
+   itself plus the trailing pause button to the far right of the row. */
+.install-section-operator .operator-density-toggle { margin-left: auto; }
+.install-section-operator .pause-btn--right { margin-left: 0; }
+
+/* The mixer-rack lays out one row of all 7 tiles (Main · Engine ·
+   Channel Gains · Channels · DCW · Library · Seed) plus a full-width
+   Prompts row beneath. Each tile is content-sized; the row stays on
+   one line and scrolls horizontally if the viewport is too narrow.
+   At ≤1500px (laptop screens) the @media block below auto-shrinks
+   the per-strip width and tile padding so the row fits without
+   scrolling. */
+.mixer-rack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+.mixer-rack-row {
+  display: flex;
+  /* Tiles keep their content-driven widths and stay on a single line
+     until the viewport drops below the compact floor (~1500px), at
+     which point they wrap onto a second line — wrapping is preferred
+     over horizontal scroll, always. The fluid clamp on
+     `--slider-strip-w` already keeps the row fitting between 1500px
+     and 2400px without wrapping. */
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: stretch;
+  flex: 0 0 auto;
+}
+/* Density scales fluidly with viewport width — no hard breakpoint, no
+   abrupt mode flip. The row's total content at standard density
+   (50px slider strips, 8/10/10 padding) measures ~1800px; on
+   anything narrower, the strips and padding interpolate down to
+   compact (36px / 6/7/7) so the rack always fits without horizontal
+   scroll. Above ~2400px viewport, full standard density takes over;
+   below ~1500px, full compact. In between (every laptop screen
+   anywhere), the controls smoothly thicken as room appears. */
+.mixer-rack {
+  --slider-strip-w: clamp(
+    36px,
+    calc(36px + (100vw - 1500px) * 14 / 900),
+    50px
+  );
+}
+.mixer-rack .mixer-tile {
+  padding:
+    clamp(6px, calc(6px + (100vw - 1500px) * 2 / 900), 8px)
+    clamp(7px, calc(7px + (100vw - 1500px) * 3 / 900), 10px)
+    clamp(7px, calc(7px + (100vw - 1500px) * 3 / 900), 10px);
+  gap: clamp(4px, calc(4px + (100vw - 1500px) * 2 / 900), 6px);
+}
+.mixer-rack .mixer-channels {
+  gap: clamp(3px, calc(3px + (100vw - 1500px) * 1 / 900), 4px);
+}
+.mixer-rack .dcw-panel {
+  width: clamp(110px, calc(110px + (100vw - 1500px) * 20 / 900), 130px);
+}
+
+/* Keyboard-shortcut hints — toggled independently of density. The
+   class lives on .mixer-rack so it covers every kbd inside the drawer
+   (slider hints, blend hint, send-prompt hint, seed F hint). The chained
+   `.mixer-rack` selector boosts specificity above the per-kbd rules
+   below (.slider-group kbd, .blend-kbd, .send-kbd) which would otherwise
+   win by source order. */
+.mixer-rack.mixer-rack--no-kbd-hints kbd,
+.mixer-rack.mixer-rack--no-kbd-hints .blend-kbd,
+.mixer-rack.mixer-rack--no-kbd-hints .send-kbd {
+  display: none;
+}
+
+/* A tile is a labeled card that groups related controls. Tiles are sized
+   to their content (no fixed widths beyond what their inner channels and
+   per-tile rules dictate), which lets them wrap densely. */
+.mixer-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.012);
+  flex: 0 0 auto;
+}
+.mixer-tile-label {
+  font-family: var(--font-mono);
+  font-size: 0.6em;
+  letter-spacing: var(--tracking-bar);
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+/* Channels row inside a tile: one horizontal row of fader strips. */
+.mixer-channels {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 4px;
+  align-items: stretch;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* ============================================================================
+   Channel strips — vertical fader columns inside a tile. The tile provides
+   the card frame; each strip is transparent. There is no Simple/Pro split
+   and no horizontal scrolling — every control is reachable on screen via
+   tile wrapping.
+   ============================================================================ */
+.slider-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  width: var(--slider-strip-w, 50px);
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.slider-label {
+  font-family: var(--font-mono);
+  font-size: 0.55em;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  text-align: center;
+  width: 100%;
+  /* Reserve 2 lines so 1-word + 2-word labels align track tops. */
+  min-height: 2.4em;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.slider-track {
+  position: relative;
+  width: 32px;
+  flex: 1 1 auto;
+  /* Shorter than the original 110px so the slider tiles in the first row
+     leave room for the prompts row beneath them without overflowing the
+     drawer. The thumb + fill scale to whatever height the flex layout
+     allocates, so no other rule needs touching. */
+  min-height: 78px;
+  background: transparent;
+  border-radius: 3px;
+  cursor: ns-resize;
+  touch-action: none;
+}
+.slider-track::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 0; bottom: 0;
+  width: 5px;
+  transform: translateX(-50%);
+  /* Rail picks up a subtle hint of the per-slider tint without losing
+     the neutral frame baseline; --slider-tint is set inline by
+     SliderGroup based on the current value. */
+  background: color-mix(in srgb, var(--slider-tint, var(--accent)) 25%, var(--frame-line));
+  border-radius: 3px;
+  transition: background 70ms linear;
+}
+.slider-fill {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 5px;
+  transform: translateX(-50%);
+  /* Fill is a solid color sampled from the palette gradient at the
+     slider's current value (--slider-tint). The thumb / label / rail-mix
+     all use the same tint so the whole slider reads as one color. */
+  background: var(--slider-tint, var(--accent));
+  border-radius: 3px;
+  pointer-events: none;
+  /* Short transition so chunky MIDI updates (e.g., a hardware knob that
+     emits coarse CC values) read as smooth fader motion. Mouse / wheel
+     drag temporarily disables this via .slider-group.dragging below. */
+  transition: height 70ms linear, background 70ms linear;
+}
+.slider-thumb {
+  position: absolute;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  background: var(--text-strong);
+  border: 2px solid var(--slider-tint, var(--accent));
+  border-radius: 50%;
+  transform: translate(-50%, 50%);
+  pointer-events: none;
+  box-shadow: 0 0 8px var(--accent-glow);
+  transition: bottom 70ms linear, border-color 70ms linear;
+}
+.slider-group.dragging .slider-fill,
+.slider-group.dragging .slider-thumb,
+.slider-group.dragging .slider-track::before,
+.slider-group.dragging .slider-value { transition: none; }
+.slider-group.active .slider-track::before {
+  box-shadow: 0 0 12px var(--accent-glow);
+}
+.slider-value {
+  font-family: var(--font-mono);
+  font-size: 0.65em;
+  color: var(--slider-tint, var(--accent));
+  transition: color 70ms linear;
+}
+
+.slider-group kbd,
+.blend-kbd,
+.send-kbd {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 5px;
+  min-height: 18px;
+  background: var(--frame);
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.55em;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+/* Send button keeps its own layout; the kbd sits to the right of the
+   button's label with a small gap. */
+.send-prompt-btn .send-kbd { margin-left: 8px; font-size: 0.65em; }
+/* Blend control already lays out left-to-right; spacing handled by gap. */
+#blend-control .blend-kbd { margin-left: 6px; }
+
+/* DCW (wavelet correction) toggle + mode/wavelet selectors. Lives inside
+   the DCW tile alongside the two DCW faders. */
+.dcw-panel {
+  display: flex;
+  flex-direction: column;
+  align-self: stretch;
+  align-items: stretch;
+  gap: 6px;
+  flex: 0 0 auto;
+  width: 130px;
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+/* Seed tile content — dice button stacked over the value display. */
+.seed-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding-top: 4px;
+  flex: 1 1 auto;
+  justify-content: center;
+}
+
+/* Prompts tile spans the full drawer width on its own row beneath the
+   fader tiles. flex-basis:100% combined with the parent's flex-wrap means
+   it always pushes to a new line; min-height keeps the row tall enough
+   that the textareas inside have somewhere to grow into (the wrap
+   container uses align-content:flex-start, so rows are content-sized —
+   without a minimum the second row would collapse). */
+.mixer-tile-prompts {
+  flex: 1 1 100%;
+  width: auto;
+  max-width: 100%;
+  min-height: 110px;
+}
+.mixer-tile-prompts #prompt-section { flex: 1 1 auto; }
+.dcw-toggle {
+  background: transparent;
+  color: var(--text-dim);
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  font-family: inherit;
+  font-size: 0.7em;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: color 120ms, border-color 120ms, background 120ms;
+}
+.dcw-toggle:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.dcw-toggle.active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--text);
+}
+.dcw-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  font-size: 0.65em;
+  color: var(--text-dim);
+}
+.dcw-row-label {
+  white-space: nowrap;
+}
+.dcw-select {
+  background: var(--input-bg);
+  color: var(--text);
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-sm);
+  padding: 2px 4px;
+  font-family: inherit;
+  font-size: 0.95em;
+  cursor: pointer;
+}
+.dcw-select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* ============================================================================
+   Inputs — ws-url + prompt textareas share one focus language.
+   ============================================================================ */
+.ws-url-input,
+.prompt-input {
+  background: var(--input-bg);
+  border: 1px solid var(--frame-line);
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  border-radius: var(--radius-sm);
+  transition: border-color 120ms, color 120ms;
+}
+.ws-url-input:focus,
+.prompt-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.ws-url-input {
+  padding: 6px 10px;
+  min-height: 32px;
+  font-size: 0.7em;
+  width: 100%;
+}
+
+.fixture-select {
+  background: var(--input-bg);
+  border: 1px solid var(--frame-line);
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  min-height: 32px;
+  font-size: 0.7em;
+  max-width: 240px;
+  transition: border-color 120ms, color 120ms;
+}
+.fixture-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.prompt-input {
+  padding: 6px 8px;
+  font-family: inherit;
+  font-size: 0.75em;
+  line-height: 1.4;
+  flex: 1 1 auto;
+  min-height: 0;
+  resize: none;
+}
+
+/* ============================================================================
+   Prompt section — A/B prompts with a blend slider and Send button. Lives
+   inside the Prompts tile.
+   ============================================================================ */
+/* Horizontal layout: [Prompt A] [A blend B] [Prompt B] [Send]. The two
+   textareas split the leftover width evenly; the blend control and Send
+   button stay sized to their content so the textareas keep most of the
+   real estate. No scroll bar — everything fits in the prompts row. */
+#prompt-section {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 10px;
+}
+
+.prompt-slot {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.prompt-label,
+.blend-label,
+.blend-value {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+#blend-control {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0;
+  flex: 0 0 auto;
+  min-width: 150px;
+  align-self: center;
+}
+
+.blend-label { font-weight: 600; flex-shrink: 0; }
+.blend-value {
+  color: var(--accent);
+  flex-shrink: 0;
+  min-width: 2.8em;
+  text-align: center;
+}
+
+/* Blend slider — native range input retheme (Webkit + Firefox). */
+#prompt-blend {
+  flex: 1;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 6px;
+  background: linear-gradient(to right, var(--accent-line), var(--accent));
+  border-radius: 3px;
+  outline: none;
+  cursor: pointer;
+  accent-color: var(--accent);
+}
+#prompt-blend::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  background: var(--text-strong);
+  border: 2px solid var(--accent);
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 0 6px var(--accent-glow);
+}
+#prompt-blend::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  background: var(--text-strong);
+  border: 2px solid var(--accent);
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 0 6px var(--accent-glow);
+}
+
+/* ============================================================================
+   MIDI badge + diag — operator-only, lives in the operator strip at the
+   top of the Advanced drawer. The badge sits inline with the other
+   operator controls; the diag panel drops to a full-width row beneath
+   them when toggled (it stays hidden by default).
+   ============================================================================ */
+#install-midi-slot {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+#midi-status {
+  display: inline-block;
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.65em;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: border-color 200ms, color 200ms, background 120ms;
+}
+#midi-status:hover         { border-color: var(--accent);   color: var(--text); background: var(--accent-soft); }
+#midi-status.midi-ok       { border-color: var(--accent);   color: var(--accent); }
+#midi-status.midi-warn     { border-color: var(--warn);     color: var(--warn); }
+#midi-status.midi-error    { border-color: var(--critical); color: var(--critical); }
+
+#midi-diag {
+  flex: 1 1 100%;
+  max-height: 110px;
+  overflow-y: auto;
+  padding: 8px;
+  background: var(--input-bg);
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.62em;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-all;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+/* ── Status placard ─────────────────────────────────────────────────────
+   Bottom-center frosted-glass surface that surfaces session messages
+   (loading, connecting, mid-session swaps, errors). Visual vocabulary is
+   intentionally lifted from `.halo-menu` (blur + dark translucent fill +
+   1px hairline border). State-aware color + motion via [data-state]:
+   - loading: accent orange, calm breathing
+   - info:    muted white, calm breathing (mid-session swaps, etc.)
+   - error:   warn yellow, breathing + soft inset glow
+   The base node stays mounted so the slide-in/out transitions on
+   .status-bar--visible are uninterrupted by React unmounts. */
+.status-bar {
+  position: fixed;
+  /* Sits in the upper third so it stays visible when the AdvancedDrawer
+     is open (the drawer slides up from the bottom and covers the lower
+     half on most viewports). Dead-center would be hidden behind it. */
+  top: 35%;
+  left: 50%;
+  /* Hidden state sits a hair below the resting position so the slide-in
+     motion lifts it into place. */
+  transform: translate(-50%, calc(-50% + 12px));
+  padding: 10px 18px;
+  text-align: center;
+  background: rgba(6, 6, 12, 0.75);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.78em;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.72);
+  z-index: 11;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition:
+    opacity 200ms ease,
+    transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.status-bar--visible {
+  opacity: 1;
+  transform: translate(-50%, -50%);
+}
+
+/* Only the TEXT inside breathes — the frosted-glass surface stays at
+   full opacity so the box reads as solid presence while the message
+   gently pulses inside it. */
+.status-bar__text {
+  display: block;
+  animation: start-whisper-breathe 2.6s ease-in-out infinite;
+}
+
+/* Optional secondary line (e.g. "this might take up to a minute"
+   under "Connecting…"). Smaller, dimmer, slightly tighter letter-
+   spacing so it reads as a sub-detail rather than a parallel message.
+   Inherits the per-state color from .status-bar[data-state] on the
+   parent. Negative animation-delay puts it ~half a breath cycle off
+   the main line so the two pulse alternately, not in lockstep. */
+.status-bar__subtitle {
+  display: block;
+  margin-top: 5px;
+  font-size: 0.7em;
+  letter-spacing: 0.22em;
+  text-transform: none;
+  opacity: 0.7;
+  animation: start-whisper-breathe 2.6s ease-in-out infinite -1.3s;
+}
+
+.status-bar[data-state="loading"] {
+  color: var(--accent);
+}
+
+.status-bar[data-state="info"] {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.status-bar[data-state="error"] {
+  color: var(--warn);
+  border-color: rgba(255, 204, 0, 0.45);
+  /* Soft inset glow that draws the eye without yelling. Layered with
+     a faint outer halo for a halo-ribbon-flavored bloom. */
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 204, 0, 0.25),
+    0 0 24px -6px rgba(255, 204, 0, 0.45);
+}
+
+/* ── Desktop-only keyboard shortcut badges ───────────────────────────────── */
+@media (pointer: coarse) { .desktop-only { display: none !important; } }
+@media (hover: none)     { .desktop-only { display: none !important; } }
+
+/* ── MIDI learn indicator ────────────────────────────────────────────────
+   Right-clicking a slider strip or any [data-midi-learn] button puts that
+   element into "waiting for MIDI" mode. The dashed warning outline pulses
+   between warn-yellow and accent-pink so the operator can tell at a glance
+   which control is armed. The next CC / Note message clears the class. */
+.midi-learning {
+  outline: 2px dashed var(--warn);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+  animation: midi-learn-pulse 0.7s ease-in-out infinite alternate;
+}
+@keyframes midi-learn-pulse {
+  from { outline-color: var(--warn); }
+  to   { outline-color: var(--accent); }
+}
+
+/* Phase 12 perf — defer layout/paint cost on the collapsed Advanced drawer.
+ * content-visibility:auto lets the browser skip rendering work entirely
+ * until the drawer scrolls into view (or here, opens). intrinsic-size
+ * gives it a placeholder so the page doesn't reflow when it expands. */
+.install-sheet:not(.open) .install-sheet-body {
+  content-visibility: auto;
+  contain-intrinsic-size: 0 320px;
+}
+
+/* ============================================================================
+   Halo Badge — single floating circular logo+account button mirrored against
+   the "Remix Strength" label at the right end of the top ribbon bar. The
+   badge inset matches the label inset (24px from the bar's inner edge,
+   vertically centered on the bar's mid-line) so the two read as deliberate
+   bookends of the same horizontal axis. The four-color conic-gradient ring
+   borrows the perimeter ribbon palette and the box-shadow halo pulses with
+   --bloom-amount, so the badge breathes alongside the ribbons on every kick.
+   ============================================================================ */
+.halo-badge {
+  position: fixed;
+  /* z-index 8: above .desktop-edge-drag (z=7) so the badge is clickable
+     even though it now overlaps the top edge bar; still below the Play
+     overlay (z=20) so the badge reads as a quiet veiled element on the
+     title screen, like the "Remix Strength" label. */
+  z-index: 8;
+  /* Aligned with the .install-edge-top label so their visible tops match.
+     The badge centers a 44px disc that's then orbited by writhing SVG ribbons
+     extending ~3px above the bbox; adding bloom halo, the visible top reaches
+     ~5–7px above bbox top. Centering the badge bbox on the label mid-line
+     made the ribbon top sit ~12px above the label cap-top. We instead
+     anchor the bbox top at (mid-line - 10), which lands the visible halo top
+     at the same Y as the label's cap-top. Right inset (24px from bar edge)
+     mirrors the label's 24px left inset. Safe-area floors for notched devices. */
+  top: max(calc(var(--hud-thickness) / 2 - 10px + var(--top-bias, 5px)), env(safe-area-inset-top, 0px));
+  right: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-right, 0px));
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  cursor: pointer;
+  /* Allow the writhing SVG ribbons to bleed slightly outside the circle. */
+  overflow: visible;
+  transition: transform 140ms cubic-bezier(.2, .8, .2, 1),
+              filter 200ms;
+}
+
+/* Plain dark inner backdrop — letting the writhing ribbon ring carry the
+   visual focus on its own. (Conic gradient removed for now; can re-layer
+   under this if we want the gradient peeking back through.) */
+.halo-badge::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: rgba(6, 6, 12, 0.6);
+  -webkit-backdrop-filter: blur(6px);
+          backdrop-filter: blur(6px);
+  transition: background 160ms;
+  z-index: 0;
+}
+.halo-badge:hover {
+  transform: scale(1.06);
+  filter: brightness(1.12) saturate(1.08);
+}
+.halo-badge:hover::before {
+  background: rgba(6, 6, 12, 0.78);
+}
+.halo-badge:active { transform: scale(0.98); }
+.halo-badge--open {
+  filter: brightness(1.18) saturate(1.12);
+}
+
+/* Real animated ribbon border — 4 writhing closed paths, one per palette
+   color, populated each frame by tickHaloRibbon in the render loop. The
+   drop-shadow filter mirrors .install-ribbons so the badge bloom-pulses
+   in lockstep with the perimeter ribbons on every kick. */
+.halo-badge .halo-ribbons {
+  position: absolute;
+  inset: -3px;
+  width: calc(100% + 6px);
+  height: calc(100% + 6px);
+  pointer-events: none;
+  overflow: visible;
+  z-index: 1;
+  filter: drop-shadow(0 0 calc(1px + var(--bloom-amount, 0) * 8px) rgba(255, 255, 255, 0.55));
+  /* Canvas-rendered (was SVG); stroke-width and opacity from the old CSS
+     contract are applied in tickHaloRibbon. */
+}
+
+.halo-badge-img {
+  position: relative;
+  z-index: 2;
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  /* Inset slightly so the icon doesn't crowd the ribbon ring. */
+  transform: scale(0.58);
+  opacity: 0.92;
+}
+.halo-badge:hover .halo-badge-img,
+.halo-badge--open .halo-badge-img { opacity: 1; }
+
+/* Floating menu anchored beneath the badge. Tracks the badge's new
+   position: badge top (mid-line - 10) + 44px height + 12px gap =
+   (--hud-thickness / 2) + 46px. Right offset matches the badge's inset. */
+.halo-menu {
+  position: fixed;
+  top: max(calc(var(--hud-thickness) / 2 + 46px + var(--top-bias, 5px)), calc(env(safe-area-inset-top, 0px) + 56px));
+  right: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-right, 0px));
+  min-width: 240px;
+  /* z-index 9 — one above the badge (z=8) so the menu paints on top. */
+  z-index: 9;
+  background: var(--sheet-bg);
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-lg);
+  padding: 6px 0;
+  box-shadow:
+    0 18px 50px rgba(0, 0, 0, 0.55),
+    0 0 0 1px var(--accent-line),
+    0 0 26px rgba(240, 138, 72, 0.18);
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-mono);
+  font-size: 0.78em;
+  overflow: hidden;
+  transform-origin: top right;
+  animation: halo-menu-in 200ms cubic-bezier(.2, .8, .2, 1);
+}
+@keyframes halo-menu-in {
+  from { opacity: 0; transform: translateY(-6px) scale(0.96); }
+  to   { opacity: 1; transform: translateY(0)   scale(1); }
+}
+/* Gradient hairline at the top, echoing the badge it descends from. */
+.halo-menu::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--dd-gradient);
+  pointer-events: none;
+}
+
+.halo-menu-email {
+  padding: 12px 16px 10px;
+  color: var(--text-dim);
+  font-size: 0.85em;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--frame-line);
+  margin-bottom: 4px;
+  word-break: break-all;
+}
+
+.halo-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 16px;
+  background: transparent;
+  border: none;
+  text-align: left;
+  color: var(--text);
+  text-decoration: none;
+  font: inherit;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 120ms, color 120ms;
+}
+.halo-menu-item:hover {
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+}
+.halo-menu-item-label { flex: 1; }
+.halo-menu-item-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  font-size: 1em;
+  color: var(--accent);
+}
+.halo-menu-item--cta {
+  color: var(--accent);
+  font-weight: 500;
+}
+.halo-menu-item--cta:hover { color: var(--accent-hover); }
+.halo-menu-item-chip {
+  font-size: 0.62em;
+  letter-spacing: 0.12em;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--accent-medium);
+  color: var(--accent-hover);
+  border: 1px solid var(--accent-line);
+}
+
+/* Mobile: keep the badge tappable (44px hits Apple's HIG minimum) and pull
+   the menu to a near-full-width sheet that's thumb-friendly. */
+@media (max-width: 480px) {
+  .halo-menu {
+    left: max(14px, env(safe-area-inset-left, 0px));
+    right: max(14px, env(safe-area-inset-right, 0px));
+    min-width: 0;
+  }
+}
+
+/* Visual separator inside the halo menu — sets MIDI/keyboard apart from the
+   destructive "Sign out" action below it. */
+.halo-menu-sep {
+  height: 1px;
+  margin: 4px 12px;
+  background: var(--frame-line);
+}
+
+/* ============================================================================
+   Config modal — backdrop + sheet for MIDI / keyboard configuration.
+   ============================================================================ */
+.config-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: var(--overlay-bg);
+  -webkit-backdrop-filter: blur(4px);
+          backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  animation: config-fade-in 180ms ease-out;
+}
+@keyframes config-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.config-modal {
+  position: relative;
+  width: min(560px, 100%);
+  max-height: min(80vh, 720px);
+  background: var(--sheet-bg);
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: config-pop-in 220ms cubic-bezier(.2, .8, .2, 1);
+}
+@keyframes config-pop-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0)   scale(1); }
+}
+.config-modal-accent {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--dd-gradient);
+}
+
+.config-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 18px 8px;
+}
+.config-modal-title {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--text-strong);
+  font-weight: 500;
+}
+.config-modal-close {
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-dim);
+  font-size: 1.4em;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 120ms, background 120ms;
+}
+.config-modal-close:hover {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.config-modal-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--frame-line);
+}
+.config-modal-tab {
+  background: transparent;
+  border: none;
+  padding: 10px 14px;
+  font-family: var(--font-mono);
+  font-size: 0.7em;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--text-dim);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 120ms, border-color 120ms;
+}
+.config-modal-tab:hover { color: var(--text); }
+.config-modal-tab--active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.config-modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 18px 18px;
+  font-family: var(--font-mono);
+  font-size: 0.78em;
+}
+
+/* MIDI tab */
+.config-midi-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.02);
+  margin-bottom: 12px;
+  font-size: 0.92em;
+  color: var(--text);
+}
+.config-midi-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-dim);
+}
+.config-midi-status--ok   .config-midi-status-dot { background: var(--dd-1); box-shadow: 0 0 8px var(--dd-1); }
+.config-midi-status--warn .config-midi-status-dot { background: var(--dd-2); box-shadow: 0 0 8px var(--dd-2); }
+.config-midi-status--info .config-midi-status-dot { background: var(--accent); }
+.config-midi-status--off  .config-midi-status-dot { background: var(--text-dim); }
+.config-midi-status-hint {
+  margin-left: auto;
+  color: var(--text-dim);
+  font-size: 0.85em;
+}
+
+.config-midi-table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.config-midi-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 48px 56px auto;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--frame-line);
+}
+.config-midi-row:last-child { border-bottom: none; }
+.config-midi-row--head {
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-dim);
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.config-midi-cell-label { color: var(--text); }
+.config-midi-cell-kind  { color: var(--text-dim); }
+.config-midi-cell-num   {
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+.config-midi-cell-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.config-midi-btn {
+  padding: 5px 10px;
+  background: transparent;
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.92em;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 120ms, border-color 120ms, background 120ms;
+}
+.config-midi-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.config-midi-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+.config-midi-btn:disabled:hover {
+  color: var(--text);
+  border-color: var(--frame-line);
+  background: transparent;
+}
+.config-midi-btn--ghost { color: var(--text-dim); }
+.config-midi-btn--learning {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-medium);
+  animation: config-pulse 1.2s ease-in-out infinite;
+}
+@keyframes config-pulse {
+  50% { box-shadow: 0 0 14px var(--accent-glow); }
+}
+
+.config-midi-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+/* Top-of-panel tip — sits above the status row to teach the right-click
+   shortcut before users hunt through the table. Subtle accent border keeps
+   it readable without competing with the status pill below. */
+.config-midi-tip {
+  margin: 0 0 12px;
+  padding: 8px 10px;
+  border-left: 2px solid var(--accent);
+  background: var(--accent-soft);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-size: 0.9em;
+  line-height: 1.4;
+}
+
+/* Keyboard tab */
+.config-keyboard-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.config-keyboard-row {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--frame-line);
+}
+.config-keyboard-row:last-child { border-bottom: none; }
+.config-keyboard-combo {
+  display: inline-block;
+  padding: 4px 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-sm);
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  letter-spacing: 0.06em;
+  text-align: center;
+}
+.config-keyboard-desc { color: var(--text); }
+.config-keyboard-note {
+  margin-top: 12px;
+  color: var(--text-dim);
+  font-size: 0.85em;
+  font-style: italic;
+}
+
+/* ============================================================================
+   Mobile Lite Controls — surfaces inside the Advanced Controls drawer below
+   the 768px breakpoint. Two tactile sliders, a seed dice, a single-line
+   prompt + Send. Power features live behind "All controls".
+   ============================================================================ */
+.install-sheet--mobile {
+  /* Lite drawer leaves room for the stage + the Remix rail above it.
+     Add safe-area-inset-bottom so the drawer (and its handle) sit above
+     the iOS home gesture zone. */
+  height: 360px;
+  bottom: env(safe-area-inset-bottom, 0px);
+}
+/* Mobile: kill the entire top HUD edge (the wordmark + halo + rail
+   carry the brand). Repurpose .install-edge-left as the Remix Strength
+   display — same writhing-ribbon system the desktop top edge uses,
+   driven by the same --fill (denoise) value. The MobileRemixRail
+   component overlays this and provides the drag interaction. */
+@media (max-width: 768px) {
+  .install-edge-top { display: none; }
+  .install-edge-left {
+    top: max(96px, calc(env(safe-area-inset-top, 0px) + 80px));
+    bottom: calc(
+      var(--drawer-handle-h, 52px) +
+      env(safe-area-inset-bottom, 0px) + 12px
+    );
+    width: 56px;
+  }
+  /* Hide the LoRA-strength label on the side edge in mobile — the rail
+     supplies its own "REMIX STRENGTH" label. */
+  .install-edge-left .install-edge-label { display: none; }
+  /* Bump halo to a bigger, easier-to-tap target on phones, and revert to
+     simple corner-inset positioning since the top ribbon bar is hidden on
+     mobile (the ribbon system shifts to the left edge there) — there's no
+     bar mid-line to mirror against. */
+  .halo-badge {
+    width: 52px;
+    height: 52px;
+    top: max(14px, env(safe-area-inset-top, 0px));
+    right: max(14px, env(safe-area-inset-right, 0px));
+  }
+  .halo-menu {
+    top: max(78px, calc(env(safe-area-inset-top, 0px) + 78px));
+    right: max(14px, env(safe-area-inset-right, 0px));
+  }
+}
+/* Bigger drawer handle on mobile — Apple HIG minimum 44pt; we use 52px so
+   the grip is easy to find with a thumb without bumping the home indicator.
+   Override the default --drawer-handle-h locally so the closed-state
+   transform also accounts for the new height. */
+.install-sheet--mobile {
+  --drawer-handle-h: 52px;
+}
+.install-sheet--mobile .install-drawer-handle {
+  font-size: 0.78em;
+  height: var(--drawer-handle-h);
+}
+.install-sheet--mobile .install-drawer-handle-grip {
+  width: 64px;
+  height: 5px;
+}
+
+.lite-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 16px 14px;
+  /* Right-side padding hugs the edge; left side leaves space for the
+     Remix rail (which lives at the screen edge, not inside the drawer)
+     so the seed button doesn't crowd against it visually. */
+  padding-left: calc(16px + var(--remix-rail-w, 0px));
+  height: 100%;
+  min-height: 0;
+}
+
+.lite-row {
+  display: flex;
+  align-items: center;
+}
+
+.lite-row--main {
+  flex: 1 1 auto;
+  min-height: 0;
+  gap: 18px;
+  justify-content: center;
+  padding: 4px 4px 6px;
+}
+.lite-row--main .slider-group {
+  flex: 0 0 80px;
+}
+.lite-row--main .slider-group .slider-label {
+  font-size: 0.62em;
+  letter-spacing: 0.18em;
+}
+.lite-row--main .slider-track {
+  width: 56px;
+  min-height: 150px;
+}
+.lite-row--main .slider-track::before { width: 8px; }
+.lite-row--main .slider-fill { width: 8px; }
+.lite-row--main .slider-thumb {
+  width: 32px;
+  height: 32px;
+  border-width: 2px;
+}
+
+.lite-seed-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 88px;
+  min-height: 88px;
+  padding: 10px 6px;
+  background: transparent;
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-md);
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 120ms, background 120ms, box-shadow 120ms;
+}
+.lite-seed-btn:hover,
+.lite-seed-btn:active {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+  box-shadow: 0 0 12px var(--accent-glow);
+}
+.lite-seed-icon {
+  font-size: 30px;
+  line-height: 1;
+}
+.lite-seed-value {
+  font-family: var(--font-mono);
+  font-size: 0.72em;
+  color: var(--accent);
+}
+
+.lite-row--prompt {
+  gap: 8px;
+  flex: 0 0 auto;
+}
+.lite-prompt-input {
+  flex: 1 1 auto;
+  height: 44px;
+  padding: 0 14px;
+  background: var(--input-bg);
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-md);
+  color: var(--text);
+  font: inherit;
+  /* 16px prevents iOS Safari auto-zoom on focus. */
+  font-size: 16px;
+  outline: none;
+  transition: border-color 120ms;
+  -webkit-appearance: none;
+}
+.lite-prompt-input:focus {
+  border-color: var(--accent);
+}
+.lite-send-btn {
+  flex: 0 0 auto;
+  height: 44px;
+  padding: 0 20px;
+  background: transparent;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-md);
+  color: var(--accent);
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: 0.82em;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 120ms, color 120ms, box-shadow 120ms;
+}
+.lite-send-btn:hover,
+.lite-send-btn:active {
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  box-shadow: 0 0 14px var(--accent-glow);
+}
+
+.lite-all-controls {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  /* 44x44 minimum tap target. */
+  min-height: 44px;
+  padding: 12px 20px;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: 0.74em;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 120ms;
+}
+.lite-all-controls:hover { color: var(--accent); }
+.lite-all-controls-arrow {
+  transition: transform 120ms;
+}
+.lite-all-controls:hover .lite-all-controls-arrow {
+  transform: translateX(4px);
+}
+
+/* iOS input — disable browser autofill yellow + match dark theme. */
+.lite-prompt-input:-webkit-autofill {
+  -webkit-text-fill-color: var(--text);
+  -webkit-box-shadow: 0 0 0 1000px var(--input-bg) inset;
+}
+
+/* ============================================================================
+   Mobile Remix rail — vertical slider on the left edge of the screen, the
+   primary mobile interaction surface. Veiled behind the Play overlay (z-6)
+   so it reads as ambient chrome until Play is pressed.
+   ============================================================================ */
+:root { --remix-rail-w: 56px; }
+
+.remix-rail {
+  position: fixed;
+  left: 0;
+  /* Sits between the wordmark area and the drawer handle, with safe-area
+     respect on top + bottom. */
+  top: max(96px, calc(env(safe-area-inset-top, 0px) + 80px));
+  bottom: calc(
+    var(--drawer-handle-h, 52px) +
+    env(safe-area-inset-bottom, 0px) + 12px
+  );
+  width: var(--remix-rail-w);
+  z-index: 6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  /* Touch target is the entire rail width; the visual track is narrower
+     and centered. The wide hit zone makes the rail forgiving on a phone. */
+  padding: 6px 0;
+  pointer-events: auto;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.remix-rail-label {
+  flex: 0 0 auto;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.72em;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text);
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  text-shadow: 0 0 12px var(--accent-glow);
+}
+
+/* Invisible drag zone — the visible "remix" is the writhing ribbons of
+   .install-edge-left underneath, which fills/animates from the same
+   denoise value via --fill (set by useEffect in MobileRemixRail). */
+.remix-rail-drag {
+  flex: 1 1 auto;
+  width: 100%;
+  cursor: ns-resize;
+  touch-action: none;
+  background: transparent;
+}
+
+.remix-rail-value {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 0.65em;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+  min-width: 3ch;
+  text-align: center;
+}
+
+/* ============================================================================
+   Mobile Full Sheet — opens over the Lite drawer when "All controls" is
+   tapped. Bottom tab bar, full-width tile per tab.
+   ============================================================================ */
+.mobile-sheet {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: var(--sheet-bg);
+  display: flex;
+  flex-direction: column;
+  animation: mobile-sheet-in 260ms cubic-bezier(.2, .8, .2, 1);
+  /* iOS safe areas. */
+  padding-top: env(safe-area-inset-top, 0px);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+@keyframes mobile-sheet-in {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.mobile-sheet-accent {
+  position: absolute;
+  top: env(safe-area-inset-top, 0px);
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--dd-gradient);
+  pointer-events: none;
+}
+
+.mobile-sheet-header {
+  flex-shrink: 0;
+  display: grid;
+  grid-template-columns: 44px 1fr 44px;
+  align-items: center;
+  padding: 12px 14px 8px;
+  border-bottom: 1px solid var(--frame-line);
+}
+.mobile-sheet-back {
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-size: 20px;
+  cursor: pointer;
+  border-radius: var(--radius-md);
+}
+.mobile-sheet-back:hover {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.mobile-sheet-title {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--text-strong);
+  font-weight: 500;
+  text-align: center;
+}
+.mobile-sheet-spacer { width: 44px; height: 44px; }
+
+/* All four sections live side-by-side in a horizontal scroll-snap track
+   so the user can swipe between Mix / Sound / Prompts / Config. The tab
+   pills below mirror whichever section is currently in view. */
+.mobile-sheet-track {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+  overscroll-behavior-x: contain;
+}
+.mobile-sheet-track::-webkit-scrollbar { display: none; }
+.mobile-sheet-section {
+  flex: 0 0 100%;
+  width: 100%;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 16px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-sizing: border-box;
+}
+/* Mixer tiles take the full sheet width and stack rather than wrap, so
+   each tile gets enough room to label itself even on narrow screens. */
+.mobile-sheet-section .mixer-tile {
+  width: 100%;
+  margin: 0;
+  box-sizing: border-box;
+}
+/* CHANNEL GAINS (8 sliders) and CHANNELS (6 sliders) won't fit at narrow
+   widths, so let the row scroll horizontally inside its tile rather than
+   crushing the slider widths. */
+.mobile-sheet-section .mixer-tile .mixer-channels {
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 4px;
+  flex-wrap: nowrap;
+}
+.mobile-sheet-section .mixer-tile .mixer-channels::-webkit-scrollbar { display: none; }
+.mobile-sheet-section .install-section-operator {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+}
+.mobile-sheet-section .install-section-operator > * { width: 100%; }
+/* Stack prompts vertically on mobile — the desktop layout is a single
+   row (Prompt A | blend | Prompt B | Send) that crushes textareas to
+   ~30px wide at 414px viewport. */
+.mobile-sheet-section #prompt-section {
+  flex-direction: column;
+  gap: 12px;
+}
+.mobile-sheet-section .prompt-slot { flex: 0 0 auto; }
+.mobile-sheet-section .prompt-input {
+  /* 16px prevents iOS from auto-zooming on focus. */
+  font-size: 16px;
+  min-height: 80px;
+  width: 100%;
+  box-sizing: border-box;
+}
+.mobile-sheet-section #blend-control {
+  gap: 10px;
+  padding: 8px 0;
+  min-width: 0;
+  width: 100%;
+}
+.mobile-sheet-section #blend-control input[type="range"] { flex: 1 1 auto; }
+.mobile-sheet-section .send-prompt-btn {
+  min-height: 44px;
+  font-size: 14px;
+  width: 100%;
+}
+
+/* Pill-style tab bar — sliding active background on tap, snappy scale
+   feedback so the swipe-to-tap interaction feels lively. */
+.mobile-sheet-tabs {
+  flex-shrink: 0;
+  display: flex;
+  gap: 4px;
+  padding: 8px 12px calc(8px + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid var(--frame-line);
+  background: var(--frame);
+}
+.mobile-sheet-tab {
+  flex: 1 1 0;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 10px 8px;
+  border-radius: 999px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 0.72em;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 180ms ease, background 180ms ease, transform 80ms ease;
+}
+.mobile-sheet-tab:hover { color: var(--text); }
+.mobile-sheet-tab--active {
+  color: var(--text-strong);
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+}
+.mobile-sheet-tab:active { transform: scale(0.97); }
+
+/* ─── Recording: The Turntable ─────────────────────────────────────────
+   Vinyl record + tonearm metaphor for audio capture. Sits floating above
+   the bottom HUD bar at the bottom-right. The grooves are real polar
+   curves whose radii are modulated by the live audio mirror — so the
+   music is literally etched into the disc as you hear it. The tonearm
+   drops onto the disc when you start recording; the disc spins. */
+
+/* Wraps the turntable button + an optional warning bubble. `display:
+   contents` keeps the wrapper invisible to layout — the button keeps
+   its existing fixed positioning. */
+.turntable-wrap { display: contents; }
+
+/* Transient warning anchored to the record buttons. Used for clicks
+   that don't make sense yet (e.g. record while still connecting), so
+   the StatusBar isn't overwritten with a click-tied message. Sits
+   above the vinyl turntable button. */
+.rec-warning {
+  position: fixed;
+  bottom: max(
+    calc(var(--hud-thickness) + 106px),
+    calc(env(safe-area-inset-bottom, 0px) + 82px)
+  );
+  right: max(calc(var(--hud-thickness) - 16px), env(safe-area-inset-right, 0px));
+  padding: 8px 14px;
+  background: rgba(6, 6, 12, 0.85);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(255, 204, 0, 0.45);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.68em;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--warn);
+  white-space: nowrap;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 204, 0, 0.25),
+    0 0 24px -6px rgba(255, 204, 0, 0.45);
+  z-index: 9;
+  pointer-events: none;
+  animation: rec-warning-fade-in 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+@keyframes rec-warning-fade-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.turntable {
+  position: fixed;
+  /* Float above the bottom HUD bar: anchor 24px above its top edge. */
+  bottom: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-bottom, 0px));
+  /* Right inset is set so the DISC center (not the container right edge)
+     visually aligns with the HaloBadge center. The container is 92px wide
+     with the disc at left:3 width:54 (disc center 30px from container left,
+     62px from container right). Halo center sits at (--hud-thickness + 46)
+     from the screen right; matching the disc center to that means container
+     right = halo_center_from_right - 62 = (--hud-thickness + 46) - 62 =
+     (--hud-thickness - 16). The tonearm pivot ends up ~3px inside the right
+     HUD bar's x-range, but they never overlap in y (bar bottom sits 24px
+     above the turntable top). */
+  right: max(calc(var(--hud-thickness) - 16px), env(safe-area-inset-right, 0px));
+  width: 92px;
+  height: 70px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  z-index: 8;
+  overflow: visible;
+  /* Subtle hover lift; same ease as HaloBadge for family resemblance. */
+  transition: transform 160ms cubic-bezier(.2, .8, .2, 1),
+              filter 200ms;
+}
+.turntable:hover { transform: scale(1.04); filter: brightness(1.08); }
+.turntable:active { transform: scale(0.99); }
+.turntable:disabled,
+.turntable--busy { cursor: progress; opacity: 0.75; }
+.turntable:focus-visible { outline: none; }
+.turntable:focus-visible .turntable-disc {
+  box-shadow: 0 0 0 2px var(--accent), 0 6px 22px rgba(0, 0, 0, 0.6);
+}
+
+/* Disc — the rotating element. Holds platter, grooves, label, spindle. */
+.turntable-disc {
+  position: absolute;
+  left: 3px;
+  top: 6px;
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  /* Stay still while idle; CSS animation toggles on for recording. */
+  transform-origin: 50% 50%;
+  /* Soft ambient halo that the audio kick punches up. */
+  filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.55))
+          drop-shadow(0 0 calc(1px + var(--bloom-amount, 0) * 12px)
+                      rgba(232, 79, 61, 0.18));
+  /* Smooth halt when animation is removed: holds whatever angle. */
+}
+.turntable--recording .turntable-disc {
+  animation: turntable-spin 6s linear infinite;
+}
+.turntable--paused .turntable-disc {
+  animation: turntable-spin 6s linear infinite;
+  animation-play-state: paused;
+}
+
+/* Platter — the black vinyl base, with a subtle radial gradient so it
+   reads as a glossy disc rather than a flat circle. */
+.turntable-platter {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 35% 30%,
+      rgba(255, 255, 255, 0.05) 0%,
+      rgba(255, 255, 255, 0) 40%),
+    radial-gradient(circle at 50% 50%,
+      #15151c 0%,
+      #08080d 70%,
+      #02020a 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow:
+    inset 0 0 12px rgba(0, 0, 0, 0.6),
+    inset 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+/* Grooves — concentric polar polylines drawn each frame by tickTurntable
+   onto a 2D canvas (was SVG paths until per-frame setAttribute thrash
+   showed up in profiles). Faint warm-on-black so they read as vinyl
+   texture, not as glowing rings. The live-waveform wobble (radius
+   modulation in tickTurntable) is a shape change, not a color one — it
+   still reads at low opacity. Stroke colors and width-vs-recording-state
+   live in turntable.ts. */
+.turntable-grooves {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  filter: drop-shadow(0 0 calc(0.5px + var(--bloom-amount, 0) * 4px)
+                      rgba(232, 79, 61, 0.28));
+}
+
+/* Center label — reads as a literal red record button: solid coral fill,
+   a thin metallic ring suggesting a pressable bezel, a soft highlight
+   from above. The spindle hole sits inside as a subtle dimple instead
+   of a separate dot so the whole center reads as one tappable target. */
+.turntable-label {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 38% 32%,
+      rgba(255, 200, 170, 0.55) 0%,
+      rgba(255, 200, 170, 0) 38%),
+    #e84f3d;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow:
+    0 0 0 1.5px rgba(0, 0, 0, 0.55),
+    0 0 8px rgba(232, 79, 61, 0.55),
+    inset 0 -1px 2px rgba(0, 0, 0, 0.35),
+    inset 0 1px 1px rgba(255, 255, 255, 0.18);
+}
+.turntable--recording .turntable-label {
+  background:
+    radial-gradient(circle at 38% 32%,
+      rgba(255, 220, 200, 0.6) 0%,
+      rgba(255, 220, 200, 0) 38%),
+    #ff5a48;
+  box-shadow:
+    0 0 0 1.5px rgba(0, 0, 0, 0.55),
+    0 0 calc(8px + var(--bloom-amount, 0) * 14px) rgba(232, 79, 61, 0.85),
+    inset 0 -1px 2px rgba(0, 0, 0, 0.35),
+    inset 0 1px 1px rgba(255, 255, 255, 0.22);
+}
+
+/* Spindle — recessed dimple in the center of the label. Subtle dot of
+   shadow rather than a bright pin, so the label reads as a button. */
+.turntable-spindle {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 50%,
+      rgba(0, 0, 0, 0.65) 0%,
+      rgba(0, 0, 0, 0.35) 60%,
+      rgba(0, 0, 0, 0) 100%);
+  box-shadow: 0 0 0 0.5px rgba(255, 255, 255, 0.12);
+}
+
+/* Tonearm — separate SVG so it doesn't rotate with the disc. The <g>
+   inside has its origin at the pivot point; CSS rotates it between
+   parked (idle) and dropped (recording). */
+.turntable-tonearm {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 2;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.55));
+}
+.turntable-tonearm-arm {
+  /* Pivot point matches the SVG geometry (cx/cy of the pivot circle). */
+  transform-origin: 95px 12px;
+  /* Idle: needle clearly parked away from the disc — at -26° on a ~48px
+     arm, the needle lifts ~21px from the recording position. */
+  transform: rotate(-26deg);
+  transition: transform 720ms cubic-bezier(.42, 0, .15, 1);
+}
+.turntable--active .turntable-tonearm-arm {
+  transform: rotate(3deg);
+}
+/* Hover preview: lift the arm a touch so it reads as "ready to drop". */
+.turntable:hover .turntable-tonearm-arm {
+  transform: rotate(-19deg);
+}
+.turntable--active:hover .turntable-tonearm-arm {
+  transform: rotate(5deg);
+}
+
+/* Live timer — coral monospace text below the disc. Doesn't rotate. */
+.turntable-time {
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 60px;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: #f08a48;
+  opacity: 0.95;
+  pointer-events: none;
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.8);
+}
+
+@keyframes turntable-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Confetti — emits from the center of the disc on save. */
+.turntable-confetti {
+  position: absolute;
+  /* Match the disc center so dots fan from the spindle outward. */
+  left: 30px;
+  top: 33px;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+  z-index: 3;
+}
+.turntable-confetti-dot {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 6px;
+  height: 6px;
+  margin: -3px 0 0 -3px;
+  border-radius: 50%;
+  opacity: 0;
+  animation: turntable-confetti-burst 720ms cubic-bezier(.2, .7, .2, 1) forwards;
+}
+.turntable-confetti-dot--0  { background: #e84f3d; --x:  46px; --y: -10px; animation-delay: 0ms; }
+.turntable-confetti-dot--1  { background: #f08a48; --x:  38px; --y:  28px; animation-delay: 20ms; }
+.turntable-confetti-dot--2  { background: #c7b566; --x:  12px; --y:  46px; animation-delay: 40ms; }
+.turntable-confetti-dot--3  { background: #3db6be; --x: -24px; --y:  42px; animation-delay: 60ms; }
+.turntable-confetti-dot--4  { background: #e84f3d; --x: -44px; --y:  18px; animation-delay: 0ms; }
+.turntable-confetti-dot--5  { background: #f08a48; --x: -46px; --y: -14px; animation-delay: 30ms; }
+.turntable-confetti-dot--6  { background: #c7b566; --x: -30px; --y: -36px; animation-delay: 80ms; }
+.turntable-confetti-dot--7  { background: #3db6be; --x:  -6px; --y: -46px; animation-delay: 50ms; }
+.turntable-confetti-dot--8  { background: #e84f3d; --x:  22px; --y: -40px; animation-delay: 10ms; }
+.turntable-confetti-dot--9  { background: #f08a48; --x:  48px; --y:  12px; animation-delay: 70ms; }
+.turntable-confetti-dot--10 { background: #c7b566; --x:  26px; --y:  40px; animation-delay: 40ms; }
+.turntable-confetti-dot--11 { background: #3db6be; --x: -18px; --y: -30px; animation-delay: 90ms; }
+
+@keyframes turntable-confetti-burst {
+  0%   { transform: translate(0, 0)   scale(0.4); opacity: 0; }
+  20%  { opacity: 1; }
+  100% { transform: translate(var(--x), var(--y)) scale(1.05); opacity: 0; }
+}
+
+@media (max-width: 768px) {
+  .turntable {
+    /* Bottom inset matches desktop (hud + 24): LiteControls renders
+       inside the drawer (z=50), which fully covers the turntable
+       (z=8) when open, so the floating turntable only needs to clear
+       the closed-state drawer handle — same clearance the desktop
+       value already gives. */
+    /* Mobile halo uses a flat 14px corner inset (no bar mid-line to
+       mirror against), so the turntable matches that — the disc can't
+       fully center-align with the halo on a phone (the disc is 62px
+       from the container right, but the halo center sits only ~40px
+       from the screen edge), but anchoring both at the same right
+       inset keeps the lower-right corner cohesive. */
+    right: max(14px, env(safe-area-inset-right, 0px));
+  }
+}
+@media (max-width: 360px) {
+  .turntable { width: 80px; height: 60px; }
+  .turntable-disc { width: 48px; height: 48px; left: 3px; top: 4px; }
+  .turntable-confetti { left: 27px; top: 28px; }
+  .turntable-time { width: 54px; font-size: 10px; }
+}
+
+/* ─── Inline record toggle (.rec-btn) ──────────────────────────────────
+   Composes on top of .pause-btn so it shares shape, size, and hover
+   behavior with KIOSK / KBD / Pause. Recording state uses .pause-btn's
+   existing .active treatment plus a tiny pulsing dot. */
+
+.rec-btn {
+  /* Just enough room for the inline dot when recording. */
+  gap: 6px;
+}
+.rec-btn-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 5px rgba(232, 79, 61, 0.6);
+  flex-shrink: 0;
+}
+.rec-btn--recording .rec-btn-dot {
+  animation: rec-btn-blink 1s ease-in-out infinite;
+  box-shadow: 0 0 calc(4px + var(--bloom-amount, 0) * 10px) rgba(232, 79, 61, 0.85);
+}
+.rec-btn--recording {
+  /* Reinforce the .active treatment from .pause-btn.active so a recording
+     button is unmistakable in a row of similar pills. */
+  color: var(--text-strong);
+}
+.rec-btn--busy { cursor: progress; opacity: 0.75; }
+@keyframes rec-btn-blink {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(0.85); }
+}
+
+/* ─── Recording preview sheet ──────────────────────────────────────────
+   Bottom-center pill that rises after stop. Three text buttons keeping
+   the lite-send-btn visual language. Audio element uses the browser's
+   native controls — no need to reinvent scrubbing UI. */
+
+.recording-preview {
+  position: fixed;
+  left: 50%;
+  bottom: 96px;
+  transform: translateX(-50%);
+  z-index: 12;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 16px 12px;
+  background: var(--sheet-bg);
+  border: 1px solid var(--accent-line);
+  border-radius: 14px;
+  min-width: 320px;
+  max-width: min(440px, calc(100vw - 32px));
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.55),
+              0 0 calc(8px + var(--bloom-amount, 0) * 14px) var(--accent-glow);
+  animation: recording-preview-in 320ms cubic-bezier(.2, .8, .2, 1);
+}
+.recording-preview-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+.recording-preview-title {
+  color: var(--text-strong);
+  text-transform: uppercase;
+  font-weight: 600;
+}
+.recording-preview-meta {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+.recording-preview-audio {
+  width: 100%;
+  height: 36px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.3);
+}
+.recording-preview-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+.recording-preview-btn {
+  appearance: none;
+  border: 1px solid var(--accent-line);
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 8px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease,
+              box-shadow 160ms ease, transform 80ms ease;
+}
+.recording-preview-btn:hover {
+  background: var(--accent-soft);
+  color: var(--text-strong);
+  box-shadow: 0 0 14px var(--accent-glow);
+}
+.recording-preview-btn:active { transform: scale(0.97); }
+.recording-preview-btn--primary {
+  background: var(--accent-medium);
+  border-color: var(--accent);
+  color: var(--text-strong);
+}
+.recording-preview-btn--primary:hover {
+  background: var(--accent);
+  color: #0a0a12;
+}
+.recording-preview-btn--ghost {
+  border-color: rgba(255, 255, 255, 0.18);
+  color: var(--text-dim);
+}
+
+@keyframes recording-preview-in {
+  from { opacity: 0; transform: translate(-50%, 12px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+
+@media (max-width: 480px) {
+  .recording-preview {
+    left: 12px;
+    right: 12px;
+    bottom: 88px;
+    transform: none;
+    min-width: 0;
+    max-width: none;
+    animation-name: recording-preview-in-mobile;
+  }
+}
+@keyframes recording-preview-in-mobile {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ============================================================================
+   AudioSourceCrate — bottom-left "now playing" placard, primary track-picker.
+   The placard itself is the click target: shows the current track at rest,
+   click to fan out a column of sleeves with a permanent "upload your own"
+   sleeve pinned at the bottom (closest to the placard, always reachable
+   regardless of scroll). The advanced-controls strip carries an unchanged
+   dropdown + upload icon for power users who prefer the dropdown.
+   ============================================================================ */
+
+.audio-source-crate {
+  position: fixed;
+  /* Float above the bottom HUD bar, mirroring the turntable's right-side
+     anchor on the left. 24px gap above the bar matches the turntable. */
+  bottom: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-bottom, 0px));
+  left: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-left, 0px));
+  z-index: 8;
+  min-width: 140px;
+  max-width: 260px;
+  padding: 7px 12px 7px 14px;
+  background: rgba(6, 6, 12, 0.72);
+  -webkit-backdrop-filter: blur(6px);
+          backdrop-filter: blur(6px);
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  text-align: left;
+  /* Bloom drop-shadow ties the placard to the perimeter ribbons so it
+     pulses subtly with the audio kick — no canvas needed. */
+  filter: drop-shadow(0 0 calc(1px + var(--bloom-amount, 0) * 6px) var(--accent-glow));
+  transition:
+    transform 140ms cubic-bezier(.2, .8, .2, 1),
+    background 160ms,
+    border-color 160ms,
+    filter 200ms;
+}
+.audio-source-marquee-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+.audio-source-crate-caret {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  color: var(--text-dim);
+  transition: transform 200ms cubic-bezier(.2, .8, .2, 1), color 160ms;
+}
+.audio-source-crate:hover .audio-source-crate-caret { color: var(--accent-hover); }
+.audio-source-crate--open .audio-source-crate-caret {
+  color: var(--accent);
+  transform: rotate(180deg);
+}
+.audio-source-crate::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--dd-gradient);
+  pointer-events: none;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+.audio-source-crate:hover {
+  transform: translateY(-1px);
+  background: rgba(6, 6, 12, 0.85);
+  border-color: var(--accent-line);
+}
+.audio-source-crate:active { transform: translateY(0); }
+.audio-source-crate--open {
+  border-color: var(--accent-line);
+  background: rgba(6, 6, 12, 0.88);
+}
+
+.audio-source-marquee-label {
+  font-size: 8.5px;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.audio-source-marquee-name {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--text-strong);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+/* ── Fan: scrollable column of track sleeves + pinned upload sleeve ──── */
+.audio-source-fan {
+  position: fixed;
+  /* Stack above the placard. Placard bottom anchor + ~38px tall + 8px gap. */
+  bottom: max(calc(var(--hud-thickness) + 24px + 38px + 8px),
+              calc(env(safe-area-inset-bottom, 0px) + 70px));
+  left: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-left, 0px));
+  z-index: 9;
+  min-width: 220px;
+  max-width: 280px;
+  /* Cap so a long catalog scrolls inside the fan rather than off-screen. */
+  max-height: min(60vh, 420px);
+  background: var(--sheet-bg);
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-lg);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-family: var(--font-mono);
+  box-shadow:
+    0 18px 50px rgba(0, 0, 0, 0.55),
+    0 0 0 1px var(--accent-line),
+    0 0 26px rgba(240, 138, 72, 0.18);
+  transform-origin: bottom left;
+  animation: audio-source-fan-in 220ms cubic-bezier(.2, .8, .2, 1);
+}
+.audio-source-fan::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--dd-gradient);
+  pointer-events: none;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+}
+@keyframes audio-source-fan-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.96); }
+  to   { opacity: 1; transform: translateY(0)   scale(1); }
+}
+.audio-source-fan-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 2px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent-line) transparent;
+}
+.audio-source-fan-scroll::-webkit-scrollbar { width: 4px; }
+.audio-source-fan-scroll::-webkit-scrollbar-thumb {
+  background: var(--accent-line);
+  border-radius: 999px;
+}
+.audio-source-fan-empty {
+  padding: 14px 10px;
+  color: var(--text-dim);
+  font-size: 11px;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  text-align: center;
+}
+
+.audio-source-sleeve {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--text);
+  font: inherit;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background 140ms,
+    border-color 140ms,
+    color 140ms;
+  /* Stagger entrance keyed to --idx (set inline per sleeve). */
+  animation: audio-source-sleeve-in 220ms cubic-bezier(.2, .8, .2, 1) backwards;
+  animation-delay: calc(var(--idx, 0) * 14ms);
+}
+.audio-source-sleeve:hover {
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+}
+.audio-source-sleeve:disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+@keyframes audio-source-sleeve-in {
+  from { opacity: 0; transform: translateY(3px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Minimal vinyl-style icon. A thin ring with a tiny center dot — same
+   color as the row text, dim by default, accent when current. No
+   gradients here so a long list of tracks stays calm. */
+.audio-source-sleeve-art {
+  position: relative;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1px solid currentColor;
+  color: var(--text-dim);
+  display: grid;
+  place-items: center;
+  opacity: 0.85;
+}
+.audio-source-sleeve-art::after {
+  content: "";
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.audio-source-sleeve-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.audio-source-sleeve--current {
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+}
+.audio-source-sleeve--current .audio-source-sleeve-art {
+  color: var(--accent);
+  opacity: 1;
+}
+
+/* Pinned upload sleeve — always rendered, separated from the scroll list
+   above by a thin hairline so it reads as a distinct "you" slot. */
+.audio-source-sleeve--upload {
+  flex-shrink: 0;
+  position: relative;
+  margin-top: 2px;
+  padding-top: 9px;
+  color: var(--accent-hover);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  font-size: 10px;
+}
+.audio-source-sleeve--upload::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 8px;
+  right: 8px;
+  height: 1px;
+  background: linear-gradient(90deg,
+    transparent,
+    var(--frame-line) 25%,
+    var(--frame-line) 75%,
+    transparent);
+}
+.audio-source-sleeve--upload:hover {
+  background: var(--accent-medium);
+  color: var(--accent-hover);
+}
+.audio-source-sleeve-art--upload {
+  border: none;
+  color: var(--accent);
+  width: 14px;
+  height: 14px;
+  opacity: 1;
+}
+.audio-source-sleeve-art--upload::after { display: none; }
+
+/* Mobile: shrink the fan to a near-full-width sheet anchored to the
+   placard corner. Match the halo-menu mobile pattern. */
+@media (max-width: 480px) {
+  .audio-source-fan {
+    left: max(14px, env(safe-area-inset-left, 0px));
+    right: max(14px, env(safe-area-inset-right, 0px));
+    max-width: none;
+  }
+  .audio-source-crate {
+    max-width: calc(100vw - 32px);
+  }
+}
+

--- a/demos/realtime_motion_graph_web/web/app/layout.tsx
+++ b/demos/realtime_motion_graph_web/web/app/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata, Viewport } from "next";
+
+import "./globals.css";
+
+import { RTMGBoot } from "./RTMGBoot";
+
+export const metadata: Metadata = {
+  title: "DEMON — Realtime Motion Graph",
+  description: "Reference UI for the realtime motion graph engine.",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+  themeColor: "#0a0a10",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en">
+      <body>
+        <RTMGBoot />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/app/page.tsx
+++ b/demos/realtime_motion_graph_web/web/app/page.tsx
@@ -1,0 +1,5 @@
+import { PerformanceShell } from "@/components/Performance/PerformanceShell";
+
+export default function Home() {
+  return <PerformanceShell />;
+}

--- a/demos/realtime_motion_graph_web/web/components/CustomCursor.tsx
+++ b/demos/realtime_motion_graph_web/web/components/CustomCursor.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+// Mount point for the canvas-rendered cursor. cursor.ts grabs this
+// element on init and drives it from the shared render loop. Single
+// composited layer so the orbital cluster + sparks + confetti all
+// stay on the GPU's fast path in every browser.
+
+export function CustomCursor() {
+  return <canvas className="cursor-canvas" aria-hidden="true" />;
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { useCurveStore } from "@/store/useCurveStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+import { ChannelGainsTile } from "./ChannelGainsTile";
+import { ChannelsTile } from "./ChannelsTile";
+import { DcwTile } from "./DcwTile";
+import { EngineTile } from "./EngineTile";
+import { LibraryTile } from "./LibraryTile";
+import { LiteControls } from "./LiteControls";
+import { MainTile } from "./MainTile";
+import { MobileFullSheet } from "./MobileFullSheet";
+import { OperatorStrip } from "./OperatorStrip";
+import { PromptsTile } from "./PromptsTile";
+import { SeedTile } from "./SeedTile";
+
+// Slide-up Advanced Controls drawer. Behavior splits at the mobile
+// breakpoint: desktop shows the dense mixer-board layout; mobile shows a
+// "Lite" layout (Structure + seed + prompt) with an "All controls" link
+// that opens a full-screen tabbed sheet. The handle is disabled while the
+// session is idle.
+
+export function AdvancedDrawer() {
+  const [open, setOpen] = useState(false);
+  const [allOpen, setAllOpen] = useState(false);
+  const isMobile = useIsMobile();
+  const status = useSessionStore((s) => s.status);
+  const showKbdHints = usePerformanceStore((s) => s.showKbdHints);
+  const started = status !== "idle";
+
+  // useKeyboardShortcuts dispatches this on Esc / `o`.
+  useEffect(() => {
+    const handler = () => {
+      if (!started) return;
+      setOpen((v) => !v);
+    };
+    document.addEventListener("dd:toggle-drawer", handler);
+    return () => document.removeEventListener("dd:toggle-drawer", handler);
+  }, [started]);
+
+  // Force-close on any transition back to idle (session reset).
+  useEffect(() => {
+    if (!started) {
+      setOpen(false);
+      setAllOpen(false);
+    }
+  }, [started]);
+
+  // Auto-close when the SCHEDULE CURVES overlay opens. The two are
+  // mutually exclusive working modes — drawing curves over the graph
+  // vs. dragging sliders in the mixer — and stacking them just shrinks
+  // both. When the user opens the curves overlay, hide the drawer
+  // (state preserved; reopens on the next dd:toggle-drawer).
+  const overlayOpen = useCurveStore((s) => s.overlayOpen);
+  useEffect(() => {
+    if (overlayOpen) {
+      setOpen(false);
+      setAllOpen(false);
+    }
+  }, [overlayOpen]);
+
+  // Mirror open state to body.drawer-open so the existing CSS rule
+  // `body[data-mode="graph"].drawer-open #install-stage { bottom: var(--drawer-h); }`
+  // shrinks the stage (and the embedded canvases) when the drawer slides up.
+  // ResizeObserver inside HUD/Graph fires on the resulting size change.
+  useEffect(() => {
+    document.body.classList.toggle("drawer-open", open);
+    return () => {
+      document.body.classList.remove("drawer-open");
+    };
+  }, [open]);
+
+  return (
+    <>
+      <aside
+        id="install-sheet"
+        className={`install-sheet${open ? " open" : ""}${isMobile ? " install-sheet--mobile" : ""}`}
+        aria-hidden={!open}
+      >
+        <button
+          id="install-adv-handle"
+          className={`install-drawer-handle${started ? "" : " install-drawer-handle--disabled"}`}
+          aria-label="Toggle advanced controls drawer"
+          aria-disabled={!started}
+          title={started ? "Advanced Controls (o)" : "Press Play to enable"}
+          onClick={() => {
+            if (!started) return;
+            setOpen((v) => !v);
+          }}
+          disabled={!started}
+          type="button"
+        >
+          <span className="install-drawer-handle-grip" aria-hidden="true" />
+          <span className="install-drawer-handle-label">Advanced Controls</span>
+          <span className="install-drawer-handle-grip" aria-hidden="true" />
+        </button>
+
+        <div className="install-sheet-body">
+          {isMobile ? (
+            <LiteControls onOpenAllControls={() => setAllOpen(true)} />
+          ) : (
+            <>
+              <OperatorStrip />
+              <div
+                className={`mixer-rack${!showKbdHints ? " mixer-rack--no-kbd-hints" : ""}`}
+                id="mixer-tiles"
+              >
+                {/* Single row with every tile, sharing the full width
+                    equally, plus a full-width prompts row beneath. CSS
+                    on .mixer-rack-row > .mixer-tile stretches each tile
+                    to an equal share via `flex: 1 1 0` + `min-width: 0`. */}
+                <div className="mixer-rack-row" data-rack-row="all">
+                  <MainTile />
+                  <EngineTile />
+                  <ChannelGainsTile />
+                  <ChannelsTile />
+                  <DcwTile />
+                  <LibraryTile />
+                  <SeedTile />
+                </div>
+                <PromptsTile />
+              </div>
+            </>
+          )}
+        </div>
+      </aside>
+
+      {isMobile && (
+        <MobileFullSheet
+          open={allOpen}
+          onClose={() => setAllOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+
+import { decodeAudioFile, listFixtures } from "@/engine/audio/loadFixture";
+import { useCustomTracksStore } from "@/store/useCustomTracksStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+// Bottom-left counterpart to the bottom-right turntable. Replaces the plain
+// fixture <select> as the primary track-picker — that dropdown hid the fact
+// that multiple preloaded tracks exist. The placard is the entire affordance:
+// always shows the current track at rest, click to fan out a column of
+// sleeves with a permanent "upload your own" sleeve pinned at the bottom.
+//
+// All track switching (built-in or upload) goes through usePerformanceStore's
+// setFixture(); useFixtureSwap (subscribed in <Performance/>) handles the
+// mid-session crossfade. The advanced-controls strip carries an unchanged
+// dropdown + upload icon for power users.
+
+interface TrackOption {
+  name: string;
+  kind: "fixture" | "custom";
+}
+
+function UploadIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width={14}
+      height={14}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.4}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M8 10V2" />
+      <path d="M4.5 5.5L8 2l3.5 3.5" />
+      <path d="M2.5 10v3a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3" />
+    </svg>
+  );
+}
+
+export function AudioSourceCrate() {
+  const fixture = usePerformanceStore((s) => s.fixture);
+  const setFixture = usePerformanceStore((s) => s.setFixture);
+  const kiosk = usePerformanceStore((s) => s.kiosk);
+  const sessionWsUrl = useSessionStore((s) => s.wsUrl);
+
+  const [fixtures, setFixtures] = useState<string[]>([]);
+  const customNames = useCustomTracksStore((s) => s.names);
+  const addCustomTrack = useCustomTracksStore((s) => s.add);
+
+  const [open, setOpen] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const placardRef = useRef<HTMLButtonElement | null>(null);
+  const fanRef = useRef<HTMLDivElement | null>(null);
+
+  // Fetch the catalog only AFTER the queue admits us. The pod proxy at
+  // /api/pod/* returns 401 without a session id, so calling pre-admit
+  // would just spam 401s in the network tab for no benefit.
+  useEffect(() => {
+    if (!sessionWsUrl) return;
+    void listFixtures()
+      .then((names) => {
+        setFixtures(names);
+        if (!usePerformanceStore.getState().fixture && names[0]) {
+          setFixture(names[0]);
+        }
+      })
+      .catch(() => setFixtures([]));
+  }, [setFixture, sessionWsUrl]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onPointer(e: PointerEvent) {
+      const t = e.target as Node | null;
+      if (!t) return;
+      if (placardRef.current?.contains(t)) return;
+      if (fanRef.current?.contains(t)) return;
+      setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("pointerdown", onPointer);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onPointer);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  async function onFilePicked(file: File) {
+    const { setStatus } = useSessionStore.getState();
+    setUploading(true);
+    setStatus(useSessionStore.getState().status, `Loading ${file.name}…`);
+    try {
+      const decoded = await decodeAudioFile(file);
+      const baseName = file.name;
+      let chosen = baseName;
+      let i = 1;
+      while (useCustomTracksStore.getState().has(chosen)) {
+        chosen = `${baseName} (${i++})`;
+      }
+      addCustomTrack(chosen, decoded);
+      setFixture(chosen);
+      setStatus(useSessionStore.getState().status, "");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setStatus(useSessionStore.getState().status, `Upload failed: ${msg}`);
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  if (kiosk) return null;
+
+  const tracks: TrackOption[] = [
+    ...fixtures.map((name) => ({ name, kind: "fixture" as const })),
+    ...customNames.map((name) => ({ name, kind: "custom" as const })),
+  ];
+  const displayedName = fixture || (tracks[0]?.name ?? "—");
+
+  return (
+    <>
+      <button
+        ref={placardRef}
+        type="button"
+        className={`audio-source-crate${open ? " audio-source-crate--open" : ""}`}
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`Pick audio track. Current: ${displayedName}`}
+        title={`Audio source: ${displayedName}`}
+      >
+        <span className="audio-source-marquee-rows">
+          <span className="audio-source-marquee-label">
+            {open ? "Pick a track" : "▶ Now playing"}
+          </span>
+          <span className="audio-source-marquee-name" title={displayedName}>
+            {open ? "or upload your own" : displayedName}
+          </span>
+        </span>
+        <span className="audio-source-crate-caret" aria-hidden="true">
+          <svg viewBox="0 0 10 10" width={10} height={10} fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M2 6.5L5 3.5L8 6.5" />
+          </svg>
+        </span>
+      </button>
+
+      {open && (
+        <div ref={fanRef} className="audio-source-fan" role="menu">
+          <div className="audio-source-fan-scroll">
+            {tracks.length === 0 && (
+              <div className="audio-source-fan-empty">Loading tracks…</div>
+            )}
+            {tracks.map((t, i) => {
+              const isCurrent = t.name === fixture;
+              return (
+                <button
+                  key={`${t.kind}:${t.name}`}
+                  type="button"
+                  role="menuitem"
+                  className={[
+                    "audio-source-sleeve",
+                    isCurrent ? "audio-source-sleeve--current" : "",
+                    t.kind === "custom" ? "audio-source-sleeve--custom" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                  style={{ "--idx": i } as CSSProperties}
+                  onClick={() => {
+                    setFixture(t.name);
+                    setOpen(false);
+                  }}
+                  title={t.name}
+                >
+                  <span className="audio-source-sleeve-art" aria-hidden="true" />
+                  <span className="audio-source-sleeve-label">{t.name}</span>
+                </button>
+              );
+            })}
+          </div>
+          {/* Upload sleeve is pinned outside the scroll region so it stays
+              visible regardless of fixture count. Always rendered. */}
+          <button
+            type="button"
+            role="menuitem"
+            className="audio-source-sleeve audio-source-sleeve--upload"
+            disabled={uploading}
+            onClick={() => fileInputRef.current?.click()}
+            title="Upload your own audio track"
+          >
+            <span
+              className="audio-source-sleeve-art audio-source-sleeve-art--upload"
+              aria-hidden="true"
+            >
+              <UploadIcon />
+            </span>
+            <span className="audio-source-sleeve-label">
+              {uploading ? "Decoding…" : "Upload your own"}
+            </span>
+          </button>
+        </div>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="audio/*,.mp3,.wav,.flac,.ogg,.m4a,.aac"
+        style={{ display: "none" }}
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          // Reset so picking the same file twice still fires onChange.
+          e.target.value = "";
+          if (file) void onFilePicked(file);
+        }}
+      />
+    </>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/ChannelGainsTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/ChannelGainsTile.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { defaultLabelFor, SliderTile } from "./SliderTile";
+
+const PARAMS = ["ch_g0", "ch_g1", "ch_g2", "ch_g3", "ch_g4", "ch_g5", "ch_g6", "ch_g7"];
+
+export function ChannelGainsTile() {
+  return (
+    <SliderTile
+      label="Channel Gains"
+      params={PARAMS.map((p) => ({ param: p, label: defaultLabelFor(p) }))}
+    />
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/ChannelsTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/ChannelsTile.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { defaultLabelFor, SliderTile } from "./SliderTile";
+
+const PARAMS = ["ch13", "ch14", "ch19", "ch23", "ch29", "ch56"];
+
+export function ChannelsTile() {
+  return (
+    <SliderTile
+      label="Channels"
+      params={PARAMS.map((p) => ({ param: p, label: defaultLabelFor(p) }))}
+    />
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/ConfigModal.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/ConfigModal.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { KEY_BINDINGS } from "@/engine/keyboard/bindings";
+import { LORA_SLOT_MARKER, type NoteAction } from "@/engine/midi/types";
+import { useMidiStore } from "@/store/useMidiStore";
+import { useUiStore } from "@/store/useUiStore";
+
+interface RowDef {
+  kind: "cc" | "note";
+  target: string;
+  label: string;
+}
+
+const CC_ROWS: RowDef[] = [
+  { kind: "cc", target: "denoise", label: "Remix strength" },
+  { kind: "cc", target: "hint_strength", label: "Structure strength" },
+  { kind: "cc", target: "feedback", label: "Feedback" },
+  { kind: "cc", target: "shift", label: "Shift" },
+  { kind: "cc", target: "noise_share", label: "Noise share" },
+  { kind: "cc", target: "ode_noise", label: "ODE noise" },
+  { kind: "cc", target: LORA_SLOT_MARKER[0], label: "LoRA slot 1 strength" },
+  { kind: "cc", target: LORA_SLOT_MARKER[1], label: "LoRA slot 2 strength" },
+];
+
+const NOTE_ACTIONS: { target: NoteAction; label: string }[] = [
+  { target: "seed", label: "Randomize seed" },
+  { target: "send_prompt", label: "Send prompt" },
+  { target: "pause", label: "Pause / resume" },
+  { target: "mode_toggle", label: "Toggle display mode" },
+  { target: "kiosk_toggle", label: "Toggle kiosk" },
+];
+
+const NOTE_ROWS: RowDef[] = NOTE_ACTIONS.map((n) => ({
+  kind: "note",
+  target: n.target,
+  label: n.label,
+}));
+
+const ALL_ROWS = [...CC_ROWS, ...NOTE_ROWS];
+
+export function ConfigModal() {
+  const open = useUiStore((s) => s.configOpen);
+  const setConfigOpen = useUiStore((s) => s.setConfigOpen);
+
+  const [tab, setTab] = useState<"midi" | "keyboard">("midi");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setConfigOpen(false);
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, setConfigOpen]);
+
+  // Cancel any in-flight MIDI learn when the modal closes.
+  useEffect(() => {
+    if (open) return;
+    const learn = useMidiStore.getState().learn;
+    if (learn) useMidiStore.getState().cancelLearn();
+  }, [open]);
+
+  if (!mounted || !open) return null;
+
+  return createPortal(
+    <div
+      className="config-modal-backdrop"
+      onClick={() => setConfigOpen(false)}
+      role="presentation"
+    >
+      <div
+        className="config-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="MIDI and keyboard configuration"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="config-modal-accent" aria-hidden="true" />
+
+        <div className="config-modal-header">
+          <h2 className="config-modal-title">Configuration</h2>
+          <button
+            type="button"
+            className="config-modal-close"
+            onClick={() => setConfigOpen(false)}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="config-modal-tabs" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "midi"}
+            className={`config-modal-tab${tab === "midi" ? " config-modal-tab--active" : ""}`}
+            onClick={() => setTab("midi")}
+          >
+            MIDI
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "keyboard"}
+            className={`config-modal-tab${tab === "keyboard" ? " config-modal-tab--active" : ""}`}
+            onClick={() => setTab("keyboard")}
+          >
+            Keyboard
+          </button>
+        </div>
+
+        <div className="config-modal-body">
+          {tab === "midi" ? <MidiTab /> : <KeyboardTab />}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function MidiTab() {
+  const map = useMidiStore((s) => s.map);
+  const learn = useMidiStore((s) => s.learn);
+  const status = useMidiStore((s) => s.status);
+  const available = useMidiStore((s) => s.available);
+  const startLearn = useMidiStore((s) => s.startLearn);
+  const cancelLearn = useMidiStore((s) => s.cancelLearn);
+  const clearBinding = useMidiStore((s) => s.clearBinding);
+  const resetMap = useMidiStore((s) => s.resetMap);
+
+  const findNum = useMemo(() => {
+    return (kind: "cc" | "note", target: string): string | null => {
+      const slot = kind === "cc" ? map.cc : map.notes;
+      for (const [num, t] of Object.entries(slot)) {
+        if (t === target) return num;
+      }
+      return null;
+    };
+  }, [map]);
+
+  return (
+    <div className="config-midi">
+      <p className="config-midi-tip">
+        Right-click any slider in Advanced Controls to learn directly.
+      </p>
+
+      <div
+        className={`config-midi-status config-midi-status--${status.tone}`}
+      >
+        <span className="config-midi-status-dot" aria-hidden="true" />
+        <span>{status.message}</span>
+        {!available && (
+          <span className="config-midi-status-hint">
+            (no devices detected — connect a controller)
+          </span>
+        )}
+      </div>
+
+      <div className="config-midi-table">
+        <div className="config-midi-row config-midi-row--head">
+          <span>Parameter</span>
+          <span>Type</span>
+          <span>#</span>
+          <span />
+        </div>
+
+        {ALL_ROWS.map((row) => {
+          const num = findNum(row.kind, row.target);
+          const isLearning =
+            learn?.kind === row.kind && learn.target === row.target;
+          return (
+            <div className="config-midi-row" key={`${row.kind}:${row.target}`}>
+              <span className="config-midi-cell-label">{row.label}</span>
+              <span className="config-midi-cell-kind">
+                {row.kind === "cc" ? "CC" : "Note"}
+              </span>
+              <span className="config-midi-cell-num">
+                {isLearning ? "…" : (num ?? "—")}
+              </span>
+              <span className="config-midi-cell-actions">
+                <button
+                  type="button"
+                  className={`config-midi-btn${isLearning ? " config-midi-btn--learning" : ""}`}
+                  onClick={() => {
+                    if (isLearning) {
+                      cancelLearn();
+                    } else {
+                      startLearn(row.kind, row.target, null);
+                    }
+                  }}
+                >
+                  {isLearning ? "Cancel" : "Learn"}
+                </button>
+                <button
+                  type="button"
+                  className="config-midi-btn config-midi-btn--ghost"
+                  onClick={() => clearBinding(row.kind, row.target)}
+                  disabled={!num}
+                >
+                  Clear
+                </button>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="config-midi-footer">
+        <button
+          type="button"
+          className="config-midi-btn config-midi-btn--ghost"
+          onClick={() => resetMap()}
+        >
+          Reset to defaults
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function KeyboardTab() {
+  return (
+    <div className="config-keyboard">
+      <div className="config-keyboard-list">
+        {KEY_BINDINGS.map((b) => (
+          <div className="config-keyboard-row" key={b.combo}>
+            <kbd className="config-keyboard-combo">{b.combo}</kbd>
+            <span className="config-keyboard-desc">{b.description}</span>
+          </div>
+        ))}
+      </div>
+      <p className="config-keyboard-note">
+        Rebinding will land in a future update. Current shortcuts are fixed.
+      </p>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/DcwTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/DcwTile.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { DCW_MODES, DCW_WAVELETS } from "@/types/engine";
+
+import { SliderGroup } from "./SliderGroup";
+import { kbdHintFor } from "./SliderTile";
+
+// DCW tile. Two faders (low / high scaler) plus a small panel with the
+// ON/OFF toggle, mode select, and wavelet select. The non-numeric state
+// rides into the params raw dict (see useParamSync) so the server picks it
+// up alongside slider values.
+
+export function DcwTile() {
+  const dcwEnabled = usePerformanceStore((s) => s.dcwEnabled);
+  const dcwMode = usePerformanceStore((s) => s.dcwMode);
+  const dcwWavelet = usePerformanceStore((s) => s.dcwWavelet);
+  const toggleDcw = usePerformanceStore((s) => s.toggleDcw);
+  const setMode = usePerformanceStore((s) => s.setDcwMode);
+  const setWavelet = usePerformanceStore((s) => s.setDcwWavelet);
+
+  return (
+    <div className="mixer-tile" data-tile="dcw">
+      <div className="mixer-tile-label">DCW</div>
+      <div className="mixer-channels">
+        <SliderGroup
+          param="dcw_scaler"
+          label="DCW low"
+          kbd={kbdHintFor("dcw_scaler")}
+        />
+        <SliderGroup
+          param="dcw_high_scaler"
+          label="DCW high"
+          kbd={kbdHintFor("dcw_high_scaler")}
+        />
+        <div className="dcw-panel">
+          <button
+            type="button"
+            className={`dcw-toggle${dcwEnabled ? " active" : ""}`}
+            data-role="dcw-enabled"
+            title="Toggle DCW (T)"
+            onClick={toggleDcw}
+          >
+            DCW: {dcwEnabled ? "ON" : "OFF"}
+          </button>
+          <label className="dcw-row">
+            <span className="dcw-row-label">DCW mode</span>
+            <select
+              className="dcw-select"
+              title="Cycle DCW mode (Shift + T)"
+              value={dcwMode}
+              onChange={(e) =>
+                setMode(e.target.value as (typeof DCW_MODES)[number])
+              }
+            >
+              {DCW_MODES.map((m) => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="dcw-row">
+            <span className="dcw-row-label">wavelet</span>
+            <select
+              className="dcw-select"
+              title="Cycle wavelet (Shift + W)"
+              value={dcwWavelet}
+              onChange={(e) =>
+                setWavelet(e.target.value as (typeof DCW_WAVELETS)[number])
+              }
+            >
+              {DCW_WAVELETS.map((w) => (
+                <option key={w} value={w}>
+                  {w}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/DesktopEdgeDrag.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/DesktopEdgeDrag.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useLoraStore } from "@/store/useLoraStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import {
+  LORA_DEFAULT_STRENGTH_FRACTION,
+  LORA_SIDE_VISIBLE_FLOOR,
+  LORA_SLIDER_MAX,
+} from "@/types/engine";
+
+import { RemixHint } from "./RemixHint";
+
+type Side = "top" | "left" | "right";
+
+interface Props {
+  side: Side;
+}
+
+const TOP_PARAM = "denoise";
+const TOP_MAX = 1.0;
+
+// localStorage key for the one-time "drag the strings" affordance hint
+// shown beneath the Remix Strength slider AND on each non-empty LoRA
+// strength bar. Once the user successfully drags any of them, the hint
+// is dismissed forever across all three sliders. Key kept as legacy
+// (`remix-strength`) to avoid resetting users who already learned.
+const HINT_DISMISSED_KEY = "remix-strength:dismissed";
+
+// Custom event used to keep the three <DesktopEdgeDrag /> instances in
+// sync: when one dismisses the hint, the others need to hear about it
+// so they can hide their hint *immediately* without waiting for a reload.
+const HINT_DISMISSED_EVENT = "dd:drag-hint-dismissed";
+
+// Transparent pointer overlay sitting on top of an .install-edge-* HUD bar
+// so the perimeter ribbons act as draggable sliders on desktop.
+//
+//   side="top"   →  horizontal drag, controls denoise (remix strength).
+//   side="left"  →  vertical drag, controls the FIRST enabled LoRA strength.
+//   side="right" →  vertical drag, controls the SECOND enabled LoRA strength.
+//
+// The LoRA-side variants read the bound id from `.install-edge-{side}`'s
+// data-bar attribute (set by useEdgeLoraBinding). When no LoRA is bound,
+// data-empty="true" switches the cursor back to default and the
+// pointerdown handler early-returns, so a drag on an empty slot is a
+// no-op. The overlay itself stays mounted and accepts hover events so
+// the RemixHint keeps rendering through "connecting" / catalog updates.
+//
+// Each side also renders <RemixHint /> as a child (until the user's first
+// successful drag dismisses it) — the orientation prop tells the hint
+// whether to track X or Y, and the side prop controls which side of the
+// bar the hint sits on.
+export function DesktopEdgeDrag({ side }: Props) {
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  // Re-render when LoRA enabled/strengths change so aria values + the
+  // data-empty attribute stay accurate. Drag handlers themselves read
+  // the latest store via getState().
+  const enabled = useLoraStore((s) => s.enabled);
+  const strengths = useLoraStore((s) => s.strengths);
+  // Reads the target (intent) so the visual responds immediately to the
+  // drag, even when smooth-mode is on (sliderValues lags via tween).
+  const denoise = usePerformanceStore((s) => s.sliderTargets[TOP_PARAM] ?? 0);
+
+  const isTop = side === "top";
+  const orientation: "horizontal" | "vertical" = isTop
+    ? "horizontal"
+    : "vertical";
+
+  // Hint state. `dismissed` reads from localStorage on mount; `hover` /
+  // `dragging` drive the live label. Position is driven by the slider's
+  // own value (see valueFraction below) so the hint always sits at the
+  // head — no separate cursor state needed.
+  const [hintDismissed, setHintDismissed] = useState(true); // SSR-safe default
+  const [hover, setHover] = useState(false);
+  const [dragging, setDragging] = useState(false);
+
+  useEffect(() => {
+    if (typeof localStorage === "undefined") {
+      setHintDismissed(false);
+      return;
+    }
+    try {
+      setHintDismissed(localStorage.getItem(HINT_DISMISSED_KEY) === "1");
+    } catch {
+      setHintDismissed(false);
+    }
+  }, []);
+
+  // Cross-instance dismissal sync: when one slider's drag dismisses the
+  // hint, the other two should hide their hint without waiting for the
+  // page to reload.
+  useEffect(() => {
+    const onDismiss = () => setHintDismissed(true);
+    document.addEventListener(HINT_DISMISSED_EVENT, onDismiss);
+    return () =>
+      document.removeEventListener(HINT_DISMISSED_EVENT, onDismiss);
+  }, []);
+
+  const slotIndex = side === "left" ? 0 : side === "right" ? 1 : -1;
+  const loraId =
+    slotIndex >= 0 ? Array.from(enabled)[slotIndex] ?? null : null;
+  const isEmpty = side !== "top" && loraId === null;
+
+  const value = (() => {
+    if (side === "top") return denoise;
+    // Empty side bar (no LoRA bound yet) — return the same default the
+    // canvas paints via --fill (see useEdgeLoraBinding), so the hint
+    // head sits where the ribbon visually ends and ARIA aria-valuenow
+    // matches what the user sees.
+    if (loraId === null) return LORA_DEFAULT_STRENGTH_FRACTION * LORA_SLIDER_MAX;
+    return strengths[loraId] ?? 0;
+  })();
+  const max = side === "top" ? TOP_MAX : LORA_SLIDER_MAX;
+  // Drives RemixHint position so the hint always sits at the head (the
+  // slider's current value), not at a stale cursor position. Side bars
+  // get the same visibility floor the canvas uses so the hint stays
+  // attached to the ribbon's visible end when strength is below the
+  // floor (otherwise the hint floats below the ribbon).
+  const rawFraction = max > 0 ? Math.max(0, Math.min(1, value / max)) : 0;
+  const valueFraction = isTop
+    ? rawFraction
+    : Math.max(rawFraction, LORA_SIDE_VISIBLE_FLOOR);
+
+  // Capture the slider's value at pointerdown so we can detect whether
+  // the drag actually moved the value (the dismissal contract requires
+  // a value-changing drag — a stationary tap-and-release shouldn't
+  // count as "the user learned to drag").
+  const readCurrentValue = useCallback((): number => {
+    if (isTop) {
+      return usePerformanceStore.getState().sliderTargets[TOP_PARAM] ?? 0;
+    }
+    const id = Array.from(useLoraStore.getState().enabled)[slotIndex];
+    return id ? useLoraStore.getState().strengths[id] ?? 0 : 0;
+  }, [isTop, slotIndex]);
+
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el) return;
+
+    // Cache the host rect at pointerdown and reuse for the lifetime of
+    // the drag. Without this, every pointermove called
+    // getBoundingClientRect(), forcing a synchronous layout flush per
+    // event. RAF-coalesce the store write so a 60–120 evt/sec pointer
+    // stream commits at most once per frame.
+    let isDragging = false;
+    let dragInitialValue = 0;
+    let cachedRect: DOMRect | null = null;
+    let pendingClientX = 0;
+    let pendingClientY = 0;
+    let rafId = 0;
+
+    const commitValue = () => {
+      if (!cachedRect) return;
+      if (isTop) {
+        const t = (pendingClientX - cachedRect.left) / cachedRect.width;
+        usePerformanceStore
+          .getState()
+          .setSlider(TOP_PARAM, Math.max(0, Math.min(1, t)) * TOP_MAX);
+        return;
+      }
+      const t = 1 - (pendingClientY - cachedRect.top) / cachedRect.height;
+      const ids = Array.from(useLoraStore.getState().enabled);
+      const id = ids[slotIndex];
+      if (!id) return;
+      useLoraStore
+        .getState()
+        .setStrength(id, Math.max(0, Math.min(1, t)) * LORA_SLIDER_MAX);
+    };
+
+    const flush = () => {
+      rafId = 0;
+      if (!cachedRect) return;
+      if (isDragging) commitValue();
+    };
+
+    const schedule = () => {
+      if (rafId === 0) rafId = requestAnimationFrame(flush);
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.button !== 0 && e.pointerType === "mouse") return;
+      // Defensive: if no LoRA is bound (or a fast LoRA disable race lands
+      // `data-empty` mid-press), don't capture — drag is a no-op.
+      if (el.dataset.empty === "true") return;
+      isDragging = true;
+      setDragging(true);
+      dragInitialValue = readCurrentValue();
+      cachedRect = el.getBoundingClientRect();
+      pendingClientX = e.clientX;
+      pendingClientY = e.clientY;
+      el.setPointerCapture(e.pointerId);
+      // Commit immediately so a click-without-drag still moves the value.
+      commitValue();
+    };
+    const onPointerMove = (e: PointerEvent) => {
+      if (!isDragging) return;
+      pendingClientX = e.clientX;
+      pendingClientY = e.clientY;
+      schedule();
+    };
+    const onPointerUp = (e: PointerEvent) => {
+      if (!isDragging) return;
+      isDragging = false;
+      if (rafId !== 0) {
+        cancelAnimationFrame(rafId);
+        rafId = 0;
+      }
+      el.releasePointerCapture(e.pointerId);
+      setDragging(false);
+      // First successful (value-changing) drag dismisses the hint forever.
+      // Broadcast to sibling instances so all three hide together.
+      const finalValue = readCurrentValue();
+      if (finalValue !== dragInitialValue) {
+        try {
+          if (typeof localStorage !== "undefined") {
+            localStorage.setItem(HINT_DISMISSED_KEY, "1");
+          }
+        } catch {}
+        setHintDismissed(true);
+        document.dispatchEvent(new CustomEvent(HINT_DISMISSED_EVENT));
+      }
+      cachedRect = null;
+    };
+
+    const onPointerEnter = () => {
+      if (el.dataset.empty === "true") return;
+      setHover(true);
+    };
+    const onPointerLeave = () => {
+      setHover(false);
+    };
+
+    el.addEventListener("pointerdown", onPointerDown);
+    el.addEventListener("pointermove", onPointerMove);
+    el.addEventListener("pointerup", onPointerUp);
+    el.addEventListener("pointercancel", onPointerUp);
+    el.addEventListener("pointerenter", onPointerEnter);
+    el.addEventListener("pointerleave", onPointerLeave);
+    return () => {
+      if (rafId !== 0) cancelAnimationFrame(rafId);
+      el.removeEventListener("pointerdown", onPointerDown);
+      el.removeEventListener("pointermove", onPointerMove);
+      el.removeEventListener("pointerup", onPointerUp);
+      el.removeEventListener("pointercancel", onPointerUp);
+      el.removeEventListener("pointerenter", onPointerEnter);
+      el.removeEventListener("pointerleave", onPointerLeave);
+    };
+  }, [readCurrentValue, isTop, slotIndex]);
+
+  // Always show the hint until dismissed — even for empty LoRA slots, so
+  // the user has a stable visual anchor through "connecting" / catalog
+  // updates. Drag on an empty slot is a no-op (data-empty guards
+  // pointerdown), but the hint stays visible so nothing "disappears".
+  const showHint = !hintDismissed;
+
+  return (
+    <div
+      ref={trackRef}
+      className="desktop-edge-drag"
+      data-side={side}
+      data-empty={isEmpty ? "true" : "false"}
+      role="slider"
+      aria-label={
+        side === "top"
+          ? "Remix strength"
+          : side === "left"
+            ? "LoRA 1 strength"
+            : "LoRA 2 strength"
+      }
+      aria-valuemin={0}
+      aria-valuemax={max}
+      aria-valuenow={value}
+    >
+      {showHint && (
+        <RemixHint
+          hover={hover}
+          dragging={dragging}
+          valueFraction={valueFraction}
+          orientation={orientation}
+          side={side === "right" ? "right" : "left"}
+          draggingLabel={
+            side === "left"
+              ? "— mosh —"
+              : side === "right"
+                ? "— vibe —"
+                : "— rave —"
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/EngineTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/EngineTile.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { defaultLabelFor, SliderTile } from "./SliderTile";
+
+const PARAMS = [
+  "feedback",
+  "shift",
+  "noise_share",
+  "ode_noise",
+];
+
+export function EngineTile() {
+  return (
+    <SliderTile
+      label="Engine"
+      params={PARAMS.map((p) => ({ param: p, label: defaultLabelFor(p) }))}
+    />
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/GraphPauseOverlay.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/GraphPauseOverlay.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { togglePauseAndAudio } from "@/engine/audio/togglePauseAndAudio";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+const FLASH_MS = 700;
+
+// Click-to-pause overlay layered on top of #graph-wrap. The whole canvas
+// area is the click target; the centered glyph fades in on each toggle and
+// fades out, YouTube-style. A one-shot discovery flash fires the first
+// time the session reaches "ready" so first-time users see the affordance
+// without having to click first.
+export function GraphPauseOverlay() {
+  const paused = usePerformanceStore((s) => s.paused);
+  const status = useSessionStore((s) => s.status);
+
+  const [flashing, setFlashing] = useState(false);
+  // Glyph reflects the state being shown — for clicks that's the
+  // post-toggle state, for the discovery flash it's the current (playing)
+  // state. Tracked separately from `paused` so the visual doesn't get
+  // overwritten by an unrelated state change mid-flash.
+  const [glyph, setGlyph] = useState<"play" | "pause">("pause");
+  const flashTimerRef = useRef<number | null>(null);
+  const discoveryFiredRef = useRef(false);
+
+  function flash(showGlyph: "play" | "pause") {
+    setGlyph(showGlyph);
+    setFlashing(true);
+    if (flashTimerRef.current !== null) {
+      window.clearTimeout(flashTimerRef.current);
+    }
+    flashTimerRef.current = window.setTimeout(() => {
+      setFlashing(false);
+      flashTimerRef.current = null;
+    }, FLASH_MS);
+  }
+
+  useEffect(() => {
+    return () => {
+      if (flashTimerRef.current !== null) {
+        window.clearTimeout(flashTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (status !== "ready" || discoveryFiredRef.current) return;
+    discoveryFiredRef.current = true;
+    // Small delay so the discovery flash lands after the launch transition
+    // settles, not during it.
+    const t = window.setTimeout(() => flash("pause"), 600);
+    return () => window.clearTimeout(t);
+  }, [status]);
+
+  function onClick() {
+    // YouTube-style: flash the icon for the action the user just took.
+    // `paused` here is still the pre-toggle value, so a click while
+    // playing (paused=false) flashes ⏸, and a click while paused
+    // (paused=true) flashes ▶.
+    flash(paused ? "play" : "pause");
+    togglePauseAndAudio();
+  }
+
+  return (
+    <button
+      type="button"
+      className={`graph-pause-overlay${flashing ? " is-flashing" : ""}`}
+      onClick={onClick}
+      aria-label={paused ? "Resume" : "Pause"}
+    >
+      <span className="graph-pause-overlay__glyph" aria-hidden="true">
+        {glyph === "pause" ? "⏸" : "▶"}
+      </span>
+    </button>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/HUDFrame.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/HUDFrame.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+// Three of the four edges (top, left, right). The bottom edge is the
+// Advanced drawer handle. ribbons.js (Phase 8) will mount SVG paths inside
+// each .install-edge-bar to drive the writhe animation; until then the bars
+// stay as plain DIVs so the layout reserves the right space.
+
+interface EdgeProps {
+  side: "top" | "left" | "right";
+  label?: string;
+  bar?: string;
+}
+
+function Edge({ side, label, bar }: EdgeProps) {
+  return (
+    <div
+      className={`install-edge install-edge-${side}`}
+      data-bar={bar}
+    >
+      <span className="install-edge-label">{label ?? ""}</span>
+      <div className="install-edge-bar" />
+    </div>
+  );
+}
+
+export function HUDFrame() {
+  return (
+    <>
+      <Edge side="top" label="Remix Strength" bar="denoise" />
+      {/* Left/right bars track the first/second currently enabled LoRA.
+          Their data-bar and label are populated at runtime from the
+          server's catalog (Phase 11). */}
+      <Edge side="left" />
+      <Edge side="right" />
+    </>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/InstallStage.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/InstallStage.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { forwardRef } from "react";
+
+import { GraphPauseOverlay } from "./GraphPauseOverlay";
+import { ScheduleCurvesOverlay } from "./ScheduleCurvesOverlay";
+
+// Stage shell: ambient video back-layer, focal video pair (A/B crossfade),
+// effects canvas overlay, focal-side blur strips, plus the legacy hud + graph
+// canvases (kept for app.js feature parity; CSS hides them in install mode).
+//
+// All canvases / videos are exposed via refs so subsequent phases (HUD,
+// Graph, EffectsRenderer, VideoLayer) can attach without JSX-level coupling.
+
+export interface InstallStageRefs {
+  ambient: HTMLVideoElement | null;
+  videoA: HTMLVideoElement | null;
+  videoB: HTMLVideoElement | null;
+  effectsCanvas: HTMLCanvasElement | null;
+  hudCanvas: HTMLCanvasElement | null;
+  graphCanvas: HTMLCanvasElement | null;
+}
+
+interface Props {
+  refs: {
+    ambient: React.RefObject<HTMLVideoElement | null>;
+    videoA: React.RefObject<HTMLVideoElement | null>;
+    videoB: React.RefObject<HTMLVideoElement | null>;
+    effectsCanvas: React.RefObject<HTMLCanvasElement | null>;
+    hudCanvas: React.RefObject<HTMLCanvasElement | null>;
+    graphCanvas: React.RefObject<HTMLCanvasElement | null>;
+  };
+}
+
+export const InstallStage = forwardRef<HTMLDivElement, Props>(
+  function InstallStage({ refs }, ref) {
+    return (
+      <div id="install-stage" ref={ref}>
+        <video ref={refs.ambient} id="install-ambient" muted loop playsInline />
+        <div id="install-video-area">
+          <div id="video-wrap">
+            <video ref={refs.videoA} id="video-a" muted playsInline />
+            <video ref={refs.videoB} id="video-b" muted playsInline />
+            <canvas
+              ref={refs.effectsCanvas}
+              id="effects-canvas"
+              aria-hidden="true"
+            />
+            <div
+              className="focal-side-blur focal-side-blur-left"
+              aria-hidden="true"
+            />
+            <div
+              className="focal-side-blur focal-side-blur-right"
+              aria-hidden="true"
+            />
+          </div>
+          <canvas ref={refs.hudCanvas} id="hud" />
+          <div id="graph-wrap">
+            <canvas ref={refs.graphCanvas} id="graph" />
+            <GraphPauseOverlay />
+            <ScheduleCurvesOverlay />
+          </div>
+        </div>
+      </div>
+    );
+  },
+);

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+import { listLoras } from "@/engine/lora/listLoras";
+import { useLoraStore } from "@/store/useLoraStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+import { LORA_SLIDER_MAX } from "@/types/engine";
+
+// LoRA library tile. Each row: pill-style enable switch, name, full-width
+// strength slider with a colored fill.
+//
+// Right-click anywhere on the row triggers MIDI learn for the
+// `lora_str_<id>` param — useMidi.ts looks for `.lora-row[data-param=…]`.
+// The strength is stored in BOTH usePerformanceStore.sliderTargets (so
+// the smooth tween sees it + useParamSync sends it) and useLoraStore
+// (so subscribed components / RemoteBackend.sendEnableLora pick it up).
+
+interface RowProps {
+  id: string;
+  name: string;
+}
+
+function LoraRow({ id, name }: RowProps) {
+  const enabled = useLoraStore((s) => s.enabled.has(id));
+  // Read the user's intent from the perf store (instant; doesn't lag
+  // behind the smoothing tween) like SliderGroup does, so dragging
+  // tracks the cursor without waiting on smoothMs. Falls back to the
+  // LoRA store for never-touched LoRAs.
+  const strength = usePerformanceStore(
+    (s) => s.sliderTargets[`lora_str_${id}`],
+  );
+  const fallbackStrength = useLoraStore((s) => s.strengths[id] ?? 0);
+  const value = typeof strength === "number" ? strength : fallbackStrength;
+  const setStrength = useLoraStore((s) => s.setStrength);
+  const enable = useLoraStore((s) => s.enable);
+  const disable = useLoraStore((s) => s.disable);
+
+  const trackRef = useRef<HTMLDivElement | null>(null);
+
+  function toggle() {
+    const remote = useSessionStore.getState().remote;
+    if (enabled) {
+      disable(id);
+      remote?.sendDisableLora(id);
+    } else {
+      enable(id);
+      const s = useLoraStore.getState().strengths[id] ?? 0;
+      remote?.sendEnableLora(id, s);
+    }
+  }
+
+  const setFromClientX = useCallback(
+    (clientX: number) => {
+      const el = trackRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const t = (clientX - rect.left) / rect.width;
+      const v = Math.max(0, Math.min(1, t)) * LORA_SLIDER_MAX;
+      // Mirror into both stores so the engine sees it (perf → param-sync)
+      // and any non-React subscriber (RemoteBackend.sendEnableLora) can
+      // read it via useLoraStore.
+      usePerformanceStore.getState().setSlider(`lora_str_${id}`, v);
+      setStrength(id, v);
+    },
+    [id, setStrength],
+  );
+
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el || !enabled) return;
+    let dragging = false;
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.button !== 0) return; // right-click → MIDI learn
+      dragging = true;
+      el.setPointerCapture(e.pointerId);
+      setFromClientX(e.clientX);
+    };
+    const onPointerMove = (e: PointerEvent) => {
+      if (!dragging) return;
+      setFromClientX(e.clientX);
+    };
+    const onPointerUp = (e: PointerEvent) => {
+      if (!dragging) return;
+      dragging = false;
+      el.releasePointerCapture(e.pointerId);
+    };
+    el.addEventListener("pointerdown", onPointerDown);
+    el.addEventListener("pointermove", onPointerMove);
+    el.addEventListener("pointerup", onPointerUp);
+    el.addEventListener("pointercancel", onPointerUp);
+    return () => {
+      el.removeEventListener("pointerdown", onPointerDown);
+      el.removeEventListener("pointermove", onPointerMove);
+      el.removeEventListener("pointerup", onPointerUp);
+      el.removeEventListener("pointercancel", onPointerUp);
+    };
+  }, [enabled, setFromClientX]);
+
+  const pct = Math.max(0, Math.min(1, value / LORA_SLIDER_MAX)) * 100;
+
+  return (
+    <div
+      className={`lora-row${enabled ? " enabled" : ""}`}
+      data-param={`lora_str_${id}`}
+      data-state={enabled ? "enabled" : "disabled"}
+    >
+      <button
+        type="button"
+        className="lora-switch"
+        role="switch"
+        aria-checked={enabled}
+        onClick={toggle}
+        title={enabled ? "Disable" : "Enable"}
+      >
+        <span className="lora-switch-thumb" aria-hidden="true" />
+      </button>
+      <span className="lora-row-name" title={id} onClick={toggle}>
+        {name}
+      </span>
+      <div className="lora-strength">
+        <div className="lora-strength-track" ref={trackRef}>
+          <div className="lora-strength-fill" style={{ width: `${pct}%` }} />
+        </div>
+        <span className="lora-strength-value">{value.toFixed(2)}</span>
+      </div>
+    </div>
+  );
+}
+
+export function LibraryTile() {
+  const catalog = useLoraStore((s) => s.catalog);
+  const setCatalog = useLoraStore((s) => s.setCatalog);
+  // /api/pod/* requires ?session=<id>; without it the proxy 401s. Wait
+  // for the queue to admit us before fetching so we don't spam 401s
+  // pre-admission. The fetch fires the moment sessionWsUrl flips truthy
+  // and re-runs whenever it changes.
+  const sessionWsUrl = useSessionStore((s) => s.wsUrl);
+
+  useEffect(() => {
+    if (!sessionWsUrl) return;
+    void listLoras().then(setCatalog).catch(() => {});
+  }, [setCatalog, sessionWsUrl]);
+
+  if (catalog.length === 0) {
+    return (
+      <div className="mixer-tile" data-tile="library">
+        <div className="mixer-tile-label">Library</div>
+        <div className="lora-empty">no LoRAs found</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mixer-tile" data-tile="library">
+      <div className="mixer-tile-label">Library</div>
+      <div className="lora-list">
+        {catalog.map((entry) => (
+          <LoraRow
+            key={entry.id}
+            id={entry.id}
+            name={entry.name ?? entry.id}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteControls.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteControls.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+import { RecordToggle } from "./RecordToggle";
+import { SliderGroup } from "./SliderGroup";
+
+interface Props {
+  onOpenAllControls: () => void;
+}
+
+// Mobile-first "Lite" mixer. Remix is also exposed here (in addition to
+// the always-visible left-edge rail) so users who already have the drawer
+// open can adjust it without reaching back to the rail. Both surfaces
+// bind to the same zustand value, so they stay in sync automatically.
+export function LiteControls({ onOpenAllControls }: Props) {
+  const seed = usePerformanceStore((s) => s.seed);
+  const promptA = usePerformanceStore((s) => s.promptA);
+  const activeKey = usePerformanceStore((s) => s.activeKey);
+  const randomize = usePerformanceStore((s) => s.randomizeSeed);
+  const setPromptA = usePerformanceStore((s) => s.setPromptA);
+
+  function sendPrompt() {
+    const remote = useSessionStore.getState().remote;
+    if (remote) remote.sendPrompt(promptA, activeKey);
+  }
+
+  return (
+    <div className="lite-controls">
+      <div className="lite-row lite-row--main">
+        <SliderGroup param="denoise" label="remix" />
+        <SliderGroup param="hint_strength" label="structure" />
+        <button
+          type="button"
+          className="lite-seed-btn"
+          data-midi-learn="seed"
+          onClick={randomize}
+          aria-label="Randomize seed"
+        >
+          <span className="lite-seed-icon" aria-hidden="true">
+            <svg
+              className="seed-dice"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="3" y="3" width="18" height="18" rx="3" />
+              <circle cx="8.5" cy="8.5" r="1.1" fill="currentColor" stroke="none" />
+              <circle cx="15.5" cy="15.5" r="1.1" fill="currentColor" stroke="none" />
+            </svg>
+          </span>
+          <span className="lite-seed-value">{seed.toFixed(2)}</span>
+        </button>
+      </div>
+
+      <div className="lite-row lite-row--prompt">
+        <input
+          type="text"
+          className="lite-prompt-input"
+          value={promptA}
+          onChange={(e) => setPromptA(e.target.value)}
+          placeholder="Describe a sound..."
+          aria-label="Prompt"
+        />
+        <button
+          type="button"
+          className="lite-send-btn"
+          data-midi-learn="send_prompt"
+          onClick={sendPrompt}
+        >
+          Send
+        </button>
+        <RecordToggle />
+      </div>
+
+      <button
+        type="button"
+        className="lite-all-controls"
+        onClick={onOpenAllControls}
+      >
+        All controls
+        <span className="lite-all-controls-arrow" aria-hidden="true">→</span>
+      </button>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/MainTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/MainTile.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { SliderGroup } from "./SliderGroup";
+
+export function MainTile() {
+  return (
+    <div className="mixer-tile" data-tile="main">
+      <div className="mixer-tile-label">Main</div>
+      <div className="mixer-channels" id="sliders">
+        <SliderGroup param="denoise" label="remix strength" kbd="A + ▲▼" />
+        <SliderGroup
+          param="hint_strength"
+          label="structure strength"
+          kbd="G + ▲▼"
+        />
+      </div>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/MidiBadge.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/MidiBadge.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+// Tiny chip that shows MIDI device count + last learn message; populated
+// inside #install-midi-slot (already styled by globals.css). Uses a portal-
+// ish injection: just render into the slot via a regular React subtree
+// inside <OperatorStrip />.
+
+import { useMidiStore } from "@/store/useMidiStore";
+
+export function MidiBadge() {
+  const status = useMidiStore((s) => s.status);
+  const cls = `midi-badge midi-${status.tone}`;
+  return (
+    <div className={cls} title="MIDI status — right-click any slider to learn">
+      {status.message}
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/MobileFullSheet.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/MobileFullSheet.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { ChannelGainsTile } from "./ChannelGainsTile";
+import { ChannelsTile } from "./ChannelsTile";
+import { DcwTile } from "./DcwTile";
+import { EngineTile } from "./EngineTile";
+import { LibraryTile } from "./LibraryTile";
+import { MainTile } from "./MainTile";
+import { OperatorStrip } from "./OperatorStrip";
+import { PromptsTile } from "./PromptsTile";
+import { SeedTile } from "./SeedTile";
+
+type Tab = "mix" | "sound" | "prompts" | "config";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "mix", label: "Mix" },
+  { id: "sound", label: "Sound" },
+  { id: "prompts", label: "Prompts" },
+  { id: "config", label: "Config" },
+];
+
+// Full-screen tabbed sheet that surfaces the desktop mixer on mobile when
+// the user taps "All controls". All four sections live in a horizontal
+// scroll-snap track so the user can swipe between them; the tab pills at
+// the bottom both reflect and drive the active section. IntersectionObserver
+// is the single source of truth — taps scroll into view, the observer
+// updates `tab` from whatever's most visible. That way swipe and tap stay
+// in sync without setState fighting the scroller.
+export function MobileFullSheet({ open, onClose }: Props) {
+  const [tab, setTab] = useState<Tab>("mix");
+  const [mounted, setMounted] = useState(false);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // Watch which section is currently in view and sync the active tab.
+  useEffect(() => {
+    if (!open) return;
+    const root = trackRef.current;
+    if (!root) return;
+
+    const obs = new IntersectionObserver(
+      (entries) => {
+        let best: IntersectionObserverEntry | null = null;
+        for (const e of entries) {
+          if (!e.isIntersecting) continue;
+          if (!best || e.intersectionRatio > best.intersectionRatio) best = e;
+        }
+        if (!best) return;
+        const id = (best.target as HTMLElement).dataset.section as Tab | undefined;
+        if (id) setTab(id);
+      },
+      { root, threshold: [0.5, 0.75, 1] },
+    );
+    for (const t of TABS) {
+      const el = root.querySelector<HTMLElement>(`[data-section="${t.id}"]`);
+      if (el) obs.observe(el);
+    }
+    return () => obs.disconnect();
+  }, [open]);
+
+  function gotoTab(id: Tab) {
+    const root = trackRef.current;
+    if (!root) return;
+    const el = root.querySelector<HTMLElement>(`[data-section="${id}"]`);
+    if (!el) return;
+    el.scrollIntoView({ behavior: "smooth", inline: "start", block: "nearest" });
+  }
+
+  if (!mounted || !open) return null;
+
+  return createPortal(
+    <div className="mobile-sheet" role="dialog" aria-modal="true">
+      <div className="mobile-sheet-accent" aria-hidden="true" />
+
+      <header className="mobile-sheet-header">
+        <button
+          type="button"
+          className="mobile-sheet-back"
+          onClick={onClose}
+          aria-label="Back"
+        >
+          <span aria-hidden="true">←</span>
+        </button>
+        <h2 className="mobile-sheet-title">All Controls</h2>
+        <span className="mobile-sheet-spacer" aria-hidden="true" />
+      </header>
+
+      <div ref={trackRef} className="mobile-sheet-track">
+        <section data-section="mix" className="mobile-sheet-section">
+          <MainTile />
+        </section>
+        <section data-section="sound" className="mobile-sheet-section">
+          <EngineTile />
+          <ChannelGainsTile />
+          <ChannelsTile />
+          <DcwTile />
+          <LibraryTile />
+          <SeedTile />
+        </section>
+        <section data-section="prompts" className="mobile-sheet-section">
+          <PromptsTile />
+        </section>
+        <section data-section="config" className="mobile-sheet-section">
+          <OperatorStrip />
+        </section>
+      </div>
+
+      <nav className="mobile-sheet-tabs" role="tablist">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            role="tab"
+            aria-selected={tab === t.id}
+            className={`mobile-sheet-tab${tab === t.id ? " mobile-sheet-tab--active" : ""}`}
+            onClick={() => gotoTab(t.id)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+    </div>,
+    document.body,
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/MobileRemixRail.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/MobileRemixRail.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+
+const PARAM = "denoise";
+const MAX = 1.0;
+
+// Always-visible vertical Remix Strength rail on the left edge. The visual
+// is the existing writhing-ribbon system rendered inside .install-edge-left
+// (same look as the desktop top edge); this component just provides the
+// rotated label, the value readout, and a wide pointer-capturing drag zone
+// stacked over it.
+export function MobileRemixRail() {
+  const value = usePerformanceStore(
+    (s) => s.sliderTargets[PARAM] ?? 0,
+  );
+  const setSlider = usePerformanceStore((s) => s.setSlider);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+
+  // Mirror denoise into --fill on .install-edge-left so the existing
+  // ribbon system writhes with the slider value (same wiring the desktop
+  // top edge uses, just on the side bar instead).
+  useEffect(() => {
+    const edge = document.querySelector<HTMLElement>(".install-edge-left");
+    if (!edge) return;
+    const frac = Math.max(0, Math.min(1, MAX > 0 ? value / MAX : 0));
+    edge.style.setProperty("--fill", frac.toString());
+  }, [value]);
+
+  const setFromClientY = useCallback(
+    (clientY: number) => {
+      const el = trackRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const t = 1 - (clientY - rect.top) / rect.height;
+      setSlider(PARAM, Math.max(0, Math.min(1, t)) * MAX);
+    },
+    [setSlider],
+  );
+
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el) return;
+    let dragging = false;
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.button !== 0 && e.pointerType === "mouse") return;
+      dragging = true;
+      el.setPointerCapture(e.pointerId);
+      setFromClientY(e.clientY);
+    };
+    const onPointerMove = (e: PointerEvent) => {
+      if (!dragging) return;
+      setFromClientY(e.clientY);
+    };
+    const onPointerUp = (e: PointerEvent) => {
+      if (!dragging) return;
+      dragging = false;
+      el.releasePointerCapture(e.pointerId);
+    };
+
+    el.addEventListener("pointerdown", onPointerDown);
+    el.addEventListener("pointermove", onPointerMove);
+    el.addEventListener("pointerup", onPointerUp);
+    el.addEventListener("pointercancel", onPointerUp);
+    return () => {
+      el.removeEventListener("pointerdown", onPointerDown);
+      el.removeEventListener("pointermove", onPointerMove);
+      el.removeEventListener("pointerup", onPointerUp);
+      el.removeEventListener("pointercancel", onPointerUp);
+    };
+  }, [setFromClientY]);
+
+  return (
+    <div
+      className="remix-rail"
+      data-param={PARAM}
+      role="slider"
+      aria-label="Remix strength"
+      aria-valuemin={0}
+      aria-valuemax={MAX}
+      aria-valuenow={value}
+    >
+      <span className="remix-rail-label">Remix Strength</span>
+      <div ref={trackRef} className="remix-rail-drag" />
+      <span className="remix-rail-value">{value.toFixed(2)}</span>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { decodeAudioFile, listFixtures } from "@/engine/audio/loadFixture";
+import { togglePauseAndAudio } from "@/engine/audio/togglePauseAndAudio";
+import { useCurveStore } from "@/store/useCurveStore";
+import { useCustomTracksStore } from "@/store/useCustomTracksStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+import { VALID_KEYSCALES } from "@/types/engine";
+
+import { MidiBadge } from "./MidiBadge";
+import { RecordToggle } from "./RecordToggle";
+
+export function OperatorStrip() {
+  const [fixtures, setFixtures] = useState<string[]>([]);
+  const fixture = usePerformanceStore((s) => s.fixture);
+  const activeKey = usePerformanceStore((s) => s.activeKey);
+  const kiosk = usePerformanceStore((s) => s.kiosk);
+  const paused = usePerformanceStore((s) => s.paused);
+  const showKbdHints = usePerformanceStore((s) => s.showKbdHints);
+  const smooth = usePerformanceStore((s) => s.smooth);
+  const smoothMs = usePerformanceStore((s) => s.smoothMs);
+  const setFixture = usePerformanceStore((s) => s.setFixture);
+  const setKey = usePerformanceStore((s) => s.setKey);
+  const toggleKiosk = usePerformanceStore((s) => s.toggleKiosk);
+  const overlayOpen = useCurveStore((s) => s.overlayOpen);
+  const toggleOverlay = useCurveStore((s) => s.toggleOverlay);
+  const toggleKbdHints = usePerformanceStore((s) => s.toggleKbdHints);
+  const toggleSmooth = usePerformanceStore((s) => s.toggleSmooth);
+  const setSmoothMs = usePerformanceStore((s) => s.setSmoothMs);
+
+  const customNames = useCustomTracksStore((s) => s.names);
+  const addCustomTrack = useCustomTracksStore((s) => s.add);
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  // The bottom-left <AudioSourceCrate /> is the primary track-picker; we
+  // keep this dropdown + upload icon here as the power-user fallback that
+  // power users will keep relying on while the advanced controls strip
+  // is open. Both surfaces drive the same setFixture() / addCustomTrack()
+  // path, so picking from either re-triggers useFixtureSwap identically.
+  const sessionWsUrl = useSessionStore((s) => s.wsUrl);
+  useEffect(() => {
+    // Pre-admit the proxy returns 401, so don't fetch until the queue
+    // hands us a wsUrl.
+    if (!sessionWsUrl) return;
+    void listFixtures()
+      .then((names) => {
+        setFixtures(names);
+        if (!usePerformanceStore.getState().fixture && names[0]) {
+          setFixture(names[0]);
+        }
+      })
+      .catch(() => setFixtures([]));
+  }, [setFixture, sessionWsUrl]);
+
+  async function onFilePicked(file: File) {
+    const { setStatus } = useSessionStore.getState();
+    setUploading(true);
+    setStatus(useSessionStore.getState().status, `Loading ${file.name}…`);
+    try {
+      const decoded = await decodeAudioFile(file);
+      // De-collide names: appending an index when the same filename is
+      // uploaded twice keeps prior uploads selectable while letting the
+      // new one win the dropdown. The decoded buffer is what the pod
+      // actually consumes, so the displayed name is purely for the UI.
+      const baseName = file.name;
+      let chosen = baseName;
+      let i = 1;
+      while (useCustomTracksStore.getState().has(chosen)) {
+        chosen = `${baseName} (${i++})`;
+      }
+      addCustomTrack(chosen, decoded);
+      setFixture(chosen);
+      setStatus(useSessionStore.getState().status, "");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setStatus(useSessionStore.getState().status, `Upload failed: ${msg}`);
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  // The pod's WS URL is allocated by the queue and not user-editable.
+  return (
+    <div className="install-section-operator">
+      <select
+        id="fixture-select"
+        className="fixture-select"
+        title="Audio source — pick a track or one of your uploaded tracks"
+        value={fixture}
+        onChange={(e) => setFixture(e.target.value)}
+      >
+        {fixtures.length === 0 && customNames.length === 0 && <option>—</option>}
+        {customNames.length > 0 && (
+          <optgroup label="Your uploads">
+            {customNames.map((n) => (
+              <option key={`u:${n}`} value={n}>
+                {n}
+              </option>
+            ))}
+          </optgroup>
+        )}
+        {fixtures.length > 0 && (
+          <optgroup label="Tracks">
+            {fixtures.map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </optgroup>
+        )}
+      </select>
+      <button
+        type="button"
+        className="pause-btn"
+        title={uploading ? "Decoding…" : "Upload audio track"}
+        aria-label="Upload audio track"
+        disabled={uploading}
+        onClick={() => fileInputRef.current?.click()}
+      >
+        <svg
+          viewBox="0 0 16 16"
+          width={14}
+          height={14}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.4}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M8 10V2" />
+          <path d="M4.5 5.5L8 2l3.5 3.5" />
+          <path d="M2.5 10v3a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3" />
+        </svg>
+      </button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="audio/*,.mp3,.wav,.flac,.ogg,.m4a,.aac"
+        style={{ display: "none" }}
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          // Reset the input so picking the same file twice still fires
+          // onChange (browsers debounce identical selections otherwise).
+          e.target.value = "";
+          if (file) void onFilePicked(file);
+        }}
+      />
+      <select
+        id="key-select"
+        className="fixture-select"
+        title="Musical key — auto-detected; override re-sends prompt"
+        value={activeKey}
+        onChange={(e) => setKey(e.target.value)}
+      >
+        {VALID_KEYSCALES.map((k) => (
+          <option key={k} value={k}>
+            {k}
+          </option>
+        ))}
+      </select>
+      <button
+        id="kiosk-toggle"
+        className={`pause-btn${kiosk ? " active" : ""}`}
+        data-midi-learn="kiosk_toggle"
+        title="Toggle kiosk mode — auto-hide cursor + idle reset (right-click to MIDI-learn)"
+        type="button"
+        onClick={toggleKiosk}
+      >
+        KIOSK
+      </button>
+      <button
+        type="button"
+        className={`pause-btn${overlayOpen ? " active" : ""}`}
+        data-midi-learn="schedule_curves_toggle"
+        title="Open the curve scheduler — draw param automation against the track (right-click to MIDI-learn)"
+        onClick={toggleOverlay}
+      >
+        SCHEDULE CURVES
+      </button>
+      <div id="install-midi-slot">
+        <MidiBadge />
+      </div>
+      <button
+        type="button"
+        className={`pause-btn${smooth ? " active" : ""}`}
+        title={
+          smooth
+            ? `Smooth slider transitions over ${smoothMs} ms — click to disable`
+            : "Smooth slider transitions: slider drags + MIDI knob movement glide to their target over the chosen duration. The visual stays instant."
+        }
+        aria-pressed={smooth}
+        onClick={toggleSmooth}
+      >
+        SMOOTH: {smooth ? `${(smoothMs / 1000).toFixed(smoothMs < 1000 ? 2 : 1)}s` : "OFF"}
+      </button>
+      <select
+        className="key-select"
+        value={String(smoothMs)}
+        disabled={!smooth}
+        onChange={(e) => setSmoothMs(parseInt(e.target.value, 10))}
+        title="Slider transition duration. Only applies when SMOOTH is ON."
+      >
+        {[100, 250, 500, 1000, 1500, 2000, 3000, 5000].map((ms) => (
+          <option key={ms} value={ms}>
+            {ms < 1000 ? `${ms}ms` : `${ms / 1000}s`}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        className={`pause-btn${showKbdHints ? " active" : ""}`}
+        title="Show keyboard-shortcut hints under each slider"
+        aria-pressed={showKbdHints}
+        onClick={toggleKbdHints}
+      >
+        KBD: {showKbdHints ? "ON" : "OFF"}
+      </button>
+      <RecordToggle />
+      <button
+        id="pause-btn"
+        className="pause-btn pause-btn--right"
+        data-midi-learn="pause"
+        title="Pause/Resume (right-click to MIDI-learn)"
+        type="button"
+        onClick={togglePauseAndAudio}
+      >
+        {paused ? "▶" : "⏸"}
+      </button>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { CustomCursor } from "@/components/CustomCursor";
+import { useBodyAttributes } from "@/hooks/useBodyAttributes";
+import { useCursor } from "@/hooks/useCursor";
+import { useEdgeLoraBinding } from "@/hooks/useEdgeLoraBinding";
+import { useFixtureSwap } from "@/hooks/useFixtureSwap";
+import { useIdleReset } from "@/hooks/useIdleReset";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useMidi } from "@/hooks/useMidi";
+import { useParamSync } from "@/hooks/useParamSync";
+import { useRecording } from "@/hooks/useRecording";
+import { useRenderLoop } from "@/hooks/useRenderLoop";
+import { useScheduledCurves } from "@/hooks/useScheduledCurves";
+import { useStartSession } from "@/hooks/useStartSession";
+import { useVideoLayer } from "@/hooks/useVideoLayer";
+import { useCurveStore } from "@/store/useCurveStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+import { AdvancedDrawer } from "./AdvancedDrawer";
+import { AudioSourceCrate } from "./AudioSourceCrate";
+import { ConfigModal } from "./ConfigModal";
+import { DesktopEdgeDrag } from "./DesktopEdgeDrag";
+import { HUDFrame } from "./HUDFrame";
+import { InstallStage } from "./InstallStage";
+import { MobileRemixRail } from "./MobileRemixRail";
+import { RecordButton } from "./RecordButton";
+import { RecordingPreview } from "./RecordingPreview";
+import { StartOverlay } from "./StartOverlay";
+import { StatusBar } from "./StatusBar";
+
+// Demo shell — wires the package's hooks + components into a working app.
+//
+// Stripped vs. the daydream webapp's Performance.tsx:
+//   - no useAuth / useQueue / useCredits (no account system in DEMON)
+//   - no QueueScene / PaywallSignedIn (no queue, no payments)
+//   - no HaloBadge (brand badge with sign-in/out menu)
+//
+// What remains is the engine UI itself: stage, HUD, graph, drawer, MIDI,
+// recording, custom cursor.
+
+export function PerformanceShell() {
+  useBodyAttributes();
+  useParamSync();
+  useScheduledCurves();
+  useEffect(() => {
+    usePerformanceStore.getState().hydratePersistedPrefs();
+    useCurveStore.getState().hydratePersistedCurves();
+  }, []);
+  useCursor();
+  useMidi();
+  useKeyboardShortcuts();
+  useRecording();
+  useFixtureSwap();
+  useEdgeLoraBinding();
+  useIdleReset(0);
+
+  const startSession = useStartSession();
+  const status = useSessionStore((s) => s.status);
+  const isMobile = useIsMobile();
+
+  const ambientRef = useRef<HTMLVideoElement | null>(null);
+  const videoARef = useRef<HTMLVideoElement | null>(null);
+  const videoBRef = useRef<HTMLVideoElement | null>(null);
+  const effectsCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const hudCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const graphCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useRenderLoop({
+    hudCanvas: hudCanvasRef,
+    graphCanvas: graphCanvasRef,
+    effectsCanvas: effectsCanvasRef,
+    videoA: videoARef,
+    videoB: videoBRef,
+  });
+  useVideoLayer({ videoA: videoARef, videoB: videoBRef });
+
+  const started = status !== "idle";
+
+  return (
+    <div id="performance" className="screen">
+      {status === "ready" && <AudioSourceCrate />}
+      <RecordButton />
+
+      <StartOverlay
+        onPlay={() => {
+          void startSession();
+        }}
+        hidden={started}
+      />
+
+      <InstallStage
+        refs={{
+          ambient: ambientRef,
+          videoA: videoARef,
+          videoB: videoBRef,
+          effectsCanvas: effectsCanvasRef,
+          hudCanvas: hudCanvasRef,
+          graphCanvas: graphCanvasRef,
+        }}
+      />
+      <HUDFrame />
+      {isMobile && <MobileRemixRail />}
+      {!isMobile && (
+        <>
+          <DesktopEdgeDrag side="top" />
+          <DesktopEdgeDrag side="left" />
+          <DesktopEdgeDrag side="right" />
+        </>
+      )}
+
+      <AdvancedDrawer />
+      <ConfigModal />
+
+      <StatusBar />
+
+      <RecordingPreview />
+
+      <CustomCursor />
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/PromptsTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/PromptsTile.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+export function PromptsTile() {
+  const promptA = usePerformanceStore((s) => s.promptA);
+  const promptB = usePerformanceStore((s) => s.promptB);
+  const blend = usePerformanceStore((s) => s.blend);
+  const activeKey = usePerformanceStore((s) => s.activeKey);
+  const setPromptA = usePerformanceStore((s) => s.setPromptA);
+  const setPromptB = usePerformanceStore((s) => s.setPromptB);
+  const setBlend = usePerformanceStore((s) => s.setBlend);
+
+  function sendPrompt() {
+    const remote = useSessionStore.getState().remote;
+    // Server expects `tags` as the prompt string. Blend is handled via
+    // params; for the prompt-text wire we just pick A (matches app.js).
+    if (remote) remote.sendPrompt(promptA, activeKey);
+  }
+
+  return (
+    <div className="mixer-tile mixer-tile-prompts" data-tile="prompts">
+      <div className="mixer-tile-label">Prompts</div>
+      <div id="prompt-section">
+        <div className="prompt-slot">
+          <label className="prompt-label" htmlFor="prompt-a">
+            Prompt A
+          </label>
+          <textarea
+            id="prompt-a"
+            className="prompt-input"
+            rows={2}
+            value={promptA}
+            onChange={(e) => setPromptA(e.target.value)}
+          />
+        </div>
+        <div id="blend-control">
+          <span className="blend-label">A</span>
+          <input
+            type="range"
+            id="prompt-blend"
+            min="0"
+            max="1"
+            step="0.01"
+            value={blend}
+            onChange={(e) => setBlend(parseFloat(e.target.value))}
+          />
+          <span className="blend-value" id="blend-value">
+            {blend.toFixed(2)}
+          </span>
+          <span className="blend-label">B</span>
+          <kbd className="desktop-only blend-kbd">B + ▲▼</kbd>
+        </div>
+        <div className="prompt-slot">
+          <label className="prompt-label" htmlFor="prompt-b">
+            Prompt B
+          </label>
+          <textarea
+            id="prompt-b"
+            className="prompt-input"
+            rows={2}
+            value={promptB}
+            onChange={(e) => setPromptB(e.target.value)}
+          />
+        </div>
+        <button
+          id="send-prompt"
+          className="send-prompt-btn"
+          data-midi-learn="send_prompt"
+          title="Send prompt — Enter (out of textarea) or ⌘/Ctrl + Enter (in textarea); right-click to MIDI-learn"
+          type="button"
+          onClick={sendPrompt}
+        >
+          Send Prompt
+          <kbd className="desktop-only send-kbd">⏎</kbd>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/RecordButton.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RecordButton.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { isRecordingSupported } from "@/hooks/useRecording";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import {
+  elapsedMs,
+  isActive,
+  useRecordingStore,
+} from "@/store/useRecordingStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+function fmtTime(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  const mm = Math.floor(s / 60);
+  const ss = s % 60;
+  return `${mm}:${ss.toString().padStart(2, "0")}`;
+}
+
+export function RecordButton() {
+  const state = useRecordingStore((s) => s.state);
+  const warning = useRecordingStore((s) => s.warning);
+  const status = useSessionStore((s) => s.status);
+  const kiosk = usePerformanceStore((s) => s.kiosk);
+
+  const [now, setNow] = useState(() => performance.now());
+  useEffect(() => {
+    if (state.kind !== "recording") return;
+    const id = window.setInterval(() => setNow(performance.now()), 250);
+    return () => window.clearInterval(id);
+  }, [state.kind]);
+
+  const [burst, setBurst] = useState(0);
+  const prevKind = useRef(state.kind);
+  useEffect(() => {
+    if (prevKind.current === "finalizing" && state.kind === "preview") {
+      setBurst((n) => n + 1);
+    }
+    prevKind.current = state.kind;
+  }, [state.kind]);
+
+  const supported = isRecordingSupported();
+  if (!supported) return null;
+  if (status === "idle" || kiosk) return null;
+
+  const active = isActive(state);
+  const busy = state.kind === "arming" || state.kind === "finalizing";
+  const elapsed = state.kind === "recording" ? elapsedMs(state, now) : 0;
+
+  const onClick = () => {
+    if (busy) return;
+    document.dispatchEvent(new CustomEvent("dd:toggle-record"));
+  };
+
+  const cls = [
+    "turntable",
+    active ? "turntable--active" : "",
+    state.kind === "recording" ? "turntable--recording" : "",
+    state.kind === "paused" ? "turntable--paused" : "",
+    busy ? "turntable--busy" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const label =
+    state.kind === "recording"
+      ? `Stop recording (${fmtTime(elapsed)})`
+      : state.kind === "paused"
+        ? "Resume recording"
+        : state.kind === "arming"
+          ? "Starting…"
+          : state.kind === "finalizing"
+            ? "Saving…"
+            : "Record (R)";
+
+  return (
+    <div className="turntable-wrap">
+      {warning && (
+        <div className="rec-warning" role="status" aria-live="polite">
+          {warning}
+        </div>
+      )}
+      <button
+      type="button"
+      className={cls}
+      onClick={onClick}
+      disabled={busy}
+      aria-label={label}
+      title={label}
+    >
+      {/* Disc — platter, audio-reactive grooves, label, spindle. The whole
+          disc rotates while recording (CSS animation on .turntable-disc). */}
+      <span className="turntable-disc">
+        <span className="turntable-platter" />
+        <canvas className="turntable-grooves" aria-hidden="true" />
+        <span className="turntable-label" />
+        <span className="turntable-spindle" />
+      </span>
+
+      {/* Tonearm — sits to the upper-right of the disc. Idle: parked,
+          rotated up-right; recording: dropped onto the outer groove. The
+          rotation is purely CSS, transitioning over 700ms with a weighted
+          ease so it reads mechanical. */}
+      <svg
+        className="turntable-tonearm"
+        viewBox="0 0 110 84"
+        preserveAspectRatio="xMidYMid meet"
+        aria-hidden="true"
+      >
+        <g className="turntable-tonearm-arm">
+          <line
+            x1="93"
+            y1="14"
+            x2="50"
+            y2="22"
+            stroke="#9ba0a6"
+            strokeWidth="2.4"
+            strokeLinecap="round"
+          />
+          <rect
+            x="46"
+            y="19"
+            width="10"
+            height="6"
+            rx="1.2"
+            fill="#23232c"
+            stroke="#5a5d63"
+            strokeWidth="0.8"
+          />
+          <circle cx="48" cy="24" r="1.6" fill="#e84f3d" />
+          <circle
+            cx="95"
+            cy="12"
+            r="6"
+            fill="#1a1a22"
+            stroke="#5a5d63"
+            strokeWidth="1"
+          />
+          <circle cx="95" cy="12" r="2" fill="#3a3d42" />
+        </g>
+      </svg>
+
+      {state.kind === "recording" && (
+        <span className="turntable-time" aria-hidden="true">
+          {fmtTime(elapsed)}
+        </span>
+      )}
+
+      {burst > 0 && (
+        <span
+          key={burst}
+          className="turntable-confetti"
+          aria-hidden="true"
+        >
+          {Array.from({ length: 12 }).map((_, i) => (
+            <span
+              key={i}
+              className={`turntable-confetti-dot turntable-confetti-dot--${i}`}
+            />
+          ))}
+        </span>
+      )}
+    </button>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/RecordToggle.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RecordToggle.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { isRecordingSupported } from "@/hooks/useRecording";
+import {
+  elapsedMs,
+  isActive,
+  useRecordingStore,
+} from "@/store/useRecordingStore";
+
+// Inline record toggle — uses the existing .pause-btn shell so it sits
+// next to the play/pause / KBD / KIOSK buttons and reads as part of the
+// same control row. Dispatches the same dd:toggle-record event as the
+// floating Turntable, so both surfaces stay in sync.
+
+function fmtTime(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  const mm = Math.floor(s / 60);
+  const ss = s % 60;
+  return `${mm}:${ss.toString().padStart(2, "0")}`;
+}
+
+export function RecordToggle() {
+  const state = useRecordingStore((s) => s.state);
+
+  const [now, setNow] = useState(() => performance.now());
+  useEffect(() => {
+    if (state.kind !== "recording") return;
+    const id = window.setInterval(() => setNow(performance.now()), 250);
+    return () => window.clearInterval(id);
+  }, [state.kind]);
+
+  // Defer render until after mount so SSR + first client render agree.
+  // `isRecordingSupported()` checks `window.MediaRecorder`, which is
+  // missing on the server — without this gate, the server returns null
+  // here and the client returns a button, shifting siblings and
+  // tripping React's hydration mismatch detector.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) return null;
+  if (!isRecordingSupported()) return null;
+
+  const active = isActive(state);
+  const busy = state.kind === "arming" || state.kind === "finalizing";
+  const elapsed = state.kind === "recording" ? elapsedMs(state, now) : 0;
+
+  const labelText =
+    state.kind === "recording"
+      ? `REC ${fmtTime(elapsed)}`
+      : state.kind === "paused"
+        ? "PAUSED"
+        : state.kind === "arming"
+          ? "…"
+          : state.kind === "finalizing"
+            ? "SAVING"
+            : "REC";
+
+  const cls = [
+    "pause-btn",
+    "rec-btn",
+    active ? "active" : "",
+    state.kind === "recording" ? "rec-btn--recording" : "",
+    busy ? "rec-btn--busy" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button
+      type="button"
+      className={cls}
+      onClick={(e) => {
+        // Prevent bubbling to drawer-handle parent which would close the drawer.
+        e.stopPropagation();
+        if (busy) return;
+        document.dispatchEvent(new CustomEvent("dd:toggle-record"));
+      }}
+      disabled={busy}
+      aria-label={active ? "Stop recording" : "Record audio"}
+      title={active ? "Stop recording (R)" : "Record audio (R)"}
+    >
+      {state.kind === "recording" && (
+        <span className="rec-btn-dot" aria-hidden="true" />
+      )}
+      <span className="rec-btn-label">{labelText}</span>
+    </button>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/RecordingPreview.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RecordingPreview.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useRecordingStore } from "@/store/useRecordingStore";
+import { encodeWav } from "@/lib/audio/encodeWav";
+
+function isoStamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-").replace(/Z$/, "");
+}
+
+function fmtDuration(ms: number): string {
+  const s = Math.max(0, Math.round(ms / 1000));
+  const mm = Math.floor(s / 60);
+  const ss = s % 60;
+  return `${mm}:${ss.toString().padStart(2, "0")}`;
+}
+
+type Prepared = { blob: Blob; filename: string; mime: string };
+
+// Re-encode the captured Opus/AAC blob to WAV so users get a DAW-friendly file.
+// Falls back silently to the original blob if decoding fails (rare).
+async function prepareDownload(
+  source: { blob: Blob; ext: string; mime: string },
+): Promise<Prepared> {
+  const stamp = isoStamp();
+  let ctx: AudioContext | null = null;
+  try {
+    ctx = new AudioContext();
+    const buf = await ctx.decodeAudioData(await source.blob.arrayBuffer());
+    return {
+      blob: encodeWav(buf),
+      filename: `daydream-${stamp}.wav`,
+      mime: "audio/wav",
+    };
+  } catch (err) {
+    console.warn("[RecordingPreview] WAV encode failed; falling back", err);
+    return {
+      blob: source.blob,
+      filename: `daydream-${stamp}.${source.ext}`,
+      mime: source.mime,
+    };
+  } finally {
+    try {
+      ctx?.close();
+    } catch {}
+  }
+}
+
+function triggerDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function RecordingPreview() {
+  const state = useRecordingStore((s) => s.state);
+
+  if (state.kind !== "preview") return null;
+
+  function dismiss() {
+    document.dispatchEvent(new CustomEvent("dd:dismiss-record-preview"));
+  }
+
+  async function save() {
+    if (state.kind !== "preview") return;
+    const prepared = await prepareDownload({
+      blob: state.blob,
+      ext: state.ext,
+      mime: state.mime,
+    });
+    triggerDownload(prepared.blob, prepared.filename);
+  }
+
+  async function share() {
+    if (state.kind !== "preview") return;
+    const nav = navigator as Navigator & {
+      canShare?: (data: ShareData) => boolean;
+    };
+    const prepared = await prepareDownload({
+      blob: state.blob,
+      ext: state.ext,
+      mime: state.mime,
+    });
+    try {
+      const file = new File([prepared.blob], prepared.filename, {
+        type: prepared.mime,
+      });
+      const data: ShareData = { files: [file], title: "Daydream clip" };
+      if (nav.canShare?.(data)) {
+        await nav.share(data);
+        return;
+      }
+    } catch (err) {
+      // User cancellation throws AbortError — just swallow.
+      if ((err as Error).name === "AbortError") return;
+      console.warn("[RecordingPreview] share failed", err);
+    }
+    triggerDownload(prepared.blob, prepared.filename);
+  }
+
+  const canShare =
+    typeof navigator !== "undefined" &&
+    "share" in navigator &&
+    "canShare" in navigator;
+
+  return (
+    <div className="recording-preview" role="dialog" aria-label="Saved clip">
+      <div className="recording-preview-header">
+        <span className="recording-preview-title">New clip</span>
+        <span className="recording-preview-meta">
+          {fmtDuration(state.durationMs)} · WAV
+        </span>
+      </div>
+      <audio
+        className="recording-preview-audio"
+        src={state.url}
+        controls
+        preload="metadata"
+      />
+      <div className="recording-preview-actions">
+        <button
+          type="button"
+          className="recording-preview-btn recording-preview-btn--primary"
+          onClick={save}
+        >
+          Save
+        </button>
+        {canShare && (
+          <button
+            type="button"
+            className="recording-preview-btn"
+            onClick={share}
+          >
+            Share
+          </button>
+        )}
+        <button
+          type="button"
+          className="recording-preview-btn recording-preview-btn--ghost"
+          onClick={dismiss}
+        >
+          Discard
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/RemixHint.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RemixHint.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useEffect, useState } from "react";
+
+// First-time-user affordance for the three "string" sliders (Remix
+// Strength on top, LoRA-1/2 on the sides). All three are non-traditional
+// — colored ribbon strings with no thumb / fill / readout — so new users
+// have no signal that the strings are draggable. This monospace hint
+// sits at the slider's *head* (its current value) along the drag axis,
+// morphs its copy by interaction state, and disappears forever after the
+// user's first successful drag (persisted in localStorage).
+//
+// Position contract (don't change without re-reading this comment):
+//   - The hint is `position: absolute` inside the slider's hit-area
+//     wrapper (.desktop-edge-drag[data-side]). It sits *inside* that
+//     wrapper (not floating beside it) so accidental clicks on the
+//     hint still hit the drag overlay's pointerdown handler — pointer-
+//     events: none on the hint lets the click pass to the parent.
+//   - Position is driven by `valueFraction` (0..1, 0 = min, 1 = max) so
+//     it always points at where the slider's value currently is — not
+//     the cursor. During drag, the value updates from cursor input, so
+//     the hint follows naturally without separate cursor tracking.
+//   - Horizontal slider: `left: <pct>%` where pct = valueFraction*100.
+//     `transform: translate(-50%, …)` handles centring + the idle bob.
+//     Keeping the % in `left` (not `transform`) is critical — % inside
+//     `translate(...)` resolves against the element itself, not the
+//     wrapper, and the math breaks.
+//   - Vertical slider: `top: <pct>%` where pct = (1 - valueFraction)*100,
+//     because the slider fills bottom→top (value 0 = bottom, max = top,
+//     mirroring the `bottom: pct%` convention used by .slider-thumb).
+//     Anchored at the inward edge of the drag overlay so the text reads
+//     toward the screen centre while still inside the click area.
+//     The arrow points *at* the bar by default (← for left bar, → for
+//     right bar) so the hint visually labels the ribbon as the thing to
+//     grab. While dragging, the arrow flips to ↕ to indicate the live
+//     drag axis. Bob is on X, toward the bar.
+
+type Orientation = "horizontal" | "vertical";
+
+interface Props {
+  /** Pointer is inside the slider's hit area. */
+  hover: boolean;
+  /** Pointer is captured (mouse-down → up). */
+  dragging: boolean;
+  /** 0..1 normalized slider value (0 = min, 1 = max). The hint sits at
+   * this position along the drag axis so it always points at the head. */
+  valueFraction: number;
+  /** Drag axis. Vertical sliders need a different position formula and
+   * a different arrow glyph. */
+  orientation: Orientation;
+  /** For vertical sliders: which side of the screen the bar lives on,
+   * so the hint can sit on the *inside* (toward the centre of the
+   * viewport) rather than off-screen. */
+  side?: "left" | "right";
+  /** Copy shown while the user is actively dragging. Differs per slider
+   * so each "string" has its own personality (rave / mosh / vibe). */
+  draggingLabel?: string;
+}
+
+export function RemixHint({
+  hover,
+  dragging,
+  valueFraction,
+  orientation,
+  side = "left",
+  draggingLabel = "— rave —",
+}: Props) {
+  const [pulse, setPulse] = useState(0);
+
+  // Idle pulse: ~4.4s sine wave (period = 2π · 700 ms) on opacity + a tiny
+  // bob. Cancelled the moment the user hovers or drags, restarted when
+  // both go false.
+  useEffect(() => {
+    if (hover || dragging) {
+      setPulse(0);
+      return;
+    }
+    let raf = 0;
+    const start = performance.now();
+    const tick = (t: number) => {
+      const p = (Math.sin((t - start) / 700) + 1) / 2;
+      setPulse(p);
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [hover, dragging]);
+
+  // Idle/hover: the arrow points *at* the bar (← for left, → for right
+  // or top horizontal) so the hint visually labels the ribbon as the
+  // thing to grab. Dragging on a vertical bar swaps to ↕ to show the
+  // live drag axis; horizontal top keeps the personality label as-is.
+  const isVerticalLeft = orientation === "vertical" && side === "left";
+  const idleArrow = isVerticalLeft ? "←" : "→";
+  // Arrow on the left of the verb only for the left bar — that's the
+  // side that needs the arrow facing back at the bar.
+  const arrowBefore = isVerticalLeft;
+  const compose = (verb: string, arrow: string) =>
+    arrowBefore ? `${arrow} ${verb}` : `${verb} ${arrow}`;
+  let label: string;
+  let opacity: number;
+  let bobAmt: number;
+  if (dragging) {
+    if (orientation === "vertical") {
+      // Live drag indicator on the side facing the bar.
+      label = compose(draggingLabel, "↕");
+    } else {
+      // Top horizontal: keep the personality label by itself.
+      label = draggingLabel;
+    }
+    opacity = 0.9;
+    bobAmt = 0;
+  } else if (hover) {
+    label = compose("pull", idleArrow);
+    opacity = 0.9;
+    bobAmt = 0;
+  } else {
+    label = compose("drag", idleArrow);
+    opacity = 0.4 + pulse * 0.35;
+    bobAmt = pulse * 6;
+  }
+
+  // Horizontal: hint below the bar at value's X, bobs down.
+  // Vertical sides: anchored INSIDE the drag overlay at the inward edge
+  //   (right edge for left bar, left edge for right bar) so clicks on
+  //   the hint area still register on the drag overlay. Bob toward the
+  //   bar — the hint nudges visually back at the slider it points at.
+  // Vertical Y is inverted (value 0 = bottom = top:100%, max = top: 0%)
+  //   so it lines up with the bottom-up fill direction of the LoRA bars.
+  const horizontalPct = valueFraction * 100;
+  const verticalPct = (1 - valueFraction) * 100;
+  let style: CSSProperties;
+  if (orientation === "horizontal") {
+    style = {
+      top: "calc(100% + 6px)",
+      left: `${horizontalPct}%`,
+      transform: `translate(-50%, ${bobAmt}px)`,
+      opacity,
+    };
+  } else if (side === "left") {
+    style = {
+      left: "auto",
+      right: "4px",
+      top: `${verticalPct}%`,
+      transform: `translate(${-bobAmt}px, -50%)`,
+      opacity,
+    };
+  } else {
+    style = {
+      right: "auto",
+      left: "4px",
+      top: `${verticalPct}%`,
+      transform: `translate(${bobAmt}px, -50%)`,
+      opacity,
+    };
+  }
+
+  return (
+    <div className="remix-hint" style={style}>
+      {label}
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
@@ -1,0 +1,657 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import {
+  buildPreset,
+  PRESET_LABEL,
+  type CurvePresetId,
+} from "@/engine/curves/presets";
+import { tessellate } from "@/engine/curves/interp";
+import {
+  computePeaks,
+  drawPeaks,
+} from "@/engine/curves/waveformPeaks";
+import { useCurveStore } from "@/store/useCurveStore";
+import { useLoraStore } from "@/store/useLoraStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+import {
+  type CurveInterpMode,
+  type CurvePoint,
+  loraCurveParam,
+  MAX_LORA_CURVES,
+  SCHEDULEABLE_PARAMS,
+  SCHEDULEABLE_PARAM_LABEL,
+} from "@/types/curves";
+
+// ScheduleCurvesOverlay — full curve scheduler. Mounts inside
+// #graph-wrap, gates on useCurveStore.overlayOpen.
+//
+// Three layered canvases (in DOM source order, painted bottom-up):
+//   1. .schedule-curves-bg     — waveform underlay (computed once
+//      per fixture-swap, redrawn on resize).
+//   2. .schedule-curves-canvas — curve, control points, playhead.
+//      Redrawn on every rAF tick (cheap; we tessellate to ~256
+//      samples and stroke a polyline) so the playhead animates
+//      smoothly. Also handles all pointer interaction.
+//
+// Interaction model (rtmg-vst lineage):
+//   - Click empty space → insert smooth point at click position.
+//   - Drag a point → move it; first/last points constrained to x
+//     endpoints (y still free).
+//   - Right-click point → cycle smooth → linear → step → smooth.
+//   - Delete / Backspace on hovered point → delete (endpoints exempt).
+//   - Right-click a tab → context menu: enable/disable, reset, presets.
+
+const WAVEFORM_BUCKETS_DESIRED = 720;
+const POINT_HIT_RADIUS_PX = 12;
+const CURVE_TESSELLATION = 256;
+
+function ensureCanvasSize(
+  canvas: HTMLCanvasElement,
+): { w: number; h: number; dpr: number } {
+  const rect = canvas.getBoundingClientRect();
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const w = Math.max(1, Math.round(rect.width));
+  const h = Math.max(1, Math.round(rect.height));
+  if (canvas.width !== w * dpr || canvas.height !== h * dpr) {
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+  }
+  return { w, h, dpr };
+}
+
+function nextInterpMode(m: CurveInterpMode): CurveInterpMode {
+  if (m === "smooth") return "linear";
+  if (m === "linear") return "step";
+  return "smooth";
+}
+
+interface PresetMenuState {
+  param: string;
+  /** Distance from overlay's left edge to the menu's left edge. */
+  left: number;
+  /** Distance from overlay's bottom edge to the menu's bottom edge. The
+   *  menu grows UPWARD from this anchor (above the tab strip), so it
+   *  always fits within the overlay no matter where the user
+   *  right-clicks. */
+  bottom: number;
+}
+
+export function ScheduleCurvesOverlay() {
+  const open = useCurveStore((s) => s.overlayOpen);
+  const closeOverlay = useCurveStore((s) => s.closeOverlay);
+  const activeCurve = useCurveStore((s) => s.activeCurve);
+  const setActiveCurve = useCurveStore((s) => s.setActiveCurve);
+  const curves = useCurveStore((s) => s.curves);
+  const setCurvePoints = useCurveStore((s) => s.setCurvePoints);
+  const setCurveEnabled = useCurveStore((s) => s.setCurveEnabled);
+  const resetCurve = useCurveStore((s) => s.resetCurve);
+  const ensureCurve = useCurveStore((s) => s.ensureCurve);
+  const scheduleEnabled = useCurveStore((s) => s.scheduleEnabled);
+  const toggleScheduleEnabled = useCurveStore(
+    (s) => s.toggleScheduleEnabled,
+  );
+  const detectedBpm = usePerformanceStore((s) => s.detectedBpm);
+
+  // First N enabled LoRAs become dynamic tabs in the strip. Set
+  // preserves insertion order, so [...enabled].slice(0, MAX) gives the
+  // user's most-recently-enabled LoRAs as their curve targets. The
+  // catalog provides the human-readable name for each id.
+  const loraEnabled = useLoraStore((s) => s.enabled);
+  const loraCatalog = useLoraStore((s) => s.catalog);
+  const loraTabs = (() => {
+    const ids = Array.from(loraEnabled).slice(0, MAX_LORA_CURVES);
+    return ids.map((id) => ({
+      id,
+      param: loraCurveParam(id),
+      label:
+        loraCatalog.find((e) => e.id === id)?.name?.toUpperCase() ??
+        id.toUpperCase(),
+    }));
+  })();
+
+  // Helper to look up a tab's display label whether it's a fixed
+  // schedulable param OR a LoRA. Used for tab buttons + preset menu
+  // header.
+  const labelFor = (param: string): string => {
+    if (param in SCHEDULEABLE_PARAM_LABEL) {
+      return SCHEDULEABLE_PARAM_LABEL[
+        param as keyof typeof SCHEDULEABLE_PARAM_LABEL
+      ];
+    }
+    const tab = loraTabs.find((t) => t.param === param);
+    return tab?.label ?? param;
+  };
+
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const bgCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const fgCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const [presetMenu, setPresetMenu] = useState<PresetMenuState | null>(null);
+
+  // Per-render snapshot of the active curve's points. We keep a ref
+  // alongside the store value so canvas event handlers see the latest
+  // without stale-closure pitfalls. Dynamic params (LoRA curves) may
+  // not exist yet; ensureCurve allocates a fresh default if missing.
+  const pointsRef = useRef<CurvePoint[]>(
+    curves[activeCurve]?.points ?? [
+      { x: 0, y: 0.5, mode: "smooth" },
+      { x: 1, y: 0.5, mode: "smooth" },
+    ],
+  );
+  useEffect(() => {
+    ensureCurve(activeCurve);
+    const c = useCurveStore.getState().curves[activeCurve];
+    if (c) pointsRef.current = c.points;
+  }, [activeCurve, curves, ensureCurve]);
+
+  // ESC closes the overlay (or the preset menu, if open).
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (presetMenu) setPresetMenu(null);
+      else closeOverlay();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, closeOverlay, presetMenu]);
+
+  // Close the preset menu on any click outside it.
+  useEffect(() => {
+    if (!presetMenu) return;
+    const onClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest(".schedule-curves-preset-menu")) setPresetMenu(null);
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [presetMenu]);
+
+  // Waveform underlay (bg canvas).
+  useEffect(() => {
+    if (!open) return;
+    const canvas = bgCanvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let peaks: Float32Array | null = null;
+
+    const redraw = () => {
+      const { w, h, dpr } = ensureCanvasSize(canvas);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, w, h);
+      if (!peaks) return;
+      // Very low opacity — the moving-lines graph behind needs to stay
+      // visible. The waveform is a reference layer, not the focal point.
+      ctx.fillStyle = "rgba(240, 138, 72, 0.08)";
+      drawPeaks(ctx, peaks, w, h);
+      ctx.fillStyle = "rgba(255, 255, 255, 0.05)";
+      drawPeaks(ctx, peaks, w, h);
+    };
+
+    const recompute = () => {
+      const player = useSessionStore.getState().player;
+      if (!player) {
+        peaks = null;
+      } else {
+        const mirror = player.getMirror();
+        peaks = computePeaks(mirror, player.channels, WAVEFORM_BUCKETS_DESIRED);
+      }
+      redraw();
+    };
+
+    recompute();
+
+    const ro = new ResizeObserver(redraw);
+    ro.observe(canvas);
+
+    const player = useSessionStore.getState().player;
+    const unsubMirror = player?.onMirrorChange?.(() => recompute()) ?? (() => {});
+    const unsubSession = useSessionStore.subscribe((s, prev) => {
+      if (s.player !== prev.player) recompute();
+    });
+
+    return () => {
+      ro.disconnect();
+      unsubMirror();
+      unsubSession();
+    };
+  }, [open]);
+
+  // Foreground canvas: curve, control points, playhead. Redrawn every
+  // rAF tick so the playhead animates smoothly. Pointer interaction is
+  // also wired here.
+  useEffect(() => {
+    if (!open) return;
+    const canvas = fgCanvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let raf = 0;
+    let cancelled = false;
+
+    // Pointer state — kept in closure so it survives across rAF ticks.
+    let dragIndex: number | null = null;
+    let hoverIndex: number | null = null;
+
+    const sizeMeta = () => ensureCanvasSize(canvas);
+
+    /** Convert a pointer event's clientX/Y to canvas-local pixels. */
+    const eventToLocal = (e: PointerEvent | MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      return {
+        x: e.clientX - rect.left,
+        y: e.clientY - rect.top,
+      };
+    };
+
+    /** Convert pixel coords → curve-space (x ∈ [0,1], y ∈ [0,1]).
+     *  Y is inverted (top of canvas = y=1, bottom = y=0). */
+    const localToCurve = (px: number, py: number, w: number, h: number) => ({
+      x: Math.min(1, Math.max(0, px / w)),
+      y: Math.min(1, Math.max(0, 1 - py / h)),
+    });
+
+    /** Hit-test a click against existing points. Returns the point's
+     *  index in `pointsRef.current`, or null if no point under the
+     *  cursor within POINT_HIT_RADIUS_PX. */
+    const hitTestPoint = (
+      px: number,
+      py: number,
+      w: number,
+      h: number,
+    ): number | null => {
+      const points = pointsRef.current;
+      let bestIdx: number | null = null;
+      let bestDist = POINT_HIT_RADIUS_PX * POINT_HIT_RADIUS_PX;
+      for (let i = 0; i < points.length; i++) {
+        const cx = points[i].x * w;
+        const cy = (1 - points[i].y) * h;
+        const dx = cx - px;
+        const dy = cy - py;
+        const d2 = dx * dx + dy * dy;
+        if (d2 < bestDist) {
+          bestDist = d2;
+          bestIdx = i;
+        }
+      }
+      return bestIdx;
+    };
+
+    // ── Render frame ─────────────────────────────────────────────────
+    const draw = () => {
+      if (cancelled) return;
+      const { w, h, dpr } = sizeMeta();
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, w, h);
+
+      const points = pointsRef.current;
+
+      // Grid: horizontal thirds + dashed midline. Helps users eyeball
+      // where 0.5 / 0.33 / 0.67 sit on the y axis.
+      ctx.strokeStyle = "rgba(255, 255, 255, 0.06)";
+      ctx.lineWidth = 1;
+      for (const yFrac of [0.25, 0.5, 0.75]) {
+        const y = h - yFrac * h;
+        ctx.beginPath();
+        ctx.moveTo(0, y);
+        ctx.lineTo(w, y);
+        ctx.stroke();
+      }
+
+      // Curve — tessellate to N samples and stroke a polyline.
+      const samples = tessellate(points, CURVE_TESSELLATION);
+      ctx.strokeStyle = "rgba(240, 138, 72, 0.95)";
+      ctx.lineWidth = 2;
+      ctx.shadowColor = "rgba(240, 138, 72, 0.55)";
+      ctx.shadowBlur = 8;
+      ctx.beginPath();
+      for (let i = 0; i < samples.length; i++) {
+        const x = (i / (samples.length - 1)) * w;
+        const y = (1 - samples[i]) * h;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.stroke();
+      ctx.shadowBlur = 0;
+
+      // Control points — circle (smooth), diamond (linear), square (step).
+      for (let i = 0; i < points.length; i++) {
+        const p = points[i];
+        const cx = p.x * w;
+        const cy = (1 - p.y) * h;
+        const isHover = hoverIndex === i;
+        const isDrag = dragIndex === i;
+        const r = isHover || isDrag ? 7 : 5;
+
+        ctx.fillStyle = isDrag
+          ? "rgba(255, 255, 255, 1)"
+          : isHover
+            ? "rgba(255, 230, 200, 0.95)"
+            : "rgba(240, 138, 72, 1)";
+        ctx.strokeStyle = "rgba(0, 0, 0, 0.6)";
+        ctx.lineWidth = 1.5;
+
+        ctx.beginPath();
+        if (p.mode === "smooth") {
+          ctx.arc(cx, cy, r, 0, Math.PI * 2);
+        } else if (p.mode === "linear") {
+          // diamond
+          ctx.moveTo(cx, cy - r);
+          ctx.lineTo(cx + r, cy);
+          ctx.lineTo(cx, cy + r);
+          ctx.lineTo(cx - r, cy);
+          ctx.closePath();
+        } else {
+          // square
+          ctx.rect(cx - r, cy - r, r * 2, r * 2);
+        }
+        ctx.fill();
+        ctx.stroke();
+      }
+
+      // Playhead — vertical orange line at currentPositionSec / duration.
+      const session = useSessionStore.getState();
+      const player = session.player;
+      const remote = session.remote;
+      if (player && remote && remote.duration > 0) {
+        const t = Math.min(1, Math.max(0, player.positionSec / remote.duration));
+        const xp = t * w;
+        ctx.strokeStyle = "rgba(240, 138, 72, 0.85)";
+        ctx.lineWidth = 1.5;
+        ctx.shadowColor = "rgba(240, 138, 72, 0.6)";
+        ctx.shadowBlur = 6;
+        ctx.beginPath();
+        ctx.moveTo(xp, 0);
+        ctx.lineTo(xp, h);
+        ctx.stroke();
+        ctx.shadowBlur = 0;
+      }
+
+      raf = requestAnimationFrame(draw);
+    };
+    raf = requestAnimationFrame(draw);
+
+    // ── Pointer events ───────────────────────────────────────────────
+    const onPointerDown = (e: PointerEvent) => {
+      // Block right-click here; handled in oncontextmenu below.
+      if (e.button === 2) return;
+      const { w, h } = sizeMeta();
+      const { x: px, y: py } = eventToLocal(e);
+      const hit = hitTestPoint(px, py, w, h);
+      if (hit !== null) {
+        dragIndex = hit;
+        canvas.setPointerCapture(e.pointerId);
+        return;
+      }
+      // Click on empty area → insert a new smooth point at that x.
+      const { x, y } = localToCurve(px, py, w, h);
+      const points = pointsRef.current.slice();
+      // Don't insert at the very edges — those are pinned endpoints.
+      if (x <= 0.001 || x >= 0.999) return;
+      const newPoint: CurvePoint = { x, y, mode: "smooth" };
+      points.push(newPoint);
+      points.sort((a, b) => a.x - b.x);
+      pointsRef.current = points;
+      setCurvePoints(activeCurve, points);
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      const { w, h } = sizeMeta();
+      const { x: px, y: py } = eventToLocal(e);
+      if (dragIndex !== null) {
+        const points = pointsRef.current.slice();
+        const i = dragIndex;
+        const { x, y } = localToCurve(px, py, w, h);
+        // Endpoint x is pinned; midpoint x must stay strictly between
+        // its neighbours so the curve stays well-formed.
+        const isFirst = i === 0;
+        const isLast = i === points.length - 1;
+        const newX = isFirst ? 0 : isLast ? 1 : Math.min(
+          Math.max(x, points[i - 1].x + 0.001),
+          points[i + 1].x - 0.001,
+        );
+        points[i] = { ...points[i], x: newX, y };
+        pointsRef.current = points;
+        // Throttle store writes by RAF cadence — pointermove fires
+        // ~mouse-event-rate; the canvas re-renders from pointsRef
+        // each frame anyway. Storing every move keeps undo / persist
+        // honest at the cost of one set per move; cheap.
+        setCurvePoints(activeCurve, points);
+        return;
+      }
+      // Hover hit-test for visual feedback only.
+      const hit = hitTestPoint(px, py, w, h);
+      if (hit !== hoverIndex) hoverIndex = hit;
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      if (dragIndex !== null) {
+        canvas.releasePointerCapture(e.pointerId);
+        dragIndex = null;
+      }
+    };
+
+    const onContextMenu = (e: MouseEvent) => {
+      e.preventDefault();
+      const { w, h } = sizeMeta();
+      const { x: px, y: py } = eventToLocal(e);
+      const hit = hitTestPoint(px, py, w, h);
+      if (hit === null) return;
+      const points = pointsRef.current.slice();
+      points[hit] = {
+        ...points[hit],
+        mode: nextInterpMode(points[hit].mode),
+      };
+      pointsRef.current = points;
+      setCurvePoints(activeCurve, points);
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Delete" && e.key !== "Backspace") return;
+      if (hoverIndex === null) return;
+      const points = pointsRef.current;
+      // Endpoints can't be deleted; they're pinned at x=0 and x=1.
+      if (hoverIndex === 0 || hoverIndex === points.length - 1) return;
+      const next = points.filter((_, i) => i !== hoverIndex);
+      pointsRef.current = next;
+      hoverIndex = null;
+      setCurvePoints(activeCurve, next);
+    };
+
+    canvas.addEventListener("pointerdown", onPointerDown);
+    canvas.addEventListener("pointermove", onPointerMove);
+    canvas.addEventListener("pointerup", onPointerUp);
+    canvas.addEventListener("pointercancel", onPointerUp);
+    canvas.addEventListener("contextmenu", onContextMenu);
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      canvas.removeEventListener("pointerdown", onPointerDown);
+      canvas.removeEventListener("pointermove", onPointerMove);
+      canvas.removeEventListener("pointerup", onPointerUp);
+      canvas.removeEventListener("pointercancel", onPointerUp);
+      canvas.removeEventListener("contextmenu", onContextMenu);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, activeCurve, setCurvePoints]);
+
+  if (!open) return null;
+
+  // Tab right-click → preset menu. Anchored to the tab button itself
+  // and grows UPWARD from above the tab strip; the overlay clips at
+  // its bounds, so positioning at the click point would clip the menu
+  // off the bottom edge.
+  const onTabContext = (
+    e: React.MouseEvent<HTMLButtonElement>,
+    param: string,
+  ) => {
+    e.preventDefault();
+    const overlay = overlayRef.current;
+    if (!overlay) return;
+    const orect = overlay.getBoundingClientRect();
+    const trect = e.currentTarget.getBoundingClientRect();
+    setPresetMenu({
+      param,
+      // Align left edge with the tab's left edge.
+      left: trect.left - orect.left,
+      // Anchor the menu's bottom 6px above the tab's top edge so it
+      // grows upward inside the overlay.
+      bottom: orect.bottom - trect.top + 6,
+    });
+  };
+
+  const applyPresetFromMenu = (preset: CurvePresetId) => {
+    if (!presetMenu) return;
+    const session = useSessionStore.getState();
+    const duration = session.remote?.duration ?? 60;
+    const points = buildPreset(preset, {
+      durationSec: duration,
+      bpm: detectedBpm,
+    });
+    setCurvePoints(presetMenu.param, points);
+    setActiveCurve(presetMenu.param);
+    setPresetMenu(null);
+  };
+
+  return (
+    <div ref={overlayRef} className="schedule-curves-overlay" role="dialog">
+      <canvas
+        ref={bgCanvasRef}
+        className="schedule-curves-bg"
+        aria-hidden="true"
+      />
+      <canvas ref={fgCanvasRef} className="schedule-curves-canvas" />
+      <div className="schedule-curves-tabs">
+        {SCHEDULEABLE_PARAMS.map((param) => {
+          const isActive = param === activeCurve;
+          const isEnabled = curves[param]?.enabled ?? false;
+          return (
+            <button
+              key={param}
+              type="button"
+              className={
+                "schedule-curves-tab" +
+                (isActive ? " schedule-curves-tab--active" : "") +
+                (isEnabled ? " schedule-curves-tab--enabled" : "")
+              }
+              onClick={() => setActiveCurve(param)}
+              onContextMenu={(e) => onTabContext(e, param)}
+              title={`${SCHEDULEABLE_PARAM_LABEL[param]} — ${
+                isEnabled ? "active" : "drawn but not driving"
+              } (right-click for presets)`}
+            >
+              {SCHEDULEABLE_PARAM_LABEL[param]}
+            </button>
+          );
+        })}
+        {loraTabs.map((tab) => {
+          const isActive = tab.param === activeCurve;
+          const isEnabled = curves[tab.param]?.enabled ?? false;
+          return (
+            <button
+              key={tab.param}
+              type="button"
+              className={
+                "schedule-curves-tab schedule-curves-tab--lora" +
+                (isActive ? " schedule-curves-tab--active" : "") +
+                (isEnabled ? " schedule-curves-tab--enabled" : "")
+              }
+              onClick={() => {
+                ensureCurve(tab.param);
+                setActiveCurve(tab.param);
+              }}
+              onContextMenu={(e) => {
+                ensureCurve(tab.param);
+                onTabContext(e, tab.param);
+              }}
+              title={`LoRA ${tab.label} — ${
+                isEnabled ? "active" : "drawn but not driving"
+              } (right-click for presets)`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+        {/* Master enable / kill switch — flips ALL curves off without
+            losing per-curve drawings. The application loop checks this
+            first; when off, no slider gets driven. */}
+        <button
+          type="button"
+          className={
+            "schedule-curves-master" +
+            (scheduleEnabled ? " schedule-curves-master--on" : "")
+          }
+          onClick={toggleScheduleEnabled}
+          title={
+            scheduleEnabled
+              ? "Curves are driving sliders. Click to pause all automation."
+              : "All curves paused. Click to resume."
+          }
+        >
+          {scheduleEnabled ? "ON" : "OFF"}
+        </button>
+        <button
+          type="button"
+          className="schedule-curves-close"
+          onClick={closeOverlay}
+          aria-label="Close schedule curves"
+          title="Close (Esc)"
+        >
+          ×
+        </button>
+      </div>
+
+      {presetMenu && (
+        <div
+          className="schedule-curves-preset-menu"
+          style={{ left: presetMenu.left, bottom: presetMenu.bottom }}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <div className="schedule-curves-preset-header">
+            {labelFor(presetMenu.param)}
+          </div>
+          <button
+            type="button"
+            className="schedule-curves-preset-item"
+            onClick={() => {
+              const enabled = curves[presetMenu.param]?.enabled ?? false;
+              setCurveEnabled(presetMenu.param, !enabled);
+              setPresetMenu(null);
+            }}
+          >
+            {curves[presetMenu.param]?.enabled ? "Disable" : "Enable"}
+          </button>
+          <button
+            type="button"
+            className="schedule-curves-preset-item"
+            onClick={() => {
+              resetCurve(presetMenu.param);
+              setPresetMenu(null);
+            }}
+          >
+            Reset
+          </button>
+          <div className="schedule-curves-preset-divider" />
+          {(Object.keys(PRESET_LABEL) as CurvePresetId[]).map((preset) => (
+            <button
+              key={preset}
+              type="button"
+              className="schedule-curves-preset-item"
+              onClick={() => applyPresetFromMenu(preset)}
+            >
+              {PRESET_LABEL[preset]}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/SeedTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/SeedTile.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+
+export function SeedTile() {
+  const seed = usePerformanceStore((s) => s.seed);
+  const randomize = usePerformanceStore((s) => s.randomizeSeed);
+  return (
+    <div className="mixer-tile mixer-tile-seed" data-tile="seed">
+      <div className="mixer-tile-label">Seed</div>
+      <div className="seed-content">
+        <button
+          id="seed-btn"
+          className="seed-btn"
+          data-midi-learn="seed"
+          title="Randomize seed (right-click to MIDI-learn)"
+          type="button"
+          onClick={randomize}
+          aria-label="Randomize seed"
+        >
+          {/* Inline SVG dice — monoline stroke, no fill, matches the
+              custom-cursor / ribbon vocabulary. Two pips visible
+              (face-2) suggest "the dice is mid-roll" without literally
+              animating. */}
+          <svg
+            className="seed-dice"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="3" y="3" width="18" height="18" rx="3" />
+            <circle cx="8.5" cy="8.5" r="1.1" fill="currentColor" stroke="none" />
+            <circle cx="15.5" cy="15.5" r="1.1" fill="currentColor" stroke="none" />
+          </svg>
+        </button>
+        <div className="slider-value" id="seed-value">
+          {seed.toFixed(2)}
+        </div>
+        <kbd className="desktop-only">F</kbd>
+      </div>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/SliderGroup.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/SliderGroup.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useEffect, useRef } from "react";
+
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { SLIDER_META } from "@/types/engine";
+
+// Vertical slider matching DEMON's CSS layout (.slider-track + .slider-fill
+// + .slider-thumb). Click + drag on the track to set; the value reads from
+// usePerformanceStore. LoRA sliders (param starting with `lora_str_`)
+// supply their own max via prop because they aren't in SLIDER_META.
+
+interface Props {
+  param: string;
+  label: string;
+  /** Override max + step for ad-hoc sliders (LoRA strength). */
+  max?: number;
+  kbd?: string;
+}
+
+// Palette stops mirror the .slider-fill gradient
+// (linear-gradient(to top, --dd-4 0%, --dd-3 35%, --dd-2 70%, --dd-1 100%)).
+// `t` is the slider fraction 0→1 measured from the BOTTOM of the track,
+// so t=0 maps to --dd-4 (coral), t=1 to --dd-1 (teal). Sampling here lets
+// the label / rail / thumb-border share the same color the fill gradient
+// would show at the current value.
+const TINT_STOPS: ReadonlyArray<readonly [number, readonly [number, number, number]]> = [
+  [0.0, [232, 79, 61]],
+  [0.3, [240, 138, 72]],
+  [0.65, [199, 181, 102]],
+  [1.0, [61, 182, 190]],
+];
+
+function tintAt(t: number): string {
+  const clamped = Math.max(0, Math.min(1, t));
+  for (let i = 1; i < TINT_STOPS.length; i++) {
+    const [p1, c1] = TINT_STOPS[i - 1];
+    const [p2, c2] = TINT_STOPS[i];
+    if (clamped <= p2) {
+      const k = p2 === p1 ? 0 : (clamped - p1) / (p2 - p1);
+      const r = Math.round(c1[0] + (c2[0] - c1[0]) * k);
+      const g = Math.round(c1[1] + (c2[1] - c1[1]) * k);
+      const b = Math.round(c1[2] + (c2[2] - c1[2]) * k);
+      return `rgb(${r} ${g} ${b})`;
+    }
+  }
+  const [, last] = TINT_STOPS[TINT_STOPS.length - 1];
+  return `rgb(${last[0]} ${last[1]} ${last[2]})`;
+}
+
+export function SliderGroup({ param, label, max, kbd }: Props) {
+  const meta = SLIDER_META[param];
+  const effectiveMax = max ?? meta?.max ?? 1.0;
+  // Read the user's target (instant), not the smoothed sent value, so
+  // dragging tracks the cursor without smoothing lag.
+  const value = usePerformanceStore(
+    (s) => s.sliderTargets[param] ?? 0,
+  );
+  const setSlider = usePerformanceStore((s) => s.setSlider);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+
+  const fraction = effectiveMax > 0 ? value / effectiveMax : 0;
+  const pct = Math.max(0, Math.min(1, fraction)) * 100;
+
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el) return;
+
+    // Cache the track rect at pointerdown and reuse for the lifetime of
+    // the drag. Without this, every pointermove called
+    // getBoundingClientRect(), which forces a synchronous layout flush
+    // and evicts paint caches — the dominant source of cursor jank
+    // during slider drags. The track does not resize during a drag.
+    let dragging = false;
+    let cachedRect: DOMRect | null = null;
+    let pendingClientY = 0;
+    let rafId = 0;
+
+    const commit = () => {
+      if (!cachedRect) return;
+      const t = 1 - (pendingClientY - cachedRect.top) / cachedRect.height;
+      setSlider(param, Math.max(0, Math.min(1, t)) * effectiveMax);
+    };
+
+    // RAF-coalesce store writes during drag: pointermove fires 60–120
+    // times/sec, but the render loop can only show ~60 frames/sec.
+    // Coalescing also collapses the cascade of React re-renders triggered
+    // by setSlider() into one per frame.
+    const flush = () => {
+      rafId = 0;
+      if (!dragging) return;
+      commit();
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      // Right-click reserved for MIDI-learn (Phase 9).
+      if (e.button !== 0) return;
+      dragging = true;
+      cachedRect = el.getBoundingClientRect();
+      el.setPointerCapture(e.pointerId);
+      pendingClientY = e.clientY;
+      // Commit immediately so a click-without-drag still moves the value.
+      commit();
+    };
+    const onPointerMove = (e: PointerEvent) => {
+      if (!dragging) return;
+      pendingClientY = e.clientY;
+      if (rafId === 0) rafId = requestAnimationFrame(flush);
+    };
+    const onPointerUp = (e: PointerEvent) => {
+      if (!dragging) return;
+      dragging = false;
+      if (rafId !== 0) {
+        cancelAnimationFrame(rafId);
+        rafId = 0;
+      }
+      cachedRect = null;
+      el.releasePointerCapture(e.pointerId);
+    };
+
+    el.addEventListener("pointerdown", onPointerDown);
+    el.addEventListener("pointermove", onPointerMove);
+    el.addEventListener("pointerup", onPointerUp);
+    el.addEventListener("pointercancel", onPointerUp);
+    return () => {
+      if (rafId !== 0) cancelAnimationFrame(rafId);
+      el.removeEventListener("pointerdown", onPointerDown);
+      el.removeEventListener("pointermove", onPointerMove);
+      el.removeEventListener("pointerup", onPointerUp);
+      el.removeEventListener("pointercancel", onPointerUp);
+    };
+  }, [param, effectiveMax, setSlider]);
+
+  const tintStyle = { "--slider-tint": tintAt(fraction) } as CSSProperties;
+
+  return (
+    <div className="slider-group" data-param={param} style={tintStyle}>
+      <div className="slider-label">{label}</div>
+      <div className="slider-track" ref={trackRef}>
+        <div className="slider-fill" style={{ height: `${pct}%` }} />
+        <div className="slider-thumb" style={{ bottom: `${pct}%` }} />
+      </div>
+      <div className="slider-value">{value.toFixed(2)}</div>
+      {kbd && <kbd className="desktop-only">{kbd}</kbd>}
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/SliderTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/SliderTile.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { SliderGroup } from "./SliderGroup";
+
+// Generic mixer tile that wraps a row of sliders. Replaces the dynamic
+// buildChannelTile() helper from app.js. `params` is the list of slider
+// names (must exist in SLIDER_META).
+
+interface Props {
+  label: string;
+  params: { param: string; label: string; max?: number }[];
+}
+
+const DISPLAY_NAMES: Record<string, string> = {
+  noise_share: "nshare",
+  ode_noise: "ode",
+  hint_strength: "structure strength",
+  dcw_scaler: "DCW low",
+  dcw_high_scaler: "DCW high",
+};
+
+// Map slider param → keyboard hint shown beneath the slider. Mirrors the
+// chord layout in hooks/useKeyboardShortcuts.ts; if you change one, change
+// the other.
+const KBD_FOR_PARAM: Record<string, string> = {
+  denoise: "A + ▲▼",
+  hint_strength: "G + ▲▼",
+  feedback: "E + ▲▼",
+  shift: "H + ▲▼",
+  noise_share: "N + ▲▼",
+  ode_noise: "D + ▲▼",
+  ch_g0: "0 + ▲▼",
+  ch_g1: "1 + ▲▼",
+  ch_g2: "2 + ▲▼",
+  ch_g3: "3 + ▲▼",
+  ch_g4: "4 + ▲▼",
+  ch_g5: "5 + ▲▼",
+  ch_g6: "6 + ▲▼",
+  ch_g7: "7 + ▲▼",
+  ch13: "⇧1 + ▲▼",
+  ch14: "⇧2 + ▲▼",
+  ch19: "⇧3 + ▲▼",
+  ch23: "⇧4 + ▲▼",
+  ch29: "⇧5 + ▲▼",
+  ch56: "⇧6 + ▲▼",
+  dcw_scaler: "W + ▲▼",
+  dcw_high_scaler: "Y + ▲▼",
+};
+
+export function kbdHintFor(param: string): string | undefined {
+  return KBD_FOR_PARAM[param];
+}
+
+export function SliderTile({ label, params }: Props) {
+  return (
+    <div className="mixer-tile" data-tile={label.toLowerCase().replace(/ /g, "-")}>
+      <div className="mixer-tile-label">{label}</div>
+      <div className="mixer-channels">
+        {params.map(({ param, label: pLabel, max }) => (
+          <SliderGroup
+            key={param}
+            param={param}
+            label={pLabel}
+            max={max}
+            kbd={KBD_FOR_PARAM[param]}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function defaultLabelFor(param: string): string {
+  return DISPLAY_NAMES[param] ?? param.replace(/_/g, " ");
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/StartOverlay.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/StartOverlay.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+
+import { START_MARK_PALETTE } from "@/engine/render/ribbons";
+import { useIsMobile } from "@/hooks/useIsMobile";
+
+interface Props {
+  onPlay: () => void;
+  hidden?: boolean;
+}
+
+// Total length of the click-to-launch CSS animation. Kept in sync with
+// the @keyframes durations in globals.css so the actual onPlay() fires
+// only after the ribbons have finished blowing up.
+const LAUNCH_DURATION_MS = 700;
+
+// The brand mark IS the play button. The icon halo + the "click/tap to
+// begin" whisper sit inside a single <button> so anywhere on either
+// element triggers onPlay — testers were instinctively trying to click
+// the copy itself. On click, the ribbons spin + explode outward while
+// the icon zooms forward; only then does onPlay fire and the overlay
+// give way to the app.
+export function StartOverlay({ onPlay, hidden }: Props) {
+  const isMobile = useIsMobile();
+  const [launching, setLaunching] = useState(false);
+
+  function handleClick() {
+    if (launching) return;
+    setLaunching(true);
+    // Fire onPlay() immediately so the queue.start() network round-trip
+    // overlaps with the 700ms animation rather than starting after it.
+    // If we deferred onPlay() to the timeout, the launching class would
+    // come off at t=700ms while queue.status is still 'idle'/'joining',
+    // briefly snapping the CTA back to its base "click to begin" state
+    // until the join response landed.
+    onPlay();
+    window.setTimeout(() => {
+      // Happy-path: parent re-renders us with hidden=true (queue admits
+      // OR session starts) and this state never matters. Sad-path: gate,
+      // error, or paywall keeps us mounted and we'd otherwise be stuck
+      // post-launch animation showing nothing — reset so the user can
+      // see + interact with the title screen again.
+      setLaunching(false);
+    }, LAUNCH_DURATION_MS);
+  }
+
+  const whisper = isMobile ? "tap to begin" : "click to begin";
+
+  return (
+    <div id="start-overlay" className={hidden ? "hidden" : ""}>
+      <button
+        type="button"
+        className={`start-cta${launching ? " start-cta--launching" : ""}`}
+        onClick={handleClick}
+        aria-label={isMobile ? "Tap to begin" : "Click to begin"}
+        disabled={launching}
+      >
+        <span className="start-cta-halo" aria-hidden="true">
+          {/* Writhing ribbon halo around the logo — populated by
+              useRenderLoop's tickStartMarkRibbon. */}
+          <svg
+            className="start-mark-ribbons"
+            viewBox="0 0 100 100"
+            preserveAspectRatio="xMidYMid meet"
+            aria-hidden="true"
+          >
+            {START_MARK_PALETTE.map((color) => (
+              <path
+                key={color}
+                stroke={color}
+                fill="none"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            ))}
+          </svg>
+          <img
+            className="start-mark"
+            src="/daydream-icon-clean.png"
+            alt=""
+          />
+        </span>
+        <span className="start-whisper">{whisper}</span>
+      </button>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/StatusBar.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/StatusBar.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useSessionStore } from "@/store/useSessionStore";
+
+// Status placard. Reads from the session store directly so consumers
+// don't have to thread props through their performance shell. The
+// `data-state` attribute drives all of the visual treatment via
+// CSS — see the `.status-bar` rules in styles.css.
+//
+// State derivation:
+//   - `idle` (no session) and `ready` + "Playing" → hidden.
+//   - `loading-fixture` / `connecting` → "loading" (accent orange,
+//     calm breathing).
+//   - `error` / `closed` → "error" (warn yellow, soft inset glow).
+//   - everything else with a non-empty message → "info" (white, mid-
+//     session swap progress and friends).
+
+type PlacardState = "loading" | "info" | "error";
+
+function deriveState(
+  status: string,
+  message: string,
+): { visible: boolean; state: PlacardState } {
+  if (!message || message === "Playing") {
+    return { visible: false, state: "info" };
+  }
+  if (status === "error" || status === "closed") {
+    return { visible: true, state: "error" };
+  }
+  if (status === "loading-fixture" || status === "connecting") {
+    return { visible: true, state: "loading" };
+  }
+  return { visible: true, state: "info" };
+}
+
+export function StatusBar() {
+  const status = useSessionStore((s) => s.status);
+  const message = useSessionStore((s) => s.message);
+  const { visible, state } = deriveState(status, message);
+
+  // While `status === "connecting"` the WS handshake + first-session
+  // model warm-up can take up to ~60s — surface that expectation under
+  // the main message so users don't think the page froze.
+  const showConnectingHint = status === "connecting";
+
+  return (
+    <div
+      className={`status-bar${visible ? " status-bar--visible" : ""}`}
+      data-state={state}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="status-bar__text">{message}</span>
+      {showConnectingHint && (
+        <span className="status-bar__subtitle">
+          this might take up to a minute
+        </span>
+      )}
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/engine/audio/AudioPlayer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/AudioPlayer.ts
@@ -1,0 +1,262 @@
+// Main-thread wrapper around the realtime-buffer AudioWorklet.
+// Falls back to ScriptProcessorNode when AudioWorklet is unavailable
+// (non-secure contexts like plain HTTP to a remote IP).
+//
+// Direct TS port of DEMON/demos/realtime_motion_graph_web/static/audio.js.
+
+import { SAMPLE_RATE } from "@/engine/protocol";
+
+type MirrorListener = () => void;
+
+interface AudioWorkletNodeWithPort extends AudioNode {
+  port: MessagePort;
+}
+
+export class AudioPlayer {
+  ctx: AudioContext | null = null;
+  node: AudioWorkletNode | ScriptProcessorNode | null = null;
+  positionSec = 0;
+  swapCount = 0;
+  channels = 2;
+  frameCount = 0;
+
+  private _listeners: Set<MirrorListener> = new Set();
+  private _mirror: Float32Array | null = null;
+  private _useWorklet = false;
+  private _spBuffer: Float32Array | null = null;
+  private _spPosition = 0;
+  private _recordDest: MediaStreamAudioDestinationNode | null = null;
+
+  get duration(): number {
+    return this.frameCount / SAMPLE_RATE;
+  }
+
+  async init(
+    initialBufferInterleaved: Float32Array,
+    channels: number,
+  ): Promise<void> {
+    this.ctx = new AudioContext({
+      sampleRate: SAMPLE_RATE,
+      latencyHint: "interactive",
+    });
+
+    this.channels = channels;
+    this.frameCount = initialBufferInterleaved.length / channels;
+    this._mirror = initialBufferInterleaved.slice();
+
+    this._useWorklet = !!this.ctx.audioWorklet;
+
+    if (this._useWorklet) {
+      // Stable URL — worklet ships from public/ so AudioContext can resolve it.
+      await this.ctx.audioWorklet.addModule("/audio-worklet.js");
+
+      const node = new AudioWorkletNode(this.ctx, "realtime-buffer", {
+        numberOfInputs: 0,
+        numberOfOutputs: 1,
+        outputChannelCount: [channels],
+      });
+      this.node = node;
+
+      node.port.onmessage = (e: MessageEvent) => {
+        const msg = e.data as { type: string; positionSec?: number; swapCount?: number };
+        if (msg.type === "position") {
+          this.positionSec = msg.positionSec ?? 0;
+          this.swapCount = msg.swapCount ?? this.swapCount;
+        }
+      };
+
+      const send = initialBufferInterleaved.slice();
+      node.port.postMessage(
+        { type: "init", buffer: send, channels },
+        [send.buffer],
+      );
+    } else {
+      // ScriptProcessorNode fallback for non-secure contexts.
+      console.warn(
+        "[AudioPlayer] AudioWorklet unavailable (non-secure context). Using ScriptProcessor fallback.",
+      );
+      this._spBuffer = initialBufferInterleaved.slice();
+      this._spPosition = 0;
+      const BUFFER_SIZE = 4096;
+      const sp = this.ctx.createScriptProcessor(BUFFER_SIZE, 0, channels);
+      this.node = sp;
+      sp.onaudioprocess = (e: AudioProcessingEvent) => this._spProcess(e);
+    }
+
+    this.node.connect(this.ctx.destination);
+  }
+
+  /** Overwrite a region of the worklet's buffer. */
+  patch(startFrame: number, audioInterleaved: Float32Array): void {
+    this._writeMirror(startFrame, audioInterleaved, false);
+    if (this._useWorklet && this.node) {
+      const send = audioInterleaved.slice();
+      (this.node as AudioWorkletNode).port.postMessage(
+        { type: "patch", start: startFrame, audio: send },
+        [send.buffer],
+      );
+    } else {
+      this._writeSPBuffer(startFrame, audioInterleaved, false);
+    }
+  }
+
+  /**
+   * Replace the entire loop buffer. The worklet crossfades old → new over
+   * CROSSFADE_SECONDS (50 ms); ScriptProcessor fallback does an instant
+   * swap (the seam-fade still hides the wrap).
+   */
+  swap(interleavedBuffer: Float32Array, channels?: number): void {
+    this.channels = channels || this.channels;
+    this.frameCount = interleavedBuffer.length / this.channels;
+    this._mirror = interleavedBuffer.slice();
+    this.swapCount++;
+    for (const fn of this._listeners) fn();
+    if (this._useWorklet && this.node) {
+      const send = interleavedBuffer.slice();
+      (this.node as AudioWorkletNode).port.postMessage(
+        { type: "swap", buffer: send, channels: this.channels },
+        [send.buffer],
+      );
+    } else {
+      this._spBuffer = interleavedBuffer.slice();
+      this._spPosition = 0;
+    }
+  }
+
+  /** Delta-add into a region of the worklet's buffer. */
+  addDelta(startFrame: number, deltaInterleaved: Float32Array): void {
+    this._writeMirror(startFrame, deltaInterleaved, true);
+    if (this._useWorklet && this.node) {
+      const send = deltaInterleaved.slice();
+      (this.node as AudioWorkletNode).port.postMessage(
+        { type: "add", start: startFrame, audio: send },
+        [send.buffer],
+      );
+    } else {
+      this._writeSPBuffer(startFrame, deltaInterleaved, true);
+    }
+  }
+
+  /** Read-only view of the current buffer (for waveform rendering). */
+  getMirror(): Float32Array | null {
+    return this._mirror;
+  }
+
+  onMirrorChange(fn: MirrorListener): () => void {
+    this._listeners.add(fn);
+    return () => {
+      this._listeners.delete(fn);
+    };
+  }
+
+  async resume(): Promise<void> {
+    if (this.ctx?.state === "suspended") await this.ctx.resume();
+  }
+
+  /**
+   * Lazily create a MediaStream tee'd off the worklet output for recording.
+   * Same node graph as the live destination — bit-identical to what the
+   * user hears. Stays alive for the rest of the session once created.
+   */
+  getRecordingStream(): MediaStream | null {
+    if (!this.ctx || !this.node) return null;
+    if (!this._recordDest) {
+      this._recordDest = this.ctx.createMediaStreamDestination();
+      this.node.connect(this._recordDest);
+    }
+    return this._recordDest.stream;
+  }
+
+  async close(): Promise<void> {
+    try {
+      this.node?.disconnect();
+    } catch {}
+    this._recordDest = null;
+    try {
+      await this.ctx?.close();
+    } catch {}
+  }
+
+  // ── internals ────────────────────────────────────────────────────────
+
+  private _writeSPBuffer(
+    startFrame: number,
+    audioInterleaved: Float32Array,
+    add: boolean,
+  ): void {
+    if (!this._spBuffer) return;
+    const ch = this.channels;
+    const base = startFrame * ch;
+    const n = Math.min(audioInterleaved.length, this._spBuffer.length - base);
+    if (n <= 0) return;
+    if (add) {
+      for (let i = 0; i < n; i++) this._spBuffer[base + i] += audioInterleaved[i];
+    } else {
+      for (let i = 0; i < n; i++) this._spBuffer[base + i] = audioInterleaved[i];
+    }
+  }
+
+  private _writeMirror(
+    startFrame: number,
+    audioInterleaved: Float32Array,
+    add: boolean,
+  ): void {
+    if (!this._mirror) return;
+    const ch = this.channels;
+    const base = startFrame * ch;
+    const n = Math.min(audioInterleaved.length, this._mirror.length - base);
+    if (n <= 0) return;
+    if (add) {
+      for (let i = 0; i < n; i++) this._mirror[base + i] += audioInterleaved[i];
+    } else {
+      for (let i = 0; i < n; i++) this._mirror[base + i] = audioInterleaved[i];
+    }
+    this.swapCount++;
+    for (const fn of this._listeners) fn();
+  }
+
+  private _spProcess(e: AudioProcessingEvent): void {
+    const output = e.outputBuffer;
+    const frames = output.length;
+    const ch = this.channels;
+    const buf = this._spBuffer;
+    if (!buf || this.frameCount === 0 || !this.ctx) {
+      for (let c = 0; c < output.numberOfChannels; c++) {
+        output.getChannelData(c).fill(0);
+      }
+      return;
+    }
+    const nFrames = this.frameCount;
+    // Mirror the worklet's loop-seam crossfade so non-secure-context playback
+    // (ScriptProcessor fallback) gets the same smooth wrap.
+    const seamFadeLen = Math.max(1, Math.floor(this.ctx.sampleRate * 0.05));
+    const seam = Math.min(seamFadeLen, Math.floor(nFrames / 4));
+    const outChs: Float32Array[] = [];
+    for (let c = 0; c < output.numberOfChannels; c++) {
+      outChs.push(output.getChannelData(c));
+    }
+    let pos = this._spPosition;
+    for (let i = 0; i < frames; i++) {
+      if (seam > 0 && nFrames - pos <= seam) {
+        const distFromEnd = nFrames - pos;
+        const t = (seam - distFromEnd) / seam;
+        const headPos = seam - distFromEnd;
+        for (let c = 0; c < outChs.length; c++) {
+          const cc = Math.min(c, ch - 1);
+          const sTail = buf[pos * ch + cc];
+          const sHead = buf[headPos * ch + cc];
+          outChs[c][i] = sTail * (1 - t) + sHead * t;
+        }
+      } else {
+        for (let c = 0; c < outChs.length; c++) {
+          const cc = Math.min(c, ch - 1);
+          outChs[c][i] = buf[pos * ch + cc];
+        }
+      }
+      pos++;
+      if (pos >= nFrames) pos = seam;
+    }
+    this._spPosition = pos;
+    this.positionSec = this._spPosition / SAMPLE_RATE;
+  }
+}

--- a/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
@@ -1,0 +1,124 @@
+// Fetch + decode an audio fixture from the DEMON pod, returning interleaved
+// float32 PCM at the audio context sample rate. Uses Web Audio's
+// decodeAudioData() so any WAV/MP3/FLAC the pod ships with works without a
+// custom decoder.
+//
+// Also handles user-uploaded tracks: useCustomTracksStore caches their
+// decoded buffers; loadFixtureAudio() checks that cache first, so the
+// existing Play / fixture-swap paths work unchanged when the active
+// fixture is an upload.
+
+import { podHttp } from "@/engine/podUrl";
+import { SAMPLE_RATE } from "@/engine/protocol";
+
+export interface DecodedFixture {
+  interleaved: Float32Array;
+  channels: number;
+  frames: number;
+  sampleRate: number;
+}
+
+/** Decoder runs on a short-lived real AudioContext at SAMPLE_RATE so the
+ *  PCM matches what the pod's pipeline expects. We previously used
+ *  OfflineAudioContext here; recent Chromium builds occasionally never
+ *  resolve OfflineAudioContext.decodeAudioData(), leaving the UI stuck on
+ *  "Loading fixture…". A regular AudioContext is the documented path and
+ *  is safe because Play is a user gesture. */
+async function decodeArrayBuffer(bytes: ArrayBuffer): Promise<DecodedFixture> {
+  const Ctx: typeof AudioContext =
+    (window.AudioContext as typeof AudioContext) ||
+    ((window as unknown as { webkitAudioContext: typeof AudioContext })
+      .webkitAudioContext as typeof AudioContext);
+  const tmpCtx = new Ctx({ sampleRate: SAMPLE_RATE });
+  let audioBuffer: AudioBuffer;
+  try {
+    // decodeAudioData mutates the input ArrayBuffer in some browsers, so
+    // we pass a copy via .slice(0).
+    audioBuffer = await tmpCtx.decodeAudioData(bytes.slice(0));
+  } finally {
+    void tmpCtx.close();
+  }
+
+  // Always emit exactly 2 channels: mono → duplicate, stereo → pass
+  // through, >2 → take front L/R only (Web Audio puts front-L=0,
+  // front-R=1 for any layout).
+  const srcChannels = audioBuffer.numberOfChannels;
+  const frames = audioBuffer.length;
+  const channels = 2;
+  const interleaved = new Float32Array(frames * channels);
+
+  if (srcChannels === 1) {
+    const m = audioBuffer.getChannelData(0);
+    for (let i = 0; i < frames; i++) {
+      const v = m[i];
+      interleaved[i * 2] = v;
+      interleaved[i * 2 + 1] = v;
+    }
+  } else {
+    const l = audioBuffer.getChannelData(0);
+    const r = audioBuffer.getChannelData(1);
+    for (let i = 0; i < frames; i++) {
+      interleaved[i * 2] = l[i];
+      interleaved[i * 2 + 1] = r[i];
+    }
+  }
+
+  return { interleaved, channels, frames, sampleRate: audioBuffer.sampleRate };
+}
+
+export async function loadFixtureAudio(name: string): Promise<DecodedFixture> {
+  // Custom uploads short-circuit the pod fetch — they live in memory only.
+  // Imported lazily to avoid a Zustand cycle at module load.
+  const { useCustomTracksStore } = await import("@/store/useCustomTracksStore");
+  const cached = useCustomTracksStore.getState().decoded.get(name);
+  if (cached) return cached;
+
+  const url = podHttp(`/fixtures/${encodeURIComponent(name)}`);
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Fixture fetch failed: ${res.status} ${res.statusText}`);
+  }
+  const bytes = await res.arrayBuffer();
+  return decodeArrayBuffer(bytes);
+}
+
+// DEMON's WebSocket server caps incoming frames at ~50 MiB
+// (websockets.serve(max_size=…)). swap_source sends an 8-byte header +
+// interleaved Float32 PCM, so the decoded buffer must fit under that cap.
+// Practical limit at 48 kHz stereo Float32 (8 B/frame) ≈ 130 s of audio.
+const MAX_SWAP_SOURCE_BYTES = 50 * 1024 * 1024;
+const SWAP_SOURCE_HEADER_BYTES = 8;
+
+function ensureFitsSwapLimit(decoded: DecodedFixture): void {
+  const totalBytes = decoded.interleaved.byteLength + SWAP_SOURCE_HEADER_BYTES;
+  if (totalBytes <= MAX_SWAP_SOURCE_BYTES) return;
+  const seconds = decoded.frames / decoded.sampleRate;
+  const bytesPerSecond = decoded.sampleRate * decoded.channels * 4;
+  const maxSeconds = Math.floor(
+    (MAX_SWAP_SOURCE_BYTES - SWAP_SOURCE_HEADER_BYTES) / bytesPerSecond,
+  );
+  throw new Error(
+    `Track too long for the engine — ${Math.round(seconds)} s decoded ` +
+      `(${(totalBytes / 1024 / 1024).toFixed(1)} MB), engine accepts ` +
+      `up to ~${maxSeconds} s. Trim the file or pick a shorter clip.`,
+  );
+}
+
+/** Decode a user-supplied audio File (mp3, wav, flac, ogg — anything the
+ *  browser supports). Used by the OperatorStrip upload affordance.
+ *  Throws if the decoded PCM would exceed DEMON's WS frame cap (~50 MiB,
+ *  ≈ 130 s at 48 kHz stereo). */
+export async function decodeAudioFile(file: File): Promise<DecodedFixture> {
+  const bytes = await file.arrayBuffer();
+  const decoded = await decodeArrayBuffer(bytes);
+  ensureFitsSwapLimit(decoded);
+  return decoded;
+}
+
+/** Fetch the pod's whitelist of fixture names. */
+export async function listFixtures(): Promise<string[]> {
+  const res = await fetch(podHttp("/api/fixtures"));
+  if (!res.ok) throw new Error(`Fixture list failed: ${res.status}`);
+  const json = (await res.json()) as string[];
+  return json;
+}

--- a/demos/realtime_motion_graph_web/web/engine/audio/togglePauseAndAudio.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/togglePauseAndAudio.ts
@@ -1,0 +1,14 @@
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+// Flips the paused flag in the performance store and mirrors that into the
+// AudioContext (suspend/resume). Used by the OperatorStrip button, the
+// spacebar shortcut, and the click-to-pause graph overlay — keeping all
+// three in lockstep so the UI flag and the audio context can't drift.
+export function togglePauseAndAudio(): void {
+  usePerformanceStore.getState().togglePause();
+  const player = useSessionStore.getState().player;
+  if (!player?.ctx) return;
+  if (player.ctx.state === "running") void player.ctx.suspend();
+  else void player.ctx.resume();
+}

--- a/demos/realtime_motion_graph_web/web/engine/cursor.ts
+++ b/demos/realtime_motion_graph_web/web/engine/cursor.ts
@@ -1,0 +1,321 @@
+// Custom cursor: a TIGHT 4-particle constellation (one per ribbon palette
+// color) orbiting close to the pointer, plus a precise white center dot.
+// Layered with two ephemeral particle systems for party energy:
+//
+//   • Sparkler trail — every few px of motion the cursor emits a small
+//     palette-colored spark with gravity that fades over ~700ms.
+//   • Confetti burst — every mousedown spawns a radial cloud.
+//
+// Renders into a single 2D canvas so the whole effect is one composited
+// layer in every browser. The previous DOM-divs + box-shadow + CSS
+// `mix-blend-mode: plus-lighter` implementation was reliably hardware-
+// composited only in Blink; Gecko fell back to software for the blend
+// group, which during slider drags (mousemove + pointermove competing
+// for the main thread) caused observable cursor lag. We draw plain
+// solid discs (no halo, no blend mode) — the orbital cluster's
+// character is in motion, not glow. Audio kicks bump the radii via
+// `bloom` so the cluster still breathes with the music.
+//
+// Tick is driven from the shared render loop (useRenderLoop) via
+// tickActiveCursor(now, bloom); a separate RAF would compete for vsync
+// and double the per-frame draw surface. Caller renders
+// <canvas class="cursor-canvas"> (see <CustomCursor />).
+
+const ORBIT_RADIUS = 9;
+const SPRING_K = 0.18;
+const DAMPING = 0.78;
+const ROTATION_SPEED = 0.0004;
+const ATTRACTOR_RANGE = 140;
+const ATTRACTOR_GAIN = 0.4;
+const BURST_DECAY = 0.9;
+const BURST_GAIN = 1.4;
+
+// Palette shared with the perimeter / halo / start-mark ribbons.
+const PALETTE = ["#3db6be", "#c7b566", "#f08a48", "#e84f3d"];
+
+// One entry per orbiting particle. `dir` flips orbit direction (some
+// clockwise, some counter-clockwise), `speedMul` shifts the rotation rate,
+// `radiusMul` shifts the resting orbital radius. Together: an asymmetric,
+// organic cluster instead of four points marching in lockstep.
+const PARTICLE_CONFIG: Array<{
+  color: string;
+  dir: 1 | -1;
+  speedMul: number;
+  radiusMul: number;
+  offset: number;
+}> = [
+  { color: PALETTE[0], dir: 1, speedMul: 0.7, radiusMul: 1.0, offset: 0.0 },
+  { color: PALETTE[1], dir: -1, speedMul: 1.05, radiusMul: 0.86, offset: Math.PI * 0.5 },
+  { color: PALETTE[2], dir: 1, speedMul: 1.45, radiusMul: 1.16, offset: Math.PI },
+  { color: PALETTE[3], dir: -1, speedMul: 0.9, radiusMul: 0.94, offset: Math.PI * 1.5 },
+];
+
+// Spark / confetti tuning. Gravity is per-frame at ~60fps; the loop scales
+// physics by dt / 16 so motion stays steady on uneven frame timing.
+const GRAVITY = 0.16;
+const SPARK_LIFE_MS = 700;
+const SPARK_MIN_SPEED = 3.2;
+const SPARK_PER_FRAME_CAP = 1;
+const CONFETTI_LIFE_MS = 900;
+const CONFETTI_COUNT = 16;
+const CONFETTI_MIN_SPEED = 3.2;
+const CONFETTI_MAX_SPEED = 7.0;
+// Hard cap on live ephemerals. Each is a data object now (no DOM node),
+// so this exists only to bound canvas draw cost during frantic motion.
+const MAX_EPHEMERAL = 90;
+
+// Solid-disc sizes (no glow). The white centre dot is bigger than the
+// orbital cluster so the precise pointer position reads cleanly while
+// the four palette particles add character around it. Audio kicks
+// nudge the radii up a touch via `bloom`, so the cluster still
+// breathes with the music — just without a blur halo.
+const PARTICLE_RADIUS = 2; // 4 px diameter, matches old CSS
+const DOT_RADIUS = 3; // 6 px diameter, matches old CSS
+const SPARK_RADIUS = 2;
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  slot: number;
+  dir: 1 | -1;
+  speedMul: number;
+  radiusMul: number;
+  color: string;
+}
+
+interface Ephemeral {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  age: number; // ms
+  life: number; // ms
+  color: string;
+}
+
+export interface CursorHandle {
+  tick: (now: number, bloom: number) => void;
+  destroy: () => void;
+}
+
+// Module-level singleton: at most one cursor instance is active at a time
+// (the Performance page mounts it once). The render loop calls
+// tickActiveCursor(now, bloom) each frame; if no cursor is mounted, it's
+// a no-op.
+let activeCursor: CursorHandle | null = null;
+
+export function tickActiveCursor(now: number, bloom = 0): void {
+  activeCursor?.tick(now, bloom);
+}
+
+export function initCursor(): CursorHandle {
+  const canvasLookup = document.querySelector(
+    ".cursor-canvas",
+  ) as HTMLCanvasElement | null;
+  if (!canvasLookup) return { tick: () => {}, destroy: () => {} };
+  const ctxLookup = canvasLookup.getContext("2d");
+  if (!ctxLookup) return { tick: () => {}, destroy: () => {} };
+  // Hold non-null aliases so the closures below (resize, tick, destroy)
+  // don't lose narrowing across the function-declaration boundary.
+  const canvas: HTMLCanvasElement = canvasLookup;
+  const ctx: CanvasRenderingContext2D = ctxLookup;
+
+  // Backing-store size = window inner * DPR. CSS-style size = window
+  // inner. setTransform makes 1 unit in our draw calls = 1 CSS px.
+  function resize() {
+    const dpr = window.devicePixelRatio || 1;
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    canvas.width = Math.max(1, Math.floor(w * dpr));
+    canvas.height = Math.max(1, Math.floor(h * dpr));
+    canvas.style.width = `${w}px`;
+    canvas.style.height = `${h}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+  resize();
+  window.addEventListener("resize", resize, { passive: true });
+
+  const particles: Particle[] = PARTICLE_CONFIG.map((cfg) => ({
+    x: window.innerWidth / 2,
+    y: window.innerHeight / 2,
+    vx: 0,
+    vy: 0,
+    slot: cfg.offset,
+    dir: cfg.dir,
+    speedMul: cfg.speedMul,
+    radiusMul: cfg.radiusMul,
+    color: cfg.color,
+  }));
+
+  const ephemerals: Ephemeral[] = [];
+
+  function spawnSpark(
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    life: number,
+    color: string,
+  ) {
+    if (ephemerals.length >= MAX_EPHEMERAL) ephemerals.shift();
+    ephemerals.push({ x, y, vx, vy, age: 0, life, color });
+  }
+
+  let mouseX = window.innerWidth / 2;
+  let mouseY = window.innerHeight / 2;
+  let lastMoveX = mouseX;
+  let lastMoveY = mouseY;
+  let burst = 0;
+
+  const onMove = (e: MouseEvent) => {
+    mouseX = e.clientX;
+    mouseY = e.clientY;
+    const dx = mouseX - lastMoveX;
+    const dy = mouseY - lastMoveY;
+    const speed = Math.hypot(dx, dy);
+    if (speed > SPARK_MIN_SPEED) {
+      // One spark per move event, capped. Spark inherits a small slice
+      // of the pointer's reverse velocity (so it trails behind motion)
+      // plus a touch of jitter.
+      for (let i = 0; i < SPARK_PER_FRAME_CAP; i++) {
+        const color = PALETTE[Math.floor(Math.random() * PALETTE.length)];
+        const trailFactor = 0.06;
+        const sparkVx = -dx * trailFactor + (Math.random() - 0.5) * 1.5;
+        const sparkVy = -dy * trailFactor + (Math.random() - 0.5) * 1.5;
+        spawnSpark(mouseX, mouseY, sparkVx, sparkVy, SPARK_LIFE_MS, color);
+      }
+    }
+    lastMoveX = mouseX;
+    lastMoveY = mouseY;
+  };
+
+  const onDown = (e: MouseEvent) => {
+    burst = 1;
+    // Confetti — a radial cloud at the click site. Each particle gets a
+    // random angle and speed, plus a small upward bias so the cloud
+    // arcs nicely under gravity instead of just splatting straight.
+    for (let i = 0; i < CONFETTI_COUNT; i++) {
+      const color = PALETTE[Math.floor(Math.random() * PALETTE.length)];
+      const angle = Math.random() * Math.PI * 2;
+      const speed =
+        CONFETTI_MIN_SPEED +
+        Math.random() * (CONFETTI_MAX_SPEED - CONFETTI_MIN_SPEED);
+      const vx = Math.cos(angle) * speed;
+      const vy = Math.sin(angle) * speed - 1.2;
+      spawnSpark(e.clientX, e.clientY, vx, vy, CONFETTI_LIFE_MS, color);
+    }
+  };
+
+  document.addEventListener("mousemove", onMove, { passive: true });
+  document.addEventListener("mousedown", onDown, { passive: true });
+
+  const proximity = (dist: number): number => {
+    if (dist <= 0) return 1;
+    if (dist >= ATTRACTOR_RANGE) return 0;
+    const f = 1 - dist / ATTRACTOR_RANGE;
+    return f * f;
+  };
+
+  let cancelled = false;
+  let lastT = 0;
+  function tick(t: number, bloom: number) {
+    if (cancelled) return;
+    const dt = lastT ? Math.min(50, t - lastT) : 16;
+    lastT = t;
+    const dtScale = dt / 16;
+
+    burst *= BURST_DECAY;
+    const burstScale = 1 + burst * BURST_GAIN;
+
+    const vw = window.innerWidth;
+    const stretchX = proximity(mouseY);
+    const stretchY = Math.max(proximity(mouseX), proximity(vw - mouseX));
+
+    const rX = ORBIT_RADIUS * burstScale * (1 + stretchX * ATTRACTOR_GAIN);
+    const rY = ORBIT_RADIUS * burstScale * (1 + stretchY * ATTRACTOR_GAIN);
+
+    // Spring-physics step for the orbital cluster — unchanged from the
+    // DOM implementation, only the side effect (DOM mutation → canvas
+    // draw) differs.
+    for (const p of particles) {
+      p.slot += ROTATION_SPEED * dt * p.dir * p.speedMul;
+      const targetX = mouseX + Math.cos(p.slot) * rX * p.radiusMul;
+      const targetY = mouseY + Math.sin(p.slot) * rY * p.radiusMul;
+      p.vx = (p.vx + (targetX - p.x) * SPRING_K) * DAMPING;
+      p.vy = (p.vy + (targetY - p.y) * SPRING_K) * DAMPING;
+      p.x += p.vx;
+      p.y += p.vy;
+    }
+
+    // Ephemeral physics + lifetime cull. Walking backwards lets us
+    // splice without index issues.
+    for (let i = ephemerals.length - 1; i >= 0; i--) {
+      const s = ephemerals[i];
+      s.age += dt;
+      if (s.age >= s.life) {
+        ephemerals.splice(i, 1);
+        continue;
+      }
+      s.vy += GRAVITY * dtScale;
+      s.x += s.vx * dtScale;
+      s.y += s.vy * dtScale;
+    }
+
+    // ── Render ────────────────────────────────────────────────────────
+    // Solid discs only — no halos, no additive blend. Audio kicks
+    // nudge the radii (via `bloom`) so the cluster still breathes
+    // with the music without smearing out into a glow.
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    ctx.clearRect(0, 0, w, h);
+
+    const sizeBoost = 1 + bloom * 0.4;
+
+    // Orbital cluster — 4 px palette dots.
+    for (const p of particles) {
+      ctx.fillStyle = p.color;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, PARTICLE_RADIUS * sizeBoost, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    // Sparks + confetti — fade and shrink by life fraction.
+    for (const s of ephemerals) {
+      const lifeFrac = s.age / s.life;
+      const opacity = 1 - lifeFrac;
+      const r = SPARK_RADIUS * sizeBoost * (1 - lifeFrac * 0.7);
+      if (r <= 0.1) continue;
+      ctx.globalAlpha = opacity;
+      ctx.fillStyle = s.color;
+      ctx.beginPath();
+      ctx.arc(s.x, s.y, r, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+
+    // White centre dot — drawn last so it sits on top of the cluster
+    // and acts as the precise pointer indicator (the OS cursor is
+    // hidden by `body.cursor-hidden { cursor: none }`).
+    ctx.fillStyle = "rgba(255, 255, 255, 0.95)";
+    ctx.beginPath();
+    ctx.arc(mouseX, mouseY, DOT_RADIUS * sizeBoost, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  const handle: CursorHandle = {
+    tick,
+    destroy: () => {
+      cancelled = true;
+      window.removeEventListener("resize", resize);
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mousedown", onDown);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ephemerals.length = 0;
+      if (activeCursor === handle) activeCursor = null;
+    },
+  };
+  activeCursor = handle;
+  return handle;
+}

--- a/demos/realtime_motion_graph_web/web/engine/curves/interp.ts
+++ b/demos/realtime_motion_graph_web/web/engine/curves/interp.ts
@@ -1,0 +1,93 @@
+// Curve interpolation. Given an array of CurvePoints (sorted by x,
+// endpoints pinned at x=0 and x=1, all y values in [0,1]), evaluate
+// the curve at arbitrary x ∈ [0,1] OR tessellate to N evenly-spaced
+// samples for rendering. Per-point `mode` chooses how that point
+// connects to the NEXT point: smooth (Catmull-Rom), linear, step.
+
+import type { CurvePoint } from "@/types/curves";
+
+/** Catmull-Rom uniform spline. Given four 1-D control values
+ *  (p0, p1, p2, p3) and a parameter `t ∈ [0,1]`, return the
+ *  interpolated value between p1 and p2. p0 and p3 shape the slope
+ *  at the endpoints — for the first/last segments we duplicate the
+ *  edge points to keep the curve smooth without a tail wiggle.
+ *  Lifted from rtmg-vst-webapp's CurveEditor.tsx; ~5 lines, well-tested. */
+export function catmull(
+  p0: number,
+  p1: number,
+  p2: number,
+  p3: number,
+  t: number,
+): number {
+  const t2 = t * t;
+  const t3 = t2 * t;
+  return (
+    0.5 *
+    (2 * p1 +
+      (-p0 + p2) * t +
+      (2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 +
+      (-p0 + 3 * p1 - 3 * p2 + p3) * t3)
+  );
+}
+
+/** Evaluate a curve at x ∈ [0,1]. Returns y ∈ [0,1] (clamped).
+ *  Caller should pass at least 2 points with endpoints pinned. */
+export function evaluateCurve(points: CurvePoint[], x: number): number {
+  if (points.length === 0) return 0;
+  if (points.length === 1) return clamp01(points[0].y);
+  // Clamp x to the curve's range.
+  const xc = Math.min(1, Math.max(0, x));
+  if (xc <= points[0].x) return clamp01(points[0].y);
+  if (xc >= points[points.length - 1].x)
+    return clamp01(points[points.length - 1].y);
+
+  // Find the segment [i, i+1] containing xc. Linear scan is fine —
+  // curves are tiny (≤30 points typical).
+  let i = 0;
+  for (let k = 0; k < points.length - 1; k++) {
+    if (xc >= points[k].x && xc <= points[k + 1].x) {
+      i = k;
+      break;
+    }
+  }
+  const p1 = points[i];
+  const p2 = points[i + 1];
+  const span = p2.x - p1.x;
+  const u = span === 0 ? 0 : (xc - p1.x) / span;
+
+  switch (p1.mode) {
+    case "step":
+      // Hold p1.y until we reach p2.x, then jump.
+      return clamp01(p1.y);
+    case "linear":
+      return clamp01(p1.y + (p2.y - p1.y) * u);
+    case "smooth":
+    default: {
+      // Catmull-Rom needs 4 control points. Duplicate the edge ones
+      // when at the boundary so the curve doesn't overshoot off the
+      // ends; that's the standard Catmull behaviour for endpoints.
+      const p0 = i > 0 ? points[i - 1] : p1;
+      const p3 = i + 2 < points.length ? points[i + 2] : p2;
+      return clamp01(catmull(p0.y, p1.y, p2.y, p3.y, u));
+    }
+  }
+}
+
+/** Tessellate the curve to N evenly-spaced samples in [0,1]. Used by
+ *  the canvas renderer — sample once, then stroke a polyline through
+ *  the samples (fast, no per-pixel evaluate). 256 is plenty for
+ *  pixel-smooth display at typical viewport widths. */
+export function tessellate(points: CurvePoint[], samples = 256): Float32Array {
+  const out = new Float32Array(samples);
+  for (let i = 0; i < samples; i++) {
+    const x = samples === 1 ? 0 : i / (samples - 1);
+    out[i] = evaluateCurve(points, x);
+  }
+  return out;
+}
+
+function clamp01(v: number): number {
+  if (v < 0) return 0;
+  if (v > 1) return 1;
+  return v;
+}

--- a/demos/realtime_motion_graph_web/web/engine/curves/presets.ts
+++ b/demos/realtime_motion_graph_web/web/engine/curves/presets.ts
@@ -1,0 +1,117 @@
+// Musical preset curves — apply via the tab right-click menu.
+// Each preset is a *function* of the current track context (BPM,
+// duration), so "sine 1/bar" actually means one full cycle per bar at
+// the detected tempo, rather than a fixed-shape curve that doesn't
+// know about the music.
+//
+// Returns a fresh CurvePoint[] anchored to x=0..1. The store's
+// setCurvePoints will sort and pin endpoints defensively.
+
+import type { CurvePoint } from "@/types/curves";
+
+export type CurvePresetId =
+  | "ramp_up"
+  | "ramp_down"
+  | "sine_1_bar"
+  | "sine_4_bar"
+  | "pulse_downbeat"
+  | "flat_low"
+  | "flat_mid"
+  | "flat_high";
+
+export const PRESET_LABEL: Record<CurvePresetId, string> = {
+  ramp_up: "Ramp up",
+  ramp_down: "Ramp down",
+  sine_1_bar: "Sine 1/bar",
+  sine_4_bar: "Sine 4/bar",
+  pulse_downbeat: "Pulse on downbeats",
+  flat_low: "Flat low",
+  flat_mid: "Flat mid",
+  flat_high: "Flat high",
+};
+
+export interface PresetContext {
+  /** Track duration in seconds; from RemoteBackend.duration. */
+  durationSec: number;
+  /** Server-detected BPM; null if unknown — preset falls back to a
+   *  fixed musically-vague rate. */
+  bpm: number | null;
+  /** Beats per bar. Default 4. */
+  beatsPerBar?: number;
+}
+
+export function buildPreset(
+  preset: CurvePresetId,
+  ctx: PresetContext,
+): CurvePoint[] {
+  const beatsPerBar = ctx.beatsPerBar ?? 4;
+  const bpm = ctx.bpm ?? 120;
+  const beatSec = 60 / bpm;
+  const barSec = beatSec * beatsPerBar;
+  const totalBars = Math.max(1, ctx.durationSec / barSec);
+
+  switch (preset) {
+    case "ramp_up":
+      return [
+        { x: 0, y: 0, mode: "smooth" },
+        { x: 1, y: 1, mode: "smooth" },
+      ];
+
+    case "ramp_down":
+      return [
+        { x: 0, y: 1, mode: "smooth" },
+        { x: 1, y: 0, mode: "smooth" },
+      ];
+
+    case "flat_low":
+      return [
+        { x: 0, y: 0.15, mode: "smooth" },
+        { x: 1, y: 0.15, mode: "smooth" },
+      ];
+
+    case "flat_mid":
+      return [
+        { x: 0, y: 0.5, mode: "smooth" },
+        { x: 1, y: 0.5, mode: "smooth" },
+      ];
+
+    case "flat_high":
+      return [
+        { x: 0, y: 0.85, mode: "smooth" },
+        { x: 1, y: 0.85, mode: "smooth" },
+      ];
+
+    case "sine_1_bar":
+    case "sine_4_bar": {
+      const cycles = preset === "sine_1_bar" ? totalBars : totalBars / 4;
+      // Sample two control points per cycle (peak + trough) so the
+      // Catmull-Rom render gets a recognisable wave without exploding
+      // the point count for long tracks.
+      const pointsPerCycle = 4;
+      const totalPoints = Math.max(2, Math.round(cycles * pointsPerCycle));
+      const out: CurvePoint[] = [];
+      for (let i = 0; i <= totalPoints; i++) {
+        const x = i / totalPoints;
+        const phase = x * cycles * 2 * Math.PI;
+        const y = 0.5 + 0.45 * Math.sin(phase);
+        out.push({ x, y, mode: "smooth" });
+      }
+      return out;
+    }
+
+    case "pulse_downbeat": {
+      // Step-up at every downbeat (start of each bar), holds for
+      // ~25% of the bar, then drops back. Useful for accent automation.
+      const pulses = Math.max(1, Math.floor(totalBars));
+      const out: CurvePoint[] = [{ x: 0, y: 0.1, mode: "step" }];
+      for (let i = 0; i < pulses; i++) {
+        const downbeatX = i / pulses;
+        const offX = Math.min(1, downbeatX + 0.25 / pulses);
+        out.push({ x: downbeatX, y: 0.9, mode: "step" });
+        if (offX < 1) out.push({ x: offX, y: 0.1, mode: "step" });
+      }
+      out.push({ x: 1, y: 0.1, mode: "step" });
+      return out;
+    }
+  }
+}

--- a/demos/realtime_motion_graph_web/web/engine/curves/waveformPeaks.ts
+++ b/demos/realtime_motion_graph_web/web/engine/curves/waveformPeaks.ts
@@ -1,0 +1,79 @@
+// Downsample an interleaved Float32 PCM buffer to a peaks array suitable
+// for drawing a static waveform silhouette. Output is alternating
+// (min, max) per pixel column — N output buckets × 2 floats each.
+//
+// Usage:
+//   const mirror = audioPlayer.getMirror();
+//   const peaks  = computePeaks(mirror, 2 /* channels */, 800 /* px wide */);
+//   drawPeaks(ctx, peaks, 800, height);
+//
+// The bg canvas of ScheduleCurvesOverlay calls this once per fixture-
+// swap (mirror change) — not per-frame — and caches the result.
+
+/** Returns a Float32Array of length `buckets * 2` with alternating
+ *  min, max per bucket. Channels are averaged before bucketing. */
+export function computePeaks(
+  interleaved: Float32Array | null,
+  channels: number,
+  buckets: number,
+): Float32Array {
+  const out = new Float32Array(buckets * 2);
+  if (!interleaved || channels <= 0 || buckets <= 0) return out;
+  const frameCount = interleaved.length / channels;
+  if (frameCount <= 0) return out;
+  const framesPerBucket = Math.max(1, Math.floor(frameCount / buckets));
+
+  for (let b = 0; b < buckets; b++) {
+    const startFrame = b * framesPerBucket;
+    let endFrame = startFrame + framesPerBucket;
+    if (b === buckets - 1) endFrame = frameCount; // last bucket eats remainder
+    let mn = Infinity;
+    let mx = -Infinity;
+    for (let f = startFrame; f < endFrame; f++) {
+      // Average across channels.
+      let sum = 0;
+      const offset = f * channels;
+      for (let c = 0; c < channels; c++) sum += interleaved[offset + c];
+      const v = sum / channels;
+      if (v < mn) mn = v;
+      if (v > mx) mx = v;
+    }
+    if (!Number.isFinite(mn)) mn = 0;
+    if (!Number.isFinite(mx)) mx = 0;
+    out[b * 2] = mn;
+    out[b * 2 + 1] = mx;
+  }
+  return out;
+}
+
+/** Stroke the peaks array as a centered silhouette spanning the canvas
+ *  width. Caller sets fillStyle / strokeStyle on the context. */
+export function drawPeaks(
+  ctx: CanvasRenderingContext2D,
+  peaks: Float32Array,
+  w: number,
+  h: number,
+): void {
+  const buckets = peaks.length / 2;
+  if (buckets <= 0 || w <= 0 || h <= 0) return;
+  const mid = h / 2;
+  const colW = w / buckets;
+  ctx.beginPath();
+  // Top edge — max envelope.
+  for (let b = 0; b < buckets; b++) {
+    const x = b * colW;
+    const mx = peaks[b * 2 + 1];
+    const y = mid - mx * mid;
+    if (b === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  // Bottom edge — min envelope, traversed right-to-left.
+  for (let b = buckets - 1; b >= 0; b--) {
+    const x = b * colW;
+    const mn = peaks[b * 2];
+    const y = mid - mn * mid;
+    ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+  ctx.fill();
+}

--- a/demos/realtime_motion_graph_web/web/engine/keyboard/bindings.ts
+++ b/demos/realtime_motion_graph_web/web/engine/keyboard/bindings.ts
@@ -1,0 +1,32 @@
+// Single source of truth for keyboard shortcuts. The hook reads these to
+// drive behavior; the config modal reads them to render the Keyboard tab.
+
+export interface KeyBinding {
+  combo: string;
+  description: string;
+}
+
+export const KEY_BINDINGS: KeyBinding[] = [
+  { combo: "A + ▲▼", description: "Remix strength (denoise)" },
+  { combo: "G + ▲▼", description: "Structure strength (hint)" },
+  { combo: "B + ▲▼", description: "Prompt blend (A↔B)" },
+  { combo: "Enter", description: "Send prompt" },
+  { combo: "⌘/Ctrl + Enter", description: "Send prompt (while in textarea)" },
+  { combo: "E + ▲▼", description: "Engine: feedback" },
+  { combo: "H + ▲▼", description: "Engine: shift" },
+  { combo: "N + ▲▼", description: "Engine: nshare" },
+  { combo: "D + ▲▼", description: "Engine: ode" },
+  { combo: "W + ▲▼", description: "DCW low" },
+  { combo: "Y + ▲▼", description: "DCW high" },
+  { combo: "T", description: "Toggle DCW on/off" },
+  { combo: "Shift + T", description: "Cycle DCW mode" },
+  { combo: "Shift + W", description: "Cycle DCW wavelet" },
+  { combo: "0…7 + ▲▼", description: "Channel gains G0…G7" },
+  { combo: "Shift + 1…6 + ▲▼", description: "Channels (CH13…CH56)" },
+  { combo: "F", description: "Randomize seed" },
+  { combo: "R", description: "Record / stop audio" },
+  { combo: "Space", description: "Pause / resume" },
+  { combo: "K", description: "Toggle kiosk mode" },
+  { combo: "O", description: "Toggle Advanced Controls drawer" },
+  { combo: "Esc", description: "Toggle Advanced Controls drawer" },
+];

--- a/demos/realtime_motion_graph_web/web/engine/lora/listLoras.ts
+++ b/demos/realtime_motion_graph_web/web/engine/lora/listLoras.ts
@@ -1,0 +1,9 @@
+import { podHttp } from "@/engine/podUrl";
+import type { LoraCatalogEntry } from "@/types/protocol";
+
+export async function listLoras(): Promise<LoraCatalogEntry[]> {
+  const res = await fetch(podHttp("/api/loras"));
+  if (!res.ok) throw new Error(`/api/loras failed: ${res.status}`);
+  const json = (await res.json()) as { dir: string; loras: LoraCatalogEntry[] };
+  return json.loras ?? [];
+}

--- a/demos/realtime_motion_graph_web/web/engine/midi/absoluteDelta.ts
+++ b/demos/realtime_motion_graph_web/web/engine/midi/absoluteDelta.ts
@@ -1,0 +1,81 @@
+// Absolute-knob → delta conversion to fix the classic MIDI takeover snap.
+//
+// The naive mapping `slider = (value/127) * max` snaps the slider to the
+// knob's physical position the instant a CC arrives, so a knob parked at
+// 127 + a slider currently at 0 produces a min→max jump on the very first
+// twist. We instead emit deltas relative to the previous raw value: each
+// MIDI message moves the slider by (Δvalue / 127) * max. The knob always
+// "tracks" the slider's current position, no matter where it physically is.
+//
+// Trade-off: absolute correspondence is lost — the knob's physical
+// position no longer maps 1:1 to the slider value. Acceptable for a live
+// performance UI (FL Studio + most VST hosts default to encoder-like
+// behavior), and it sidesteps the secondary bug where decodeKnob's
+// auto-detect misclassifies a barely-turned absolute knob as relative
+// when its history sits in the 0-4 / 123-127 zone.
+
+const lastValue = new Map<number, number>();
+
+// Cap delta at this many raw ticks per message. Fast spins on a real
+// hardware knob can produce 30-60 ticks between two CC frames; anything
+// bigger is a state-mismatch (e.g. operator manually repositioned the
+// knob while we weren't listening). We CLAMP rather than DROP so a fast
+// sweep still moves the slider — the prior "drop on |delta|>cap" rule
+// produced dead zones near the knob extremes when the user spun fast.
+const MAX_DELTA_TICKS = 64;
+
+/** Knob position considered "at the extreme" — useMidi snaps the slider
+ *  hard to min or max in this band so a fast sweep that ends at 0 or
+ *  127 always reaches the bound, even if the prior delta-tracked value
+ *  was off. */
+export const EXTREME_LOW_THRESHOLD = 1;
+export const EXTREME_HIGH_THRESHOLD = 126;
+
+export interface KnobReading {
+  /** When non-null, caller should setSlider(value/127 * max) — the knob
+   *  is parked at an extreme and the slider should snap there. */
+  absolute: number | null;
+  /** Otherwise, caller bumpSlider(delta/127 * max). null on the first
+   *  CC frame for this knob (no prior value to delta against). */
+  delta: number | null;
+}
+
+/** Decide what the slider should do for this MIDI value. */
+export function readKnob(cc: number, value: number): KnobReading {
+  const last = lastValue.get(cc);
+  lastValue.set(cc, value);
+
+  // Snap to extremes regardless of prior history. Without this, a fast
+  // sweep from mid-range to 0 might leave the slider at 0.07 because
+  // delta clamping limited each step.
+  if (value <= EXTREME_LOW_THRESHOLD) {
+    return { absolute: 0, delta: null };
+  }
+  if (value >= EXTREME_HIGH_THRESHOLD) {
+    return { absolute: 127, delta: null };
+  }
+
+  if (last === undefined) return { absolute: null, delta: null };
+  const raw = value - last;
+  // Clamp instead of drop. A fast sweep still produces motion in the
+  // right direction; the next message refines.
+  const clamped = Math.max(-MAX_DELTA_TICKS, Math.min(MAX_DELTA_TICKS, raw));
+  return { absolute: null, delta: clamped };
+}
+
+/** Legacy compat — useMidi previously called `knobDelta` and applied
+ *  delta math only. Kept for callers that don't yet handle the
+ *  absolute-snap path. */
+export function knobDelta(cc: number, value: number): number | null {
+  const r = readKnob(cc, value);
+  return r.delta;
+}
+
+/** Drop the cached previous value for one CC (or all). Use when the
+ *  operator rebinds a CC to a different slider — otherwise the first
+ *  post-rebind message would be interpreted as a delta from the previous
+ *  slider's last value. */
+export function resetKnobDelta(cc?: number): void {
+  if (cc === undefined) lastValue.clear();
+  else lastValue.delete(cc);
+}

--- a/demos/realtime_motion_graph_web/web/engine/midi/knob.ts
+++ b/demos/realtime_motion_graph_web/web/engine/midi/knob.ts
@@ -1,0 +1,61 @@
+// Per-CC knob mode auto-detect (absolute vs relative 2's complement). Some
+// MIDI controllers (MPK Mini in increment/decrement mode, many endless
+// encoders) send relative deltas instead of absolute positions. Direct port
+// of the decodeKnob() helper in static/app.js.
+
+interface KnobState {
+  history: number[];
+  mode: "unknown" | "absolute" | "relative";
+}
+
+export type KnobDecoded =
+  | { mode: "absolute"; absolute: number }
+  | { mode: "relative"; delta: number };
+
+const knobState = new Map<number, KnobState>();
+
+export function decodeKnob(cc: number, value: number): KnobDecoded {
+  let s = knobState.get(cc);
+  if (!s) {
+    s = { history: [], mode: "unknown" };
+    knobState.set(cc, s);
+  }
+  s.history.push(value);
+  if (s.history.length > 6) s.history.shift();
+
+  if (s.mode === "unknown" && s.history.length >= 3) {
+    const allExtreme = s.history.every((v) => v <= 4 || v >= 123);
+    s.mode = allExtreme ? "relative" : "absolute";
+  }
+
+  // Demote a misclassified "relative" knob back to absolute the moment
+  // it sends a value clearly inconsistent with 2's-complement deltas.
+  // Real relative encoders only emit small CW values (1-15) or values
+  // close to 128 (113-127, i.e. -1..-15). A value in 5-122 means we're
+  // looking at an absolute knob that happened to be parked near 0 or
+  // 127 when the user first nudged it through the auto-detect window.
+  // Without this, the relative branch interprets value=30 as "+30 ticks"
+  // and slams the slider against its bound.
+  if (s.mode === "relative" && value >= 5 && value <= 122) {
+    s.mode = "absolute";
+  }
+
+  if (s.mode === "absolute") {
+    return { mode: "absolute", absolute: value / 127 };
+  }
+  if (s.mode === "relative") {
+    let delta = 0;
+    if (value > 0 && value < 64) delta = value;
+    else if (value > 64 && value <= 127) delta = value - 128;
+    return { mode: "relative", delta };
+  }
+  // Unknown: extreme → relative tick; mid-range → commits to absolute.
+  if (value <= 4 || value >= 123) {
+    let delta = 0;
+    if (value > 0 && value < 64) delta = value;
+    else if (value > 64 && value <= 127) delta = value - 128;
+    return { mode: "relative", delta };
+  }
+  s.mode = "absolute";
+  return { mode: "absolute", absolute: value / 127 };
+}

--- a/demos/realtime_motion_graph_web/web/engine/midi/types.ts
+++ b/demos/realtime_motion_graph_web/web/engine/midi/types.ts
@@ -1,0 +1,48 @@
+// Static names for actions a Note button can trigger. Storing the action by
+// name (instead of a function reference) lets localStorage round-trip a
+// learned mapping cleanly.
+
+export const LORA_SLOT_MARKER = ["lora_slot_0", "lora_slot_1"] as const;
+
+export type LoraSlotMarker = (typeof LORA_SLOT_MARKER)[number];
+
+export type NoteAction =
+  | "seed"
+  | "send_prompt"
+  | "mode_toggle"
+  | "pause"
+  | "kiosk_toggle"
+  | "schedule_curves_toggle";
+
+export interface MidiMap {
+  /** CC number → param name (or LORA_SLOT_MARKER). Continuous controllers
+   *  driving slider params. */
+  cc: Record<string, string>;
+  /** Note number → action name. Pads / buttons that fire one-shot actions. */
+  notes: Record<string, NoteAction>;
+  /** CC number → action name. Some pad controllers send CC instead of
+   *  NOTE on press; this lets those CCs trigger discrete actions like
+   *  randomize-seed without forcing the user to reconfigure their hardware
+   *  mode. Optional for backward compatibility with old localStorage maps. */
+  ccActions?: Record<string, NoteAction>;
+}
+
+export const DEFAULT_MIDI_MAP: MidiMap = {
+  cc: {
+    "70": "denoise",
+    "71": LORA_SLOT_MARKER[0],
+    "72": LORA_SLOT_MARKER[1],
+    "73": "hint_strength",
+    "74": "feedback",
+    "75": "shift",
+    "76": "noise_share",
+    "77": "ode_noise",
+  },
+  notes: {
+    "36": "seed",
+    "37": "send_prompt",
+  },
+  ccActions: {},
+};
+
+export const MIDI_STORAGE_KEY = "dd_music_midi_map_v1";

--- a/demos/realtime_motion_graph_web/web/engine/podUrl.ts
+++ b/demos/realtime_motion_graph_web/web/engine/podUrl.ts
@@ -1,0 +1,23 @@
+// URL helpers — back-compat re-export shim.
+
+export {
+  podHttp,
+  setPodSessionId,
+  getPodSessionId,
+} from "./rtmgConfig";
+
+/** WS URL fallback. Returns `?ws=<override>` from the URL or
+ *  `NEXT_PUBLIC_POD_BASE_URL` rewritten as `ws://`. */
+export function defaultWsUrl(): string {
+  if (typeof window !== "undefined") {
+    const params = new URLSearchParams(window.location.search);
+    const override = params.get("ws");
+    if (override) return override;
+  }
+  const base = process.env.NEXT_PUBLIC_POD_BASE_URL ?? "";
+  return base.replace(/\/$/, "").replace(/^http/, "ws") + "/";
+}
+
+export function podBaseUrl(): string {
+  return (process.env.NEXT_PUBLIC_POD_BASE_URL ?? "").replace(/\/$/, "");
+}

--- a/demos/realtime_motion_graph_web/web/engine/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/engine/protocol.ts
@@ -1,0 +1,450 @@
+// WebSocket client for the DEMON realtime motion-to-music backend.
+// Direct TS port of DEMON/demos/realtime_motion_graph_web/static/protocol.js.
+//
+// Phases:
+//   1. config   client sends JSON config + binary (uint32 channels, uint32
+//               samples) + float32 PCM
+//   2. ready    server replies with JSON {type: "ready", ...} then a
+//               binary float16 initial buffer (interleaved)
+//   3. stream   client sends JSON params/prompt/enable_lora/swap_source;
+//               server sends binary slices + JSON params_update / prompt_applied /
+//               lora_catalog / swap_ready / swap_failed
+
+import * as fzstd from "fzstd";
+
+import {
+  SAMPLE_RATE,
+  SLICE_FLAG_DELTA,
+  SLICE_HDR_SIZE,
+  type AudioSlice,
+  type LoraCatalogEntry,
+  type SessionConfig,
+  type SwapReadyMessage,
+} from "@/types/protocol";
+
+export {
+  SAMPLE_RATE,
+  T,
+  CROSSFADE_SECONDS,
+  SLICE_FLAG_DELTA,
+  SLICE_FLAG_RAW,
+  SLICE_HDR_SIZE,
+} from "@/types/protocol";
+
+// ── float16 → float32 ──────────────────────────────────────────────────
+// Browsers don't have native float16; decode by hand via a reusable
+// Uint32Array/Float32Array overlay to avoid per-sample object churn.
+
+const _fBuf = new ArrayBuffer(4);
+const _fU32 = new Uint32Array(_fBuf);
+const _fF32 = new Float32Array(_fBuf);
+
+function _half2single(h: number): number {
+  const s = (h & 0x8000) << 16;
+  let e = (h & 0x7c00) >> 10;
+  let f = h & 0x03ff;
+  if (e === 0) {
+    if (f === 0) {
+      _fU32[0] = s;
+      return _fF32[0];
+    }
+    while ((f & 0x0400) === 0) {
+      f <<= 1;
+      e--;
+    }
+    e++;
+    f &= ~0x0400;
+  } else if (e === 31) {
+    _fU32[0] = s | 0x7f800000 | (f << 13);
+    return _fF32[0];
+  }
+  e = e + (127 - 15);
+  _fU32[0] = s | (e << 23) | (f << 13);
+  return _fF32[0];
+}
+
+export function float16ArrayToFloat32(u16: Uint16Array): Float32Array {
+  const out = new Float32Array(u16.length);
+  for (let i = 0; i < u16.length; i++) out[i] = _half2single(u16[i]);
+  return out;
+}
+
+// ── RemoteBackend ──────────────────────────────────────────────────────
+
+type Phase = "config" | "ready" | "initial-buffer" | "streaming";
+
+interface PendingPayload {
+  interleaved: Float32Array;
+  channels: number;
+  config: SessionConfig;
+}
+
+export class RemoteBackend extends EventTarget {
+  readonly url: string;
+  ws: WebSocket | null = null;
+  ready = false;
+  initialBuffer: Float32Array | null = null;
+  duration = 0;
+  channels = 0;
+  sampleRate = SAMPLE_RATE;
+  loraCatalog: LoraCatalogEntry[] = [];
+  loraDir = "";
+  detectedBpm: number | null = null;
+  detectedKey: string | null = null;
+
+  private _pending: PendingPayload | null;
+  private _pendingSwap: SwapReadyMessage | null = null;
+  // Slice decoder runs in a worker so fzstd.decompress + float16→float32
+  // never block the render loop or input handling. Worker is single-threaded
+  // and postMessage is FIFO, so audio slices stay in order.
+  private _decoderWorker: Worker | null = null;
+  private _nextDecodeId = 1;
+
+  constructor(
+    url: string,
+    interleaved: Float32Array,
+    channels: number,
+    config: SessionConfig,
+  ) {
+    super();
+    this.url = url;
+    this._pending = { interleaved, channels, config };
+    this._initDecoderWorker();
+  }
+
+  private _initDecoderWorker(): void {
+    if (typeof Worker === "undefined") return;
+    try {
+      const worker = new Worker(
+        new URL("./workers/sliceDecoder.worker.mjs", import.meta.url),
+        { type: "module" },
+      );
+      worker.onmessage = (ev: MessageEvent) => {
+        const msg = ev.data;
+        if (!msg || typeof msg !== "object") return;
+        if (msg.ok === false) {
+          console.error("[protocol] slice decode failed:", msg.error);
+          return;
+        }
+        if (msg.ok !== true) return;
+        const slice: AudioSlice = {
+          flags: msg.flags,
+          startSample: msg.startSample,
+          numSamples: msg.numSamples,
+          channels: msg.channels,
+          tickMs: msg.tickMs,
+          decMs: msg.decMs,
+          numGens: msg.numGens,
+          audio: msg.audio,
+        };
+        this.dispatchEvent(new CustomEvent("slice", { detail: slice }));
+      };
+      worker.onerror = (e) => {
+        console.error("[protocol] slice decoder worker error:", e);
+      };
+      this._decoderWorker = worker;
+    } catch (e) {
+      console.warn("[protocol] worker init failed, falling back to main-thread decode:", e);
+      this._decoderWorker = null;
+    }
+  }
+
+  async connect(): Promise<this> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.url);
+      ws.binaryType = "arraybuffer";
+      this.ws = ws;
+
+      let phase: Phase = "config";
+
+      ws.onopen = () => {
+        if (!this._pending) return;
+        // Phase 1: JSON config + binary audio upload.
+        ws.send(JSON.stringify(this._pending.config));
+        const { interleaved, channels } = this._pending;
+        const samples = interleaved.length / channels;
+        const hdr = new ArrayBuffer(8);
+        const dv = new DataView(hdr);
+        dv.setUint32(0, channels, true);
+        dv.setUint32(4, samples, true);
+        const pcm = new Uint8Array(interleaved.buffer);
+        const combined = new Uint8Array(hdr.byteLength + pcm.byteLength);
+        combined.set(new Uint8Array(hdr), 0);
+        combined.set(pcm, hdr.byteLength);
+        ws.send(combined);
+        phase = "ready";
+      };
+
+      ws.onmessage = (ev) => {
+        if (phase === "ready") {
+          try {
+            const msg = JSON.parse(ev.data as string);
+            if (msg.type === "error") {
+              reject(
+                new Error(
+                  msg.message || `Server error: ${msg.code || "unknown"}`,
+                ),
+              );
+              return;
+            }
+            if (msg.type !== "ready") {
+              reject(new Error(`Unexpected init message: ${ev.data}`));
+              return;
+            }
+            this.duration = msg.duration;
+            this.channels = msg.channels;
+            this.sampleRate = msg.sample_rate;
+            this.loraCatalog = msg.lora_catalog || [];
+            this.loraDir = msg.lora_dir || "";
+            this.detectedBpm = msg.bpm ?? null;
+            this.detectedKey = msg.key ?? null;
+            phase = "initial-buffer";
+          } catch (e) {
+            reject(e);
+          }
+          return;
+        }
+
+        if (phase === "initial-buffer") {
+          const u16 = new Uint16Array(ev.data as ArrayBuffer);
+          this.initialBuffer = float16ArrayToFloat32(u16);
+          this.ready = true;
+          phase = "streaming";
+          this._pending = null;
+          resolve(this);
+          this.dispatchEvent(new CustomEvent("ready"));
+          return;
+        }
+
+        // The pending-swap state turns the next binary frame into a full
+        // buffer replacement (sent right after the swap_ready JSON).
+        if (this._pendingSwap && ev.data instanceof ArrayBuffer) {
+          const u16 = new Uint16Array(ev.data);
+          const interleaved = float16ArrayToFloat32(u16);
+          const meta = this._pendingSwap;
+          this._pendingSwap = null;
+          this.duration = meta.duration;
+          this.channels = meta.channels;
+          this.dispatchEvent(
+            new CustomEvent("swap_ready", {
+              detail: { ...meta, interleaved },
+            }),
+          );
+          return;
+        }
+
+        if (typeof ev.data === "string") {
+          let msg: { type: string; [k: string]: unknown };
+          try {
+            msg = JSON.parse(ev.data);
+          } catch {
+            return;
+          }
+          if (msg.type === "params_update") {
+            this.dispatchEvent(
+              new CustomEvent("params", { detail: msg.params }),
+            );
+          } else if (msg.type === "prompt_applied") {
+            this.dispatchEvent(
+              new CustomEvent("prompt_applied", { detail: msg.tags }),
+            );
+          } else if (msg.type === "lora_catalog") {
+            this.loraCatalog =
+              (msg.catalog as LoraCatalogEntry[] | undefined) || [];
+            this.dispatchEvent(
+              new CustomEvent("lora_catalog", { detail: this.loraCatalog }),
+            );
+          } else if (msg.type === "swap_ready") {
+            this._pendingSwap = msg as unknown as SwapReadyMessage;
+          } else if (msg.type === "swap_failed") {
+            this.dispatchEvent(
+              new CustomEvent("swap_failed", { detail: msg.error }),
+            );
+          } else {
+            this.dispatchEvent(new CustomEvent("json", { detail: msg }));
+          }
+          return;
+        }
+
+        if (this._decoderWorker) {
+          const buf = ev.data as ArrayBuffer;
+          this._decoderWorker.postMessage(
+            { id: this._nextDecodeId++, buffer: buf },
+            [buf],
+          );
+        } else {
+          try {
+            const slice = this._parseSlice(ev.data as ArrayBuffer);
+            if (slice) {
+              this.dispatchEvent(new CustomEvent("slice", { detail: slice }));
+            }
+          } catch (e) {
+            console.error("[protocol] slice parse failed:", e);
+          }
+        }
+      };
+
+      ws.onerror = (e) => {
+        console.error("[protocol] ws error", e);
+        if (!this.ready) {
+          reject(
+            new Error(
+              "WebSocket connection failed (network / port unreachable)",
+            ),
+          );
+        }
+        this.dispatchEvent(new CustomEvent("error", { detail: e }));
+      };
+
+      ws.onclose = (e) => {
+        // If the socket closes before we finished the init handshake, the
+        // connect() promise must reject — otherwise the launcher sits on
+        // "Uploading..." forever when the server crashes mid-init.
+        if (!this.ready) {
+          const reason = e.reason || `code ${e.code}`;
+          reject(
+            new Error(
+              `WebSocket closed before server sent 'ready' (${reason}). Check the server console.`,
+            ),
+          );
+        }
+        this.dispatchEvent(new CustomEvent("close", { detail: e }));
+      };
+    });
+  }
+
+  private _parseSlice(buf: ArrayBuffer): AudioSlice | null {
+    if (buf.byteLength < SLICE_HDR_SIZE) return null;
+    const dv = new DataView(buf);
+    let o = 0;
+    const flags = dv.getUint8(o);
+    o += 1;
+    const startSample = dv.getUint32(o, true);
+    o += 4;
+    const numSamples = dv.getUint32(o, true);
+    o += 4;
+    const channels = dv.getUint16(o, true);
+    o += 2;
+    const tickMs = dv.getFloat32(o, true);
+    o += 4;
+    const decMs = dv.getFloat32(o, true);
+    o += 4;
+    const numGens = dv.getUint32(o, true);
+    o += 4;
+
+    let payload: Uint8Array = new Uint8Array(buf, SLICE_HDR_SIZE);
+    if (flags === SLICE_FLAG_DELTA) {
+      payload = fzstd.decompress(payload);
+    }
+    // Copy so the Uint16Array is 2-byte aligned regardless of the underlying
+    // buffer's origin (zstd output has its own backing).
+    const aligned = new ArrayBuffer(payload.byteLength);
+    new Uint8Array(aligned).set(payload);
+    const u16 = new Uint16Array(aligned);
+    const audio = float16ArrayToFloat32(u16);
+
+    return {
+      flags,
+      startSample,
+      numSamples,
+      channels,
+      tickMs,
+      decMs,
+      numGens,
+      audio,
+    };
+  }
+
+  sendParams(
+    raw: Record<string, number | string | boolean>,
+    playbackPos: number,
+  ): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    try {
+      this.ws.send(
+        JSON.stringify({
+          type: "params",
+          raw,
+          playback_pos: playbackPos,
+        }),
+      );
+    } catch {}
+  }
+
+  sendPrompt(tags: string, key?: string): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    try {
+      const msg: { type: string; tags: string; key?: string } = {
+        type: "prompt",
+        tags,
+      };
+      if (key) msg.key = key;
+      this.ws.send(JSON.stringify(msg));
+    } catch {}
+  }
+
+  sendEnableLora(id: string, strength?: number): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    try {
+      const msg: { type: string; id: string; strength?: number } = {
+        type: "enable_lora",
+        id,
+      };
+      if (typeof strength === "number") msg.strength = strength;
+      this.ws.send(JSON.stringify(msg));
+    } catch {}
+  }
+
+  sendDisableLora(id: string): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    try {
+      this.ws.send(JSON.stringify({ type: "disable_lora", id }));
+    } catch {}
+  }
+
+  /**
+   * Replace the source audio in-flight. Server pauses generation, re-runs
+   * prepare_source / encode_text on the new waveform, then replies with
+   * swap_ready + a binary buffer (handled in onmessage).
+   */
+  sendSwapSource(
+    interleaved: Float32Array,
+    channels: number,
+    tags?: string,
+    key?: string,
+  ): boolean {
+    if (this.ws?.readyState !== WebSocket.OPEN) return false;
+    try {
+      const msg: { type: string; tags?: string; key?: string } = {
+        type: "swap_source",
+      };
+      if (tags) msg.tags = tags;
+      if (key) msg.key = key;
+      this.ws.send(JSON.stringify(msg));
+      const samples = interleaved.length / channels;
+      const hdr = new ArrayBuffer(8);
+      const dv = new DataView(hdr);
+      dv.setUint32(0, channels, true);
+      dv.setUint32(4, samples, true);
+      const pcm = new Uint8Array(interleaved.buffer);
+      const combined = new Uint8Array(hdr.byteLength + pcm.byteLength);
+      combined.set(new Uint8Array(hdr), 0);
+      combined.set(pcm, hdr.byteLength);
+      this.ws.send(combined);
+      return true;
+    } catch (e) {
+      console.error("[protocol] sendSwapSource failed:", e);
+      return false;
+    }
+  }
+
+  close(): void {
+    try {
+      this.ws?.close();
+    } catch {}
+    try {
+      this._decoderWorker?.terminate();
+    } catch {}
+    this._decoderWorker = null;
+  }
+}

--- a/demos/realtime_motion_graph_web/web/engine/render/AmbientRenderer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/AmbientRenderer.ts
@@ -1,0 +1,1159 @@
+// @ts-nocheck
+// ---------------------------------------------------------------------------
+// AmbientRenderer.ts -- WebGL2 GPU fluid simulation for ambient light effects.
+//
+// Direct port of static/ambient.js. The implementation is shader-heavy and
+// already verified against the existing visual; @ts-nocheck above keeps the
+// TS compiler off our back rather than annotating ~1100 lines of GL state.
+//
+// Phase 7 perf tweaks vs. the original:
+//   SIM_RESOLUTION      128 -> 96    (fluid grid; ~40% cheaper)
+//   DYE_RESOLUTION      512 -> 320   (dye field; cheaper texture binds)
+//   PRESSURE_ITERATIONS 20 -> 12     (Jacobi steps; visually nearly identical)
+// Run loop drops to 30 FPS via TARGET_INTERVAL_MS.
+//
+// Public API (unchanged):
+//   new AmbientRenderer(canvas)
+//   attach(analyser, getVideoEl)
+//   start() / stop() / resize() / destroy()
+
+/* ======================================================================== */
+/*  TUNING CONSTANTS                                                        */
+/* ======================================================================== */
+
+const SIM_RESOLUTION       = 96;     // perf: 128 -> 96
+const DYE_RESOLUTION       = 320;    // perf: 512 -> 320
+const PRESSURE_ITERATIONS  = 12;     // perf: 20 -> 12
+const VELOCITY_DISSIPATION = 0.98;
+const DYE_DISSIPATION      = 0.985;
+const CURL_STRENGTH        = 20;
+const SPLAT_RADIUS         = 0.012;
+const FORCE_SCALE          = 6000;
+const AUDIO_SMOOTH         = 0.18;
+const VIDEO_SAMPLE_SIZE    = 16;
+const VIDEO_SMOOTH         = 0.12;
+const TARGET_INTERVAL_MS   = 1000 / 30; // perf: cap at 30 FPS
+
+/* ======================================================================== */
+/*  GLSL SHADER SOURCES                                                     */
+/* ======================================================================== */
+
+const VERT_FULLSCREEN = `#version 300 es
+precision highp float;
+out vec2 vUv;
+void main() {
+    // Fullscreen triangle: vertices (-1,-1), (3,-1), (-1,3)
+    float x = -1.0 + float((gl_VertexID & 1) << 2);
+    float y = -1.0 + float((gl_VertexID & 2) << 1);
+    gl_Position = vec4(x, y, 0.0, 1.0);
+    vUv = gl_Position.xy * 0.5 + 0.5;
+}
+`;
+
+const FRAG_ADVECTION = `#version 300 es
+precision highp float;
+precision highp sampler2D;
+uniform sampler2D uVelocity;
+uniform sampler2D uSource;
+uniform vec2 uTexelSize;
+uniform float uDt;
+uniform float uDissipation;
+in vec2 vUv;
+out vec4 fragColor;
+void main() {
+    vec2 coord = vUv - uDt * texture(uVelocity, vUv).xy * uTexelSize;
+    fragColor = uDissipation * texture(uSource, coord);
+}
+`;
+
+const FRAG_DIVERGENCE = `#version 300 es
+precision highp float;
+precision highp sampler2D;
+uniform sampler2D uVelocity;
+uniform vec2 uTexelSize;
+in vec2 vUv;
+out vec4 fragColor;
+void main() {
+    float L = texture(uVelocity, vUv - vec2(uTexelSize.x, 0.0)).x;
+    float R = texture(uVelocity, vUv + vec2(uTexelSize.x, 0.0)).x;
+    float B = texture(uVelocity, vUv - vec2(0.0, uTexelSize.y)).y;
+    float T = texture(uVelocity, vUv + vec2(0.0, uTexelSize.y)).y;
+    float div = 0.5 * (R - L + T - B);
+    fragColor = vec4(div, 0.0, 0.0, 1.0);
+}
+`;
+
+const FRAG_PRESSURE = `#version 300 es
+precision highp float;
+precision highp sampler2D;
+uniform sampler2D uPressure;
+uniform sampler2D uDivergence;
+uniform vec2 uTexelSize;
+in vec2 vUv;
+out vec4 fragColor;
+void main() {
+    float pL = texture(uPressure, vUv - vec2(uTexelSize.x, 0.0)).x;
+    float pR = texture(uPressure, vUv + vec2(uTexelSize.x, 0.0)).x;
+    float pB = texture(uPressure, vUv - vec2(0.0, uTexelSize.y)).x;
+    float pT = texture(uPressure, vUv + vec2(0.0, uTexelSize.y)).x;
+    float div = texture(uDivergence, vUv).x;
+    fragColor = vec4((pL + pR + pB + pT - div) * 0.25, 0.0, 0.0, 1.0);
+}
+`;
+
+const FRAG_GRADIENT_SUB = `#version 300 es
+precision highp float;
+precision highp sampler2D;
+uniform sampler2D uPressure;
+uniform sampler2D uVelocity;
+uniform vec2 uTexelSize;
+in vec2 vUv;
+out vec4 fragColor;
+void main() {
+    float pL = texture(uPressure, vUv - vec2(uTexelSize.x, 0.0)).x;
+    float pR = texture(uPressure, vUv + vec2(uTexelSize.x, 0.0)).x;
+    float pB = texture(uPressure, vUv - vec2(0.0, uTexelSize.y)).x;
+    float pT = texture(uPressure, vUv + vec2(0.0, uTexelSize.y)).x;
+    vec2 vel = texture(uVelocity, vUv).xy;
+    vel -= 0.5 * vec2(pR - pL, pT - pB);
+    fragColor = vec4(vel, 0.0, 1.0);
+}
+`;
+
+const FRAG_CURL = `#version 300 es
+precision highp float;
+precision highp sampler2D;
+uniform sampler2D uVelocity;
+uniform vec2 uTexelSize;
+in vec2 vUv;
+out vec4 fragColor;
+void main() {
+    float L = texture(uVelocity, vUv - vec2(uTexelSize.x, 0.0)).y;
+    float R = texture(uVelocity, vUv + vec2(uTexelSize.x, 0.0)).y;
+    float B = texture(uVelocity, vUv - vec2(0.0, uTexelSize.y)).x;
+    float T = texture(uVelocity, vUv + vec2(0.0, uTexelSize.y)).x;
+    float curl = R - L - T + B;
+    fragColor = vec4(0.5 * curl, 0.0, 0.0, 1.0);
+}
+`;
+
+const FRAG_VORTICITY = `#version 300 es
+precision highp float;
+precision highp sampler2D;
+uniform sampler2D uVelocity;
+uniform sampler2D uCurl;
+uniform vec2 uTexelSize;
+uniform float uCurlStrength;
+uniform float uDt;
+in vec2 vUv;
+out vec4 fragColor;
+void main() {
+    float cL = texture(uCurl, vUv - vec2(uTexelSize.x, 0.0)).x;
+    float cR = texture(uCurl, vUv + vec2(uTexelSize.x, 0.0)).x;
+    float cB = texture(uCurl, vUv - vec2(0.0, uTexelSize.y)).x;
+    float cT = texture(uCurl, vUv + vec2(0.0, uTexelSize.y)).x;
+    float cC = texture(uCurl, vUv).x;
+
+    vec2 force = 0.5 * vec2(abs(cT) - abs(cB), abs(cR) - abs(cL));
+    float len = length(force) + 1e-5;
+    force = force / len * uCurlStrength * cC;
+
+    vec2 vel = texture(uVelocity, vUv).xy + force * uDt;
+    fragColor = vec4(vel, 0.0, 1.0);
+}
+`;
+
+const FRAG_SPLAT = `#version 300 es
+precision highp float;
+precision highp sampler2D;
+uniform sampler2D uSource;
+uniform vec2 uSplatPos;
+uniform vec3 uSplatColor;
+uniform float uSplatRadius;
+uniform float uAspect;
+in vec2 vUv;
+out vec4 fragColor;
+void main() {
+    vec2 d = vUv - uSplatPos;
+    d.x *= uAspect;
+    float w = exp(-dot(d, d) / uSplatRadius);
+    vec3 base = texture(uSource, vUv).rgb;
+    fragColor = vec4(base + uSplatColor * w, 1.0);
+}
+`;
+
+const FRAG_CLEAR_PRESSURE = `#version 300 es
+precision highp float;
+precision highp sampler2D;
+uniform sampler2D uPressure;
+uniform float uValue;
+in vec2 vUv;
+out vec4 fragColor;
+void main() {
+    fragColor = vec4(uValue * texture(uPressure, vUv).x, 0.0, 0.0, 1.0);
+}
+`;
+
+const FRAG_RENDER = `#version 300 es
+precision highp float;
+precision highp sampler2D;
+uniform sampler2D uDye;
+in vec2 vUv;
+out vec4 fragColor;
+void main() {
+    vec3 dye = texture(uDye, vUv).rgb;
+    // Tone-map to prevent harsh clipping
+    dye = dye / (1.0 + dye);
+    // Alpha from brightness so canvas is transparent where there's no dye
+    float a = max(dye.r, max(dye.g, dye.b));
+    fragColor = vec4(dye, a);
+}
+`;
+
+/* ======================================================================== */
+/*  WEBGL UTILITIES                                                         */
+/* ======================================================================== */
+
+function compileShader(gl, type, source) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        const info = gl.getShaderInfoLog(shader);
+        gl.deleteShader(shader);
+        throw new Error("Shader compilation failed: " + info);
+    }
+    return shader;
+}
+
+function createProgram(gl, vertSrc, fragSrc) {
+    const vs = compileShader(gl, gl.VERTEX_SHADER, vertSrc);
+    const fs = compileShader(gl, gl.FRAGMENT_SHADER, fragSrc);
+    const prog = gl.createProgram();
+    gl.attachShader(prog, vs);
+    gl.attachShader(prog, fs);
+    gl.linkProgram(prog);
+    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+        const info = gl.getProgramInfoLog(prog);
+        gl.deleteProgram(prog);
+        throw new Error("Program link failed: " + info);
+    }
+    // Cache uniform locations
+    const uniforms = {};
+    const count = gl.getProgramParameter(prog, gl.ACTIVE_UNIFORMS);
+    for (let i = 0; i < count; i++) {
+        const info = gl.getActiveUniform(prog, i);
+        uniforms[info.name] = gl.getUniformLocation(prog, info.name);
+    }
+    return { program: prog, uniforms };
+}
+
+/**
+ * Create a double-buffered framebuffer object pair for ping-pong rendering.
+ * Returns { read, write, swap(), width, height }.
+ * Each side has { fbo, texture }.
+ */
+function createDoubleFBO(gl, width, height, internalFormat, format, type, filter) {
+    const a = createFBO(gl, width, height, internalFormat, format, type, filter);
+    const b = createFBO(gl, width, height, internalFormat, format, type, filter);
+    return {
+        width,
+        height,
+        read: a,
+        write: b,
+        swap() { const t = this.read; this.read = this.write; this.write = t; },
+    };
+}
+
+function createFBO(gl, width, height, internalFormat, format, type, filter) {
+    const texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filter);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, width, height, 0, format, type, null);
+
+    const fbo = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+    gl.viewport(0, 0, width, height);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+    if (status !== gl.FRAMEBUFFER_COMPLETE) {
+        throw new Error("Framebuffer incomplete: " + status);
+    }
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    return { fbo, texture, width, height };
+}
+
+function destroyFBO(gl, fboObj) {
+    if (!fboObj) return;
+    if (fboObj.texture) gl.deleteTexture(fboObj.texture);
+    if (fboObj.fbo) gl.deleteFramebuffer(fboObj.fbo);
+}
+
+function destroyDoubleFBO(gl, dFBO) {
+    if (!dFBO) return;
+    destroyFBO(gl, dFBO.read);
+    destroyFBO(gl, dFBO.write);
+}
+
+/* ======================================================================== */
+/*  FLUID SIMULATION (LOW-LEVEL GPU SOLVER)                                 */
+/* ======================================================================== */
+
+class FluidSim {
+    constructor(canvas) {
+        this.canvas = canvas;
+        this.gl = null;
+        this.programs = {};
+        this.velocity = null;
+        this.pressure = null;
+        this.divergenceFBO = null;
+        this.curlFBO = null;
+        this.dye = null;
+        this.simWidth = 0;
+        this.simHeight = 0;
+        this.dyeWidth = 0;
+        this.dyeHeight = 0;
+        this._videoTexture = null;
+        this._lost = false;
+
+        this._initGL();
+    }
+
+    _initGL() {
+        const gl = this.canvas.getContext("webgl2", {
+            alpha: true,
+            depth: false,
+            stencil: false,
+            antialias: false,
+            preserveDrawingBuffer: false,
+            premultipliedAlpha: false,
+        });
+        if (!gl) throw new Error("WebGL2 not available");
+        this.gl = gl;
+
+        // Handle context loss/restore
+        this.canvas.addEventListener("webglcontextlost", (e) => {
+            e.preventDefault();
+            this._lost = true;
+        });
+        this.canvas.addEventListener("webglcontextrestored", () => {
+            this._lost = false;
+            this._initGL();
+            this._initFramebuffers();
+        });
+
+        // Required extension for float render targets
+        const extFloat = gl.getExtension("EXT_color_buffer_float");
+        if (!extFloat) {
+            // Try half-float fallback
+            gl.getExtension("EXT_color_buffer_half_float");
+        }
+        gl.getExtension("OES_texture_float_linear");
+        gl.getExtension("OES_texture_half_float_linear");
+
+        // Determine best supported float format
+        this._floatInternal = gl.RGBA16F;
+        this._floatType = gl.HALF_FLOAT;
+        this._rInternal = gl.R16F;
+        this._rgInternal = gl.RG16F;
+
+        // Test if float rendering works, otherwise try half-float
+        if (!this._testRenderTarget(gl, gl.RG16F, gl.RG, gl.HALF_FLOAT)) {
+            if (!this._testRenderTarget(gl, gl.RG32F, gl.RG, gl.FLOAT)) {
+                throw new Error("No float render target support");
+            }
+            this._floatInternal = gl.RGBA32F;
+            this._floatType = gl.FLOAT;
+            this._rInternal = gl.R32F;
+            this._rgInternal = gl.RG32F;
+        }
+
+        // Compile all shader programs
+        this.programs.advection   = createProgram(gl, VERT_FULLSCREEN, FRAG_ADVECTION);
+        this.programs.divergence  = createProgram(gl, VERT_FULLSCREEN, FRAG_DIVERGENCE);
+        this.programs.pressure    = createProgram(gl, VERT_FULLSCREEN, FRAG_PRESSURE);
+        this.programs.gradientSub = createProgram(gl, VERT_FULLSCREEN, FRAG_GRADIENT_SUB);
+        this.programs.curl        = createProgram(gl, VERT_FULLSCREEN, FRAG_CURL);
+        this.programs.vorticity   = createProgram(gl, VERT_FULLSCREEN, FRAG_VORTICITY);
+        this.programs.splat       = createProgram(gl, VERT_FULLSCREEN, FRAG_SPLAT);
+        this.programs.clearPressure = createProgram(gl, VERT_FULLSCREEN, FRAG_CLEAR_PRESSURE);
+        this.programs.render      = createProgram(gl, VERT_FULLSCREEN, FRAG_RENDER);
+
+        // Create a dummy VAO (required by WebGL2 for draw calls)
+        this._vao = gl.createVertexArray();
+
+        // Create reusable video upload texture
+        this._videoTexture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, this._videoTexture);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+        // Clear to transparent so the canvas doesn't show as white/opaque
+        // before the simulation starts.
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.clearColor(0, 0, 0, 0);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+    }
+
+    _testRenderTarget(gl, internalFormat, format, type) {
+        const tex = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, tex);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, 4, 4, 0, format, type, null);
+
+        const fbo = gl.createFramebuffer();
+        gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+        const ok = gl.checkFramebufferStatus(gl.FRAMEBUFFER) === gl.FRAMEBUFFER_COMPLETE;
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.deleteFramebuffer(fbo);
+        gl.deleteTexture(tex);
+        return ok;
+    }
+
+    _initFramebuffers() {
+        const gl = this.gl;
+        if (!gl) return;
+
+        // Clean up any existing FBOs
+        destroyDoubleFBO(gl, this.velocity);
+        destroyDoubleFBO(gl, this.pressure);
+        destroyDoubleFBO(gl, this.dye);
+        destroyFBO(gl, this.divergenceFBO);
+        destroyFBO(gl, this.curlFBO);
+
+        const aspect = this.canvas.width / this.canvas.height;
+
+        // Simulation fields at SIM_RESOLUTION
+        this.simWidth  = Math.max(1, Math.round(SIM_RESOLUTION * aspect));
+        this.simHeight = SIM_RESOLUTION;
+
+        // Dye field at DYE_RESOLUTION
+        this.dyeWidth  = Math.max(1, Math.round(DYE_RESOLUTION * aspect));
+        this.dyeHeight = DYE_RESOLUTION;
+
+        const sW = this.simWidth;
+        const sH = this.simHeight;
+        const dW = this.dyeWidth;
+        const dH = this.dyeHeight;
+
+        const lin = gl.LINEAR;
+        const near = gl.NEAREST;
+        const hf = this._floatType;
+
+        this.velocity     = createDoubleFBO(gl, sW, sH, this._rgInternal, gl.RG, hf, lin);
+        this.pressure     = createDoubleFBO(gl, sW, sH, this._rInternal, gl.RED, hf, near);
+        this.divergenceFBO = createFBO(gl, sW, sH, this._rInternal, gl.RED, hf, near);
+        this.curlFBO      = createFBO(gl, sW, sH, this._rInternal, gl.RED, hf, near);
+        this.dye          = createDoubleFBO(gl, dW, dH, this._floatInternal, gl.RGBA, hf, lin);
+    }
+
+    resize(w, h) {
+        if (w <= 0 || h <= 0) return;
+        if (w === this.canvas.width && h === this.canvas.height && this.dye) return;
+        this.canvas.width = w;
+        this.canvas.height = h;
+        this._initFramebuffers();
+    }
+
+    /**
+     * Upload the current video frame as a texture for edge sampling on the CPU.
+     * Returns { pixels, width, height } or null if not available.
+     */
+    sampleVideoEdges(videoEl, sampleCanvas, sampleCtx, sampleSize) {
+        if (!videoEl || videoEl.paused || !videoEl.videoWidth) return null;
+        try {
+            sampleCtx.drawImage(videoEl, 0, 0, sampleSize, sampleSize);
+        } catch {
+            return null;
+        }
+        return sampleCtx.getImageData(0, 0, sampleSize, sampleSize);
+    }
+
+    /**
+     * Run one full simulation step.
+     * splats: Array of { x, y, dx, dy, r, g, b, radius }
+     *   x,y in [0,1] UV space, dx/dy are force components,
+     *   r/g/b are dye color, radius is Gaussian radius.
+     */
+    step(dt, splats) {
+        const gl = this.gl;
+        if (!gl || this._lost || !this.dye) return;
+
+        gl.bindVertexArray(this._vao);
+        gl.disable(gl.BLEND);
+
+        // 1. Advect velocity
+        this._advect(this.velocity, this.velocity, dt, VELOCITY_DISSIPATION);
+
+        // 2. Inject forces via splats on velocity field
+        for (const s of splats) {
+            this._splat(
+                this.velocity,
+                s.x, s.y,
+                s.dx, s.dy, 0.0,
+                s.radius,
+                this.simWidth / this.simHeight
+            );
+        }
+
+        // 3. Vorticity confinement
+        this._computeCurl();
+        this._applyVorticity(dt);
+
+        // 4. Divergence
+        this._computeDivergence();
+
+        // 5. Clear pressure (slight damping to help convergence)
+        this._clearPressure(0.8);
+
+        // 6. Pressure solve (Jacobi iterations)
+        for (let i = 0; i < PRESSURE_ITERATIONS; i++) {
+            this._pressureIteration();
+        }
+
+        // 7. Gradient subtraction (project velocity to be divergence-free)
+        this._gradientSubtract();
+
+        // 8. Advect dye
+        this._advectDye(dt);
+
+        // 9. Inject dye via splats
+        for (const s of splats) {
+            this._splat(
+                this.dye,
+                s.x, s.y,
+                s.r, s.g, s.b,
+                s.radius * 1.5, // dye radius slightly larger than force radius
+                this.dyeWidth / this.dyeHeight
+            );
+        }
+    }
+
+    /**
+     * Render the dye field to the screen.
+     */
+    render() {
+        const gl = this.gl;
+        if (!gl || this._lost || !this.dye) return;
+
+        gl.bindVertexArray(this._vao);
+
+        const prog = this.programs.render;
+        gl.useProgram(prog.program);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, this.dye.read.texture);
+        gl.uniform1i(prog.uniforms.uDye, 0);
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+        gl.clearColor(0, 0, 0, 0);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.drawArrays(gl.TRIANGLES, 0, 3);
+    }
+
+    // -- internal passes ---------------------------------------------------
+
+    _advect(target, velocitySource, dt, dissipation) {
+        const gl = this.gl;
+        const prog = this.programs.advection;
+        gl.useProgram(prog.program);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, velocitySource.read.texture);
+        gl.uniform1i(prog.uniforms.uVelocity, 0);
+
+        gl.activeTexture(gl.TEXTURE1);
+        gl.bindTexture(gl.TEXTURE_2D, target.read.texture);
+        gl.uniform1i(prog.uniforms.uSource, 1);
+
+        gl.uniform2f(prog.uniforms.uTexelSize, 1.0 / target.width, 1.0 / target.height);
+        gl.uniform1f(prog.uniforms.uDt, dt);
+        gl.uniform1f(prog.uniforms.uDissipation, dissipation);
+
+        this._drawToFBO(target.write, target.width, target.height);
+        target.swap();
+    }
+
+    _advectDye(dt) {
+        const gl = this.gl;
+        const prog = this.programs.advection;
+        gl.useProgram(prog.program);
+
+        // Velocity is at sim resolution, dye at dye resolution.
+        // We sample velocity using the dye UVs (linear filtering handles the mismatch).
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, this.velocity.read.texture);
+        gl.uniform1i(prog.uniforms.uVelocity, 0);
+
+        gl.activeTexture(gl.TEXTURE1);
+        gl.bindTexture(gl.TEXTURE_2D, this.dye.read.texture);
+        gl.uniform1i(prog.uniforms.uSource, 1);
+
+        gl.uniform2f(prog.uniforms.uTexelSize, 1.0 / this.dyeWidth, 1.0 / this.dyeHeight);
+        gl.uniform1f(prog.uniforms.uDt, dt);
+        gl.uniform1f(prog.uniforms.uDissipation, DYE_DISSIPATION);
+
+        this._drawToFBO(this.dye.write, this.dyeWidth, this.dyeHeight);
+        this.dye.swap();
+    }
+
+    _computeDivergence() {
+        const gl = this.gl;
+        const prog = this.programs.divergence;
+        gl.useProgram(prog.program);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, this.velocity.read.texture);
+        gl.uniform1i(prog.uniforms.uVelocity, 0);
+
+        gl.uniform2f(prog.uniforms.uTexelSize, 1.0 / this.simWidth, 1.0 / this.simHeight);
+
+        this._drawToFBO(this.divergenceFBO, this.simWidth, this.simHeight);
+    }
+
+    _clearPressure(value) {
+        const gl = this.gl;
+        const prog = this.programs.clearPressure;
+        gl.useProgram(prog.program);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, this.pressure.read.texture);
+        gl.uniform1i(prog.uniforms.uPressure, 0);
+        gl.uniform1f(prog.uniforms.uValue, value);
+
+        this._drawToFBO(this.pressure.write, this.simWidth, this.simHeight);
+        this.pressure.swap();
+    }
+
+    _pressureIteration() {
+        const gl = this.gl;
+        const prog = this.programs.pressure;
+        gl.useProgram(prog.program);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, this.pressure.read.texture);
+        gl.uniform1i(prog.uniforms.uPressure, 0);
+
+        gl.activeTexture(gl.TEXTURE1);
+        gl.bindTexture(gl.TEXTURE_2D, this.divergenceFBO.texture);
+        gl.uniform1i(prog.uniforms.uDivergence, 1);
+
+        gl.uniform2f(prog.uniforms.uTexelSize, 1.0 / this.simWidth, 1.0 / this.simHeight);
+
+        this._drawToFBO(this.pressure.write, this.simWidth, this.simHeight);
+        this.pressure.swap();
+    }
+
+    _gradientSubtract() {
+        const gl = this.gl;
+        const prog = this.programs.gradientSub;
+        gl.useProgram(prog.program);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, this.pressure.read.texture);
+        gl.uniform1i(prog.uniforms.uPressure, 0);
+
+        gl.activeTexture(gl.TEXTURE1);
+        gl.bindTexture(gl.TEXTURE_2D, this.velocity.read.texture);
+        gl.uniform1i(prog.uniforms.uVelocity, 1);
+
+        gl.uniform2f(prog.uniforms.uTexelSize, 1.0 / this.simWidth, 1.0 / this.simHeight);
+
+        this._drawToFBO(this.velocity.write, this.simWidth, this.simHeight);
+        this.velocity.swap();
+    }
+
+    _computeCurl() {
+        const gl = this.gl;
+        const prog = this.programs.curl;
+        gl.useProgram(prog.program);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, this.velocity.read.texture);
+        gl.uniform1i(prog.uniforms.uVelocity, 0);
+
+        gl.uniform2f(prog.uniforms.uTexelSize, 1.0 / this.simWidth, 1.0 / this.simHeight);
+
+        this._drawToFBO(this.curlFBO, this.simWidth, this.simHeight);
+    }
+
+    _applyVorticity(dt) {
+        const gl = this.gl;
+        const prog = this.programs.vorticity;
+        gl.useProgram(prog.program);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, this.velocity.read.texture);
+        gl.uniform1i(prog.uniforms.uVelocity, 0);
+
+        gl.activeTexture(gl.TEXTURE1);
+        gl.bindTexture(gl.TEXTURE_2D, this.curlFBO.texture);
+        gl.uniform1i(prog.uniforms.uCurl, 1);
+
+        gl.uniform2f(prog.uniforms.uTexelSize, 1.0 / this.simWidth, 1.0 / this.simHeight);
+        gl.uniform1f(prog.uniforms.uCurlStrength, CURL_STRENGTH);
+        gl.uniform1f(prog.uniforms.uDt, dt);
+
+        this._drawToFBO(this.velocity.write, this.simWidth, this.simHeight);
+        this.velocity.swap();
+    }
+
+    /**
+     * Add a Gaussian splat to a double-buffered field.
+     * color is (r, g, b) -- for velocity fields, only (r, g) are used.
+     */
+    _splat(target, x, y, cr, cg, cb, radius, aspect) {
+        const gl = this.gl;
+        const prog = this.programs.splat;
+        gl.useProgram(prog.program);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, target.read.texture);
+        gl.uniform1i(prog.uniforms.uSource, 0);
+
+        gl.uniform2f(prog.uniforms.uSplatPos, x, y);
+        gl.uniform3f(prog.uniforms.uSplatColor, cr, cg, cb);
+        gl.uniform1f(prog.uniforms.uSplatRadius, radius);
+        gl.uniform1f(prog.uniforms.uAspect, aspect);
+
+        this._drawToFBO(target.write, target.width, target.height);
+        target.swap();
+    }
+
+    _drawToFBO(fbo, w, h) {
+        const gl = this.gl;
+        gl.bindFramebuffer(gl.FRAMEBUFFER, fbo.fbo);
+        gl.viewport(0, 0, w, h);
+        gl.drawArrays(gl.TRIANGLES, 0, 3);
+    }
+
+    destroy() {
+        const gl = this.gl;
+        if (!gl) return;
+
+        destroyDoubleFBO(gl, this.velocity);
+        destroyDoubleFBO(gl, this.pressure);
+        destroyDoubleFBO(gl, this.dye);
+        destroyFBO(gl, this.divergenceFBO);
+        destroyFBO(gl, this.curlFBO);
+
+        if (this._videoTexture) gl.deleteTexture(this._videoTexture);
+        if (this._vao) gl.deleteVertexArray(this._vao);
+
+        for (const key in this.programs) {
+            gl.deleteProgram(this.programs[key].program);
+        }
+
+        this.gl = null;
+    }
+}
+
+/* ======================================================================== */
+/*  AMBIENT LIGHT (PUBLIC API)                                              */
+/* ======================================================================== */
+
+export class AmbientLight {
+    constructor(canvas) {
+        this.canvas = canvas;
+        this._analyser = null;
+        this._freqData = null;
+        this._getVideoEl = null;
+        this._running = false;
+        this._raf = null;
+        this._lastTime = 0;
+        this._sim = null;
+        this._webgl2 = false;
+
+        // Audio band accumulators (smoothed, 0-1)
+        this._bands = { sub: 0, bass: 0, mid: 0, high: 0 };
+
+        // Edge color accumulators (smoothed, 0-1)
+        this._edges = {
+            left:   [0, 0, 0],
+            right:  [0, 0, 0],
+            top:    [0, 0, 0],
+            bottom: [0, 0, 0],
+        };
+
+        // Precompute edge pixel indices for the sampling grid
+        const S = VIDEO_SAMPLE_SIZE;
+        this._sampleSize = S;
+        this._sampCvs = document.createElement("canvas");
+        this._sampCvs.width = S;
+        this._sampCvs.height = S;
+        this._sampCtx = this._sampCvs.getContext("2d", { willReadFrequently: true });
+
+        this._edgeIdx = {};
+        for (const [side, fn] of [
+            ["left",   (i) => [0, i, 1, i]],
+            ["right",  (i) => [S - 1, i, S - 2, i]],
+            ["top",    (i) => [i, 0, i, 1]],
+            ["bottom", (i) => [i, S - 1, i, S - 2]],
+        ]) {
+            const flat = [];
+            for (let i = 0; i < S; i++) flat.push(...fn(i));
+            this._edgeIdx[side] = flat;
+        }
+
+        // Try to initialise WebGL2 fluid sim
+        try {
+            this._sim = new FluidSim(canvas);
+            this._webgl2 = true;
+        } catch (e) {
+            console.warn("AmbientLight: WebGL2 fluid sim unavailable, running as no-op.", e);
+            this._webgl2 = false;
+        }
+
+        this._onResize = () => this.resize();
+        window.addEventListener("resize", this._onResize);
+    }
+
+    attach(analyser, getVideoEl) {
+        this._analyser = analyser;
+        this._freqData = new Uint8Array(analyser.frequencyBinCount);
+        this._getVideoEl = getVideoEl;
+    }
+
+    start() {
+        this._running = true;
+        this.resize();
+        this._lastTime = performance.now();
+        this._tick();
+    }
+
+    stop() {
+        this._running = false;
+        if (this._raf != null) {
+            cancelAnimationFrame(this._raf);
+            this._raf = null;
+        }
+        // Clear the canvas
+        if (this._sim && this._sim.gl) {
+            const gl = this._sim.gl;
+            gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+            gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+            gl.clearColor(0, 0, 0, 0);
+            gl.clear(gl.COLOR_BUFFER_BIT);
+        }
+    }
+
+    resize() {
+        const w = this.canvas.clientWidth;
+        const h = this.canvas.clientHeight;
+        if (!w || !h) return;
+        const dpr = Math.min(devicePixelRatio || 1, 2);
+        const pw = Math.floor(w * dpr);
+        const ph = Math.floor(h * dpr);
+        if (this._sim && this._webgl2) {
+            this._sim.resize(pw, ph);
+        }
+    }
+
+    destroy() {
+        this.stop();
+        window.removeEventListener("resize", this._onResize);
+        if (this._sim) {
+            this._sim.destroy();
+            this._sim = null;
+        }
+    }
+
+    // -- render loop -------------------------------------------------------
+
+    _tick() {
+        if (!this._running) return;
+
+        const now = performance.now();
+        // Phase 7 perf: target 30 FPS. RAF still runs at the display rate
+        // but we skip the simulation step until enough time has elapsed.
+        const sinceLast = now - this._lastTime;
+        if (sinceLast < TARGET_INTERVAL_MS) {
+            this._raf = requestAnimationFrame(() => this._tick());
+            return;
+        }
+        // Clamp dt to avoid huge jumps (e.g. tab was backgrounded)
+        const dt = Math.min(sinceLast / 1000, 0.05);
+        this._lastTime = now;
+
+        if (this._webgl2 && this._sim && !this._sim._lost) {
+            this._readAudio();
+            this._readVideo();
+            const splats = this._buildSplats();
+            this._sim.step(dt, splats);
+            this._sim.render();
+        }
+
+        this._raf = requestAnimationFrame(() => this._tick());
+    }
+
+    // -- audio frequency bands ---------------------------------------------
+
+    _readAudio() {
+        if (!this._analyser) return;
+        this._analyser.getByteFrequencyData(this._freqData);
+        const d = this._freqData;
+        const n = d.length;
+
+        const avg = (lo, hi) => {
+            let s = 0;
+            const end = Math.min(hi, n);
+            for (let i = lo; i < end; i++) s += d[i];
+            return end > lo ? s / (end - lo) / 255 : 0;
+        };
+
+        const t = AUDIO_SMOOTH;
+        this._bands.sub  += (avg(0,   3)   - this._bands.sub)  * t;
+        this._bands.bass += (avg(3,   11)  - this._bands.bass) * t;
+        this._bands.mid  += (avg(11,  86)  - this._bands.mid)  * t;
+        this._bands.high += (avg(86, 342)  - this._bands.high) * t;
+    }
+
+    // -- video edge color sampling -----------------------------------------
+
+    _readVideo() {
+        const el = this._getVideoEl?.();
+        if (!el || el.paused || !el.videoWidth) return;
+
+        const S = this._sampleSize;
+        try {
+            this._sampCtx.drawImage(el, 0, 0, S, S);
+        } catch {
+            return;
+        }
+        const px = this._sampCtx.getImageData(0, 0, S, S).data;
+        const ct = VIDEO_SMOOTH;
+
+        for (const side of ["left", "right", "top", "bottom"]) {
+            const idx = this._edgeIdx[side];
+            const count = idx.length / 2;
+            let r = 0, g = 0, b = 0;
+            for (let j = 0; j < idx.length; j += 2) {
+                const p = (idx[j + 1] * S + idx[j]) * 4;
+                r += px[p]; g += px[p + 1]; b += px[p + 2];
+            }
+            r /= count; g /= count; b /= count;
+            // Normalize to [0, 1]
+            r /= 255; g /= 255; b /= 255;
+            const e = this._edges[side];
+            e[0] += (r - e[0]) * ct;
+            e[1] += (g - e[1]) * ct;
+            e[2] += (b - e[2]) * ct;
+        }
+    }
+
+    // -- build splat list from audio + video state -------------------------
+
+    _buildSplats() {
+        const splats = [];
+        const { sub, bass, mid, high } = this._bands;
+
+        // If there's no meaningful audio, emit faint idle splats so the
+        // simulation doesn't go completely still.
+        const totalEnergy = sub + bass + mid + high;
+
+        // Video rect in UV space -- the video is centered in the viewport,
+        // constrained to the middle column.  We approximate its position as
+        // roughly the center 40% horizontally, full height.  Exact bounds
+        // aren't critical; they define where edge dye appears.
+        const vL = 0.30; // left edge of video in UV
+        const vR = 0.70; // right edge
+        const vT = 0.15; // top edge (note: UV y=0 is bottom in GL, but
+        const vB = 0.85; // our shaders have vUv.y=0 at bottom)
+
+        // Each edge produces splat(s): force pushes outward, dye = edge color.
+
+        // --- Sub-bass: large radial splats from each edge ------------------
+        const subForce = sub * FORCE_SCALE;
+        const subRadius = SPLAT_RADIUS + sub * 0.15;
+
+        if (sub > 0.01) {
+            // Left edge: multiple splat points distributed vertically
+            for (let i = 0; i < 3; i++) {
+                const t = (i + 0.5) / 3;
+                const y = vT + t * (vB - vT);
+                const c = this._edges.left;
+                splats.push({
+                    x: vL, y,
+                    dx: -subForce * 0.5, dy: (t - 0.5) * subForce * 0.15,
+                    r: c[0] * sub * 0.8, g: c[1] * sub * 0.8, b: c[2] * sub * 0.8,
+                    radius: subRadius,
+                });
+            }
+            // Right edge
+            for (let i = 0; i < 3; i++) {
+                const t = (i + 0.5) / 3;
+                const y = vT + t * (vB - vT);
+                const c = this._edges.right;
+                splats.push({
+                    x: vR, y,
+                    dx: subForce * 0.5, dy: (t - 0.5) * subForce * 0.15,
+                    r: c[0] * sub * 0.8, g: c[1] * sub * 0.8, b: c[2] * sub * 0.8,
+                    radius: subRadius,
+                });
+            }
+            // Top edge
+            {
+                const c = this._edges.top;
+                splats.push({
+                    x: 0.5, y: vT,
+                    dx: 0, dy: -subForce * 0.4,
+                    r: c[0] * sub * 0.7, g: c[1] * sub * 0.7, b: c[2] * sub * 0.7,
+                    radius: subRadius * 1.2,
+                });
+            }
+            // Bottom edge
+            {
+                const c = this._edges.bottom;
+                splats.push({
+                    x: 0.5, y: vB,
+                    dx: 0, dy: subForce * 0.4,
+                    r: c[0] * sub * 0.7, g: c[1] * sub * 0.7, b: c[2] * sub * 0.7,
+                    radius: subRadius * 1.2,
+                });
+            }
+        }
+
+        // --- Bass: medium splats from edges --------------------------------
+        const bassForce = bass * FORCE_SCALE * 0.7;
+        const bassRadius = SPLAT_RADIUS + bass * 0.08;
+
+        if (bass > 0.01) {
+            for (let i = 0; i < 5; i++) {
+                const t = (i + 0.5) / 5;
+                const y = vT + t * (vB - vT);
+                const cL = this._edges.left;
+                const cR = this._edges.right;
+                splats.push({
+                    x: vL, y,
+                    dx: -bassForce * 0.4, dy: (Math.random() - 0.5) * bassForce * 0.1,
+                    r: cL[0] * bass * 0.6, g: cL[1] * bass * 0.6, b: cL[2] * bass * 0.6,
+                    radius: bassRadius,
+                });
+                splats.push({
+                    x: vR, y,
+                    dx: bassForce * 0.4, dy: (Math.random() - 0.5) * bassForce * 0.1,
+                    r: cR[0] * bass * 0.6, g: cR[1] * bass * 0.6, b: cR[2] * bass * 0.6,
+                    radius: bassRadius,
+                });
+            }
+            // Top and bottom bass splats
+            for (let i = 0; i < 3; i++) {
+                const t = (i + 0.5) / 3;
+                const x = vL + t * (vR - vL);
+                const cT = this._edges.top;
+                const cB = this._edges.bottom;
+                splats.push({
+                    x, y: vT,
+                    dx: (Math.random() - 0.5) * bassForce * 0.1, dy: -bassForce * 0.3,
+                    r: cT[0] * bass * 0.5, g: cT[1] * bass * 0.5, b: cT[2] * bass * 0.5,
+                    radius: bassRadius * 0.9,
+                });
+                splats.push({
+                    x, y: vB,
+                    dx: (Math.random() - 0.5) * bassForce * 0.1, dy: bassForce * 0.3,
+                    r: cB[0] * bass * 0.5, g: cB[1] * bass * 0.5, b: cB[2] * bass * 0.5,
+                    radius: bassRadius * 0.9,
+                });
+            }
+        }
+
+        // --- Mid: smaller perturbations from all edges --------------------
+        const midForce = mid * FORCE_SCALE * 0.35;
+        const midRadius = SPLAT_RADIUS * 0.6 + mid * 0.04;
+
+        if (mid > 0.02) {
+            const phase = performance.now() * 0.001;
+            for (let i = 0; i < 4; i++) {
+                const t = (i + 0.5) / 4;
+                const osc = Math.sin(phase * 2.3 + i * 1.7) * 0.02;
+
+                // Left / right
+                const cL = this._edges.left;
+                const cR = this._edges.right;
+                const y = vT + t * (vB - vT) + osc;
+                splats.push({
+                    x: vL, y,
+                    dx: -midForce * 0.25, dy: Math.cos(phase + i) * midForce * 0.08,
+                    r: cL[0] * mid * 0.4, g: cL[1] * mid * 0.4, b: cL[2] * mid * 0.4,
+                    radius: midRadius,
+                });
+                splats.push({
+                    x: vR, y,
+                    dx: midForce * 0.25, dy: Math.cos(phase + i) * midForce * 0.08,
+                    r: cR[0] * mid * 0.4, g: cR[1] * mid * 0.4, b: cR[2] * mid * 0.4,
+                    radius: midRadius,
+                });
+            }
+        }
+
+        // --- High: shimmer -- modulate existing dye brightness by adding
+        //     tiny splats with the edge color at random positions near edges.
+        if (high > 0.03) {
+            const shimmerForce = high * FORCE_SCALE * 0.15;
+            const shimmerRadius = SPLAT_RADIUS * 0.3;
+            const sides = [
+                { edge: "left",   x: vL, dir: [-1, 0] },
+                { edge: "right",  x: vR, dir: [1, 0] },
+            ];
+            for (const s of sides) {
+                for (let i = 0; i < 2; i++) {
+                    const y = vT + Math.random() * (vB - vT);
+                    const c = this._edges[s.edge];
+                    splats.push({
+                        x: s.x + (Math.random() - 0.5) * 0.03,
+                        y,
+                        dx: s.dir[0] * shimmerForce * 0.2,
+                        dy: (Math.random() - 0.5) * shimmerForce * 0.15,
+                        r: c[0] * high * 0.25,
+                        g: c[1] * high * 0.25,
+                        b: c[2] * high * 0.25,
+                        radius: shimmerRadius,
+                    });
+                }
+            }
+        }
+
+        // --- Idle: very faint splats to keep gentle motion when silent ----
+        if (totalEnergy < 0.05) {
+            const t = performance.now() * 0.0003;
+            const idleForce = 200;
+            const idleColor = 0.02;
+            for (const [edge, x, dirX, dirY] of [
+                ["left",  vL, -1,  0],
+                ["right", vR,  1,  0],
+            ]) {
+                const c = this._edges[edge];
+                const y = 0.5 + Math.sin(t + (edge === "left" ? 0 : Math.PI)) * 0.15;
+                splats.push({
+                    x, y,
+                    dx: dirX * idleForce, dy: dirY * idleForce + Math.sin(t * 1.3) * 80,
+                    r: Math.max(c[0], 0.05) * idleColor,
+                    g: Math.max(c[1], 0.05) * idleColor,
+                    b: Math.max(c[2], 0.05) * idleColor,
+                    radius: SPLAT_RADIUS * 2,
+                });
+            }
+        }
+
+        return splats;
+    }
+}
+
+// Public re-export so callers can use the more descriptive name. The
+// historical class name (AmbientLight) refers to the visual effect; the
+// renderer term matches the rest of engine/render.
+export { AmbientLight as AmbientRenderer };
+

--- a/demos/realtime_motion_graph_web/web/engine/render/EffectsRenderer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/EffectsRenderer.ts
@@ -1,0 +1,554 @@
+// Audio-reactive video shader pipeline (WebGL2, 5-pass).
+// Direct port of static/effects.js. Phase 6 perf: blur radius 18 → 12 (looks
+// nearly identical, ~1.5x cheaper); render targets resize only on actual
+// viewport change (already in place).
+//
+// Pipeline:
+//   1. parallax  video -> sceneRT       (saturation-masked horizontal shift + warp)
+//   2. bright    sceneRT -> bloomRT0    (luminance threshold)
+//   3. blur H    bloomRT0 -> bloomRT1
+//   4. blur V    bloomRT1 -> bloomRT0
+//   5. composite scene + bloom*kick -> screen (with chroma + tint flavors)
+
+const VERT = /* glsl */ `#version 300 es
+in vec2 aPos;
+out vec2 vUv;
+void main() {
+  vUv = aPos * 0.5 + 0.5;
+  gl_Position = vec4(aPos, 0.0, 1.0);
+}`;
+
+const PARALLAX_FRAG = /* glsl */ `#version 300 es
+precision highp float;
+uniform sampler2D uSource;
+uniform float uTime;
+uniform float uKick;
+uniform float uParallaxStrength;
+uniform float uWarpStrength;
+in vec2 vUv;
+out vec4 fragColor;
+
+const float SWAY_HZ = 0.7;
+const float SWAY_AMP = 0.0008;
+const float KICK_SHIFT = 0.012;
+const float SAT_KNEE_LO = 0.40;
+const float SAT_KNEE_HI = 0.70;
+const float WARP_SCALE = 0.025;
+const float WARP_BASE  = 0.30;
+
+float satOf(vec3 rgb) {
+  float maxC = max(max(rgb.r, rgb.g), rgb.b);
+  float minC = min(min(rgb.r, rgb.g), rgb.b);
+  return maxC > 0.001 ? (maxC - minC) / maxC : 0.0;
+}
+
+vec2 organicWarp(vec2 uv, float t) {
+  vec2 p = uv * 4.0;
+  vec2 v;
+  v.x = sin(p.x * 1.3 + t * 0.9) * cos(p.y * 1.7 - t * 0.6);
+  v.y = cos(p.x * 1.9 - t * 0.5) * sin(p.y * 1.1 + t * 1.2);
+  v.x += 0.5 * sin(p.x * 3.7 + t * 1.7) * cos(p.y * 4.1 - t * 1.3);
+  v.y += 0.5 * cos(p.x * 4.3 - t * 1.5) * sin(p.y * 3.9 + t * 1.9);
+  return v;
+}
+
+void main() {
+  float warpAmt = (WARP_BASE + (1.0 - WARP_BASE) * uKick) * uWarpStrength;
+  vec2 uv = vUv + organicWarp(vUv, uTime) * WARP_SCALE * warpAmt;
+
+  float sway = sin(uTime * 6.2831853 * SWAY_HZ) * SWAY_AMP;
+  float kick = uKick * KICK_SHIFT;
+  vec2 shift = vec2(sway + kick, 0.0) * uParallaxStrength;
+
+  vec3 srcLocal = texture(uSource, uv).rgb;
+  vec3 srcShifted = texture(uSource, uv - shift).rgb;
+
+  float satShifted = satOf(srcShifted);
+  float mask = smoothstep(SAT_KNEE_LO, SAT_KNEE_HI, satShifted);
+  float satLocal = satOf(srcLocal);
+  mask *= 1.0 - smoothstep(0.6, 1.0, satLocal) * 0.4;
+
+  vec3 col = mix(srcLocal, srcShifted, mask);
+  fragColor = vec4(col, 1.0);
+}`;
+
+const BRIGHT_FRAG = /* glsl */ `#version 300 es
+precision highp float;
+uniform sampler2D uScene;
+uniform float uThreshold;
+uniform float uKnee;
+in vec2 vUv;
+out vec4 fragColor;
+
+void main() {
+  vec3 c = texture(uScene, vUv).rgb;
+  float lum = dot(c, vec3(0.2126, 0.7152, 0.0722));
+  float k = max(0.0001, uKnee);
+  float w = smoothstep(uThreshold - k, uThreshold + k, lum);
+  fragColor = vec4(c * w, 1.0);
+}`;
+
+const BLUR_FRAG = /* glsl */ `#version 300 es
+precision highp float;
+uniform sampler2D uTex;
+uniform vec2 uTexel;
+uniform vec2 uDir;
+uniform float uRadius;
+in vec2 vUv;
+out vec4 fragColor;
+
+const float W0 = 0.227027;
+const float W1 = 0.194595;
+const float W2 = 0.121622;
+const float W3 = 0.054054;
+const float W4 = 0.016216;
+
+void main() {
+  vec2 stp = uDir * uTexel * (uRadius / 4.0);
+  vec3 acc = texture(uTex, vUv).rgb * W0;
+  acc += texture(uTex, vUv + stp * 1.0).rgb * W1;
+  acc += texture(uTex, vUv - stp * 1.0).rgb * W1;
+  acc += texture(uTex, vUv + stp * 2.0).rgb * W2;
+  acc += texture(uTex, vUv - stp * 2.0).rgb * W2;
+  acc += texture(uTex, vUv + stp * 3.0).rgb * W3;
+  acc += texture(uTex, vUv - stp * 3.0).rgb * W3;
+  acc += texture(uTex, vUv + stp * 4.0).rgb * W4;
+  acc += texture(uTex, vUv - stp * 4.0).rgb * W4;
+  fragColor = vec4(acc, 1.0);
+}`;
+
+const COMPOSITE_FRAG = /* glsl */ `#version 300 es
+precision highp float;
+uniform sampler2D uScene;
+uniform sampler2D uBloom;
+uniform float uKick;
+uniform float uBloomOnKick;
+uniform float uBloomBase;
+uniform vec3  uBloomTint;
+uniform float uChroma;
+uniform float uChromaKick;
+in vec2 vUv;
+out vec4 fragColor;
+
+vec3 sampleSceneChroma(vec2 uv) {
+  vec2 toCenter = uv - vec2(0.5);
+  float r2 = dot(toCenter, toCenter);
+  float falloff = 0.4 + 1.6 * r2;
+  float amount = uChroma + uChromaKick * uKick;
+  vec2 dir = normalize(toCenter + 1e-6) * amount * falloff;
+  vec3 col;
+  col.r = texture(uScene, uv + dir).r;
+  col.g = texture(uScene, uv).g;
+  col.b = texture(uScene, uv - dir).b;
+  return col;
+}
+
+void main() {
+  vec3 scene = sampleSceneChroma(vUv);
+  vec3 bloom = texture(uBloom, vUv).rgb * uBloomTint;
+  float bloomAmt = uBloomBase + uKick * uBloomOnKick;
+  vec3 col = min(scene + bloom * bloomAmt, vec3(1.0));
+  fragColor = vec4(col, 1.0);
+}`;
+
+const BLOOM_DOWNSCALE = 0.5;
+// Phase 6 perf: 18 → 12. Visually nearly identical at typical bloom amounts;
+// halves Gaussian sample fan-out cost across both blur passes.
+const BLOOM_BLUR_RADIUS_PX = 12;
+
+interface RenderTarget {
+  tex: WebGLTexture;
+  fbo: WebGLFramebuffer;
+  w: number;
+  h: number;
+}
+
+function compileShader(
+  gl: WebGL2RenderingContext,
+  type: number,
+  src: string,
+): WebGLShader {
+  const sh = gl.createShader(type);
+  if (!sh) throw new Error("createShader returned null");
+  gl.shaderSource(sh, src);
+  gl.compileShader(sh);
+  if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
+    const log = gl.getShaderInfoLog(sh);
+    gl.deleteShader(sh);
+    throw new Error(`Shader compile failed: ${log}`);
+  }
+  return sh;
+}
+
+function makeProgram(
+  gl: WebGL2RenderingContext,
+  fragSrc: string,
+): WebGLProgram {
+  const prog = gl.createProgram();
+  if (!prog) throw new Error("createProgram returned null");
+  const v = compileShader(gl, gl.VERTEX_SHADER, VERT);
+  const f = compileShader(gl, gl.FRAGMENT_SHADER, fragSrc);
+  gl.attachShader(prog, v);
+  gl.attachShader(prog, f);
+  gl.bindAttribLocation(prog, 0, "aPos");
+  gl.linkProgram(prog);
+  if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+    const log = gl.getProgramInfoLog(prog);
+    gl.deleteProgram(prog);
+    throw new Error(`Program link failed: ${log}`);
+  }
+  gl.deleteShader(v);
+  gl.deleteShader(f);
+  return prog;
+}
+
+function makeRT(
+  gl: WebGL2RenderingContext,
+  w: number,
+  h: number,
+): RenderTarget {
+  const tex = gl.createTexture();
+  if (!tex) throw new Error("createTexture returned null");
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(
+    gl.TEXTURE_2D,
+    0,
+    gl.RGBA,
+    w,
+    h,
+    0,
+    gl.RGBA,
+    gl.UNSIGNED_BYTE,
+    null,
+  );
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  const fbo = gl.createFramebuffer();
+  if (!fbo) throw new Error("createFramebuffer returned null");
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+  gl.framebufferTexture2D(
+    gl.FRAMEBUFFER,
+    gl.COLOR_ATTACHMENT0,
+    gl.TEXTURE_2D,
+    tex,
+    0,
+  );
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  return { tex, fbo, w, h };
+}
+
+function disposeRT(
+  gl: WebGL2RenderingContext,
+  rt: RenderTarget | null,
+): void {
+  if (!rt) return;
+  gl.deleteTexture(rt.tex);
+  gl.deleteFramebuffer(rt.fbo);
+}
+
+interface UniformLocations {
+  parallax: {
+    uSource: WebGLUniformLocation | null;
+    uTime: WebGLUniformLocation | null;
+    uKick: WebGLUniformLocation | null;
+    uParallaxStrength: WebGLUniformLocation | null;
+    uWarpStrength: WebGLUniformLocation | null;
+  };
+  bright: {
+    uScene: WebGLUniformLocation | null;
+    uThreshold: WebGLUniformLocation | null;
+    uKnee: WebGLUniformLocation | null;
+  };
+  blur: {
+    uTex: WebGLUniformLocation | null;
+    uTexel: WebGLUniformLocation | null;
+    uDir: WebGLUniformLocation | null;
+    uRadius: WebGLUniformLocation | null;
+  };
+  composite: {
+    uScene: WebGLUniformLocation | null;
+    uBloom: WebGLUniformLocation | null;
+    uKick: WebGLUniformLocation | null;
+    uBloomOnKick: WebGLUniformLocation | null;
+    uBloomBase: WebGLUniformLocation | null;
+    uBloomTint: WebGLUniformLocation | null;
+    uChroma: WebGLUniformLocation | null;
+    uChromaKick: WebGLUniformLocation | null;
+  };
+}
+
+export class EffectsRenderer {
+  readonly canvas: HTMLCanvasElement;
+  readonly gl: WebGL2RenderingContext;
+
+  private readonly _vao: WebGLVertexArrayObject;
+  private readonly _buf: WebGLBuffer;
+
+  private readonly _parallax: WebGLProgram;
+  private readonly _bright: WebGLProgram;
+  private readonly _blur: WebGLProgram;
+  private readonly _composite: WebGLProgram;
+  private readonly _u: UniformLocations;
+
+  private readonly _srcTex: WebGLTexture;
+  private _srcW = 0;
+  private _srcH = 0;
+
+  private _scene: RenderTarget | null = null;
+  private _bloom0: RenderTarget | null = null;
+  private _bloom1: RenderTarget | null = null;
+
+  private _parallaxStrength = 0.4;
+  private _bloomOnKick = 0.3;
+  private _bloomThreshold = 0.15;
+  private _bloomKnee = 0.2;
+  private _warpStrength = 0.4;
+  private _dubstep = 0;
+  private _daft = 0;
+  private _everDrew = false;
+
+  private readonly _resizeObs: ResizeObserver;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+    const gl = canvas.getContext("webgl2", {
+      alpha: true,
+      antialias: false,
+      preserveDrawingBuffer: false,
+      powerPreference: "high-performance",
+    });
+    if (!gl) throw new Error("WebGL2 not supported");
+    this.gl = gl;
+
+    const buf = gl.createBuffer();
+    if (!buf) throw new Error("createBuffer returned null");
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([-1, -1, 3, -1, -1, 3]),
+      gl.STATIC_DRAW,
+    );
+    const vao = gl.createVertexArray();
+    if (!vao) throw new Error("createVertexArray returned null");
+    gl.bindVertexArray(vao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(0);
+    gl.bindVertexArray(null);
+    this._vao = vao;
+    this._buf = buf;
+
+    this._parallax = makeProgram(gl, PARALLAX_FRAG);
+    this._bright = makeProgram(gl, BRIGHT_FRAG);
+    this._blur = makeProgram(gl, BLUR_FRAG);
+    this._composite = makeProgram(gl, COMPOSITE_FRAG);
+
+    this._u = {
+      parallax: {
+        uSource: gl.getUniformLocation(this._parallax, "uSource"),
+        uTime: gl.getUniformLocation(this._parallax, "uTime"),
+        uKick: gl.getUniformLocation(this._parallax, "uKick"),
+        uParallaxStrength: gl.getUniformLocation(this._parallax, "uParallaxStrength"),
+        uWarpStrength: gl.getUniformLocation(this._parallax, "uWarpStrength"),
+      },
+      bright: {
+        uScene: gl.getUniformLocation(this._bright, "uScene"),
+        uThreshold: gl.getUniformLocation(this._bright, "uThreshold"),
+        uKnee: gl.getUniformLocation(this._bright, "uKnee"),
+      },
+      blur: {
+        uTex: gl.getUniformLocation(this._blur, "uTex"),
+        uTexel: gl.getUniformLocation(this._blur, "uTexel"),
+        uDir: gl.getUniformLocation(this._blur, "uDir"),
+        uRadius: gl.getUniformLocation(this._blur, "uRadius"),
+      },
+      composite: {
+        uScene: gl.getUniformLocation(this._composite, "uScene"),
+        uBloom: gl.getUniformLocation(this._composite, "uBloom"),
+        uKick: gl.getUniformLocation(this._composite, "uKick"),
+        uBloomOnKick: gl.getUniformLocation(this._composite, "uBloomOnKick"),
+        uBloomBase: gl.getUniformLocation(this._composite, "uBloomBase"),
+        uBloomTint: gl.getUniformLocation(this._composite, "uBloomTint"),
+        uChroma: gl.getUniformLocation(this._composite, "uChroma"),
+        uChromaKick: gl.getUniformLocation(this._composite, "uChromaKick"),
+      },
+    };
+
+    const tex = gl.createTexture();
+    if (!tex) throw new Error("createTexture returned null");
+    this._srcTex = tex;
+    gl.bindTexture(gl.TEXTURE_2D, this._srcTex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    this._resizeObs = new ResizeObserver(() => this._resize());
+    this._resizeObs.observe(canvas);
+    this._resize();
+  }
+
+  setParallaxStrength(v: number): void { this._parallaxStrength = v; }
+  setBloomOnKick(v: number): void { this._bloomOnKick = v; }
+  setBloomThreshold(v: number): void { this._bloomThreshold = v; }
+  setWarpStrength(v: number): void { this._warpStrength = v; }
+  setDubstep(v: number): void { this._dubstep = Math.max(0, Math.min(1, v)); }
+  setDaftPunk(v: number): void { this._daft = Math.max(0, Math.min(1, v)); }
+
+  private _resize(): void {
+    const gl = this.gl;
+    const dpr = Math.min(2, window.devicePixelRatio || 1);
+    const rect = this.canvas.getBoundingClientRect();
+    const w = Math.max(2, Math.floor(rect.width * dpr));
+    const h = Math.max(2, Math.floor(rect.height * dpr));
+    if (this.canvas.width === w && this.canvas.height === h && this._scene) {
+      return;
+    }
+    this.canvas.width = w;
+    this.canvas.height = h;
+
+    disposeRT(gl, this._scene);
+    this._scene = makeRT(gl, w, h);
+
+    const bw = Math.max(2, Math.round(w * BLOOM_DOWNSCALE));
+    const bh = Math.max(2, Math.round(h * BLOOM_DOWNSCALE));
+    disposeRT(gl, this._bloom0);
+    disposeRT(gl, this._bloom1);
+    this._bloom0 = makeRT(gl, bw, bh);
+    this._bloom1 = makeRT(gl, bw, bh);
+  }
+
+  private _uploadVideo(videoEl: HTMLVideoElement | null): boolean {
+    if (!videoEl) return this._srcW > 0;
+    const vw = videoEl.videoWidth | 0;
+    const vh = videoEl.videoHeight | 0;
+    const ready = videoEl.readyState >= 2 && vw > 0 && vh > 0;
+    if (!ready) return this._srcW > 0;
+    const gl = this.gl;
+    gl.bindTexture(gl.TEXTURE_2D, this._srcTex);
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+    if (this._srcW !== vw || this._srcH !== vh) {
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, videoEl);
+      this._srcW = vw;
+      this._srcH = vh;
+    } else {
+      gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, videoEl);
+    }
+    return true;
+  }
+
+  private _drawTo(target: RenderTarget | null): void {
+    const gl = this.gl;
+    if (target) {
+      gl.bindFramebuffer(gl.FRAMEBUFFER, target.fbo);
+      gl.viewport(0, 0, target.w, target.h);
+    } else {
+      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+      gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    }
+    gl.bindVertexArray(this._vao);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+  }
+
+  tick(
+    videoEl: HTMLVideoElement | null,
+    timeSeconds: number,
+    kick: number,
+  ): void {
+    const gl = this.gl;
+    if (!this._uploadVideo(videoEl)) {
+      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+      gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+      gl.clearColor(0, 0, 0, 0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      return;
+    }
+
+    if (!this._scene || !this._bloom0 || !this._bloom1) return;
+
+    // 1. Parallax: video -> scene
+    gl.useProgram(this._parallax);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this._srcTex);
+    gl.uniform1i(this._u.parallax.uSource, 0);
+    gl.uniform1f(this._u.parallax.uTime, timeSeconds);
+    gl.uniform1f(this._u.parallax.uKick, kick);
+    gl.uniform1f(this._u.parallax.uParallaxStrength, this._parallaxStrength);
+    gl.uniform1f(this._u.parallax.uWarpStrength, this._warpStrength);
+    this._drawTo(this._scene);
+
+    // 2. Brightpass: scene -> bloom0.
+    gl.useProgram(this._bright);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this._scene.tex);
+    gl.uniform1i(this._u.bright.uScene, 0);
+    const effThreshold = Math.max(0.02, this._bloomThreshold - this._daft * 0.1);
+    gl.uniform1f(this._u.bright.uThreshold, effThreshold);
+    gl.uniform1f(this._u.bright.uKnee, this._bloomKnee);
+    this._drawTo(this._bloom0);
+
+    // 3+4. Two-pass Gaussian blur.
+    gl.useProgram(this._blur);
+    gl.uniform2f(this._u.blur.uTexel, 1 / this._bloom0.w, 1 / this._bloom0.h);
+    gl.uniform1f(this._u.blur.uRadius, BLOOM_BLUR_RADIUS_PX);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this._bloom0.tex);
+    gl.uniform1i(this._u.blur.uTex, 0);
+    gl.uniform2f(this._u.blur.uDir, 1, 0);
+    this._drawTo(this._bloom1);
+
+    gl.bindTexture(gl.TEXTURE_2D, this._bloom1.tex);
+    gl.uniform2f(this._u.blur.uDir, 0, 1);
+    this._drawTo(this._bloom0);
+
+    // 5. Composite.
+    gl.useProgram(this._composite);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this._scene.tex);
+    gl.uniform1i(this._u.composite.uScene, 0);
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, this._bloom0.tex);
+    gl.uniform1i(this._u.composite.uBloom, 1);
+    gl.uniform1f(this._u.composite.uKick, kick);
+    gl.uniform1f(this._u.composite.uBloomOnKick, this._bloomOnKick);
+
+    const daft = this._daft;
+    gl.uniform1f(this._u.composite.uBloomBase, daft * 0.3);
+    const tintMix = daft * 0.5;
+    gl.uniform3f(
+      this._u.composite.uBloomTint,
+      1.0,
+      1.0 + (0.78 - 1.0) * tintMix,
+      1.0 + (0.82 - 1.0) * tintMix,
+    );
+
+    const dub = this._dubstep;
+    gl.uniform1f(this._u.composite.uChroma, dub * 0.005);
+    gl.uniform1f(this._u.composite.uChromaKick, dub * 0.012);
+
+    this._drawTo(null);
+
+    if (!this._everDrew) {
+      this._everDrew = true;
+      this.canvas.classList.add("effects-ready");
+    }
+  }
+
+  destroy(): void {
+    const gl = this.gl;
+    this._resizeObs.disconnect();
+    disposeRT(gl, this._scene);
+    disposeRT(gl, this._bloom0);
+    disposeRT(gl, this._bloom1);
+    gl.deleteTexture(this._srcTex);
+    gl.deleteVertexArray(this._vao);
+    gl.deleteBuffer(this._buf);
+    gl.deleteProgram(this._parallax);
+    gl.deleteProgram(this._bright);
+    gl.deleteProgram(this._blur);
+    gl.deleteProgram(this._composite);
+  }
+}

--- a/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
@@ -1,0 +1,242 @@
+// Parameter-history graph display. Maintains a rolling buffer per signal
+// and renders glowing polylines + a playhead. Direct port of static/graph.js.
+//
+// Phase 4 perf note: ctx.filter:blur is software-rendered in many browsers;
+// reduce blur intensity slightly vs. the original (4px → 3px baseline) to
+// keep frame budget healthy. Visually nearly identical at typical pulse
+// values.
+
+import { SLIDER_META, type SliderMeta } from "@/types/engine";
+
+type RGB = [number, number, number];
+
+const GRAPH_COLORS: Record<string, RGB> = {
+  denoise: [61, 182, 190],
+  feedback: [240, 138, 72],
+  shift: [232, 79, 61],
+  hint_strength: [199, 181, 102],
+  noise_share: [61, 182, 190],
+  ode_noise: [199, 181, 102],
+  seed: [240, 138, 72],
+  ch_g0: [255, 80, 80],
+  ch_g1: [255, 160, 60],
+  ch_g2: [255, 220, 40],
+  ch_g3: [180, 255, 60],
+  ch_g4: [60, 255, 140],
+  ch_g5: [40, 220, 255],
+  ch_g6: [100, 140, 255],
+  ch_g7: [200, 120, 255],
+  ch13: [255, 100, 100],
+  ch14: [255, 180, 80],
+  ch19: [220, 255, 80],
+  ch23: [80, 255, 180],
+  ch29: [80, 180, 255],
+  ch56: [180, 80, 255],
+};
+
+const _LORA_HUE_PALETTE: RGB[] = [
+  [255, 50, 200],
+  [200, 50, 255],
+  [50, 200, 255],
+  [255, 150, 50],
+  [120, 255, 80],
+  [255, 80, 120],
+  [180, 255, 200],
+  [255, 200, 100],
+];
+
+function _loraColor(id: string): RGB {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) | 0;
+  return _LORA_HUE_PALETTE[Math.abs(h) % _LORA_HUE_PALETTE.length];
+}
+
+function _colorFor(name: string): RGB {
+  if (name in GRAPH_COLORS) return GRAPH_COLORS[name];
+  if (name.startsWith("lora_str_"))
+    return _loraColor(name.slice("lora_str_".length));
+  return [255, 255, 255];
+}
+
+const HISTORY_LEN = 600;
+// How many of the most-recent samples fill the canvas width. Sampling
+// runs at SAMPLE_INTERVAL_MS = 50 ms (see useRenderLoop), so 120 samples =
+// 6 s of visible history. Newest sample sits at the right edge; samples
+// older than this drift past the left edge and are clipped (not recycled
+// back onto the right). The playhead is offset rightward of center by
+// PLAYHEAD_LEAD_SEC so a fresh slider change drifts from the right edge
+// to the playhead in ~engine-latency seconds — i.e. the visual marker
+// reaches the playhead just as the audio change becomes audible.
+const VISIBLE_SAMPLES = 120;
+const VISIBLE_SEC = 6; // VISIBLE_SAMPLES * SAMPLE_INTERVAL_MS / 1000
+// Lead time between the right edge ("just sampled") and the playhead
+// ("audible now"). Tuned to the engine's round-trip latency. If the graph
+// reads ahead of the audio, raise; if behind, lower.
+const PLAYHEAD_LEAD_SEC = 1.0;
+// Vertical breathing room so polylines at v=0 / v=1 (e.g. side-LoRA
+// strengths pulled all the way) aren't clipped against the canvas edge.
+// Sized for the max stroke width (5 px) + shadow blur (~3 px) + a little
+// air.
+const Y_PAD = 12;
+
+interface History {
+  buf: Float32Array;
+  head: number;
+  filled: number;
+}
+
+export class GraphRenderer {
+  readonly canvas: HTMLCanvasElement;
+  private readonly ctx: CanvasRenderingContext2D;
+  private readonly histories: Map<string, History> = new Map();
+  private readonly _resizeObs: ResizeObserver;
+  private w = 1;
+  private h = 1;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("GraphRenderer: 2D context unavailable");
+    this.ctx = ctx;
+    this._resizeObs = new ResizeObserver(() => this._resize());
+    this._resizeObs.observe(canvas);
+    this._resize();
+  }
+
+  private _resize(): void {
+    const dpr = window.devicePixelRatio || 1;
+    const r = this.canvas.getBoundingClientRect();
+    this.canvas.width = Math.max(1, Math.floor(r.width * dpr));
+    this.canvas.height = Math.max(1, Math.floor(r.height * dpr));
+    this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    this.w = r.width;
+    this.h = r.height;
+  }
+
+  /** Append a new sample point per signal. `defs` supplies max for normalization. */
+  sample(
+    values: Record<string, number>,
+    defs: Record<string, SliderMeta> = SLIDER_META,
+  ): void {
+    for (const name of Object.keys(values)) {
+      const v = values[name];
+      const max = defs[name]?.max ?? 1;
+      let hist = this.histories.get(name);
+      if (!hist) {
+        hist = { buf: new Float32Array(HISTORY_LEN), head: 0, filled: 0 };
+        this.histories.set(name, hist);
+      }
+      hist.buf[hist.head] = Math.max(0, Math.min(1, v / max));
+      hist.head = (hist.head + 1) % HISTORY_LEN;
+      if (hist.filled < HISTORY_LEN) hist.filled += 1;
+    }
+  }
+
+  draw(pulse = 0): void {
+    // ResizeObserver in the constructor already keeps {w, h} in sync,
+    // including the display:none → block transition. The legacy
+    // getBoundingClientRect() self-heal that used to live here forced a
+    // synchronous full-document layout flush every frame, clearing the
+    // browser's paint-region caches and tanking cursor box-shadow paint.
+    const ctx = this.ctx;
+    const { w, h } = this;
+    pulse = Math.max(0, Math.min(1, pulse));
+
+    ctx.fillStyle = "#000";
+    ctx.fillRect(0, 0, w, h);
+
+    // Playhead offset rightward so the newest sample at the right edge takes
+    // PLAYHEAD_LEAD_SEC to drift to the playhead. That delay matches the
+    // engine round-trip, so a slider change reaches the playhead just as the
+    // audio change becomes audible.
+    const playheadX = w * (1 - PLAYHEAD_LEAD_SEC / VISIBLE_SEC);
+
+    if (pulse > 0.02) {
+      const grad = ctx.createRadialGradient(
+        playheadX,
+        h / 2,
+        0,
+        playheadX,
+        h / 2,
+        h * 0.8,
+      );
+      grad.addColorStop(0, `rgba(150, 180, 220, ${0.18 * pulse})`);
+      grad.addColorStop(1, "rgba(150, 180, 220, 0)");
+      ctx.fillStyle = grad;
+      ctx.fillRect(0, 0, w, h);
+    }
+
+    // Glow + crisp line per signal. Build the path once, stroke twice:
+    // first wide with shadowBlur (GPU-accelerated on Chromium/Safari's
+    // accelerated canvas), then thin and sharp on top. This replaces
+    // `ctx.filter = blur(...)`, which falls back to software in Skia
+    // and was eating 5–15 ms / frame during active music — exactly the
+    // "whole-page lag during beats" shape.
+    for (const [name, hist] of this.histories) {
+      const n = Math.min(hist.filled, VISIBLE_SAMPLES);
+      if (n < 2) continue;
+      const [r, g, b] = _colorFor(name);
+
+      const pxPerSample = w / (VISIBLE_SAMPLES - 1);
+      const xStart = w - (n - 1) * pxPerSample;
+      ctx.beginPath();
+      for (let i = 0; i < n; i++) {
+        // Walk the ring backward from the newest sample (head - 1) so we
+        // always plot the freshest n entries in chronological order.
+        const bufIdx = (hist.head - n + i + HISTORY_LEN) % HISTORY_LEN;
+        const v = hist.buf[bufIdx];
+        const x = xStart + i * pxPerSample;
+        const y = (h - Y_PAD) - v * (h - 2 * Y_PAD);
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+
+      if (pulse > 0.05) {
+        ctx.save();
+        ctx.globalCompositeOperation = "lighter";
+        ctx.shadowColor = `rgba(${r},${g},${b},${0.8 + 0.2 * pulse})`;
+        ctx.shadowBlur = 3 + 2 * pulse;
+        ctx.shadowOffsetX = 0;
+        ctx.shadowOffsetY = 0;
+        ctx.strokeStyle = `rgba(${r},${g},${b},${0.6 + 0.4 * pulse})`;
+        ctx.lineWidth = 3 + 2 * pulse;
+        ctx.stroke();
+        ctx.restore();
+      }
+
+      ctx.shadowBlur = 0;
+      ctx.strokeStyle = `rgba(${r},${g},${b},1)`;
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+
+    // Playhead — same shadowBlur trick. Glow halo + crisp 1px line.
+    if (pulse > 0.05) {
+      ctx.save();
+      ctx.globalCompositeOperation = "lighter";
+      ctx.shadowColor = `rgba(150, 180, 220, ${0.9 * pulse})`;
+      ctx.shadowBlur = 4 * pulse;
+      ctx.shadowOffsetX = 0;
+      ctx.shadowOffsetY = 0;
+      ctx.strokeStyle = `rgba(150, 180, 220, ${0.9 * pulse})`;
+      ctx.lineWidth = 2 + 5 * pulse;
+      ctx.beginPath();
+      ctx.moveTo(playheadX + 0.5, 0);
+      ctx.lineTo(playheadX + 0.5, h);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    ctx.shadowBlur = 0;
+    ctx.strokeStyle = `rgba(255, 255, 255, ${0.6 + 0.4 * pulse})`;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(playheadX + 0.5, 0);
+    ctx.lineTo(playheadX + 0.5, h);
+    ctx.stroke();
+  }
+
+  destroy(): void {
+    this._resizeObs.disconnect();
+  }
+}

--- a/demos/realtime_motion_graph_web/web/engine/render/HUD.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/HUD.ts
@@ -1,0 +1,137 @@
+// Scrolling waveform HUD. Playhead fixed at horizontal center; waveform
+// scrolls past it. Direct port of static/hud.js, no behavior changes.
+
+export class HUD {
+  readonly canvas: HTMLCanvasElement;
+  private readonly ctx: CanvasRenderingContext2D;
+  private _peaks: Float32Array | null = null;
+  private _nFrames = 0;
+  private _channels = 2;
+  private _resizeObserver: ResizeObserver;
+  private w = 1;
+  private h = 1;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("HUD: 2D context unavailable");
+    this.ctx = ctx;
+    this._resizeObserver = new ResizeObserver(() => this._resize());
+    this._resizeObserver.observe(canvas);
+    this._resize();
+  }
+
+  private _resize(): void {
+    const dpr = Math.min(2, window.devicePixelRatio || 1);
+    const rect = this.canvas.getBoundingClientRect();
+    const w = rect.width || window.innerWidth || 800;
+    const h = rect.height || window.innerHeight || 600;
+    this.canvas.width = Math.floor(w * dpr);
+    this.canvas.height = Math.floor(h * dpr);
+    this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    this.w = w;
+    this.h = h;
+  }
+
+  resize(): void {
+    this._resize();
+  }
+
+  /** Recompute peak envelope from the full interleaved buffer. */
+  updateWaveform(interleaved: Float32Array, channels: number): void {
+    if (!interleaved || !interleaved.length) return;
+    this._channels = channels;
+    this._nFrames = (interleaved.length / channels) | 0;
+
+    // One peak per ~200 frames (~4 ms at 48 kHz) — enough for smooth
+    // scrolling at any canvas width.
+    const chunk = 200;
+    const nPeaks = Math.floor(this._nFrames / chunk);
+    if (nPeaks < 2) return;
+
+    const peaks = new Float32Array(nPeaks);
+    let pmax = 0;
+    for (let col = 0; col < nPeaks; col++) {
+      let m = 0;
+      const base = col * chunk * channels;
+      for (let i = 0; i < chunk; i++) {
+        let sum = 0;
+        for (let c = 0; c < channels; c++) {
+          sum += interleaved[base + i * channels + c];
+        }
+        const v = Math.abs(sum / channels);
+        if (v > m) m = v;
+      }
+      peaks[col] = m;
+      if (m > pmax) pmax = m;
+    }
+    if (pmax > 0) for (let i = 0; i < nPeaks; i++) peaks[i] /= pmax;
+    this._peaks = peaks;
+  }
+
+  /** Draw one frame. playbackFrac is 0..1 through the track. */
+  draw(playbackFrac: number, opts: { transparentBg?: boolean } = {}): void {
+    const ctx = this.ctx;
+    const { w, h } = this;
+    if (opts.transparentBg) {
+      ctx.clearRect(0, 0, w, h);
+    } else {
+      ctx.fillStyle = "#06060c";
+      ctx.fillRect(0, 0, w, h);
+    }
+
+    if (!this._peaks || this._peaks.length < 2) return;
+    const peaks = this._peaks;
+    const nPeaks = peaks.length;
+    const centerX = Math.floor(w / 2);
+    const cy = Math.floor(h / 2);
+    const maxAmp = cy * 0.75;
+
+    const pxPerPeak = 2;
+    const peaksOnScreen = Math.floor(w / pxPerPeak);
+    const currentPeak = playbackFrac * (nPeaks - 1);
+    const halfScreen = peaksOnScreen / 2;
+    const startPeak = currentPeak - halfScreen;
+
+    for (let i = 0; i < peaksOnScreen; i++) {
+      const peakIdx = Math.floor(startPeak + i);
+      if (peakIdx < 0 || peakIdx >= nPeaks) continue;
+
+      const x = i * pxPerPeak;
+      const amp = peaks[peakIdx] * maxAmp;
+      const isPlayed = x < centerX;
+
+      if (isPlayed) {
+        const fade = 0.25 + 0.35 * (x / centerX);
+        ctx.fillStyle = `rgba(22, 85, 110, ${fade})`;
+      } else {
+        const fade = 0.6 + 0.3 * (1 - (x - centerX) / (w - centerX));
+        ctx.fillStyle = `rgba(40, 140, 180, ${fade})`;
+      }
+      ctx.fillRect(x, cy - amp, pxPerPeak - 1, amp * 2);
+    }
+
+    // Playhead.
+    ctx.save();
+    ctx.shadowBlur = 16;
+    ctx.shadowColor = "rgba(90, 184, 138, 0.8)";
+    ctx.strokeStyle = "rgba(90, 184, 138, 0.9)";
+    ctx.lineWidth = 2.5;
+    ctx.beginPath();
+    ctx.moveTo(centerX, 0);
+    ctx.lineTo(centerX, h);
+    ctx.stroke();
+    ctx.restore();
+
+    const glow = ctx.createLinearGradient(centerX - 40, 0, centerX + 40, 0);
+    glow.addColorStop(0, "rgba(90, 184, 138, 0)");
+    glow.addColorStop(0.5, "rgba(90, 184, 138, 0.06)");
+    glow.addColorStop(1, "rgba(90, 184, 138, 0)");
+    ctx.fillStyle = glow;
+    ctx.fillRect(centerX - 40, 0, 80, h);
+  }
+
+  destroy(): void {
+    this._resizeObserver.disconnect();
+  }
+}

--- a/demos/realtime_motion_graph_web/web/engine/render/audioFeatures.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/audioFeatures.ts
@@ -1,0 +1,34 @@
+// Cheap kick / RMS extraction from an interleaved float32 buffer at a given
+// playhead position. Used to drive the bloom amount, graph pulse, and
+// effects shader uniform.
+
+const KICK_WINDOW_FRAMES = 480; // ~10 ms at 48 kHz
+
+export function kickRms(
+  interleaved: Float32Array | null,
+  positionSec: number,
+  durationSec: number,
+  channels: number,
+): number {
+  if (!interleaved || interleaved.length === 0 || durationSec <= 0) return 0;
+  const totalFrames = interleaved.length / channels;
+  const playFrame = Math.floor(
+    (positionSec / durationSec) * totalFrames,
+  );
+  const start = Math.max(0, playFrame - KICK_WINDOW_FRAMES);
+  const end = Math.min(totalFrames, start + KICK_WINDOW_FRAMES);
+  if (end <= start) return 0;
+  let acc = 0;
+  let count = 0;
+  for (let i = start; i < end; i++) {
+    let s = 0;
+    for (let c = 0; c < channels; c++) s += interleaved[i * channels + c];
+    s /= channels;
+    acc += s * s;
+    count++;
+  }
+  if (count === 0) return 0;
+  // Soft-clip RMS so bright passages don't blow out the bloom.
+  const rms = Math.sqrt(acc / count);
+  return Math.max(0, Math.min(1, rms * 1.6));
+}

--- a/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
@@ -1,0 +1,575 @@
+// Multi-color organic ribbons painted along the three slider edges + the
+// halo badge perimeter. Edge bars and the halo render to 2D canvases (was
+// SVG paths until per-frame setAttribute('d', …) thrash showed up in
+// profiles); the start-mark on the title screen stays SVG because it
+// participates in CSS transform animations during the launch sequence.
+//
+// Visual contract: same trig-noise writhe math as before, same stroke
+// colors, same per-frame stroke width / opacity scaling against
+// --bloom-amount. Drop-shadow glow filters live in CSS on the canvas
+// elements (CSS filter applies to canvases just like SVG).
+
+import { LORA_SIDE_VISIBLE_FLOOR } from "@/types/engine";
+
+const PALETTE = [
+  "#3db6be", // teal
+  "#c7b566", // mustard
+  "#f08a48", // orange
+  "#e84f3d", // coral
+];
+
+const ALONG = 1000;
+const ACROSS = 100;
+const SEGMENTS = 24; // perf: 36 -> 24
+const RIBBON_SPACING = 3;
+const NOISE_AMP_BASE = 6;
+const NOISE_AMP_KICK = 8;
+const INWARD_DISTANCE = 8;
+// Along-axis margin (in canvas CSS pixels) reserved for stroke half-width
+// + bloom drop-shadow halo, so the writhe path's start and end don't sit
+// flush against the canvas bitmap edge and get sliced. Stroke peaks at
+// ~6 px wide and the drop-shadow blur reaches ~11 px past the stroke at
+// max --bloom-amount, so 16 px leaves clear headroom on both ends.
+const ALONG_END_INSET_PX = 16;
+
+// Floor for the side-bar (LoRA) ribbon length. Defined in types/engine
+// so DesktopEdgeDrag can floor the hint head against the same value —
+// otherwise drags below this threshold leave the hint floating below
+// the ribbon's visible end. Top bar (Remix Strength) is excluded —
+// denoise=0 there is a meaningful "off" that should collapse the ribbon
+// fully so the user can grade all the way to zero.
+
+interface BarConfig {
+  sel: string;
+  horizontal: boolean;
+  flipAlong: boolean;
+  innerSign: 1 | -1;
+  /** Which side of the canvas (in CSS layout terms) has the inward bleed
+   * — i.e. extra canvas pixels past the host's content area into the
+   * central gutter, so writhing curls aren't clipped. The CSS rules in
+   * globals.css extend the canvas in the corresponding direction. */
+  bleedSide: "bottom" | "left" | "right";
+}
+
+const BAR_CONFIG: BarConfig[] = [
+  { sel: ".install-edge-top", horizontal: true, flipAlong: false, innerSign: 1, bleedSide: "bottom" },
+  { sel: ".install-edge-left", horizontal: false, flipAlong: true, innerSign: 1, bleedSide: "right" },
+  { sel: ".install-edge-right", horizontal: false, flipAlong: true, innerSign: -1, bleedSide: "left" },
+];
+
+export interface RibbonBar {
+  edge: HTMLElement;
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  resizeObs: ResizeObserver;
+  horizontal: boolean;
+  flipAlong: boolean;
+  innerSign: 1 | -1;
+  bleedSide: "bottom" | "left" | "right";
+  w: number; // CSS pixels (canvas, including bleed)
+  h: number;
+  /** Cached --ribbon-bleed (CSS custom prop). Refreshed on resize so we
+   * don't pay for getComputedStyle on every frame. */
+  bleedPx: number;
+}
+
+function makeRibbonCanvas(): HTMLCanvasElement {
+  const c = document.createElement("canvas");
+  c.className = "install-ribbons";
+  c.setAttribute("aria-hidden", "true");
+  return c;
+}
+
+function attachResize(
+  canvas: HTMLCanvasElement,
+  ctx: CanvasRenderingContext2D,
+  setSize: (w: number, h: number) => void,
+  onResized?: () => void,
+): ResizeObserver {
+  const resize = () => {
+    const dpr = window.devicePixelRatio || 1;
+    const r = canvas.getBoundingClientRect();
+    canvas.width = Math.max(1, Math.floor(r.width * dpr));
+    canvas.height = Math.max(1, Math.floor(r.height * dpr));
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    setSize(r.width, r.height);
+    onResized?.();
+  };
+  const obs = new ResizeObserver(resize);
+  obs.observe(canvas);
+  resize();
+  return obs;
+}
+
+function readBleed(canvas: HTMLCanvasElement): number {
+  // Bleed = how much the canvas overflows its host bar in the inward axis.
+  // Computed from actual layout dimensions because CSS custom-property values
+  // do not auto-resolve calc()/clamp() expressions in the computed-value
+  // string returned by getComputedStyle().getPropertyValue() — without
+  // CSS.registerProperty({syntax: "<length>"}), `--ribbon-bleed` reads back
+  // as the literal "calc(...)" token and parseFloat returns NaN. Reading the
+  // already-resolved bounding boxes side-steps that entirely.
+  const host = canvas.parentElement;
+  if (!host) return 0;
+  const c = canvas.getBoundingClientRect();
+  const h = host.getBoundingClientRect();
+  return Math.max(c.width - h.width, c.height - h.height, 0);
+}
+
+export function initRibbons(): RibbonBar[] {
+  const bars: RibbonBar[] = [];
+  for (const cfg of BAR_CONFIG) {
+    const edge = document.querySelector(cfg.sel) as HTMLElement | null;
+    if (!edge) continue;
+
+    // Drop the legacy 2 px bar; the canvas owns the meter now.
+    const oldBar = edge.querySelector(".install-edge-bar");
+    if (oldBar) oldBar.remove();
+    // Drop any leftover SVG from a hot-reloaded prior shape.
+    const oldSvg = edge.querySelector("svg.install-ribbons");
+    if (oldSvg) oldSvg.remove();
+
+    const canvas = makeRibbonCanvas();
+    const ctx = canvas.getContext("2d");
+    if (!ctx) continue;
+    edge.appendChild(canvas);
+
+    const bar: RibbonBar = {
+      edge,
+      canvas,
+      ctx,
+      resizeObs: null as unknown as ResizeObserver,
+      horizontal: cfg.horizontal,
+      flipAlong: cfg.flipAlong,
+      innerSign: cfg.innerSign,
+      bleedSide: cfg.bleedSide,
+      w: 1,
+      h: 1,
+      bleedPx: 0,
+    };
+    bar.resizeObs = attachResize(
+      canvas,
+      ctx,
+      (w, h) => {
+        bar.w = w;
+        bar.h = h;
+      },
+      () => {
+        bar.bleedPx = readBleed(canvas);
+      },
+    );
+    bars.push(bar);
+  }
+  return bars;
+}
+
+export function destroyRibbons(bars: RibbonBar[]): void {
+  for (const bar of bars) {
+    try {
+      bar.resizeObs.disconnect();
+    } catch {}
+    try {
+      bar.canvas.remove();
+    } catch {}
+  }
+}
+
+function drawRibbon(
+  ctx: CanvasRenderingContext2D,
+  progress: number,
+  ribbonIdx: number,
+  time: number,
+  kick: number,
+  bar: RibbonBar,
+  bleedPx: number,
+): void {
+  // Side bars (LoRA strengths) get a visibility floor so the ribbon
+  // never disappears even at strength=0. Top bar (Remix) is excluded —
+  // see LORA_SIDE_VISIBLE_FLOOR comment.
+  const drawProgress = bar.horizontal
+    ? progress
+    : Math.max(progress, LORA_SIDE_VISIBLE_FLOOR);
+  const drawLen = drawProgress * ALONG;
+  const lateral = (ribbonIdx - (PALETTE.length - 1) / 2) * RIBBON_SPACING;
+  const phase = ribbonIdx * 0.8;
+  const writheAmp = NOISE_AMP_BASE + kick * NOISE_AMP_KICK;
+  const center =
+    bar.innerSign > 0 ? ACROSS - INWARD_DISTANCE : INWARD_DISTANCE;
+
+  // The canvas is bleedPx larger than the host on its bleedSide. Map the
+  // viewBox so the ACROSS axis fills only the host content area; values
+  // past 0..ACROSS land in the bleed pixels (which is exactly where the
+  // writhing curls want to go).
+  const alongSize = bar.horizontal ? bar.w : bar.h;
+  const acrossSize = bar.horizontal ? bar.h : bar.w;
+  const hostAcross = Math.max(1, acrossSize - bleedPx);
+  const acrossPerUnit = hostAcross / ACROSS;
+  // Where viewBox across=0 maps to in canvas pixels. For "top" / "left" /
+  // "right", bleed lives on the inward side of the host, so across=0
+  // (the outer side) is at the canvas edge — except the right bar has
+  // its bleed on the left, so across=0 (bar's left = host's left edge,
+  // which is in the central gutter, beyond the inner side's bleed) needs
+  // to start at canvas_x = bleedPx, then increase toward the screen edge
+  // (across=100 = bar's right edge).
+  // ── wait: the right bar has innerSign=-1 (inner side at across=8), and
+  //    we want across=0 at the host's left edge (which IS the inner side
+  //    visually, in the central gutter). The CSS for .install-edge-right
+  //    pins the host with right:0, so the bar's right edge in CSS is the
+  //    screen's right edge (across=100 in viewBox), and the bar's left
+  //    edge (across=0 in viewBox) is hud-thickness inward. The canvas
+  //    extends LEFT of the bar by bleedPx — so canvas_x=0 is bleedPx
+  //    leftward of the bar's left edge (deeper into the central gutter).
+  //    Therefore across=0 → canvas_x = bleedPx. across=100 → canvas_x =
+  //    bleedPx + hostAcross = bar.w. across=-something (writhe curling
+  //    further inward) → canvas_x < bleedPx (into the bleed zone). ✓
+  const acrossOffset = bar.bleedSide === "left" ? bleedPx : 0;
+  // Same idea as acrossOffset but on the along axis: the writhe path's
+  // first and last points (along=0 and along=ALONG) would sit flush with
+  // the canvas bitmap edge, so the stroke half-width + drop-shadow halo
+  // get sliced. Inset both ends by ALONG_END_INSET_PX to give them room.
+  const hostAlong = Math.max(1, alongSize - 2 * ALONG_END_INSET_PX);
+  const alongPerUnit = hostAlong / ALONG;
+  const alongOffset = ALONG_END_INSET_PX;
+  const sx = bar.horizontal ? alongPerUnit : acrossPerUnit;
+  const sy = bar.horizontal ? acrossPerUnit : alongPerUnit;
+
+  ctx.beginPath();
+  let prevX = 0,
+    prevY = 0,
+    lastX = 0,
+    lastY = 0;
+  for (let i = 0; i <= SEGMENTS; i++) {
+    const t = i / SEGMENTS;
+    const along = t * drawLen;
+    const noise =
+      Math.sin(along * 0.012 + time * 1.3 + phase) * 0.7 +
+      Math.sin(along * 0.025 - time * 0.9 + phase * 1.4) * 0.3;
+    const across = center + lateral + noise * writheAmp;
+
+    let x: number, y: number;
+    if (bar.horizontal) {
+      x = along;
+      y = across;
+    } else {
+      x = across;
+      y = bar.flipAlong ? ALONG - along : along;
+    }
+    // For horizontal bars, the across axis is y; for vertical bars, it's
+    // x. Apply the bleed offset to whichever one is the across axis (only
+    // matters when bleedSide === "left" → right-edge bar). The along
+    // offset packs the writhe inside ALONG_END_INSET_PX of margin on
+    // both ends so strokes don't get clipped at the canvas bitmap edge.
+    const px = bar.horizontal ? alongOffset + x * sx : acrossOffset + x * sx;
+    const py = bar.horizontal ? y * sy : alongOffset + y * sy;
+    if (i > 0) {
+      prevX = lastX;
+      prevY = lastY;
+    }
+    if (i === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
+    lastX = x;
+    lastY = y;
+  }
+
+  // Curling arrowhead at the leading edge (in viewBox space, then scaled).
+  if (drawLen > 8) {
+    const dx = lastX - prevX;
+    const dy = lastY - prevY;
+    const segLen = Math.hypot(dx, dy) || 1;
+    const ux = dx / segLen;
+    const uy = dy / segLen;
+    const altSign = ribbonIdx % 2 === 0 ? 1 : -1;
+    const sign = altSign * (bar.innerSign > 0 ? 1 : -1);
+    const px = -uy * sign;
+    const py = ux * sign;
+    const r = 7 + kick * 3;
+    const cx = lastX + px * r;
+    const cy = lastY + py * r;
+    const curlSteps = 8;
+    for (let j = 1; j <= curlSteps; j++) {
+      const a = (j / curlSteps) * Math.PI;
+      const sa = Math.sin(a);
+      const ca = Math.cos(a);
+      const rx = -px * ca + ux * sa;
+      const ry = -py * ca + uy * sa;
+      // The arrowhead tip lives in viewBox space as (cx + rx*r, cy + ry*r).
+      // For a horizontal bar this is (along, across); for vertical bars it's
+      // (across, along). Match the same axis-aware offset as above.
+      const tipAlong = bar.horizontal ? cx + rx * r : cy + ry * r;
+      const tipAcross = bar.horizontal ? cy + ry * r : cx + rx * r;
+      const tipX = bar.horizontal
+        ? alongOffset + tipAlong * sx
+        : acrossOffset + tipAcross * sx;
+      const tipY = bar.horizontal
+        ? tipAcross * sy
+        : alongOffset + tipAlong * sy;
+      ctx.lineTo(tipX, tipY);
+    }
+  }
+  ctx.stroke();
+}
+
+export function tickRibbons(
+  bars: RibbonBar[],
+  time: number,
+  kick: number,
+  bloom = 0,
+): void {
+  // CSS contract from .install-ribbons: stroke-width = 2px + bloom*4px,
+  // opacity = 0.6 + bloom*0.45. Mirror exactly so canvas matches the SVG.
+  // `bloom` is passed in (the binned kick the render loop also writes
+  // into --bloom-amount) so we don't pay for a getComputedStyle flush.
+  const lineWidthPx = 2 + bloom * 4;
+  const alpha = Math.min(1, 0.6 + bloom * 0.45);
+
+  for (const bar of bars) {
+    if (bar.w <= 0 || bar.h <= 0) continue;
+    const fill = parseFloat(bar.edge.style.getPropertyValue("--fill")) || 0;
+    const ctx = bar.ctx;
+    ctx.clearRect(0, 0, bar.w, bar.h);
+    ctx.save();
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    ctx.lineWidth = lineWidthPx;
+    ctx.globalAlpha = alpha;
+    for (let i = 0; i < PALETTE.length; i++) {
+      ctx.strokeStyle = PALETTE[i];
+      drawRibbon(ctx, fill, i, time, kick, bar, bar.bleedPx);
+    }
+    ctx.restore();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Halo badge ribbons — same trig-noise writhe language as the linear bars
+// but in polar coordinates, so the four ribbons trace the badge's circular
+// border. Renders to a 2D canvas inside <HaloBadge />.
+// ---------------------------------------------------------------------------
+
+const HALO_SEGMENTS = 56;
+const HALO_BASE_R = 46;
+const HALO_RADIAL_SPREAD = 0.9;
+const HALO_NOISE_AMP_BASE = 1.6;
+const HALO_NOISE_AMP_KICK = 3.4;
+const HALO_TIME_SCALE = 1.3;
+const HALO_VIEWBOX = 100;
+
+/** Stroke colors for the halo ribbons in the order paths are rendered.
+ * Exported so HaloBadge / queue scenes can reuse without redefining. */
+export const HALO_PALETTE = PALETTE;
+
+export interface HaloRibbon {
+  el: HTMLElement;
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  resizeObs: ResizeObserver;
+  w: number;
+  h: number;
+}
+
+export function initHaloRibbon(host: HTMLElement): HaloRibbon | null {
+  const canvas = host.querySelector(
+    "canvas.halo-ribbons",
+  ) as HTMLCanvasElement | null;
+  if (!canvas) return null;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  const ring: HaloRibbon = {
+    el: host,
+    canvas,
+    ctx,
+    resizeObs: null as unknown as ResizeObserver,
+    w: 1,
+    h: 1,
+  };
+  ring.resizeObs = attachResize(canvas, ctx, (w, h) => {
+    ring.w = w;
+    ring.h = h;
+  });
+  return ring;
+}
+
+export function destroyHaloRibbon(ring: HaloRibbon): void {
+  try {
+    ring.resizeObs.disconnect();
+  } catch {}
+}
+
+/**
+ * Path-d builder shared by the canvas-driven HaloBadge tick and the
+ * SVG-driven QueueScene tick. Returns a Path "d" string in halo viewBox
+ * space (0..100), centered around (50, 50).
+ */
+function haloRingPathD(ribbonIdx: number, time: number, kick: number): string {
+  const cx = 50;
+  const cy = 50;
+  const phase = ribbonIdx * 0.7;
+  const radialOffset =
+    (ribbonIdx - (PALETTE.length - 1) / 2) * HALO_RADIAL_SPREAD;
+  const writheAmp = HALO_NOISE_AMP_BASE + kick * HALO_NOISE_AMP_KICK;
+  const t = time * HALO_TIME_SCALE;
+  let d = "";
+  for (let i = 0; i <= HALO_SEGMENTS; i++) {
+    const theta = (i / HALO_SEGMENTS) * Math.PI * 2;
+    const noise =
+      Math.sin(theta * 3 + t * 1.2 + phase) * 0.7 +
+      Math.sin(theta * 7 - t * 0.9 + phase * 1.4) * 0.3;
+    const r = HALO_BASE_R + radialOffset + noise * writheAmp;
+    const x = cx + r * Math.cos(theta);
+    const y = cy + r * Math.sin(theta);
+    d += (i === 0 ? "M" : "L") + x.toFixed(2) + " " + y.toFixed(2) + " ";
+  }
+  d += "Z";
+  return d;
+}
+
+/**
+ * SVG-path variant — used by QueueScene which composes its own halo SVG
+ * (rather than a dedicated `<canvas class="halo-ribbons">`). Cheaper-than-
+ * canvas-migration: the queue scene is a low-traffic warmup screen, so
+ * the per-frame setAttribute cost is acceptable. Each path is written
+ * only when its "d" actually changes.
+ */
+export function tickHaloRibbonPaths(
+  paths: SVGPathElement[],
+  time: number,
+  kick: number,
+  lastD?: string[],
+): void {
+  for (let i = 0; i < paths.length; i++) {
+    const d = haloRingPathD(i, time, kick);
+    if (!lastD || lastD[i] !== d) {
+      paths[i].setAttribute("d", d);
+      if (lastD) lastD[i] = d;
+    }
+  }
+}
+
+export function tickHaloRibbon(
+  ring: HaloRibbon,
+  time: number,
+  kick: number,
+  bloom = 0,
+): void {
+  const w = ring.w;
+  const h = ring.h;
+  if (w <= 0 || h <= 0) return;
+  const ctx = ring.ctx;
+  ctx.clearRect(0, 0, w, h);
+
+  // Halo viewBox is 100x100 with preserveAspectRatio xMidYMid meet — i.e.
+  // uniform scale to fit, centered. Match that.
+  const scale = Math.min(w, h) / HALO_VIEWBOX;
+  const offsetX = (w - HALO_VIEWBOX * scale) / 2;
+  const offsetY = (h - HALO_VIEWBOX * scale) / 2;
+
+  // CSS contract: stroke-width = 1px + bloom*1.2px, opacity = 0.6 + bloom*0.3.
+  // `bloom` comes from the render loop (same binned kick).
+  const lineWidthPx = 1 + bloom * 1.2;
+  const alpha = Math.min(1, 0.6 + bloom * 0.3);
+
+  ctx.save();
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  ctx.lineWidth = lineWidthPx;
+  ctx.globalAlpha = alpha;
+
+  const cx = HALO_VIEWBOX / 2;
+  const cy = HALO_VIEWBOX / 2;
+  const tScaled = time * HALO_TIME_SCALE;
+  const writheAmp = HALO_NOISE_AMP_BASE + kick * HALO_NOISE_AMP_KICK;
+
+  for (let r = 0; r < PALETTE.length; r++) {
+    const phase = r * 0.7;
+    const radialOffset =
+      (r - (PALETTE.length - 1) / 2) * HALO_RADIAL_SPREAD;
+    ctx.strokeStyle = PALETTE[r];
+    ctx.beginPath();
+    for (let i = 0; i <= HALO_SEGMENTS; i++) {
+      const theta = (i / HALO_SEGMENTS) * Math.PI * 2;
+      const noise =
+        Math.sin(theta * 3 + tScaled * 1.2 + phase) * 0.7 +
+        Math.sin(theta * 7 - tScaled * 0.9 + phase * 1.4) * 0.3;
+      const radius = HALO_BASE_R + radialOffset + noise * writheAmp;
+      const x = offsetX + (cx + radius * Math.cos(theta)) * scale;
+      const y = offsetY + (cy + radius * Math.sin(theta)) * scale;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+// ---------------------------------------------------------------------------
+// Start-mark ribbons — the title-screen logo's writhing halo. Stays SVG
+// because the launch sequence applies CSS transforms (rotate + scale) and
+// SVG strokes don't widen with the transform thanks to non-scaling-stroke,
+// which has no canvas equivalent without per-frame compensation.
+// ---------------------------------------------------------------------------
+
+const START_MARK_SEGMENTS = 72;
+const START_MARK_BASE_R = 40;
+const START_MARK_RADIAL_SPREAD = 2.4;
+const START_MARK_NOISE_AMP = 5.5;
+const START_MARK_TIME_SCALE = 0.55;
+
+export interface StartMarkRibbon {
+  el: HTMLElement;
+  paths: SVGPathElement[];
+  // Last-written `d` per path so we can skip redundant setAttribute calls
+  // (still cheaper than full string rebuild but avoids SVG repaint).
+  lastD: string[];
+}
+
+export function initStartMarkRibbon(host: HTMLElement): StartMarkRibbon | null {
+  const svg = host.querySelector(".start-mark-ribbons");
+  if (!svg) return null;
+  const paths = Array.from(svg.querySelectorAll<SVGPathElement>("path"));
+  if (paths.length === 0) return null;
+  return { el: host, paths, lastD: paths.map(() => "") };
+}
+
+function startMarkRingPathD(ribbonIdx: number, time: number): string {
+  const cx = 50;
+  const cy = 50;
+  const phase = ribbonIdx * 0.9;
+  const radialOffset =
+    (ribbonIdx - (PALETTE.length - 1) / 2) * START_MARK_RADIAL_SPREAD;
+  const t = time * START_MARK_TIME_SCALE;
+
+  let d = "";
+  for (let i = 0; i <= START_MARK_SEGMENTS; i++) {
+    const theta = (i / START_MARK_SEGMENTS) * Math.PI * 2;
+    const noise =
+      Math.sin(theta * 2 + t + phase) * 0.65 +
+      Math.sin(theta * 5 - t * 1.3 + phase * 1.5) * 0.35;
+    const r = START_MARK_BASE_R + radialOffset + noise * START_MARK_NOISE_AMP;
+    const x = cx + r * Math.cos(theta);
+    const y = cy + r * Math.sin(theta);
+    d += (i === 0 ? "M" : "L") + x.toFixed(2) + " " + y.toFixed(2) + " ";
+  }
+  d += "Z";
+  return d;
+}
+
+export function tickStartMarkRibbon(
+  ring: StartMarkRibbon,
+  time: number,
+): void {
+  // Skip work entirely when the host has been removed from the DOM
+  // (start-cta unmounts after the user clicks play). Detached SVGs
+  // wouldn't paint anyway, but the math still costs cycles.
+  if (!ring.el.isConnected) return;
+  for (let i = 0; i < ring.paths.length; i++) {
+    const d = startMarkRingPathD(i, time);
+    if (d !== ring.lastD[i]) {
+      ring.paths[i].setAttribute("d", d);
+      ring.lastD[i] = d;
+    }
+  }
+}
+
+/** Same color order as halo + bar ribbons; exported for StartOverlay JSX. */
+export const START_MARK_PALETTE = PALETTE;

--- a/demos/realtime_motion_graph_web/web/engine/render/turntable.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/turntable.ts
@@ -1,0 +1,135 @@
+// Turntable grooves — concentric polar polylines whose radii are modulated
+// by the live audio mirror buffer, so the grooves literally render the
+// music being played. Renders to a 2D canvas (was SVG paths until the
+// per-frame setAttribute('d', …) thrash showed up in profiles).
+//
+// The canvas inherits the disc's CSS filter (drop-shadow keyed off
+// --bloom-amount) so the warm coral glow follows the audio kick exactly
+// like the SVG did.
+
+const SEGMENTS = 72;
+const VIEWBOX = 64;
+const CENTER = VIEWBOX / 2;
+const INNER_R = 13;
+const OUTER_R = 28;
+const AMPLITUDE = 1.6; // px deflection at sample = 1.0 (in viewBox units)
+const N_GROOVES = 6;
+
+// Stroke colors mirror the original SVG CSS exactly (alpha baked in).
+const STROKE_EVEN = "rgba(232, 79, 61, 0.28)";
+const STROKE_ODD = "rgba(240, 138, 72, 0.22)";
+
+export interface Turntable {
+  el: HTMLElement;
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  resizeObs: ResizeObserver;
+  w: number;
+  h: number;
+}
+
+export function initTurntable(host: HTMLElement): Turntable | null {
+  const canvas = host.querySelector(
+    ".turntable-grooves",
+  ) as HTMLCanvasElement | null;
+  if (!canvas || canvas.tagName !== "CANVAS") return null;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+
+  const tt: Turntable = {
+    el: host,
+    canvas,
+    ctx,
+    resizeObs: null as unknown as ResizeObserver,
+    w: 1,
+    h: 1,
+  };
+  const resize = () => {
+    const dpr = window.devicePixelRatio || 1;
+    const r = canvas.getBoundingClientRect();
+    canvas.width = Math.max(1, Math.floor(r.width * dpr));
+    canvas.height = Math.max(1, Math.floor(r.height * dpr));
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    tt.w = r.width;
+    tt.h = r.height;
+  };
+  tt.resizeObs = new ResizeObserver(resize);
+  tt.resizeObs.observe(canvas);
+  resize();
+  return tt;
+}
+
+/**
+ * Repaint each groove. `mirror` is the interleaved Float32Array exposed by
+ * AudioPlayer.getMirror(); each groove samples a different region of it so
+ * the rings don't overlap visually. `time` advances the sample window so
+ * the waveform appears to scroll, mimicking a record being played. `bloom`
+ * is the same binned value the render loop writes into `--bloom-amount`
+ * (passed in directly so we don't pay for a `getComputedStyle` flush per
+ * frame).
+ */
+export function tickTurntable(
+  tt: Turntable,
+  mirror: Float32Array | null,
+  channels: number,
+  time: number,
+  bloom = 0,
+): void {
+  const N = mirror ? Math.floor(mirror.length / Math.max(1, channels)) : 0;
+  const phase = time * 0.35;
+  const ctx = tt.ctx;
+  const w = tt.w;
+  const h = tt.h;
+  if (w <= 0 || h <= 0) return;
+
+  ctx.clearRect(0, 0, w, h);
+
+  // Map viewBox (0..64) to actual canvas size; the host preserves a square
+  // aspect, so width-based scaling is sufficient.
+  const scale = w / VIEWBOX;
+
+  const recording = tt.el.classList.contains("turntable--recording");
+
+  ctx.save();
+  ctx.lineWidth = (recording ? 1 + bloom * 0.6 : 0.85) * scale;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  ctx.globalAlpha = recording ? 0.5 : 1;
+
+  for (let g = 0; g < N_GROOVES; g++) {
+    const t = N_GROOVES > 1 ? g / (N_GROOVES - 1) : 0;
+    const r0 = INNER_R + t * (OUTER_R - INNER_R);
+    const grooveOffset = g * 0.137;
+
+    ctx.strokeStyle = g % 2 === 0 ? STROKE_EVEN : STROKE_ODD;
+    ctx.beginPath();
+    for (let i = 0; i <= SEGMENTS; i++) {
+      const theta = (i / SEGMENTS) * Math.PI * 2;
+      let amp = 0;
+      if (mirror && N > 0) {
+        let pos = theta / (Math.PI * 2) + phase + grooveOffset;
+        pos = pos - Math.floor(pos);
+        const idx = Math.min(N - 1, Math.floor(pos * N));
+        let s = 0;
+        for (let c = 0; c < channels; c++) {
+          s += mirror[idx * channels + c] || 0;
+        }
+        amp = (s / channels) * AMPLITUDE;
+      }
+      const r = r0 + amp;
+      const x = (CENTER + r * Math.cos(theta)) * scale;
+      const y = (CENTER + r * Math.sin(theta)) * scale;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+export function destroyTurntable(tt: Turntable): void {
+  try {
+    tt.resizeObs.disconnect();
+  } catch {}
+}

--- a/demos/realtime_motion_graph_web/web/engine/rtmgConfig.ts
+++ b/demos/realtime_motion_graph_web/web/engine/rtmgConfig.ts
@@ -1,0 +1,50 @@
+// Host-injection seam.
+//
+// Each host wires its own URL builder, optional API key getter, and
+// optional session id once at app boot. Module-level setters rather
+// than React context so non-React readers (stores, workers) can read
+// the values too.
+
+export type EngineUrlBuilder = (path: string) => string;
+export type ApiKeyGetter = () => string | null;
+
+const NOT_CONFIGURED = (): never => {
+  throw new Error(
+    "URL builder not configured — call setEngineUrlBuilder() before any " +
+      "engine fetch.",
+  );
+};
+
+let _engineUrlBuilder: EngineUrlBuilder = NOT_CONFIGURED;
+let _apiKey: ApiKeyGetter = () => null;
+let _podSessionId: string | null = null;
+
+/** Host wires this once at mount. The default throws to surface
+ *  forgotten-configuration bugs loudly instead of producing silent 404s. */
+export function setEngineUrlBuilder(fn: EngineUrlBuilder): void {
+  _engineUrlBuilder = fn;
+}
+
+/** Host wires this once at mount. Default returns null (no auth). */
+export function setApiKeyGetter(fn: ApiKeyGetter): void {
+  _apiKey = fn;
+}
+
+/** Optional session id readable by the URL builder. */
+export function setPodSessionId(id: string | null): void {
+  _podSessionId = id;
+}
+
+export function getPodSessionId(): string | null {
+  return _podSessionId;
+}
+
+/** Build a URL via the host-provided builder. */
+export function podHttp(path: string): string {
+  return _engineUrlBuilder(path);
+}
+
+/** Returns the host-provided API key, or null. */
+export function getApiKey(): string | null {
+  return _apiKey();
+}

--- a/demos/realtime_motion_graph_web/web/engine/video/VideoLayer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/video/VideoLayer.ts
@@ -1,0 +1,229 @@
+// Video layer: crossfade player with beat-grid sync and marker detection.
+// Direct port of static/video.js. Phase 5 perf: pause inactive <video> once
+// the crossfade window finishes, halving video decoder cost between swaps.
+
+import { podHttp } from "@/engine/podUrl";
+
+interface Options {
+  videoA: HTMLVideoElement;
+  videoB: HTMLVideoElement;
+  bpm?: number;
+  crossfadeDuration?: number;
+  useMarkers?: boolean;
+}
+
+type GetAudioPos = () => number;
+
+export class VideoLayer {
+  videoA: HTMLVideoElement;
+  videoB: HTMLVideoElement;
+  activeVideo: HTMLVideoElement;
+  inactiveVideo: HTMLVideoElement;
+  hasVideo = false;
+  videos: string[] = [];
+  currentIndex = 0;
+
+  bpm: number;
+  beatDuration: number;
+  crossfadeDuration: number;
+
+  private useMarkers: boolean;
+  private _markerCanvas: HTMLCanvasElement;
+  private _markerCtx: CanvasRenderingContext2D | null;
+  private _lastMarkerDetected = false;
+  private _beatOffset: number | null = null;
+  private _markerCount = 0;
+
+  private _getAudioPos: GetAudioPos = () => 0;
+  private _hasAudio = false;
+
+  private _markerRaf = 0;
+  private _driftInterval: number;
+
+  constructor(opts: Options) {
+    this.videoA = opts.videoA;
+    this.videoB = opts.videoB;
+    this.activeVideo = opts.videoA;
+    this.inactiveVideo = opts.videoB;
+    this.bpm = opts.bpm ?? 134;
+    this.beatDuration = 60 / this.bpm;
+    this.crossfadeDuration = opts.crossfadeDuration ?? 1.5;
+    this.useMarkers = opts.useMarkers ?? false;
+
+    this._markerCanvas = document.createElement("canvas");
+    this._markerCanvas.width = 4;
+    this._markerCanvas.height = 4;
+    this._markerCtx = this._markerCanvas.getContext("2d", {
+      willReadFrequently: true,
+    });
+
+    if (this.useMarkers) {
+      this._markerRaf = requestAnimationFrame(() => this._markerLoop());
+    }
+
+    this._driftInterval = window.setInterval(() => this._correctDrift(), 1000);
+  }
+
+  setBpm(bpm: number): void {
+    this.bpm = bpm;
+    this.beatDuration = 60 / bpm;
+  }
+
+  setAudioSource(getPos: GetAudioPos, hasAudio: boolean): void {
+    this._getAudioPos = getPos;
+    this._hasAudio = hasAudio;
+  }
+
+  setVideos(videos: string[]): void {
+    this.videos = videos;
+    this.currentIndex = 0;
+  }
+
+  /** Crossfade to a new video. Pauses the outgoing one once the fade completes. */
+  play(filename: string, transition: "crossfade" | "cut" = "crossfade"): void {
+    this._resetMarkerState();
+    const url = podHttp(`/videos/${encodeURIComponent(filename)}`);
+
+    if (transition === "crossfade" && this.hasVideo) {
+      const inactive = this.inactiveVideo;
+      const active = this.activeVideo;
+      inactive.src = url;
+      inactive.loop = true;
+      inactive.muted = true;
+      const onReady = () => {
+        inactive.removeEventListener("canplay", onReady);
+        this._syncToBeat(inactive);
+        inactive.play().catch(() => {});
+        inactive.style.opacity = "1";
+        active.style.opacity = "0";
+        setTimeout(
+          () => {
+            // Perf: pause + tear down outgoing instead of leaving it
+            // decoding silently in the background. Halves video decoder
+            // cost between swaps.
+            active.pause();
+            active.removeAttribute("src");
+            active.load();
+            const tmp = this.activeVideo;
+            this.activeVideo = this.inactiveVideo;
+            this.inactiveVideo = tmp;
+          },
+          this.crossfadeDuration * 1000 + 100,
+        );
+      };
+      inactive.addEventListener("canplay", onReady);
+      inactive.load();
+    } else {
+      const el = this.activeVideo;
+      el.src = url;
+      el.loop = true;
+      el.muted = true;
+      el.style.opacity = "1";
+      const onReady = () => {
+        el.removeEventListener("canplay", onReady);
+        this.hasVideo = true;
+        this._syncToBeat(el);
+        el.play().catch(() => {});
+      };
+      el.addEventListener("canplay", onReady);
+      el.load();
+    }
+  }
+
+  next(): void {
+    if (this.videos.length === 0) return;
+    this.currentIndex = (this.currentIndex + 1) % this.videos.length;
+    this.play(this.videos[this.currentIndex]);
+  }
+
+  previous(): void {
+    if (this.videos.length === 0) return;
+    this.currentIndex =
+      (this.currentIndex - 1 + this.videos.length) % this.videos.length;
+    this.play(this.videos[this.currentIndex]);
+  }
+
+  destroy(): void {
+    if (this._markerRaf) cancelAnimationFrame(this._markerRaf);
+    clearInterval(this._driftInterval);
+    try {
+      this.activeVideo.pause();
+    } catch {}
+    try {
+      this.inactiveVideo.pause();
+    } catch {}
+  }
+
+  // ── internals ────────────────────────────────────────────────────────
+
+  private _resetMarkerState(): void {
+    this._lastMarkerDetected = false;
+    this._beatOffset = null;
+    this._markerCount = 0;
+  }
+
+  private _markerLoop(): void {
+    if (this.hasVideo && this.activeVideo && !this.activeVideo.paused) {
+      this._sampleMarker(this.activeVideo);
+    }
+    this._markerRaf = requestAnimationFrame(() => this._markerLoop());
+  }
+
+  private _sampleMarker(el: HTMLVideoElement): void {
+    if (!el || el.paused || !el.videoWidth || !this._markerCtx) return;
+    this._markerCtx.drawImage(el, 0, 0, 8, 8, 0, 0, 4, 4);
+    const px = this._markerCtx.getImageData(1, 1, 1, 1).data;
+    const detected = px[1] > 50 && px[1] > px[0] * 3 && px[1] > px[2] * 3;
+    if (detected && !this._lastMarkerDetected) this._onVideoDownbeat(el);
+    this._lastMarkerDetected = detected;
+  }
+
+  private _onVideoDownbeat(el: HTMLVideoElement): void {
+    if (!this._hasAudio) return;
+    const audioPos = this._getAudioPos();
+    const phase = (audioPos % this.beatDuration) / this.beatDuration;
+    const near = phase < 0.2 || phase > 0.8;
+    this._markerCount++;
+    if (near) {
+      this._beatOffset =
+        el.currentTime -
+        ((Math.round(audioPos / this.beatDuration) * this.beatDuration) %
+          (el.duration || 1));
+    } else {
+      const nearest =
+        Math.round(audioPos / this.beatDuration) * this.beatDuration;
+      const vd = el.duration;
+      const target =
+        this._beatOffset !== null
+          ? (nearest % vd) + this._beatOffset
+          : nearest % vd;
+      el.currentTime = ((target % vd) + vd) % vd;
+    }
+  }
+
+  private _syncToBeat(el: HTMLVideoElement): void {
+    if (!el.duration || el.duration === Infinity) return;
+    if (this._hasAudio) {
+      const ap = this._getAudioPos();
+      el.currentTime =
+        (Math.floor(ap / this.beatDuration) * this.beatDuration) % el.duration;
+    } else {
+      el.currentTime = 0;
+    }
+  }
+
+  private _correctDrift(): void {
+    if (!this._hasAudio || !this.hasVideo) return;
+    if (!this.activeVideo.duration || this.activeVideo.paused) return;
+    if (this._markerCount > 0) return;
+    const ap = this._getAudioPos();
+    const vd = this.activeVideo.duration;
+    let drift = (ap % vd) - this.activeVideo.currentTime;
+    if (drift > vd / 2) drift -= vd;
+    if (drift < -vd / 2) drift += vd;
+    if (Math.abs(drift) > this.beatDuration * 0.4) {
+      this.activeVideo.currentTime =
+        (Math.floor(ap / this.beatDuration) * this.beatDuration) % vd;
+    }
+  }
+}

--- a/demos/realtime_motion_graph_web/web/engine/video/listVideos.ts
+++ b/demos/realtime_motion_graph_web/web/engine/video/listVideos.ts
@@ -1,0 +1,9 @@
+import { podHttp } from "@/engine/podUrl";
+
+/** List videos available in the pod's static/videos/ directory. */
+export async function listVideos(): Promise<string[]> {
+  const res = await fetch(podHttp("/api/videos"));
+  if (!res.ok) throw new Error(`/api/videos failed: ${res.status}`);
+  const json = (await res.json()) as string[];
+  return json;
+}

--- a/demos/realtime_motion_graph_web/web/engine/workers/sliceDecoder.worker.ts
+++ b/demos/realtime_motion_graph_web/web/engine/workers/sliceDecoder.worker.ts
@@ -1,0 +1,128 @@
+// Slice decoder worker — owns fzstd + float16→float32 conversion off the main
+// thread. Server delta slices can compress to a few hundred KB; decompressing
+// inline blocks RAF and input handling. Each ws binary frame is forwarded
+// here and a parsed AudioSlice is posted back, transferring buffers so we
+// never copy the audio Float32Array.
+
+import * as fzstd from "fzstd";
+
+import { SLICE_FLAG_DELTA, SLICE_HDR_SIZE } from "@/types/protocol";
+
+interface DecodeRequest {
+  id: number;
+  buffer: ArrayBuffer;
+}
+
+interface DecodeResponse {
+  id: number;
+  ok: true;
+  flags: number;
+  startSample: number;
+  numSamples: number;
+  channels: number;
+  tickMs: number;
+  decMs: number;
+  numGens: number;
+  audio: Float32Array;
+}
+
+interface DecodeError {
+  id: number;
+  ok: false;
+  error: string;
+}
+
+// Reusable scratch overlay for half-precision decode (one allocation, not
+// per-sample object churn).
+const _fBuf = new ArrayBuffer(4);
+const _fU32 = new Uint32Array(_fBuf);
+const _fF32 = new Float32Array(_fBuf);
+
+function _half2single(h: number): number {
+  const s = (h & 0x8000) << 16;
+  let e = (h & 0x7c00) >> 10;
+  let f = h & 0x03ff;
+  if (e === 0) {
+    if (f === 0) {
+      _fU32[0] = s;
+      return _fF32[0];
+    }
+    while ((f & 0x0400) === 0) {
+      f <<= 1;
+      e--;
+    }
+    e++;
+    f &= ~0x0400;
+  } else if (e === 31) {
+    _fU32[0] = s | 0x7f800000 | (f << 13);
+    return _fF32[0];
+  }
+  e = e + (127 - 15);
+  _fU32[0] = s | (e << 23) | (f << 13);
+  return _fF32[0];
+}
+
+function float16ArrayToFloat32(u16: Uint16Array): Float32Array {
+  const out = new Float32Array(u16.length);
+  for (let i = 0; i < u16.length; i++) out[i] = _half2single(u16[i]);
+  return out;
+}
+
+self.onmessage = (ev: MessageEvent<DecodeRequest>) => {
+  const { id, buffer } = ev.data;
+  try {
+    if (buffer.byteLength < SLICE_HDR_SIZE) {
+      const err: DecodeError = { id, ok: false, error: "slice too short" };
+      (self as unknown as Worker).postMessage(err);
+      return;
+    }
+    const dv = new DataView(buffer);
+    let o = 0;
+    const flags = dv.getUint8(o);
+    o += 1;
+    const startSample = dv.getUint32(o, true);
+    o += 4;
+    const numSamples = dv.getUint32(o, true);
+    o += 4;
+    const channels = dv.getUint16(o, true);
+    o += 2;
+    const tickMs = dv.getFloat32(o, true);
+    o += 4;
+    const decMs = dv.getFloat32(o, true);
+    o += 4;
+    const numGens = dv.getUint32(o, true);
+    o += 4;
+
+    let payload: Uint8Array = new Uint8Array(buffer, SLICE_HDR_SIZE);
+    if (flags === SLICE_FLAG_DELTA) {
+      payload = fzstd.decompress(payload);
+    }
+    const aligned = new ArrayBuffer(payload.byteLength);
+    new Uint8Array(aligned).set(payload);
+    const u16 = new Uint16Array(aligned);
+    const audio = float16ArrayToFloat32(u16);
+
+    const reply: DecodeResponse = {
+      id,
+      ok: true,
+      flags,
+      startSample,
+      numSamples,
+      channels,
+      tickMs,
+      decMs,
+      numGens,
+      audio,
+    };
+    (self as unknown as Worker).postMessage(reply, [audio.buffer]);
+  } catch (e) {
+    const err: DecodeError = {
+      id,
+      ok: false,
+      error: e instanceof Error ? e.message : String(e),
+    };
+    (self as unknown as Worker).postMessage(err);
+  }
+};
+
+export {};

--- a/demos/realtime_motion_graph_web/web/hooks/useBodyAttributes.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useBodyAttributes.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+// Project performance state onto <body> attributes / classes so DEMON's CSS
+// selectors (body[data-mode], body.kiosk, body.cursor-idle, etc.) light up
+// without React owning every styling concern.
+
+export function useBodyAttributes() {
+  const mode = usePerformanceStore((s) => s.mode);
+  const kiosk = usePerformanceStore((s) => s.kiosk);
+  const status = useSessionStore((s) => s.status);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.body.dataset.mode = mode;
+    return () => {
+      delete document.body.dataset.mode;
+    };
+  }, [mode]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.body.classList.toggle("kiosk", kiosk);
+    return () => {
+      document.body.classList.remove("kiosk");
+    };
+  }, [kiosk]);
+
+  // session status drives whether the graph + playhead are shown — before
+  // the user clicks play, the title screen should not have stray graph
+  // lines drawing through the overlay.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.body.dataset.session = status;
+    return () => {
+      delete document.body.dataset.session;
+    };
+  }, [status]);
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useCursor.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useCursor.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { initCursor } from "@/engine/cursor";
+
+// Toggle the body class that drives the global `cursor: none` rule
+// (app/globals.css). The class is only present while the Performance
+// surface is mounted — admin pages, 404, and any future shell screens
+// keep the system cursor. Inside the Performance UI, modals (anything
+// with role="dialog") get their cursor restored via a separate CSS
+// override so users can still see where they're clicking.
+export function useCursor() {
+  useEffect(() => {
+    const handle = initCursor();
+    document.body.classList.add("cursor-hidden");
+    return () => {
+      document.body.classList.remove("cursor-hidden");
+      handle.destroy();
+    };
+  }, []);
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useEdgeLoraBinding.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useEdgeLoraBinding.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useLoraStore } from "@/store/useLoraStore";
+import {
+  LORA_DEFAULT_STRENGTH_FRACTION,
+  LORA_SLIDER_MAX,
+} from "@/types/engine";
+
+// Subscribes to useLoraStore and mirrors the first two enabled LoRAs onto
+// the .install-edge-left / .install-edge-right HUD bars. Sets data-bar,
+// label text, --fill, and toggles .install-edge-empty so the perimeter
+// ribbons reflect LoRA strength visually. DesktopEdgeDrag reads data-bar
+// to know which LoRA each side controls.
+//
+// Lives outside useRenderLoop because LoRA state moves much less often
+// than audio-driven values; subscribing only writes when state actually
+// changes and keeps the per-frame loop focused.
+
+const SIDES = ["left", "right"] as const;
+
+function applyBindings() {
+  const { enabled, strengths, catalog } = useLoraStore.getState();
+  const ids = Array.from(enabled);
+
+  for (let i = 0; i < SIDES.length; i++) {
+    const side = SIDES[i];
+    const id = ids[i] ?? null;
+    const edge = document.querySelector<HTMLElement>(`.install-edge-${side}`);
+    if (!edge) continue;
+
+    const labelEl = edge.querySelector<HTMLElement>(".install-edge-label");
+
+    if (id === null) {
+      edge.classList.add("install-edge-empty");
+      delete edge.dataset.bar;
+      if (labelEl) labelEl.textContent = "";
+      // Show the empty-state slider at the shared default fill so the
+      // ribbon canvas (which reads --fill directly) renders at a useful
+      // length and the hint's value-driven head position lands at the
+      // matching point on the bar.
+      edge.style.setProperty(
+        "--fill",
+        LORA_DEFAULT_STRENGTH_FRACTION.toString(),
+      );
+      continue;
+    }
+
+    edge.classList.remove("install-edge-empty");
+    edge.dataset.bar = `lora_str_${id}`;
+
+    if (labelEl) {
+      const entry = catalog.find((e) => e.id === id);
+      labelEl.textContent = entry?.name ?? id;
+    }
+
+    const strength = strengths[id] ?? 0;
+    const frac =
+      LORA_SLIDER_MAX > 0 ? strength / LORA_SLIDER_MAX : 0;
+    edge.style.setProperty(
+      "--fill",
+      Math.max(0, Math.min(1, frac)).toString(),
+    );
+  }
+}
+
+export function useEdgeLoraBinding(): void {
+  useEffect(() => {
+    // Apply once on mount in case the store already has state.
+    applyBindings();
+    // Re-apply on every store change. The selector returns the same
+    // object reference each time so we just use the global subscribe API.
+    const unsub = useLoraStore.subscribe(() => {
+      applyBindings();
+    });
+    return () => unsub();
+  }, []);
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { loadFixtureAudio } from "@/engine/audio/loadFixture";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+// In-place fixture swap. Mirrors swapToFixture() in DEMON's app.js: when the
+// user picks a different fixture mid-session, the server keeps the model
+// loaded and re-encodes the new source; the worklet crossfades the new
+// buffer in over 50 ms. We surface "Decoding ..." then "Swapping to ..."
+// in the status bar so the user knows the swap is in flight.
+//
+// Falls back to a full session restart on swap_failed (e.g. server in a
+// state where it can't accept a new source). The full restart is delegated
+// back to useStartSession via the same fixture name.
+
+export function useFixtureSwap() {
+  // Skip the very first fixture write (which fires when the catalog populates
+  // and writes the default name into the store).
+  const lastSwappedTo = useRef<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async (name: string) => {
+      if (cancelled) return;
+      const session = useSessionStore.getState();
+      if (session.status !== "ready" || !session.remote || !session.player) {
+        return; // No live session yet; the next Play will pick the new fixture.
+      }
+      if (lastSwappedTo.current === name) return;
+
+      const { setStatus } = useSessionStore.getState();
+      setStatus("ready", `Loading ${name}…`);
+
+      let interleaved: Float32Array;
+      let channels: number;
+      try {
+        const decoded = await loadFixtureAudio(name);
+        interleaved = decoded.interleaved;
+        channels = decoded.channels;
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setStatus("ready", `Load failed: ${msg}`);
+        return;
+      }
+      if (cancelled) return;
+
+      setStatus("ready", `Swapping to ${name}…`);
+
+      const remote = session.remote;
+      const ok = await new Promise<boolean>((resolve) => {
+        const onReady = (e: Event) => {
+          remote.removeEventListener("swap_ready", onReady);
+          remote.removeEventListener("swap_failed", onFail);
+          const detail = (e as CustomEvent<{
+            interleaved: Float32Array;
+            channels: number;
+            key?: string;
+          }>).detail;
+          session.player?.swap(detail.interleaved, detail.channels);
+          if (detail.key) usePerformanceStore.getState().setKey(detail.key);
+          resolve(true);
+        };
+        const onFail = (e: Event) => {
+          remote.removeEventListener("swap_ready", onReady);
+          remote.removeEventListener("swap_failed", onFail);
+          console.warn("[fixture-swap] server swap_failed:", (e as CustomEvent).detail);
+          resolve(false);
+        };
+        remote.addEventListener("swap_ready", onReady);
+        remote.addEventListener("swap_failed", onFail);
+
+        const perf = usePerformanceStore.getState();
+        const sent = remote.sendSwapSource(
+          interleaved,
+          channels,
+          perf.promptA,
+          perf.activeKey,
+        );
+        if (!sent) {
+          remote.removeEventListener("swap_ready", onReady);
+          remote.removeEventListener("swap_failed", onFail);
+          resolve(false);
+        }
+      });
+
+      if (cancelled) return;
+      if (!ok) {
+        setStatus("ready", "Swap failed — please try again");
+        return;
+      }
+      lastSwappedTo.current = name;
+      setStatus("ready", "Playing");
+    };
+
+    const unsub = usePerformanceStore.subscribe((s, prev) => {
+      if (s.fixture !== prev.fixture && s.fixture) {
+        void run(s.fixture);
+      }
+    });
+
+    // Seed lastSwappedTo with the current fixture so the initial population
+    // (catalog → default fixture write) doesn't trigger a no-op swap.
+    lastSwappedTo.current = usePerformanceStore.getState().fixture;
+
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, []);
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useIdleReset.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useIdleReset.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useLoraStore } from "@/store/useLoraStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+
+// After N seconds with no user interaction (pointer move, key, MIDI), revert
+// every slider + seed + blend back to defaults. The DEMON original gates
+// this by config.controls.reset_seconds; 0 disables. Phase 10 keeps the
+// gating: hook accepts an optional duration (seconds); 0 = disabled.
+//
+// Also drives `body.cursor-idle` (existing CSS toggle) for the auto-hide
+// cursor in kiosk mode.
+
+const CURSOR_IDLE_MS = 2000;
+
+export function useIdleReset(seconds: number) {
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    let resetTimer: number | null = null;
+    let idleTimer: number | null = null;
+    const intervalMs = seconds > 0 ? seconds * 1000 : 0;
+
+    function bump() {
+      document.body.classList.remove("cursor-idle");
+      if (idleTimer !== null) clearTimeout(idleTimer);
+      idleTimer = window.setTimeout(
+        () => document.body.classList.add("cursor-idle"),
+        CURSOR_IDLE_MS,
+      );
+      if (intervalMs > 0) {
+        if (resetTimer !== null) clearTimeout(resetTimer);
+        resetTimer = window.setTimeout(() => {
+          usePerformanceStore.getState().resetToDefaults();
+          useLoraStore.getState().reset();
+        }, intervalMs);
+      }
+    }
+
+    bump();
+    document.addEventListener("mousemove", bump, { passive: true });
+    document.addEventListener("pointerdown", bump, { passive: true });
+    document.addEventListener("keydown", bump);
+    // MIDI: route via the same listener pattern. The MIDI hook fires
+    // store updates; we listen on those updates to reset the timers.
+    const unsubPerf = usePerformanceStore.subscribe(bump);
+
+    return () => {
+      document.removeEventListener("mousemove", bump);
+      document.removeEventListener("pointerdown", bump);
+      document.removeEventListener("keydown", bump);
+      unsubPerf();
+      if (resetTimer !== null) clearTimeout(resetTimer);
+      if (idleTimer !== null) clearTimeout(idleTimer);
+      document.body.classList.remove("cursor-idle");
+    };
+  }, [seconds]);
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useIsMobile.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useIsMobile.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const QUERY = "(max-width: 768px)";
+
+// Returns true while the viewport matches the mobile breakpoint. SSR-safe:
+// initial value is false on the server, then synchronized after mount.
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(QUERY);
+    setIsMobile(mql.matches);
+    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return isMobile;
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useKeyboardShortcuts.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,239 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { togglePauseAndAudio } from "@/engine/audio/togglePauseAndAudio";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+import { DCW_MODES, DCW_WAVELETS, SLIDER_META } from "@/types/engine";
+
+// Keyboard layout. Chord = letter held + ▲▼; single-tap keys do
+// toggles/cycles/sends. Display-side source of truth lives in
+// engine/keyboard/bindings.ts (rendered by ConfigModal).
+//
+//   A + ▲▼      remix (denoise)
+//   G + ▲▼      structure (hint_strength)
+//   B + ▲▼      prompt blend
+//   E/H/N/D + ▲▼   feedback / shift / nshare / ode (engine)
+//   W/Y + ▲▼    DCW low / DCW high
+//   T            toggle DCW on/off
+//   Shift+T      cycle DCW mode
+//   Shift+W      cycle DCW wavelet
+//   0..7 + ▲▼  channel-gain ch_g0..ch_g7 (digit code, layout-independent)
+//   Shift + 1..6 + ▲▼  channel sliders ch13/14/19/23/29/56
+//   Enter        send prompt (when no editable focused)
+//   ⌘/Ctrl+Enter inside #prompt-a/#prompt-b → send prompt
+//   F            randomize seed
+//   Space        pause / resume
+//   K            toggle kiosk mode
+//   Esc / O      toggle Advanced Controls drawer
+//   R            record / stop audio (no modifiers — ⌘R still reloads)
+
+const HELD_KEYS = new Set<string>();
+const HELD_DIGITS = new Set<string>(); // KeyboardEvent.code, e.g. "Digit3"
+
+// param mapped per chord modifier
+const ENGINE_DCW_CHORDS: Record<string, string> = {
+  e: "feedback",
+  h: "shift",
+  n: "noise_share",
+  d: "ode_noise",
+  w: "dcw_scaler",
+  y: "dcw_high_scaler",
+};
+
+const CH_GAIN_PARAMS = [
+  "ch_g0",
+  "ch_g1",
+  "ch_g2",
+  "ch_g3",
+  "ch_g4",
+  "ch_g5",
+  "ch_g6",
+  "ch_g7",
+] as const;
+
+// Channels in the order the screen presents them (top-down in the tile).
+const CH_PARAMS = ["ch13", "ch14", "ch19", "ch23", "ch29", "ch56"] as const;
+
+export function useKeyboardShortcuts() {
+  useEffect(() => {
+    function inEditable(target: EventTarget | null): boolean {
+      const el = target as HTMLElement | null;
+      if (!el) return false;
+      const tag = el.tagName;
+      return (
+        tag === "TEXTAREA" ||
+        tag === "INPUT" ||
+        tag === "SELECT" ||
+        el.isContentEditable
+      );
+    }
+
+    function bumpParam(param: string, direction: 1 | -1): void {
+      const meta = SLIDER_META[param];
+      const step = meta?.step ?? 0.05;
+      usePerformanceStore.getState().bumpSlider(param, direction * step);
+    }
+
+    function bumpBlend(direction: 1 | -1): void {
+      const s = usePerformanceStore.getState();
+      s.setBlend(Math.max(0, Math.min(1, s.blend + direction * 0.05)));
+    }
+
+    function sendPrompt(): void {
+      const { promptA, activeKey } = usePerformanceStore.getState();
+      const remote = useSessionStore.getState().remote;
+      if (remote) remote.sendPrompt(promptA, activeKey);
+    }
+
+    function cycleDcwMode(): void {
+      const s = usePerformanceStore.getState();
+      const i = DCW_MODES.indexOf(s.dcwMode);
+      const next = DCW_MODES[(i + 1) % DCW_MODES.length];
+      s.setDcwMode(next);
+    }
+    function cycleWavelet(): void {
+      const s = usePerformanceStore.getState();
+      const i = DCW_WAVELETS.indexOf(s.dcwWavelet);
+      const next = DCW_WAVELETS[(i + 1) % DCW_WAVELETS.length];
+      s.setDcwWavelet(next);
+    }
+
+    function onKeyDown(e: KeyboardEvent) {
+      // ⌘/Ctrl+Enter while in a prompt textarea sends — runs BEFORE the
+      // inEditable early-return so users can fire while typing.
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        const el = e.target as HTMLElement | null;
+        if (
+          el?.tagName === "TEXTAREA" &&
+          (el.id === "prompt-a" || el.id === "prompt-b")
+        ) {
+          e.preventDefault();
+          sendPrompt();
+          return;
+        }
+      }
+
+      if (inEditable(e.target)) return;
+
+      const k = e.key.toLowerCase();
+      HELD_KEYS.add(k);
+      if (e.code.startsWith("Digit")) HELD_DIGITS.add(e.code);
+
+      if (k === "arrowup" || k === "arrowdown") {
+        const dir: 1 | -1 = k === "arrowup" ? 1 : -1;
+
+        if (HELD_KEYS.has("a")) {
+          e.preventDefault();
+          bumpParam("denoise", dir);
+          return;
+        }
+        if (HELD_KEYS.has("g")) {
+          e.preventDefault();
+          bumpParam("hint_strength", dir);
+          return;
+        }
+        if (HELD_KEYS.has("b")) {
+          e.preventDefault();
+          bumpBlend(dir);
+          return;
+        }
+
+        for (const [letter, param] of Object.entries(ENGINE_DCW_CHORDS)) {
+          if (HELD_KEYS.has(letter)) {
+            e.preventDefault();
+            bumpParam(param, dir);
+            return;
+          }
+        }
+
+        // Channels (Shift + 1..6). Checked before plain digits so Shift+1
+        // routes to ch13 instead of ch_g1.
+        if (e.shiftKey) {
+          for (let i = 1; i <= 6; i++) {
+            if (HELD_DIGITS.has(`Digit${i}`)) {
+              e.preventDefault();
+              bumpParam(CH_PARAMS[i - 1], dir);
+              return;
+            }
+          }
+        } else {
+          for (let i = 0; i < 8; i++) {
+            if (HELD_DIGITS.has(`Digit${i}`)) {
+              e.preventDefault();
+              bumpParam(CH_GAIN_PARAMS[i], dir);
+              return;
+            }
+          }
+        }
+      }
+
+      if (k === "enter") {
+        // Enter on a focused button/link must keep its native click
+        // behavior; otherwise (focus on body) treat it as send-prompt.
+        const el = e.target as HTMLElement | null;
+        const tag = el?.tagName;
+        if (tag === "BUTTON" || tag === "A") return;
+        sendPrompt();
+        return;
+      }
+      if (k === "f") {
+        usePerformanceStore.getState().randomizeSeed();
+        return;
+      }
+      if (k === " ") {
+        e.preventDefault();
+        togglePauseAndAudio();
+        return;
+      }
+      if (k === "k") {
+        usePerformanceStore.getState().toggleKiosk();
+        return;
+      }
+      // Shift cases must precede the plain T/W toggles below.
+      if (k === "t" && e.shiftKey) {
+        cycleDcwMode();
+        return;
+      }
+      if (k === "w" && e.shiftKey) {
+        cycleWavelet();
+        return;
+      }
+      if (k === "t") {
+        usePerformanceStore.getState().toggleDcw();
+        return;
+      }
+      if (k === "o" || k === "escape") {
+        document.dispatchEvent(new CustomEvent("dd:toggle-drawer"));
+        return;
+      }
+      // Plain `r` toggles recording. Skip when any modifier is held so
+      // ⌘R / ⌘⇧R / Ctrl+R / Alt+R remain pure browser-reload shortcuts.
+      if (k === "r" && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+        document.dispatchEvent(new CustomEvent("dd:toggle-record"));
+        return;
+      }
+    }
+
+    function onKeyUp(e: KeyboardEvent) {
+      HELD_KEYS.delete(e.key.toLowerCase());
+      if (e.code.startsWith("Digit")) HELD_DIGITS.delete(e.code);
+    }
+    function onBlur() {
+      HELD_KEYS.clear();
+      HELD_DIGITS.clear();
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
+    window.addEventListener("blur", onBlur);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("blur", onBlur);
+      HELD_KEYS.clear();
+      HELD_DIGITS.clear();
+    };
+  }, []);
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useMidi.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useMidi.ts
@@ -1,0 +1,225 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { readKnob } from "@/engine/midi/absoluteDelta";
+import { decodeKnob } from "@/engine/midi/knob";
+import { LORA_SLOT_MARKER, type NoteAction } from "@/engine/midi/types";
+import { useCurveStore } from "@/store/useCurveStore";
+import { useLoraStore } from "@/store/useLoraStore";
+import { useMidiStore } from "@/store/useMidiStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+import { SLIDER_META } from "@/types/engine";
+
+// Web MIDI bootstrap. Asks for navigator.requestMIDIAccess on mount, wires
+// onmidimessage to either the learn handler (if learn is active) or the
+// CC/note router (otherwise). Mirrors the contextmenu→learn binding from
+// app.js.
+
+function noteAction(action: NoteAction): void {
+  switch (action) {
+    case "seed":
+      usePerformanceStore.getState().randomizeSeed();
+      return;
+    case "send_prompt": {
+      const perf = usePerformanceStore.getState();
+      const remote = useSessionStore.getState().remote;
+      if (remote) remote.sendPrompt(perf.promptA, perf.activeKey);
+      return;
+    }
+    case "mode_toggle":
+      usePerformanceStore.getState().toggleMode();
+      return;
+    case "pause":
+      usePerformanceStore.getState().togglePause();
+      return;
+    case "kiosk_toggle":
+      usePerformanceStore.getState().toggleKiosk();
+      return;
+    case "schedule_curves_toggle":
+      useCurveStore.getState().toggleOverlay();
+      return;
+  }
+}
+
+function resolveCcParam(rawName: string): string | null {
+  if (rawName === LORA_SLOT_MARKER[0] || rawName === LORA_SLOT_MARKER[1]) {
+    const ids = Array.from(useLoraStore.getState().enabled);
+    const idx = rawName === LORA_SLOT_MARKER[0] ? 0 : 1;
+    return ids[idx] ? `lora_str_${ids[idx]}` : null;
+  }
+  return rawName;
+}
+
+function handleCC(cc: number, value: number): void {
+  if (useMidiStore.getState().applyLearn("cc", cc)) return;
+
+  const map = useMidiStore.getState().map;
+
+  // CC-as-action bindings (pads in CC mode mapped to discrete actions
+  // like seed-randomize). Fire only on the rising edge — pad presses
+  // typically send a non-zero value on press and 0 on release.
+  const ccAction = map.ccActions?.[String(cc)];
+  if (ccAction && value > 0) {
+    noteAction(ccAction);
+    return;
+  }
+
+  const rawName = map.cc[String(cc)];
+  if (!rawName) return;
+  const param = resolveCcParam(rawName);
+  if (!param) return;
+
+  const meta = SLIDER_META[param];
+  const max = meta?.max ?? 2.0;
+  const step = meta?.step ?? 0.05;
+
+  const decoded = decodeKnob(cc, value);
+  const perf = usePerformanceStore.getState();
+  if (decoded.mode === "relative") {
+    if (!decoded.delta) return;
+    applyMidiBump(param, decoded.delta * step);
+    return;
+  }
+
+  // Absolute knobs: delta-track most of the way (no takeover snap), but
+  // hard-snap when the knob is parked at min/max so a fast sweep
+  // always reaches the bound.
+  const reading = readKnob(cc, value);
+  if (reading.absolute !== null) {
+    applyMidiSet(param, (reading.absolute / 127) * max);
+    return;
+  }
+  if (reading.delta === null) return;
+  applyMidiBump(param, (reading.delta / 127) * max);
+}
+
+/** Setter that propagates to both the perf store (drives engine via
+ *  param-sync, also runs the smoothing tween) AND to useLoraStore for
+ *  lora_str_<id> params (drives the LoRA UI's strength display, since
+ *  LoraRow reads from useLoraStore). Without the LoRA mirror, MIDI
+ *  knobs would change the engine's behaviour but the visual slider in
+ *  the Library tile would stay frozen. */
+function applyMidiSet(param: string, value: number): void {
+  usePerformanceStore.getState().setSlider(param, value);
+  if (param.startsWith("lora_str_")) {
+    const id = param.slice("lora_str_".length);
+    useLoraStore.getState().setStrength(id, value);
+  }
+}
+
+function applyMidiBump(param: string, delta: number): void {
+  usePerformanceStore.getState().bumpSlider(param, delta);
+  if (param.startsWith("lora_str_")) {
+    const id = param.slice("lora_str_".length);
+    // Mirror the bumped value (the perf store already clamped) so the
+    // LoRA UI shows the same number.
+    const v = usePerformanceStore.getState().sliderTargets[param] ?? 0;
+    useLoraStore.getState().setStrength(id, v);
+  }
+}
+
+function handleNote(note: number): void {
+  if (useMidiStore.getState().applyLearn("note", note)) return;
+  const action = useMidiStore.getState().map.notes[String(note)];
+  if (!action) return;
+  noteAction(action);
+}
+
+function bindInput(input: MIDIInput): void {
+  input.onmidimessage = (e) => {
+    const data = e.data;
+    if (!data || data.length < 2) return;
+    const status = data[0] & 0xf0;
+    if (status === 0xb0) {
+      // Control change.
+      handleCC(data[1], data[2]);
+    } else if (status === 0x90 && data[2] > 0) {
+      // Note on (velocity > 0).
+      handleNote(data[1]);
+    }
+  };
+}
+
+export function useMidi() {
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !navigator.requestMIDIAccess) {
+      useMidiStore.getState().setStatus("MIDI N/A", "off");
+      return;
+    }
+
+    let access: MIDIAccess | null = null;
+    let cancelled = false;
+
+    navigator
+      .requestMIDIAccess({ sysex: false })
+      .then((a) => {
+        if (cancelled) return;
+        access = a;
+        useMidiStore.getState().setAvailable(true);
+        useMidiStore
+          .getState()
+          .setStatus(`MIDI ${a.inputs.size} dev`, "ok");
+        a.inputs.forEach(bindInput);
+        a.onstatechange = () => {
+          a.inputs.forEach(bindInput);
+          useMidiStore
+            .getState()
+            .setStatus(`MIDI ${a.inputs.size} dev`, "ok");
+        };
+      })
+      .catch(() => {
+        useMidiStore.getState().setStatus("MIDI denied", "warn");
+      });
+
+    // Right-click → MIDI learn. Targets:
+    //   .slider-group[data-param=...] → CC
+    //   .lora-row[data-param=...]     → CC (Phase 11 will populate)
+    //   [data-midi-learn=...]         → note (transport buttons, send-prompt, etc.)
+    const onContextMenu = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      const slider = target.closest<HTMLElement>(".slider-group");
+      if (slider?.dataset.param) {
+        e.preventDefault();
+        useMidiStore.getState().startLearn("cc", slider.dataset.param, slider);
+        return;
+      }
+      const loraRow = target.closest<HTMLElement>(".lora-row");
+      if (loraRow?.dataset.param) {
+        e.preventDefault();
+        useMidiStore.getState().startLearn("cc", loraRow.dataset.param, loraRow);
+        return;
+      }
+      const learnEl = target.closest<HTMLElement>("[data-midi-learn]");
+      if (learnEl?.dataset.midiLearn) {
+        e.preventDefault();
+        useMidiStore
+          .getState()
+          .startLearn("note", learnEl.dataset.midiLearn, learnEl);
+        return;
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && useMidiStore.getState().learn) {
+        useMidiStore.getState().cancelLearn();
+        useMidiStore.getState().setStatus("Learn cancelled", "info");
+      }
+    };
+    document.addEventListener("contextmenu", onContextMenu);
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("contextmenu", onContextMenu);
+      document.removeEventListener("keydown", onKeyDown);
+      if (access) {
+        access.inputs.forEach((i) => {
+          i.onmidimessage = null;
+        });
+        access.onstatechange = null;
+      }
+    };
+  }, []);
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useParamSync.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useParamSync.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useLoraStore } from "@/store/useLoraStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+// Continuous param-sync. Mirrors DEMON's app.js Session._sendTick which runs
+// on a setInterval (8 ms) and pushes the full slider/seed/dcw raw dict +
+// the current playback position EVERY tick — not just on change.
+//
+// The original cadence matters: the streaming pipeline samples params at
+// the start of each generation window. If we only sent on store mutation,
+// the engine would drift back to its prior state between user gestures
+// (the symptom: "param updates aren't affecting generation"). Continuous
+// flow also lets time-keyed curves (e.g. SDE denoise schedules) line up
+// against the real playhead in seconds.
+
+const TICK_MS = 33;
+
+export function useParamSync() {
+  useEffect(() => {
+    let cancelled = false;
+
+    const id = window.setInterval(() => {
+      if (cancelled) return;
+      const session = useSessionStore.getState();
+      if (session.status !== "ready" || !session.remote || !session.player) {
+        return;
+      }
+      if (session.player.ctx?.state === "suspended") return; // paused
+
+      const perf = usePerformanceStore.getState();
+      const lora = useLoraStore.getState();
+
+      const raw: Record<string, number | string | boolean> = {
+        // seed first so it can never be overwritten by a slider name collision.
+        seed: perf.seed,
+        ...perf.sliderValues,
+      };
+      // Per-LoRA strength sliders ride along under lora_str_<id> keys.
+      // We prefer perf.sliderValues (smoothed via the tween) and only
+      // fall back to lora.strengths when the perf store hasn't seen
+      // the LoRA yet (e.g. the user just enabled it but hasn't moved
+      // the slider). Without this gate, the LoRA store's instant
+      // value used to clobber the smoothed one and smoothing felt
+      // broken on LoRA knobs.
+      for (const id of lora.enabled) {
+        const k = `lora_str_${id}`;
+        if (k in raw) continue;
+        const v = lora.strengths[id];
+        if (typeof v === "number") raw[k] = v;
+      }
+      // DCW non-numeric controls — server reads raw.get("dcw_enabled") etc.
+      raw.dcw_enabled = perf.dcwEnabled;
+      raw.dcw_mode = perf.dcwMode;
+      raw.dcw_wavelet = perf.dcwWavelet;
+
+      // Playback position is *seconds* (raw audio.positionSec), not a 0..1
+      // ratio. The server uses absolute time for curve sampling.
+      const playbackSec = session.player.positionSec;
+      session.remote.sendParams(raw, playbackSec);
+    }, TICK_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useRecording.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useRecording.ts
@@ -1,0 +1,394 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useRecordingStore } from "@/store/useRecordingStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+// Owns the MediaRecorder lifecycle. UI components dispatch
+// document.dispatchEvent(new CustomEvent("dd:toggle-record")) — keyboard
+// shortcut handler does the same. Mirrors the dd:toggle-drawer pattern.
+//
+// Strategy notes:
+//   • Audio-only. Stream comes from AudioPlayer.getRecordingStream() — a
+//     MediaStreamAudioDestinationNode tee'd off the same worklet output the
+//     user hears, at 48 kHz / 2 ch.
+//   • MIME ladder picks Opus-in-WebM first (transparent at 192 kbps), falls
+//     back to AAC-in-MP4 for Safari/iOS, gracefully disables otherwise.
+//   • start(1000) yields 1-second chunks so a tab crash loses at most ~1s.
+//   • Visibility / AudioContext statechange handlers auto-pause and surface
+//     status into the existing StatusBar via useSessionStore.setStatus.
+
+const SOFT_CAP_MS = 60 * 60 * 1000; // 60 minutes
+const SOFT_CAP_BYTES = 150 * 1024 * 1024; // ~150 MB
+
+interface MimeChoice {
+  mime: string;
+  ext: string;
+  bitrate: number;
+}
+
+const MIME_LADDER: MimeChoice[] = [
+  { mime: "audio/webm;codecs=opus", ext: "webm", bitrate: 192_000 },
+  { mime: "audio/webm", ext: "webm", bitrate: 192_000 },
+  { mime: "audio/mp4;codecs=mp4a.40.2", ext: "m4a", bitrate: 256_000 },
+  { mime: "audio/mp4", ext: "m4a", bitrate: 256_000 },
+];
+
+function pickMime(): MimeChoice | null {
+  if (typeof window === "undefined") return null;
+  if (typeof MediaRecorder === "undefined") return null;
+  for (const choice of MIME_LADDER) {
+    try {
+      if (MediaRecorder.isTypeSupported(choice.mime)) return choice;
+    } catch {
+      // Some browsers throw on bare types; keep walking the ladder.
+    }
+  }
+  return null;
+}
+
+export function isRecordingSupported(): boolean {
+  return pickMime() !== null;
+}
+
+export function useRecording() {
+  useEffect(() => {
+    let recorder: MediaRecorder | null = null;
+    let chunks: Blob[] = [];
+    let pickedMime: MimeChoice | null = null;
+    let startedAt = 0;
+    let pausedTotalMs = 0;
+    let pausedSinceMs = 0;
+    let capTimer: number | null = null;
+    let visibilityPaused = false;
+
+    function setMessage(msg: string) {
+      // Reuse the StatusBar — it shows whenever message != "" and != "Playing".
+      useSessionStore.getState().setStatus(
+        useSessionStore.getState().status,
+        msg,
+      );
+    }
+
+    function clearCapTimer() {
+      if (capTimer !== null) {
+        window.clearTimeout(capTimer);
+        capTimer = null;
+      }
+    }
+
+    function teardown() {
+      clearCapTimer();
+      if (recorder) {
+        try {
+          recorder.ondataavailable = null;
+          recorder.onstop = null;
+          recorder.onerror = null;
+        } catch {}
+      }
+      recorder = null;
+      chunks = [];
+      pickedMime = null;
+      startedAt = 0;
+      pausedTotalMs = 0;
+      pausedSinceMs = 0;
+      visibilityPaused = false;
+    }
+
+    function finalize() {
+      if (!recorder || !pickedMime) return;
+      const { mime, ext } = pickedMime;
+
+      useRecordingStore.getState().set({ kind: "finalizing" });
+
+      const onstop = () => {
+        const blob = new Blob(chunks, { type: mime });
+        const url = URL.createObjectURL(blob);
+        const now = performance.now();
+        const elapsed = now - startedAt - pausedTotalMs;
+
+        useRecordingStore.getState().set({
+          kind: "preview",
+          blob,
+          url,
+          mime,
+          ext,
+          durationMs: Math.max(0, elapsed),
+        });
+        // Brief celebratory note in the StatusBar.
+        const seconds = Math.max(1, Math.round(elapsed / 1000));
+        setMessage(`Saved ${seconds}s clip`);
+        teardown();
+      };
+
+      try {
+        if (recorder.state !== "inactive") {
+          recorder.onstop = onstop;
+          recorder.stop();
+        } else {
+          onstop();
+        }
+      } catch (err) {
+        console.warn("[useRecording] stop failed", err);
+        teardown();
+        useRecordingStore.getState().set({
+          kind: "error",
+          reason: "Could not finalize recording",
+        });
+      }
+    }
+
+    function start() {
+      const cur = useRecordingStore.getState().state;
+      if (cur.kind !== "idle" && cur.kind !== "preview" && cur.kind !== "error") {
+        return;
+      }
+
+      // If a previous preview exists, revoke its url before starting fresh.
+      if (cur.kind === "preview") {
+        try {
+          URL.revokeObjectURL(cur.url);
+        } catch {}
+      }
+
+      const session = useSessionStore.getState();
+      if (session.status === "idle" || !session.player) {
+        useRecordingStore.getState().set({ kind: "idle" });
+        // Show the warning anchored to the record buttons themselves —
+        // do NOT overwrite session.message, which is reserved for
+        // loading/connecting/error progress in the global StatusBar.
+        const { setWarning } = useRecordingStore.getState();
+        setWarning("Wait for connection first");
+        window.setTimeout(() => {
+          if (
+            useRecordingStore.getState().warning ===
+            "Wait for connection first"
+          ) {
+            setWarning(null);
+          }
+        }, 2000);
+        return;
+      }
+
+      const choice = pickMime();
+      if (!choice) {
+        useRecordingStore.getState().set({
+          kind: "error",
+          reason: "Recording not supported on this browser",
+        });
+        return;
+      }
+
+      const stream = session.player.getRecordingStream();
+      if (!stream) {
+        useRecordingStore.getState().set({
+          kind: "error",
+          reason: "Audio engine not ready",
+        });
+        return;
+      }
+
+      useRecordingStore.getState().set({ kind: "arming" });
+
+      try {
+        recorder = new MediaRecorder(stream, {
+          mimeType: choice.mime,
+          audioBitsPerSecond: choice.bitrate,
+        });
+      } catch (err) {
+        console.warn("[useRecording] MediaRecorder init failed", err);
+        useRecordingStore.getState().set({
+          kind: "error",
+          reason: "Could not start recorder",
+        });
+        teardown();
+        return;
+      }
+
+      pickedMime = choice;
+      chunks = [];
+      pausedTotalMs = 0;
+      pausedSinceMs = 0;
+      startedAt = performance.now();
+
+      recorder.ondataavailable = (e: BlobEvent) => {
+        if (!e.data || e.data.size === 0) return;
+        chunks.push(e.data);
+        useRecordingStore.getState().bumpBytes(e.data.size);
+        const cur = useRecordingStore.getState().state;
+        if (cur.kind === "recording" && cur.bytes >= SOFT_CAP_BYTES) {
+          setMessage("Long clip saved — start a new one to keep going");
+          finalize();
+        }
+      };
+      recorder.onerror = (e: Event) => {
+        console.warn("[useRecording] recorder error", e);
+        useRecordingStore.getState().set({
+          kind: "error",
+          reason: "Recorder error",
+        });
+        teardown();
+      };
+
+      try {
+        recorder.start(1000);
+      } catch (err) {
+        console.warn("[useRecording] start() failed", err);
+        useRecordingStore.getState().set({
+          kind: "error",
+          reason: "Could not start recorder",
+        });
+        teardown();
+        return;
+      }
+
+      useRecordingStore.getState().set({
+        kind: "recording",
+        startedAt,
+        bytes: 0,
+        pausedMs: 0,
+      });
+
+      capTimer = window.setTimeout(() => {
+        if (useRecordingStore.getState().state.kind === "recording") {
+          setMessage("Long clip saved — start a new one to keep going");
+          finalize();
+        }
+      }, SOFT_CAP_MS);
+    }
+
+    function stop() {
+      const cur = useRecordingStore.getState().state;
+      if (cur.kind !== "recording" && cur.kind !== "paused") return;
+      if (cur.kind === "paused") {
+        // Closing on a paused recorder loses the in-flight chunk on Safari;
+        // resume momentarily so onstop fires cleanly.
+        try {
+          recorder?.resume();
+        } catch {}
+        pausedTotalMs += performance.now() - cur.pausedAt;
+      }
+      finalize();
+    }
+
+    function togglePause() {
+      const cur = useRecordingStore.getState().state;
+      if (!recorder) return;
+      if (cur.kind === "recording") {
+        try {
+          recorder.pause();
+        } catch {
+          return;
+        }
+        pausedSinceMs = performance.now();
+        useRecordingStore.getState().set({
+          kind: "paused",
+          startedAt: cur.startedAt,
+          bytes: cur.bytes,
+          pausedMs: cur.pausedMs,
+          pausedAt: pausedSinceMs,
+        });
+      } else if (cur.kind === "paused") {
+        try {
+          recorder.resume();
+        } catch {
+          return;
+        }
+        const delta = performance.now() - cur.pausedAt;
+        pausedTotalMs += delta;
+        useRecordingStore.getState().set({
+          kind: "recording",
+          startedAt: cur.startedAt,
+          bytes: cur.bytes,
+          pausedMs: cur.pausedMs + delta,
+        });
+      }
+    }
+
+    function dismissPreview() {
+      const cur = useRecordingStore.getState().state;
+      if (cur.kind === "preview") {
+        try {
+          URL.revokeObjectURL(cur.url);
+        } catch {}
+      }
+      useRecordingStore.getState().set({ kind: "idle" });
+      if (useSessionStore.getState().message.startsWith("Saved ")) {
+        setMessage("");
+      }
+    }
+
+    function onToggle() {
+      const cur = useRecordingStore.getState().state;
+      if (cur.kind === "idle" || cur.kind === "error") {
+        start();
+      } else if (cur.kind === "recording" || cur.kind === "paused") {
+        stop();
+      } else if (cur.kind === "preview") {
+        dismissPreview();
+        start();
+      }
+      // arming/finalizing: ignore — debounce double-taps.
+    }
+
+    function onPause() {
+      togglePause();
+    }
+
+    function onDismiss() {
+      dismissPreview();
+    }
+
+    function onVisibilityChange() {
+      const cur = useRecordingStore.getState().state;
+      if (document.visibilityState === "hidden") {
+        if (cur.kind === "recording") {
+          togglePause();
+          visibilityPaused = true;
+          setMessage("Paused — tab hidden");
+        }
+      } else if (document.visibilityState === "visible" && visibilityPaused) {
+        if (useRecordingStore.getState().state.kind === "paused") {
+          togglePause();
+          if (useSessionStore.getState().message === "Paused — tab hidden") {
+            setMessage("");
+          }
+        }
+        visibilityPaused = false;
+      }
+    }
+
+    document.addEventListener("dd:toggle-record", onToggle);
+    document.addEventListener("dd:pause-record", onPause);
+    document.addEventListener("dd:dismiss-record-preview", onDismiss);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    // Auto-stop if the AudioContext is interrupted (e.g. iOS phone call).
+    const unsubscribeSession = useSessionStore.subscribe((s, prev) => {
+      if (s.player !== prev.player) {
+        // Session reset (or new session) — finalize anything in-flight.
+        const cur = useRecordingStore.getState().state;
+        if (cur.kind === "recording" || cur.kind === "paused") {
+          setMessage("Audio dropped — saved what we had");
+          finalize();
+        }
+      }
+    });
+
+    return () => {
+      document.removeEventListener("dd:toggle-record", onToggle);
+      document.removeEventListener("dd:pause-record", onPause);
+      document.removeEventListener("dd:dismiss-record-preview", onDismiss);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      unsubscribeSession();
+      // If the page is unmounting mid-record, ditch the in-progress data.
+      if (recorder && recorder.state !== "inactive") {
+        try {
+          recorder.stop();
+        } catch {}
+      }
+      teardown();
+    };
+  }, []);
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useRenderLoop.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useRenderLoop.ts
@@ -1,0 +1,278 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+import { tickActiveCursor } from "@/engine/cursor";
+import { kickRms } from "@/engine/render/audioFeatures";
+import { EffectsRenderer } from "@/engine/render/EffectsRenderer";
+import { GraphRenderer } from "@/engine/render/GraphRenderer";
+import { HUD } from "@/engine/render/HUD";
+import {
+  destroyHaloRibbon,
+  destroyRibbons,
+  initHaloRibbon,
+  initRibbons,
+  initStartMarkRibbon,
+  tickHaloRibbon,
+  tickRibbons,
+  tickStartMarkRibbon,
+  type HaloRibbon,
+  type RibbonBar,
+  type StartMarkRibbon,
+} from "@/engine/render/ribbons";
+import {
+  destroyTurntable,
+  initTurntable,
+  tickTurntable,
+  type Turntable,
+} from "@/engine/render/turntable";
+import { useLoraStore } from "@/store/useLoraStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+// Single top-level render loop. Owns HUD + GraphRenderer + EffectsRenderer.
+// RAF-driven; pauses when document is hidden (Phase 8 perf goal #8). Other
+// renderers (Ambient, Ribbons) hook into the same loop in later phases.
+
+interface Refs {
+  hudCanvas: RefObject<HTMLCanvasElement | null>;
+  graphCanvas: RefObject<HTMLCanvasElement | null>;
+  effectsCanvas: RefObject<HTMLCanvasElement | null>;
+  videoA: RefObject<HTMLVideoElement | null>;
+  videoB: RefObject<HTMLVideoElement | null>;
+}
+
+export function useRenderLoop(refs: Refs) {
+  useEffect(() => {
+    const hudEl = refs.hudCanvas.current;
+    const graphEl = refs.graphCanvas.current;
+    const effectsEl = refs.effectsCanvas.current;
+    if (!hudEl || !graphEl) return;
+
+    let cancelled = false;
+    let raf = 0;
+
+    const hud = new HUD(hudEl);
+    const graph = new GraphRenderer(graphEl);
+
+    // Initialise ribbons (one-time DOM mutation against the .install-edge-*
+    // divs rendered by <HUDFrame />). Bars come back as { edge, ribbons[] }.
+    const ribbons: RibbonBar[] = initRibbons();
+
+    // Halo badge ribbons — the SVG itself is rendered by <HaloBadge />;
+    // we just grab a handle to its 4 paths so we can tick them in the
+    // same RAF as the perimeter ribbons.
+    const haloHost = document.querySelector(".halo-badge") as HTMLElement | null;
+    const halo: HaloRibbon | null = haloHost ? initHaloRibbon(haloHost) : null;
+
+    // Turntable grooves — concentric polar paths driven by the live audio
+    // mirror buffer (the music is literally etched into the disc surface).
+    // The button mounts/unmounts with session state so re-query each frame
+    // and cache once it appears.
+    let turntable: Turntable | null = null;
+    let lastTurntableHost: Element | null = null;
+
+    // Start-mark ribbons — wreathe the title-screen logo with the same
+    // ribbon language. The .start-cta doubles as the play button (icon +
+    // whisper share one click target); the render loop ticks the ribbons
+    // regardless so the writhe is already in motion the moment the
+    // overlay is shown.
+    const startMarkHost = document.querySelector(".start-cta") as HTMLElement | null;
+    const startMark: StartMarkRibbon | null = startMarkHost
+      ? initStartMarkRibbon(startMarkHost)
+      : null;
+
+    let effects: EffectsRenderer | null = null;
+    if (effectsEl) {
+      try {
+        effects = new EffectsRenderer(effectsEl);
+        // Sensible defaults; Phase 12 / future hooks may bind these to
+        // sliders. Static values are fine because the kick/time uniforms
+        // are the per-frame variation.
+        effects.setParallaxStrength(0.4);
+        effects.setBloomOnKick(0.3);
+        effects.setBloomThreshold(0.15);
+        effects.setWarpStrength(0.4);
+        effects.setDubstep(0);
+        effects.setDaftPunk(0);
+      } catch (e) {
+        // WebGL2 unavailable → fall back to the raw <video> the canvas
+        // overlays. App still works without bloom/parallax.
+        console.warn("[EffectsRenderer] init failed:", e);
+        effects = null;
+      }
+    }
+
+    let mirrorUnsub: (() => void) | null = null;
+    const sessionUnsub = useSessionStore.subscribe((s) => {
+      mirrorUnsub?.();
+      mirrorUnsub = null;
+      if (s.player) {
+        const refreshHud = () => {
+          const m = s.player!.getMirror();
+          if (m) hud.updateWaveform(m, s.player!.channels);
+        };
+        refreshHud();
+        mirrorUnsub = s.player.onMirrorChange(refreshHud);
+      }
+    });
+    {
+      const player = useSessionStore.getState().player;
+      if (player) {
+        const m = player.getMirror();
+        if (m) hud.updateWaveform(m, player.channels);
+      }
+    }
+
+    let lastSampleAt = 0;
+    const SAMPLE_INTERVAL_MS = 50;
+    const startedAt = performance.now();
+    // Last value written to --bloom-amount. Skipping no-op writes prevents
+    // the rest of the document (badge / perimeter / button drop-shadows
+    // that read --bloom-amount) from re-rastering on frames where the
+    // binned kick hasn't actually changed.
+    let lastBloom = -1;
+
+    function tick(now: number) {
+      if (cancelled) return;
+      const session = useSessionStore.getState();
+      const perf = usePerformanceStore.getState();
+
+      let frac = 0;
+      let kick = 0;
+      if (session.player) {
+        const dur = session.player.duration;
+        const pos = session.player.positionSec;
+        frac = dur > 0 ? Math.max(0, Math.min(1, pos / dur)) : 0;
+        const mirror = session.player.getMirror();
+        kick = kickRms(mirror, pos, dur, session.player.channels);
+      }
+
+      // Bloom CSS var, rounded to 0.1 bins so the document doesn't
+      // re-paint every drop-shadow consumer on every frame. Skip the
+      // write entirely when the binned value hasn't moved — most frames
+      // are no-ops once audio settles. We also pass the binned value
+      // into the canvas tickers (turntable / ribbons / halo / cursor)
+      // so they don't have to call getComputedStyle every frame, which
+      // would force a style recalc and jank the page.
+      const bloom = Math.round(kick * 10) / 10;
+      if (typeof document !== "undefined") {
+        if (bloom !== lastBloom) {
+          document.documentElement.style.setProperty(
+            "--bloom-amount",
+            bloom.toString(),
+          );
+          lastBloom = bloom;
+        }
+      }
+
+      // While paused: AudioContext is suspended, positionSec freezes, and
+      // the playhead marker stops. Skip sampling so the parameter history
+      // also stops advancing — otherwise polylines keep drifting left
+      // behind a frozen playhead. Leaving lastSampleAt untouched means the
+      // next tick after resume samples immediately, no warm-up gap.
+      if (now - lastSampleAt >= SAMPLE_INTERVAL_MS && !perf.paused) {
+        lastSampleAt = now;
+        const lora = useLoraStore.getState();
+        const sample: Record<string, number> = { ...perf.sliderValues };
+        sample.seed = perf.seed;
+        for (const id of lora.enabled) {
+          const v = lora.strengths[id];
+          if (typeof v === "number") sample[`lora_str_${id}`] = v;
+        }
+        graph.sample(sample);
+      }
+
+      hud.draw(frac, { transparentBg: false });
+      graph.draw(kick);
+
+      // Drive ribbons. The top-edge bar's --fill is the denoise slider; the
+      // L/R bars track the first/second active LoRA. For Phase 8 just feed
+      // the denoise value to the top bar so the ribbons animate
+      // immediately; LoRA-driven --fill on the side bars lands in Phase 11.
+      const denoiseFrac = (perf.sliderValues.denoise ?? 0) / 1.0;
+      for (const bar of ribbons) {
+        if (bar.edge.classList.contains("install-edge-top")) {
+          bar.edge.style.setProperty("--fill", denoiseFrac.toString());
+        }
+      }
+      const ribbonTime = (now - startedAt) / 1000;
+      tickRibbons(ribbons, ribbonTime, kick, bloom);
+      if (halo) tickHaloRibbon(halo, ribbonTime, kick, bloom);
+      if (startMark) tickStartMarkRibbon(startMark, ribbonTime);
+
+      // Turntable: the grooves trace the actual audio waveform from the
+      // worklet's mirror buffer. Each frame we walk a slowly-advancing
+      // window over the buffer so the wave appears to "scroll" around the
+      // disc, mimicking a record being played.
+      const turntableHost = document.querySelector(".turntable");
+      if (turntableHost !== lastTurntableHost) {
+        if (turntable) destroyTurntable(turntable);
+        turntable = turntableHost
+          ? initTurntable(turntableHost as HTMLElement)
+          : null;
+        lastTurntableHost = turntableHost;
+      }
+      if (turntable) {
+        const player = useSessionStore.getState().player;
+        const mirror = player?.getMirror() ?? null;
+        const channels = player?.channels ?? 2;
+        tickTurntable(turntable, mirror, channels, ribbonTime, bloom);
+      }
+
+      if (effects) {
+        // Pull whichever <video> is currently the displayed one. VideoLayer
+        // swaps which element holds the active stream; reading both and
+        // picking the one with non-zero opacity is more robust than
+        // tracking who's "active" externally.
+        const videoEl = pickActiveVideo(refs.videoA.current, refs.videoB.current);
+        const elapsed = (now - startedAt) / 1000;
+        effects.tick(videoEl, elapsed, kick);
+      }
+
+      // Cursor — driven from this loop instead of its own RAF (saves a
+      // vsync wakeup and keeps draws in one batch per frame). Bloom is
+      // the same binned kick value the ribbons receive, so the cursor's
+      // glow halo pulses in lockstep with the perimeter ribbons without
+      // either side needing to read a CSS variable.
+      tickActiveCursor(now, bloom);
+
+      raf = requestAnimationFrame(tick);
+    }
+
+    function onVisibility() {
+      if (document.hidden) {
+        if (raf) cancelAnimationFrame(raf);
+        raf = 0;
+      } else if (!raf && !cancelled) {
+        raf = requestAnimationFrame(tick);
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+
+    raf = requestAnimationFrame(tick);
+
+    return () => {
+      cancelled = true;
+      if (raf) cancelAnimationFrame(raf);
+      document.removeEventListener("visibilitychange", onVisibility);
+      sessionUnsub();
+      mirrorUnsub?.();
+      hud.destroy();
+      graph.destroy();
+      effects?.destroy();
+      if (turntable) destroyTurntable(turntable);
+      destroyRibbons(ribbons);
+      if (halo) destroyHaloRibbon(halo);
+    };
+  }, [refs.hudCanvas, refs.graphCanvas, refs.effectsCanvas, refs.videoA, refs.videoB]);
+}
+
+function pickActiveVideo(
+  a: HTMLVideoElement | null,
+  b: HTMLVideoElement | null,
+): HTMLVideoElement | null {
+  if (a && a.style.opacity !== "0" && a.readyState >= 2) return a;
+  if (b && b.style.opacity !== "0" && b.readyState >= 2) return b;
+  return a ?? b;
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useScheduledCurves.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useScheduledCurves.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { evaluateCurve } from "@/engine/curves/interp";
+import {
+  isManualOverrideActive,
+  usePerformanceStore,
+} from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+import { useCurveStore } from "@/store/useCurveStore";
+import { LORA_SLIDER_MAX, SLIDER_META } from "@/types/engine";
+
+// Per-frame application of curve-scheduled param values.
+//
+// Each rAF tick:
+//   1. Read the active session's playhead in seconds.
+//   2. For every curve where `enabled === true`:
+//      - Map playhead seconds → t ∈ [0,1] over the track duration.
+//      - Evaluate the curve at t (Catmull-Rom / linear / step).
+//      - Map y ∈ [0,1] → param's [0, max] via SLIDER_META.
+//      - Write directly into sliderValues + sliderTargets via
+//        usePerformanceStore.setSliderDirect.
+//   3. If the user manually touched a slider in the last 500 ms, the
+//      curve yields for that param — manual override briefly wins,
+//      then the curve resumes on the next tick past the window.
+//
+// Subscribes to neither store via reactive selectors — reads via
+// .getState() every frame. This is intentional: curves change at
+// rAF cadence, not at React-render cadence; reactive subscriptions
+// would just churn renders without any visible effect.
+export function useScheduledCurves(): void {
+  useEffect(() => {
+    let raf = 0;
+    let cancelled = false;
+
+    const tick = () => {
+      if (cancelled) return;
+      const curveState = useCurveStore.getState();
+      // Master kill-switch: when disabled, no curve drives anything,
+      // regardless of per-curve enabled flags. The user's drawings are
+      // preserved; they just don't apply.
+      if (!curveState.scheduleEnabled) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+      const session = useSessionStore.getState();
+      const player = session.player;
+      const remote = session.remote;
+      // Need both: player gives us positionSec, remote gives duration
+      // (audio length the engine is generating against). Skip cleanly
+      // when not playing.
+      if (player && remote && remote.duration > 0) {
+        const t = Math.min(
+          1,
+          Math.max(0, player.positionSec / remote.duration),
+        );
+        const curves = curveState.curves;
+        const setSliderDirect =
+          usePerformanceStore.getState().setSliderDirect;
+        for (const param of Object.keys(curves)) {
+          const c = curves[param];
+          if (!c.enabled) continue;
+          if (isManualOverrideActive(param)) continue;
+          const yNorm = evaluateCurve(c.points, t);
+          // LoRA strength params (lora_str_<id>) aren't in SLIDER_META;
+          // their range is fixed by LORA_SLIDER_MAX. Everything else
+          // looks up its own max from SLIDER_META.
+          const max = param.startsWith("lora_str_")
+            ? LORA_SLIDER_MAX
+            : (SLIDER_META[param]?.max ?? 1.0);
+          setSliderDirect(param, yNorm * max);
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+    };
+  }, []);
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -1,0 +1,193 @@
+"use client";
+
+import { useCallback } from "react";
+
+import { AudioPlayer } from "@/engine/audio/AudioPlayer";
+import { listFixtures, loadFixtureAudio } from "@/engine/audio/loadFixture";
+import { defaultWsUrl } from "@/engine/podUrl";
+import { RemoteBackend, SLICE_FLAG_DELTA } from "@/engine/protocol";
+import { getApiKey } from "@/engine/rtmgConfig";
+import { useLoraStore } from "@/store/useLoraStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+import type { AudioSlice, SessionConfig } from "@/types/protocol";
+
+/**
+ * Resolve the WS URL for this session. Preference order:
+ *   1. server-issued wsUrl (from /api/queue/join, signed when RTMG_TOKEN_SECRET set)
+ *   2. defaultWsUrl() — `?ws=` URL override or NEXT_PUBLIC_POD_BASE_URL
+ *
+ * If signed in, the daydream apiKey is appended as `?apiKey=<key>` so the
+ * pod can identify the user it's debiting via webhook. Mirrors the rtmg
+ * engine's WS handshake — the pod side must accept the parameter (out of
+ * scope for this repo).
+ */
+function resolveWsUrl(serverWsUrl: string | null): string {
+  let url = serverWsUrl ?? defaultWsUrl();
+  const apiKey = getApiKey();
+  if (apiKey) {
+    const sep = url.includes("?") ? "&" : "?";
+    url = `${url}${sep}apiKey=${encodeURIComponent(apiKey)}`;
+  }
+  return url;
+}
+
+// Drives the whole "click Play" flow:
+//   1. resolve fixture (use store, fall back to first listed)
+//   2. load + decode audio
+//   3. open WS with config built from current store state
+//   4. on "ready": init AudioPlayer with initial buffer
+//   5. wire slice → patch/addDelta, lora_catalog → useLoraStore, etc.
+//   6. resume audio context
+
+function buildConfig(): SessionConfig {
+  const perf = usePerformanceStore.getState();
+  const lora = useLoraStore.getState();
+  const enabledLoras = Array.from(lora.enabled);
+  const loraStrengths: Record<string, number> = {};
+  for (const id of enabledLoras) {
+    const v = lora.strengths[id];
+    if (typeof v === "number") loraStrengths[id] = v;
+  }
+  return {
+    sde: false,
+    lora: true,
+    depth: 8,
+    vae_window: 6,
+    crop: 0,
+    steps: 8,
+    fast_vae: false,
+    key: perf.activeKey,
+    enabled_loras: enabledLoras,
+    prompt: perf.promptA,
+    lora_strengths: loraStrengths,
+  };
+}
+
+export function useStartSession() {
+  return useCallback(async () => {
+    const { setStatus, setSession, reset } = useSessionStore.getState();
+
+    // Tear down any in-flight session.
+    const prev = useSessionStore.getState();
+    try {
+      await prev.player?.close();
+    } catch {}
+    try {
+      prev.remote?.close();
+    } catch {}
+    reset();
+
+    setStatus("loading-fixture", "Loading track…");
+
+    let fixtureName = usePerformanceStore.getState().fixture;
+    if (!fixtureName) {
+      try {
+        const list = await listFixtures();
+        fixtureName = list[0] ?? "";
+        if (fixtureName) {
+          usePerformanceStore.getState().setFixture(fixtureName);
+        }
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setStatus("error", `Track list failed: ${msg}`);
+        return;
+      }
+    }
+    if (!fixtureName) {
+      setStatus("error", "No tracks available. Please refresh.");
+      return;
+    }
+
+    let interleaved: Float32Array;
+    let channels: number;
+    try {
+      const decoded = await loadFixtureAudio(fixtureName);
+      interleaved = decoded.interleaved;
+      channels = decoded.channels;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setStatus("error", `Track failed to load: ${msg}`);
+      return;
+    }
+
+    setStatus("connecting", "Connecting…");
+    const config = buildConfig();
+    const wsUrl = resolveWsUrl(useSessionStore.getState().wsUrl);
+    const remote = new RemoteBackend(
+      wsUrl,
+      interleaved,
+      channels,
+      config,
+    );
+
+    // Wire engine → store. Bind BEFORE connect() so we never miss the first
+    // few slices (server can send within milliseconds of "ready").
+    remote.addEventListener("slice", (e) => {
+      const detail = (e as CustomEvent<AudioSlice>).detail;
+      const player = useSessionStore.getState().player;
+      if (!player) return;
+      const startFrame = Math.floor(detail.startSample);
+      if (detail.flags === SLICE_FLAG_DELTA) {
+        player.addDelta(startFrame, detail.audio);
+      } else {
+        player.patch(startFrame, detail.audio);
+      }
+    });
+
+    remote.addEventListener("lora_catalog", (e) => {
+      const detail = (e as CustomEvent).detail;
+      useLoraStore.getState().setCatalog(detail);
+    });
+
+    remote.addEventListener("close", (e) => {
+      const detail = (e as CustomEvent<CloseEvent>).detail;
+      const reason = detail?.reason || `code ${detail?.code}`;
+      useSessionStore.getState().setStatus(
+        "closed",
+        `Something went wrong and you’ve been disconnected. Disconnect code: (${reason})`,
+      );
+    });
+
+    remote.addEventListener("error", () => {
+      // The connect() promise will reject too; defer messaging to that path.
+    });
+
+    try {
+      await remote.connect();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setStatus("error", msg);
+      return;
+    }
+
+    if (!remote.initialBuffer) {
+      setStatus("error", "Track failed to load.");
+      return;
+    }
+
+    setStatus("connecting", "Starting audio…");
+
+    const player = new AudioPlayer();
+    try {
+      await player.init(remote.initialBuffer, remote.channels);
+      await player.resume();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setStatus("error", `Audio failed to start: ${msg}`);
+      return;
+    }
+
+    // Server-detected metadata flows into the perf store so the key select
+    // and HUD reflect it without manual sync.
+    usePerformanceStore
+      .getState()
+      .setDetected(remote.detectedBpm, remote.detectedKey);
+    if (remote.loraCatalog.length > 0) {
+      useLoraStore.getState().setCatalog(remote.loraCatalog);
+    }
+
+    setSession(remote, player);
+    setStatus("ready", "Playing");
+  }, []);
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useVideoLayer.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useVideoLayer.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+import { listVideos } from "@/engine/video/listVideos";
+import { VideoLayer } from "@/engine/video/VideoLayer";
+import { useSessionStore } from "@/store/useSessionStore";
+
+interface Refs {
+  videoA: RefObject<HTMLVideoElement | null>;
+  videoB: RefObject<HTMLVideoElement | null>;
+}
+
+// Mounts VideoLayer once both <video> refs are populated. Wires the audio
+// position feed from the live AudioPlayer; queues + plays the first
+// available video. Phase 11 / future: per-prompt video selection.
+
+export function useVideoLayer(refs: Refs) {
+  const layerRef = useRef<VideoLayer | null>(null);
+
+  // Effect 1 — VideoLayer lifecycle. Stays bound to the refs only, not
+  // session state, so we don't recreate the layer on every queue tick.
+  useEffect(() => {
+    const a = refs.videoA.current;
+    const b = refs.videoB.current;
+    if (!a || !b) return;
+
+    const layer = new VideoLayer({
+      videoA: a,
+      videoB: b,
+      bpm: 134, // Server overrides via setBpm() once detected.
+      crossfadeDuration: 1.5,
+      useMarkers: false, // Drift-correction fallback by default.
+    });
+    layerRef.current = layer;
+
+    // Hook into the live audio player whenever the session changes.
+    const sessionUnsub = useSessionStore.subscribe((s) => {
+      if (s.player) {
+        layer.setAudioSource(() => s.player?.positionSec ?? 0, true);
+      } else {
+        layer.setAudioSource(() => 0, false);
+      }
+    });
+    {
+      const initial = useSessionStore.getState().player;
+      if (initial) {
+        layer.setAudioSource(() => initial.positionSec, true);
+      }
+    }
+
+    return () => {
+      sessionUnsub();
+      layer.destroy();
+      layerRef.current = null;
+    };
+  }, [refs.videoA, refs.videoB]);
+
+  // Effect 2 — fetch the available video list once the queue admits us
+  // (sessionWsUrl flips truthy). The pod proxy at /api/pod/* refuses
+  // requests pre-admit, so calling listVideos() on mount before the
+  // queue completes would 401. Re-runs if wsUrl changes (re-admission).
+  const sessionWsUrl = useSessionStore((s) => s.wsUrl);
+  useEffect(() => {
+    if (!sessionWsUrl) return;
+    const layer = layerRef.current;
+    if (!layer) return;
+    let cancelled = false;
+    void listVideos()
+      .then((names) => {
+        if (cancelled || names.length === 0) return;
+        layer.setVideos(names);
+        layer.play(names[0]);
+      })
+      .catch(() => {
+        // Pod may not have any videos; silently fall back to no video.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionWsUrl]);
+}

--- a/demos/realtime_motion_graph_web/web/lib/audio/encodeWav.ts
+++ b/demos/realtime_motion_graph_web/web/lib/audio/encodeWav.ts
@@ -1,0 +1,57 @@
+// Encode an AudioBuffer as 16-bit PCM WAV. Channels are interleaved.
+// Float samples are clamped to [-1, 1] and scaled to Int16 range.
+export function encodeWav(buffer: AudioBuffer): Blob {
+  const numCh = buffer.numberOfChannels;
+  const sampleRate = buffer.sampleRate;
+  const numFrames = buffer.length;
+  const bytesPerSample = 2;
+  const dataLen = numFrames * numCh * bytesPerSample;
+  const bufferSize = 44 + dataLen;
+
+  const out = new ArrayBuffer(bufferSize);
+  const view = new DataView(out);
+
+  // RIFF header
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataLen, true);
+  writeAscii(view, 8, "WAVE");
+
+  // fmt subchunk (PCM)
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true); // subchunk size
+  view.setUint16(20, 1, true); // PCM format
+  view.setUint16(22, numCh, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * numCh * bytesPerSample, true); // byte rate
+  view.setUint16(32, numCh * bytesPerSample, true); // block align
+  view.setUint16(34, 8 * bytesPerSample, true); // bits per sample
+
+  // data subchunk
+  writeAscii(view, 36, "data");
+  view.setUint32(40, dataLen, true);
+
+  // Pre-pull channel data — getChannelData() can be expensive if called per-sample.
+  const channels: Float32Array[] = new Array(numCh);
+  for (let c = 0; c < numCh; c++) channels[c] = buffer.getChannelData(c);
+
+  // Interleave + convert. Use a typed-array view onto the existing buffer so
+  // we don't allocate a second copy.
+  const pcm = new Int16Array(out, 44, numFrames * numCh);
+  let p = 0;
+  for (let i = 0; i < numFrames; i++) {
+    for (let c = 0; c < numCh; c++) {
+      const s = channels[c][i];
+      const clamped = s < -1 ? -1 : s > 1 ? 1 : s;
+      // Asymmetric scaling (32767 / 32768) keeps full negative range without wrapping.
+      pcm[p++] = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+    }
+  }
+
+  return new Blob([out], { type: "audio/wav" });
+}
+
+function writeAscii(view: DataView, offset: number, text: string) {
+  for (let i = 0; i < text.length; i++) {
+    view.setUint8(offset + i, text.charCodeAt(i));
+  }
+}

--- a/demos/realtime_motion_graph_web/web/next.config.ts
+++ b/demos/realtime_motion_graph_web/web/next.config.ts
@@ -1,0 +1,23 @@
+import type { NextConfig } from "next";
+
+// During development, Next runs on :3000 and the Python engine on :8765.
+// The UI's engine-URL builder fetches /api/* and /fixtures/* (etc.) at
+// the same origin; rewrites bridge those to the engine. Same trick the
+// vanilla static demo gets for free since it's served by the engine
+// directly.
+//
+// In production, you'd typically `next build && next start` and run the
+// engine on a different port (or front Next behind nginx that does the
+// routing). For local dev this is the one-line fix.
+const nextConfig: NextConfig = {
+  async rewrites() {
+    return [
+      { source: "/api/:path*", destination: "http://localhost:8765/api/:path*" },
+      { source: "/fixtures/:path*", destination: "http://localhost:8765/fixtures/:path*" },
+      { source: "/loras/:path*", destination: "http://localhost:8765/loras/:path*" },
+      { source: "/videos/:path*", destination: "http://localhost:8765/videos/:path*" },
+    ];
+  },
+};
+
+export default nextConfig;

--- a/demos/realtime_motion_graph_web/web/package-lock.json
+++ b/demos/realtime_motion_graph_web/web/package-lock.json
@@ -1,0 +1,1021 @@
+{
+  "name": "demon-realtime-motion-graph-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "demon-realtime-motion-graph-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "fzstd": "^0.1.1",
+        "next": "16.2.4",
+        "react": "19.2.4",
+        "react-dom": "19.2.4",
+        "zustand": "^5.0.12"
+      },
+      "devDependencies": {
+        "@types/node": "^20",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "@types/webmidi": "^2.1.0",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
+      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/webmidi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/webmidi/-/webmidi-2.1.0.tgz",
+      "integrity": "sha512-k898MjEUSHB+6rSeCPQk/kLgie0wgWZ2t78GlWj86HbTQ+XmtbBafYg5LNjn8bVHfItEhPGZPf579Xfc6keV6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
+      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.4",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.4",
+        "@next/swc-darwin-x64": "16.2.4",
+        "@next/swc-linux-arm64-gnu": "16.2.4",
+        "@next/swc-linux-arm64-musl": "16.2.4",
+        "@next/swc-linux-x64-gnu": "16.2.4",
+        "@next/swc-linux-x64-musl": "16.2.4",
+        "@next/swc-win32-arm64-msvc": "16.2.4",
+        "@next/swc-win32-x64-msvc": "16.2.4",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/demos/realtime_motion_graph_web/web/package.json
+++ b/demos/realtime_motion_graph_web/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "demon-realtime-motion-graph-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "fzstd": "^0.1.1",
+    "next": "16.2.4",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "zustand": "^5.0.12"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@types/webmidi": "^2.1.0",
+    "typescript": "^5"
+  }
+}

--- a/demos/realtime_motion_graph_web/web/public/audio-worklet.js
+++ b/demos/realtime_motion_graph_web/web/public/audio-worklet.js
@@ -1,0 +1,157 @@
+// AudioWorklet that plays a looping PCM buffer the main thread can
+// patch in place. Mirrors demos/realtime_motion_graph_web/audio_engine.py
+// (swap / patch / crossfade behaviour).
+//
+// Messages from main thread:
+//   {type:'init',     buffer:Float32Array (interleaved), channels:int}
+//   {type:'patch',    start:int (frame),  audio:Float32Array (interleaved)}
+//   {type:'add',      start:int (frame),  audio:Float32Array (interleaved)}  // delta add
+//   {type:'swap',     buffer:Float32Array, channels:int}
+//
+// Messages to main thread:
+//   {type:'position', positionSec:float, swapCount:int}
+
+const CROSSFADE_SECONDS = 0.05;
+const SEAM_FADE_SECONDS = 0.05;  // loop-seam crossfade at end-of-buffer
+const REPORT_EVERY = 1024;  // frames between position reports
+
+class RealtimeBufferProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.current = null;          // Float32Array, interleaved
+    this.channels = 2;
+    this.frameCount = 0;          // frames in current buffer
+    this.position = 0;            // playhead in frames
+    this.swapCount = 0;
+
+    this.oldBuffer = null;
+    this.oldFrameCount = 0;
+    this.fading = false;
+    this.fadePos = 0;
+    this.crossfadeLen = Math.max(1, Math.floor(sampleRate * CROSSFADE_SECONDS));
+    this.seamFadeLen = Math.max(1, Math.floor(sampleRate * SEAM_FADE_SECONDS));
+
+    this._framesSinceReport = 0;
+
+    this.port.onmessage = (e) => this._onmessage(e.data);
+  }
+
+  _onmessage(msg) {
+    const { type } = msg;
+    if (type === "init") {
+      this.current = msg.buffer;
+      this.channels = msg.channels || 2;
+      this.frameCount = this.current.length / this.channels;
+      this.position = 0;
+      this.swapCount = 0;
+      return;
+    }
+    if (type === "swap") {
+      this.oldBuffer = this.current;
+      this.oldFrameCount = this.frameCount;
+      this.current = msg.buffer;
+      this.channels = msg.channels || this.channels;
+      this.frameCount = this.current.length / this.channels;
+      this.swapCount++;
+      this.fading = true;
+      this.fadePos = 0;
+      return;
+    }
+    if (type === "patch" || type === "add") {
+      if (!this.current) return;
+      const start = msg.start | 0;
+      const slice = msg.audio;            // Float32Array, interleaved
+      const ch = this.channels;
+      const sliceFrames = (slice.length / ch) | 0;
+      if (sliceFrames <= 0) return;
+
+      const end = Math.min(start + sliceFrames, this.frameCount);
+      const actual = end - start;
+      if (actual <= 0) return;
+
+      const base = start * ch;
+      const count = actual * ch;
+      if (type === "add") {
+        // Delta add: matches ``current[s:e] += data`` in server/client path.
+        for (let i = 0; i < count; i++) this.current[base + i] += slice[i];
+      } else {
+        // Raw patch: matches AudioEngine.patch.  Server only sends raw
+        // patches for the initial buffer, so seam xfades are unnecessary.
+        for (let i = 0; i < count; i++) this.current[base + i] = slice[i];
+      }
+      return;
+    }
+  }
+
+  process(_inputs, outputs) {
+    const output = outputs[0];
+    const frames = output[0].length;
+    const outChannels = output.length;
+
+    if (!this.current || this.frameCount === 0) {
+      for (let c = 0; c < outChannels; c++) output[c].fill(0);
+      return true;
+    }
+
+    const ch = this.channels;
+    const nCur = this.frameCount;
+    // Loop-seam crossfade: blend the last `seam` frames with the first
+    // `seam` frames of the buffer, then wrap the playhead to `seam` so
+    // the head we just mixed isn't replayed. Hides the click that would
+    // otherwise pop on every wrap, and softens the structural mismatch
+    // when the source song doesn't loop musically.
+    const seam = Math.min(this.seamFadeLen, Math.floor(nCur / 4));
+
+    for (let i = 0; i < frames; i++) {
+      const pos = this.position;
+
+      if (this.fading && this.oldBuffer) {
+        const fadeT = Math.min(1, this.fadePos / this.crossfadeLen);
+        const oldPos = this.position % this.oldFrameCount;
+        for (let c = 0; c < outChannels; c++) {
+          const cc = Math.min(c, ch - 1);
+          const sNew = this.current[pos * ch + cc];
+          const sOld = this.oldBuffer[oldPos * ch + cc];
+          output[c][i] = sOld * (1 - fadeT) + sNew * fadeT;
+        }
+        this.fadePos++;
+        if (this.fadePos >= this.crossfadeLen) {
+          this.fading = false;
+          this.oldBuffer = null;
+        }
+      } else if (seam > 0 && (nCur - pos) <= seam) {
+        const distFromEnd = nCur - pos;
+        const t = (seam - distFromEnd) / seam;
+        const headPos = seam - distFromEnd;
+        for (let c = 0; c < outChannels; c++) {
+          const cc = Math.min(c, ch - 1);
+          const sTail = this.current[pos * ch + cc];
+          const sHead = this.current[headPos * ch + cc];
+          output[c][i] = sTail * (1 - t) + sHead * t;
+        }
+      } else {
+        for (let c = 0; c < outChannels; c++) {
+          const cc = Math.min(c, ch - 1);
+          output[c][i] = this.current[pos * ch + cc];
+        }
+      }
+
+      this.position++;
+      if (this.position >= nCur) this.position = seam;
+    }
+
+    this._framesSinceReport += frames;
+    if (this._framesSinceReport >= REPORT_EVERY) {
+      this._framesSinceReport = 0;
+      this.port.postMessage({
+        type: "position",
+        positionSec: this.position / sampleRate,
+        swapCount: this.swapCount,
+      });
+    }
+
+    return true;
+  }
+}
+
+registerProcessor("realtime-buffer", RealtimeBufferProcessor);

--- a/demos/realtime_motion_graph_web/web/store/useCurveStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useCurveStore.ts
@@ -1,0 +1,192 @@
+"use client";
+
+import { create } from "zustand";
+
+import {
+  type CurvePoint,
+  type CurveState,
+  SCHEDULEABLE_PARAMS,
+  defaultCurveState,
+} from "@/types/curves";
+
+// Curve-scheduling state. Per-param curves the user draws in the
+// ScheduleCurvesOverlay; applied by useScheduledCurves at rAF cadence.
+//
+// Persistence: the entire state (curves + scheduleEnabled + activeCurve)
+// is JSON-stringified to a single localStorage key so user state
+// survives reloads. Hydration runs in a client-only useEffect.
+//
+// Dynamic params: keys can be any string the engine accepts (the fixed
+// set in SCHEDULEABLE_PARAMS is just the always-shown tabs; LoRA
+// strength curves use lora_str_<id> keys added at runtime when the
+// LoRA catalog arrives).
+
+const CURVES_STORAGE_KEY = "demon:curves";
+const SCHEDULE_ENABLED_KEY = "demon:scheduleEnabled";
+
+type CurveMap = Record<string, CurveState>;
+
+function freshCurveMap(): CurveMap {
+  const out: CurveMap = {};
+  for (const p of SCHEDULEABLE_PARAMS) out[p] = defaultCurveState();
+  return out;
+}
+
+function loadCurves(): CurveMap | null {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(CURVES_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<CurveMap>;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    // Merge with defaults so a stored snapshot from an earlier version
+    // (with fewer params) hydrates cleanly. Persist any extra param
+    // keys (LoRA curves) too.
+    const fresh: CurveMap = freshCurveMap();
+    for (const key of Object.keys(parsed)) {
+      const stored = parsed[key];
+      if (
+        stored &&
+        Array.isArray(stored.points) &&
+        stored.points.length >= 2 &&
+        typeof stored.enabled === "boolean"
+      ) {
+        fresh[key] = stored as CurveState;
+      }
+    }
+    return fresh;
+  } catch {
+    return null;
+  }
+}
+
+function saveCurves(curves: CurveMap): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(CURVES_STORAGE_KEY, JSON.stringify(curves));
+  } catch {}
+}
+
+function loadScheduleEnabled(): boolean {
+  if (typeof localStorage === "undefined") return true;
+  try {
+    const v = localStorage.getItem(SCHEDULE_ENABLED_KEY);
+    if (v === null) return true;
+    return v === "1";
+  } catch {
+    return true;
+  }
+}
+
+function saveScheduleEnabled(b: boolean): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(SCHEDULE_ENABLED_KEY, b ? "1" : "0");
+  } catch {}
+}
+
+interface CurveStore {
+  curves: CurveMap;
+  /** Which curve is shown / edited in the tab strip. Stored as a
+   *  string so LoRA params (lora_str_<id>) work too. */
+  activeCurve: string;
+  /** Overlay open / closed. Toggled from OperatorStrip's SCHEDULE
+   *  CURVES button (and ESC / × inside the overlay). */
+  overlayOpen: boolean;
+  /** Master enable. When false, NO curve drives any param, regardless
+   *  of per-curve enabled flags. Lets the user "pause" all
+   *  automation without losing their drawings. Persisted. */
+  scheduleEnabled: boolean;
+
+  setCurvePoints: (param: string, points: CurvePoint[]) => void;
+  setCurveEnabled: (param: string, enabled: boolean) => void;
+  setActiveCurve: (param: string) => void;
+  toggleOverlay: () => void;
+  closeOverlay: () => void;
+  resetCurve: (param: string) => void;
+  toggleScheduleEnabled: () => void;
+  setScheduleEnabled: (b: boolean) => void;
+  /** Lazily allocate a curve for a param the first time it's
+   *  referenced. Useful for dynamic params (LoRA strengths) that
+   *  weren't in SCHEDULEABLE_PARAMS at boot. */
+  ensureCurve: (param: string) => void;
+
+  /** Read localStorage (client-only) and apply. SSR returns null so
+   *  this is a no-op until a useEffect calls it post-mount. */
+  hydratePersistedCurves: () => void;
+}
+
+export const useCurveStore = create<CurveStore>((set, get) => ({
+  curves: freshCurveMap(),
+  activeCurve: "denoise",
+  overlayOpen: false,
+  scheduleEnabled: true,
+
+  setCurvePoints: (param, points) => {
+    const sorted = [...points].sort((a, b) => a.x - b.x);
+    if (sorted.length >= 2) {
+      sorted[0] = { ...sorted[0], x: 0 };
+      sorted[sorted.length - 1] = { ...sorted[sorted.length - 1], x: 1 };
+    }
+    const prev = get().curves[param] ?? defaultCurveState();
+    const next: CurveMap = {
+      ...get().curves,
+      [param]: { enabled: true, points: sorted },
+    };
+    if (prev.enabled === false && sorted.length === prev.points.length) {
+      next[param].enabled = prev.enabled;
+    }
+    saveCurves(next);
+    set({ curves: next });
+  },
+
+  setCurveEnabled: (param, enabled) => {
+    const prev = get().curves[param] ?? defaultCurveState();
+    const next: CurveMap = {
+      ...get().curves,
+      [param]: { ...prev, enabled },
+    };
+    saveCurves(next);
+    set({ curves: next });
+  },
+
+  setActiveCurve: (param) => set({ activeCurve: param }),
+
+  toggleOverlay: () => set((s) => ({ overlayOpen: !s.overlayOpen })),
+  closeOverlay: () => set({ overlayOpen: false }),
+
+  resetCurve: (param) => {
+    const next: CurveMap = {
+      ...get().curves,
+      [param]: defaultCurveState(),
+    };
+    saveCurves(next);
+    set({ curves: next });
+  },
+
+  toggleScheduleEnabled: () =>
+    set((s) => {
+      const v = !s.scheduleEnabled;
+      saveScheduleEnabled(v);
+      return { scheduleEnabled: v };
+    }),
+  setScheduleEnabled: (b) => {
+    saveScheduleEnabled(b);
+    set({ scheduleEnabled: b });
+  },
+
+  ensureCurve: (param) => {
+    if (get().curves[param]) return;
+    const next: CurveMap = {
+      ...get().curves,
+      [param]: defaultCurveState(),
+    };
+    set({ curves: next });
+  },
+
+  hydratePersistedCurves: () => {
+    const loaded = loadCurves();
+    if (loaded) set({ curves: loaded });
+    set({ scheduleEnabled: loadScheduleEnabled() });
+  },
+}));

--- a/demos/realtime_motion_graph_web/web/store/useCustomTracksStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useCustomTracksStore.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { create } from "zustand";
+
+import type { DecodedFixture } from "@/engine/audio/loadFixture";
+
+// In-memory cache for user-uploaded tracks. The decoded PCM lives in a
+// non-reactive Map (Float32Array doesn't survive JSON / localStorage), and
+// the names are mirrored into a reactive list so the fixture dropdown
+// re-renders when an upload completes. Cleared on page reload — uploads
+// are session-scoped, matching how the pod treats fixtures (it only ever
+// sees the decoded PCM, never the file).
+
+interface CustomTracksState {
+  /** Names in upload order. Reactive — components subscribe to this. */
+  names: string[];
+  /** Decoded buffers keyed by name. Read directly via getState() from
+   *  non-React code (loadFixtureAudio); updates don't re-render. */
+  decoded: Map<string, DecodedFixture>;
+
+  add: (name: string, decoded: DecodedFixture) => void;
+  has: (name: string) => boolean;
+}
+
+export const useCustomTracksStore = create<CustomTracksState>((set, get) => ({
+  names: [],
+  decoded: new Map(),
+
+  add: (name, decoded) =>
+    set((s) => {
+      const nextDecoded = new Map(s.decoded);
+      nextDecoded.set(name, decoded);
+      const nextNames = s.names.includes(name) ? s.names : [...s.names, name];
+      return { names: nextNames, decoded: nextDecoded };
+    }),
+
+  has: (name) => get().decoded.has(name),
+}));

--- a/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { create } from "zustand";
+
+import {
+  LORA_DEFAULT_STRENGTH_FRACTION,
+  LORA_SLIDER_MAX,
+} from "@/types/engine";
+import type { LoraCatalogEntry } from "@/types/protocol";
+
+// Server-driven LoRA catalog + per-id strength + enabled set. The catalog
+// arrives via /api/loras (cheap filesystem scan, available before WS) and
+// is updated mid-session via the WS "lora_catalog" frame.
+
+// LoRAs flipped on the first time the catalog arrives populated. Matches the
+// safetensors filename stems delivered by /api/loras (see scripts/loras.default.txt).
+// One-shot: a later WS lora_catalog re-broadcast won't re-enable a LoRA the
+// user has explicitly disabled.
+const DEFAULT_ENABLED_LORAS = new Set(["deathstep", "synthpop"]);
+
+interface LoraState {
+  catalog: LoraCatalogEntry[];
+  /** Per-id strength (0..LORA_SLIDER_MAX). */
+  strengths: Record<string, number>;
+  /** Set of enabled LoRA ids. */
+  enabled: Set<string>;
+  /** Whether default-on LoRAs have already been seeded for this session. */
+  _seeded: boolean;
+
+  setCatalog: (catalog: LoraCatalogEntry[]) => void;
+  setStrength: (id: string, value: number) => void;
+  enable: (id: string) => void;
+  disable: (id: string) => void;
+  toggle: (id: string) => void;
+  reset: () => void;
+}
+
+export const useLoraStore = create<LoraState>((set) => ({
+  catalog: [],
+  strengths: {},
+  enabled: new Set(),
+  _seeded: false,
+
+  setCatalog: (catalog) =>
+    set((s) => {
+      // Seed missing strengths from the server's reported defaults so a
+      // freshly-arrived LoRA picks up its on-disk default. If the server
+      // omits `strength` (current Python backend behavior), fall back to
+      // LORA_DEFAULT_STRENGTH_FRACTION so the slider lands at a useful
+      // initial level instead of silently sitting at 0.
+      const next: Record<string, number> = { ...s.strengths };
+      for (const entry of catalog) {
+        if (!(entry.id in next)) {
+          next[entry.id] =
+            typeof entry.strength === "number"
+              ? entry.strength
+              : LORA_DEFAULT_STRENGTH_FRACTION * LORA_SLIDER_MAX;
+        }
+      }
+      // First populated catalog: flip on the canonical default LoRAs so the
+      // demo plays with its intended sound out of the box. Skipped on later
+      // re-broadcasts so disabling a default LoRA sticks.
+      let enabled = s.enabled;
+      let seeded = s._seeded;
+      if (!s._seeded && catalog.length > 0) {
+        const nextEnabled = new Set(s.enabled);
+        for (const entry of catalog) {
+          if (DEFAULT_ENABLED_LORAS.has(entry.id)) nextEnabled.add(entry.id);
+        }
+        enabled = nextEnabled;
+        seeded = true;
+      }
+      return { catalog, strengths: next, enabled, _seeded: seeded };
+    }),
+  setStrength: (id, value) =>
+    set((s) => ({ strengths: { ...s.strengths, [id]: value } })),
+  enable: (id) =>
+    set((s) => {
+      if (s.enabled.has(id)) return {} as Partial<LoraState>;
+      const next = new Set(s.enabled);
+      next.add(id);
+      return { enabled: next };
+    }),
+  disable: (id) =>
+    set((s) => {
+      if (!s.enabled.has(id)) return {} as Partial<LoraState>;
+      const next = new Set(s.enabled);
+      next.delete(id);
+      return { enabled: next };
+    }),
+  toggle: (id) =>
+    set((s) => {
+      const next = new Set(s.enabled);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return { enabled: next };
+    }),
+  reset: () =>
+    set({ catalog: [], strengths: {}, enabled: new Set(), _seeded: false }),
+}));

--- a/demos/realtime_motion_graph_web/web/store/useMidiStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useMidiStore.ts
@@ -1,0 +1,169 @@
+"use client";
+
+import { create } from "zustand";
+
+import {
+  DEFAULT_MIDI_MAP,
+  MIDI_STORAGE_KEY,
+  type MidiMap,
+  type NoteAction,
+} from "@/engine/midi/types";
+
+function loadMap(): MidiMap {
+  if (typeof localStorage === "undefined") {
+    return {
+      cc: { ...DEFAULT_MIDI_MAP.cc },
+      notes: { ...DEFAULT_MIDI_MAP.notes },
+      ccActions: { ...(DEFAULT_MIDI_MAP.ccActions ?? {}) },
+    };
+  }
+  try {
+    const stored = JSON.parse(localStorage.getItem(MIDI_STORAGE_KEY) || "null");
+    if (stored && stored.cc && stored.notes) {
+      return {
+        cc: { ...stored.cc },
+        notes: { ...stored.notes },
+        ccActions: { ...(stored.ccActions ?? {}) },
+      };
+    }
+  } catch {}
+  return {
+    cc: { ...DEFAULT_MIDI_MAP.cc },
+    notes: { ...DEFAULT_MIDI_MAP.notes },
+    ccActions: { ...(DEFAULT_MIDI_MAP.ccActions ?? {}) },
+  };
+}
+
+function saveMap(m: MidiMap): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(MIDI_STORAGE_KEY, JSON.stringify(m));
+  } catch {}
+}
+
+interface LearnState {
+  kind: "cc" | "note";
+  target: string;
+  el: HTMLElement | null;
+}
+
+interface MidiState {
+  map: MidiMap;
+  status: { message: string; tone: "ok" | "warn" | "info" | "off" };
+  learn: LearnState | null;
+  available: boolean;
+
+  setStatus: (message: string, tone?: MidiState["status"]["tone"]) => void;
+  setAvailable: (b: boolean) => void;
+
+  startLearn: (
+    kind: LearnState["kind"],
+    target: string,
+    el: HTMLElement | null,
+  ) => void;
+  cancelLearn: () => void;
+  applyLearn: (kind: "cc" | "note", num: number) => boolean;
+  clearBinding: (kind: "cc" | "note", target: string) => void;
+
+  resetMap: () => void;
+}
+
+export const useMidiStore = create<MidiState>((set, get) => ({
+  map: loadMap(),
+  status: { message: "MIDI", tone: "off" },
+  learn: null,
+  available: false,
+
+  setStatus: (message, tone = "info") => set({ status: { message, tone } }),
+  setAvailable: (b) => set({ available: b }),
+
+  startLearn: (kind, target, el) => {
+    const prev = get().learn;
+    if (prev?.el) prev.el.classList.remove("midi-learning");
+    if (el) el.classList.add("midi-learning");
+    set({
+      learn: { kind, target, el },
+      status: { message: `Learn: ${target} — twist or press`, tone: "warn" },
+    });
+  },
+  cancelLearn: () => {
+    const { learn } = get();
+    if (learn?.el) learn.el.classList.remove("midi-learning");
+    set({ learn: null });
+  },
+  applyLearn: (kind, num) => {
+    const { learn, map } = get();
+    if (!learn) return false;
+    // Strict match: learning a slider param ("cc") only accepts CC.
+    // Permissive match: learning an action button ("note") accepts EITHER
+    // a NOTE message (the usual pad signal) OR a CC message — some pads
+    // send CC even in pad/trigger mode and it's friendlier to bind it
+    // than to demand the user reconfigure their hardware. The CC binding
+    // for an action goes into `ccActions` so the dispatcher can fire the
+    // discrete action when that CC arrives, separately from the
+    // continuous-controller `cc` map used by sliders.
+    if (learn.kind === "cc" && kind !== "cc") return false;
+    const next: MidiMap = {
+      cc: { ...map.cc },
+      notes: { ...map.notes },
+      ccActions: { ...(map.ccActions ?? {}) },
+    };
+    if (learn.kind === "cc") {
+      // Slider param learning a CC.
+      for (const k of Object.keys(next.cc)) {
+        if (next.cc[k] === learn.target) delete next.cc[k];
+      }
+      next.cc[String(num)] = learn.target;
+    } else if (kind === "note") {
+      // Action button learning a NOTE.
+      for (const k of Object.keys(next.notes)) {
+        if (next.notes[k] === learn.target) delete next.notes[k];
+      }
+      next.notes[String(num)] = learn.target as NoteAction;
+    } else {
+      // Action button learning a CC (pad in CC mode).
+      const ccActions = next.ccActions ?? {};
+      for (const k of Object.keys(ccActions)) {
+        if (ccActions[k] === learn.target) delete ccActions[k];
+      }
+      ccActions[String(num)] = learn.target as NoteAction;
+      next.ccActions = ccActions;
+    }
+    saveMap(next);
+    if (learn.el) learn.el.classList.remove("midi-learning");
+    set({
+      map: next,
+      learn: null,
+      status: {
+        message: `Learned ${learn.target} ← ${kind} ${num}`,
+        tone: "ok",
+      },
+    });
+    return true;
+  },
+  clearBinding: (kind, target) => {
+    const { map } = get();
+    const next: MidiMap = {
+      cc: { ...map.cc },
+      notes: { ...map.notes },
+    };
+    const slot = kind === "cc" ? next.cc : next.notes;
+    for (const k of Object.keys(slot)) {
+      if (slot[k] === target) delete slot[k];
+    }
+    saveMap(next);
+    set({
+      map: next,
+      status: { message: `Cleared ${target}`, tone: "info" },
+    });
+  },
+
+  resetMap: () => {
+    const def: MidiMap = {
+      cc: { ...DEFAULT_MIDI_MAP.cc },
+      notes: { ...DEFAULT_MIDI_MAP.notes },
+    };
+    saveMap(def);
+    set({ map: def, status: { message: "MIDI reset", tone: "ok" } });
+  },
+}));

--- a/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
@@ -1,0 +1,428 @@
+"use client";
+
+import { create } from "zustand";
+
+import {
+  SLIDER_META,
+  type DcwMode,
+  type DcwWavelet,
+  type DisplayMode,
+} from "@/types/engine";
+
+// Top-level performance state. Mirrors app.js's module-level vars
+// (sliderValues, seedValue, blendValue, activeKey, prompts, fixture, mode,
+// kiosk). LoRA strength sliders live in useLoraStore.
+
+const SHOW_KBD_HINTS_STORAGE_KEY = "demon:showKbdHints";
+const SMOOTH_STORAGE_KEY = "demon:smooth";
+const SMOOTH_MS_STORAGE_KEY = "demon:smoothMs";
+
+const DEFAULT_SMOOTH_MS = 1000;
+const MIN_SMOOTH_MS = 50;
+const MAX_SMOOTH_MS = 10000;
+
+function loadBool(key: string, fallback: boolean): boolean {
+  if (typeof localStorage === "undefined") return fallback;
+  try {
+    const v = localStorage.getItem(key);
+    if (v === null) return fallback;
+    return v === "1";
+  } catch {
+    return fallback;
+  }
+}
+
+function saveBool(key: string, b: boolean): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(key, b ? "1" : "0");
+  } catch {}
+}
+
+function loadNum(key: string, fallback: number): number {
+  if (typeof localStorage === "undefined") return fallback;
+  try {
+    const v = localStorage.getItem(key);
+    if (v === null) return fallback;
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) ? n : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function saveNum(key: string, n: number): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(key, String(n));
+  } catch {}
+}
+
+// ── Slider tween manager ────────────────────────────────────────────────
+// Two-tier model: `sliderTargets` is the user's intent (updated instantly
+// on drag / arrow key / MIDI bump); `sliderValues` is what we actually
+// send to the engine. When `smooth` is off the two are identical; when on,
+// `sliderValues` chases `sliderTargets` along a cubic ease-out tween.
+//
+// Slider UIs read `sliderTargets` so dragging feels immediate. The
+// param-sync tick (hooks/useParamSync.ts, 33 ms) reads `sliderValues`
+// so the engine sees the smoothed curve. MIDI knobs hit bumpSlider
+// repeatedly; each bump retargets and the tween chases without stutter.
+
+interface Tween {
+  start: number;
+  startTime: number;
+}
+const tweens = new Map<string, Tween>();
+let rafId: number | null = null;
+
+function tickTweens(): void {
+  rafId = null;
+  const state = usePerformanceStore.getState();
+  if (tweens.size === 0) return;
+  const now = performance.now();
+  const durationMs = state.smoothMs;
+  const updates: Record<string, number> = {};
+  for (const [param, t] of tweens) {
+    const target = state.sliderTargets[param] ?? 0;
+    const elapsed = now - t.startTime;
+    if (elapsed >= durationMs) {
+      updates[param] = target;
+      tweens.delete(param);
+      continue;
+    }
+    const k = elapsed / durationMs;
+    // Cubic ease-out: snappy start, settles into target.
+    const eased = 1 - Math.pow(1 - k, 3);
+    updates[param] = t.start + (target - t.start) * eased;
+  }
+  if (Object.keys(updates).length > 0) {
+    usePerformanceStore.setState((s) => ({
+      sliderValues: { ...s.sliderValues, ...updates },
+    }));
+  }
+  if (tweens.size > 0 && typeof requestAnimationFrame !== "undefined") {
+    rafId = requestAnimationFrame(tickTweens);
+  }
+}
+
+/** Start (or restart) a tween for `param`. The tween's "start" is whatever
+ *  sliderValues[param] is right now; the "end" is read from sliderTargets
+ *  on every tick so retargets mid-flight (MIDI knob spinning) just bend
+ *  the curve toward the new target. */
+function ensureTween(param: string): void {
+  const sliderValues = usePerformanceStore.getState().sliderValues;
+  tweens.set(param, {
+    start: sliderValues[param] ?? 0,
+    startTime: performance.now(),
+  });
+  if (rafId === null && typeof requestAnimationFrame !== "undefined") {
+    rafId = requestAnimationFrame(tickTweens);
+  }
+}
+
+function cancelTween(param: string): void {
+  tweens.delete(param);
+}
+
+// ── Manual-override timestamps ─────────────────────────────────────────
+// When a user drags a slider OR bumps it via MIDI / arrow key while
+// useScheduledCurves is also driving that param, we let the manual
+// touch win for a short window. After that window, the curve resumes.
+// The timestamps live in a module-level Map (not zustand state) so
+// tracking them doesn't trigger re-renders. Read by useScheduledCurves.
+const MANUAL_OVERRIDE_WINDOW_MS = 500;
+const manualTouchedAt = new Map<string, number>();
+
+function stampManualTouch(param: string): void {
+  manualTouchedAt.set(param, performance.now());
+}
+
+/** True if `param` was manually touched within MANUAL_OVERRIDE_WINDOW_MS. */
+export function isManualOverrideActive(param: string): boolean {
+  const ts = manualTouchedAt.get(param);
+  if (!ts) return false;
+  return performance.now() - ts < MANUAL_OVERRIDE_WINDOW_MS;
+}
+
+const DEFAULT_SLIDER_VALUES: Record<string, number> = {
+  denoise: 0.7,
+  hint_strength: 1.4,
+  feedback: 0.0,
+  shift: 0.5,
+  noise_share: 0.0,
+  ode_noise: 0.0,
+  ch_g0: 1.0,
+  ch_g1: 1.0,
+  ch_g2: 1.0,
+  ch_g3: 1.0,
+  ch_g4: 1.0,
+  ch_g5: 1.0,
+  ch_g6: 1.0,
+  ch_g7: 1.0,
+  ch13: 1.0,
+  ch14: 1.0,
+  ch19: 1.0,
+  ch23: 1.0,
+  ch29: 1.0,
+  ch56: 1.0,
+  dcw_scaler: 0.05,
+  dcw_high_scaler: 0.02,
+};
+
+interface PerformanceState {
+  /** What we're actually sending to the engine. When `smooth` is on, this
+   *  trails `sliderTargets` along a tween; otherwise it equals it. Read by
+   *  param-sync (hooks/useParamSync.ts) and the render loop (the audio-
+   *  reactive graph in hooks/useRenderLoop.ts). */
+  sliderValues: Record<string, number>;
+  /** What the user *intends* — instant target. Slider UIs (SliderGroup,
+   *  MobileRemixRail, DesktopEdgeDrag) read this so the visual position
+   *  follows the cursor / MIDI knob without the smoothing lag. */
+  sliderTargets: Record<string, number>;
+  /** Random seed in 0..1; "dice" button reroll. */
+  seed: number;
+  /** Prompt A/B blend (0 = A, 1 = B). */
+  blend: number;
+  /** Two prompts. */
+  promptA: string;
+  promptB: string;
+  /** Currently active key (e.g. "G# minor"). May come from auto-detect. */
+  activeKey: string;
+  /** Selected fixture name (from /api/fixtures). */
+  fixture: string;
+  /** Detected musical metadata from server's "ready" frame. */
+  detectedBpm: number | null;
+  detectedKey: string | null;
+  /** Display mode toggle. */
+  mode: DisplayMode;
+  /** Kiosk mode (auto-hide cursor + idle reset). */
+  kiosk: boolean;
+  /** Pause flag (audio context state). */
+  paused: boolean;
+
+  /** DCW (wavelet-domain post-step correction) non-numeric state. The two
+   * numeric knobs (dcw_scaler, dcw_high_scaler) live in sliderValues. */
+  dcwEnabled: boolean;
+  dcwMode: DcwMode;
+  dcwWavelet: DcwWavelet;
+  /** Show keyboard-shortcut hints under each slider / next to buttons.
+   * Default true. Persisted to localStorage. */
+  showKbdHints: boolean;
+  /** Smooth slider transitions: when enabled, setSlider interpolates
+   *  from the current value to the target over `smoothMs` instead of
+   *  jumping. bumpSlider stays immediate (small deltas are already
+   *  smooth). Persisted to localStorage. */
+  smooth: boolean;
+  smoothMs: number;
+
+  // ── actions ───────────────────────────────────────────────────────────
+  setSlider: (param: string, value: number) => void;
+  /** Curve-driven slider write. Skips the smoothing tween (the curve
+   *  IS the source of truth, not a target to chase), writes both
+   *  sliderTargets and sliderValues synchronously. Does NOT stamp the
+   *  manual-override timestamp — useScheduledCurves uses that to
+   *  decide when manual drags should briefly win over the curve. */
+  setSliderDirect: (param: string, value: number) => void;
+  bumpSlider: (param: string, delta: number) => void;
+  setSeed: (seed: number) => void;
+  randomizeSeed: () => void;
+  setBlend: (b: number) => void;
+  setPromptA: (s: string) => void;
+  setPromptB: (s: string) => void;
+  setKey: (k: string) => void;
+  setFixture: (name: string) => void;
+  setDetected: (bpm: number | null, key: string | null) => void;
+  setMode: (m: DisplayMode) => void;
+  toggleMode: () => void;
+  setKiosk: (k: boolean) => void;
+  toggleKiosk: () => void;
+  setPaused: (p: boolean) => void;
+  togglePause: () => void;
+  setDcwEnabled: (b: boolean) => void;
+  toggleDcw: () => void;
+  setDcwMode: (m: DcwMode) => void;
+  setDcwWavelet: (w: DcwWavelet) => void;
+  toggleKbdHints: () => void;
+  toggleSmooth: () => void;
+  setSmoothMs: (ms: number) => void;
+  /** Read localStorage-backed prefs (showKbdHints) and
+   *  apply them to the store. Called from a client-only useEffect so SSR
+   *  always renders with the defaults — without this, hydration mismatches
+   *  on OperatorStrip's COMPACT/STANDARD + KBD: ON/OFF buttons. */
+  hydratePersistedPrefs: () => void;
+  /** Reset every slider + seed + blend to defaults (idle-reset). */
+  resetToDefaults: () => void;
+}
+
+function clampToMeta(param: string, value: number): number {
+  const meta = SLIDER_META[param];
+  // LoRA sliders (lora_str_<id>) aren't in SLIDER_META — clamp to [0, 2].
+  const max = meta?.max ?? 2.0;
+  if (Number.isNaN(value)) return 0;
+  return Math.max(0, Math.min(max, value));
+}
+
+export const usePerformanceStore = create<PerformanceState>((set) => ({
+  sliderValues: { ...DEFAULT_SLIDER_VALUES },
+  sliderTargets: { ...DEFAULT_SLIDER_VALUES },
+  seed: 0,
+  blend: 0.4,
+  promptA: "heavy dubstep, deathstep, afxdump, growl heavy bass distortion",
+  promptB: "daft punk style, beautiful, four to the floor, angelic",
+  activeKey: "G# minor",
+  fixture: "",
+  detectedBpm: null,
+  detectedKey: null,
+  mode: "graph",
+  kiosk: false,
+  paused: false,
+
+  dcwEnabled: true,
+  dcwMode: "double",
+  dcwWavelet: "haar",
+
+  // Hydrated from localStorage after mount via hydratePersistedPrefs() —
+  // do NOT read localStorage here, that breaks SSR hydration.
+  showKbdHints: true,
+  smooth: false,
+  smoothMs: DEFAULT_SMOOTH_MS,
+
+  setSlider: (param, value) => {
+    stampManualTouch(param);
+    const target = clampToMeta(param, value);
+    const state = usePerformanceStore.getState();
+    if (!state.smooth || state.smoothMs <= 0) {
+      cancelTween(param);
+      set((s) => ({
+        sliderValues: { ...s.sliderValues, [param]: target },
+        sliderTargets: { ...s.sliderTargets, [param]: target },
+      }));
+      return;
+    }
+    // Smooth: write the target instantly (so the UI snaps to where the
+    // user wants), kick off a tween that pulls sliderValues toward it.
+    set((s) => ({
+      sliderTargets: { ...s.sliderTargets, [param]: target },
+    }));
+    ensureTween(param);
+  },
+  setSliderDirect: (param, value) => {
+    // Curve-driven write: bypass smoothing, do NOT stamp a manual-touch
+    // timestamp. We want both fields to reflect the curve value
+    // synchronously so the param-sync tick AND the slider UI both see
+    // the new value on the next read.
+    const target = clampToMeta(param, value);
+    cancelTween(param);
+    set((s) => ({
+      sliderValues: { ...s.sliderValues, [param]: target },
+      sliderTargets: { ...s.sliderTargets, [param]: target },
+    }));
+  },
+  bumpSlider: (param, delta) => {
+    stampManualTouch(param);
+    const state = usePerformanceStore.getState();
+    const newTarget = clampToMeta(
+      param,
+      (state.sliderTargets[param] ?? 0) + delta,
+    );
+    if (!state.smooth || state.smoothMs <= 0) {
+      cancelTween(param);
+      set((s) => ({
+        sliderValues: { ...s.sliderValues, [param]: newTarget },
+        sliderTargets: { ...s.sliderTargets, [param]: newTarget },
+      }));
+      return;
+    }
+    // Smoothed bump: retarget instantly, let the tween chase. Each MIDI
+    // knob message just bends the in-flight curve toward the new target
+    // — no stutter, no per-bump 1 s lag.
+    set((s) => ({
+      sliderTargets: { ...s.sliderTargets, [param]: newTarget },
+    }));
+    ensureTween(param);
+  },
+  setSeed: (seed) => set({ seed: Math.max(0, Math.min(1, seed)) }),
+  randomizeSeed: () => set({ seed: Math.random() }),
+  setBlend: (b) => set({ blend: Math.max(0, Math.min(1, b)) }),
+  setPromptA: (s) => set({ promptA: s }),
+  setPromptB: (s) => set({ promptB: s }),
+  setKey: (k) => set({ activeKey: k }),
+  setFixture: (name) => set({ fixture: name }),
+  setDetected: (bpm, key) =>
+    set((s) => ({
+      detectedBpm: bpm,
+      detectedKey: key,
+      // If user hasn't manually overridden the key (still on default),
+      // adopt the detection. Caller can re-set if needed.
+      activeKey: key ?? s.activeKey,
+    })),
+  setMode: (m) => set({ mode: m }),
+  toggleMode: () => set((s) => ({ mode: s.mode === "graph" ? "video" : "graph" })),
+  setKiosk: (k) => set({ kiosk: k }),
+  toggleKiosk: () => set((s) => ({ kiosk: !s.kiosk })),
+  setPaused: (p) => set({ paused: p }),
+  togglePause: () => set((s) => ({ paused: !s.paused })),
+  setDcwEnabled: (b) => set({ dcwEnabled: b }),
+  toggleDcw: () => set((s) => ({ dcwEnabled: !s.dcwEnabled })),
+  setDcwMode: (m) => set({ dcwMode: m }),
+  setDcwWavelet: (w) => set({ dcwWavelet: w }),
+  toggleKbdHints: () =>
+    set((s) => {
+      const next = !s.showKbdHints;
+      saveBool(SHOW_KBD_HINTS_STORAGE_KEY, next);
+      return { showKbdHints: next };
+    }),
+  toggleSmooth: () =>
+    set((s) => {
+      const next = !s.smooth;
+      // Smooth is intentionally NOT persisted — the user always starts a
+      // fresh session with smoothing OFF, and opts in per-session.
+      // Cancelling tweens on disable means in-flight transitions snap to
+      // their target (current sliderValues).
+      if (!next) tweens.clear();
+      return { smooth: next };
+    }),
+  setSmoothMs: (ms) =>
+    set(() => {
+      const clamped = Math.max(MIN_SMOOTH_MS, Math.min(MAX_SMOOTH_MS, Math.round(ms)));
+      saveNum(SMOOTH_MS_STORAGE_KEY, clamped);
+      return { smoothMs: clamped };
+    }),
+  hydratePersistedPrefs: () =>
+    set({
+      showKbdHints: loadBool(SHOW_KBD_HINTS_STORAGE_KEY, true),
+      // Smooth always defaults to off on page load (operators don't want
+      // a stale ON from a previous session silently reshaping their
+      // first slider drag). The duration knob still persists.
+      smooth: false,
+      smoothMs: Math.max(
+        MIN_SMOOTH_MS,
+        Math.min(MAX_SMOOTH_MS, loadNum(SMOOTH_MS_STORAGE_KEY, DEFAULT_SMOOTH_MS)),
+      ),
+    }),
+  resetToDefaults: () => {
+    tweens.clear();
+    set(() => ({
+      sliderValues: { ...DEFAULT_SLIDER_VALUES },
+      sliderTargets: { ...DEFAULT_SLIDER_VALUES },
+      seed: 0,
+      blend: 0.4,
+    }));
+  },
+}));
+
+/** Compute the prompt string sent to the server given the current blend. */
+export function computePromptTags(state: {
+  promptA: string;
+  promptB: string;
+  blend: number;
+}): string {
+  const { promptA, promptB, blend } = state;
+  if (blend <= 0) return promptA;
+  if (blend >= 1) return promptB;
+  // Server handles A/B blend by receiving both — but the simple wire is one
+  // string. Match app.js's pattern: send "<A> | <B>" with the blend
+  // parameter delivered separately via params.
+  return promptA;
+}

--- a/demos/realtime_motion_graph_web/web/store/useRecordingStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useRecordingStore.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { create } from "zustand";
+
+// Audio recording state. Discriminated union prevents impossible states
+// (preview without blob, recording without start time, etc.). The
+// useRecording hook drives transitions; UI components read state and
+// dispatch via document CustomEvents (parallel to dd:toggle-drawer).
+
+export type RecState =
+  | { kind: "idle" }
+  | { kind: "arming" }
+  | { kind: "recording"; startedAt: number; bytes: number; pausedMs: number }
+  | {
+      kind: "paused";
+      startedAt: number;
+      bytes: number;
+      pausedMs: number;
+      pausedAt: number;
+    }
+  | { kind: "finalizing" }
+  | {
+      kind: "preview";
+      blob: Blob;
+      url: string;
+      durationMs: number;
+      mime: string;
+      ext: string;
+    }
+  | { kind: "error"; reason: string };
+
+interface RecordingStore {
+  state: RecState;
+  // Single setter — the hook owns the state machine logic, this just stores.
+  set: (next: RecState) => void;
+  // Live byte tally so the UI can show approximate file size while
+  // recording without forcing a state replacement on every chunk.
+  bumpBytes: (delta: number) => void;
+  /** Transient warning anchored to the record buttons (e.g. "Wait for
+   *  connection first" when you click record before the session is
+   *  ready). Lives separately from the global StatusBar so it doesn't
+   *  overwrite the session's loading/connecting message. */
+  warning: string | null;
+  setWarning: (msg: string | null) => void;
+}
+
+export const useRecordingStore = create<RecordingStore>((set) => ({
+  state: { kind: "idle" },
+  set: (next) => set({ state: next }),
+  bumpBytes: (delta) =>
+    set((s) => {
+      if (s.state.kind !== "recording" && s.state.kind !== "paused") return s;
+      return { state: { ...s.state, bytes: s.state.bytes + delta } };
+    }),
+  warning: null,
+  setWarning: (msg) => set({ warning: msg }),
+}));
+
+// Selectors — keep the discriminated union out of components that only
+// care "is something happening?".
+export function isActive(state: RecState): boolean {
+  return state.kind === "recording" || state.kind === "paused";
+}
+
+export function elapsedMs(state: RecState, now: number): number {
+  if (state.kind === "recording") {
+    return now - state.startedAt - state.pausedMs;
+  }
+  if (state.kind === "paused") {
+    return state.pausedAt - state.startedAt - state.pausedMs;
+  }
+  return 0;
+}

--- a/demos/realtime_motion_graph_web/web/store/useSessionStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useSessionStore.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { create } from "zustand";
+
+import type { AudioPlayer } from "@/engine/audio/AudioPlayer";
+import type { RemoteBackend } from "@/engine/protocol";
+
+// Live-session lifecycle state. The non-serializable RemoteBackend +
+// AudioPlayer instances live here so React components and hooks can react
+// to state changes (status, errors) without owning the lifecycle directly.
+
+export type SessionStatus =
+  | "idle"
+  | "loading-fixture"
+  | "connecting"
+  | "ready"
+  | "error"
+  | "closed";
+
+interface SessionState {
+  status: SessionStatus;
+  message: string;
+  remote: RemoteBackend | null;
+  player: AudioPlayer | null;
+  /** Server-issued WS URL (from /api/queue/join). Null when no queue is in
+   *  use — useStartSession falls back to defaultWsUrl(). */
+  wsUrl: string | null;
+
+  setStatus: (status: SessionStatus, message?: string) => void;
+  setSession: (remote: RemoteBackend | null, player: AudioPlayer | null) => void;
+  setWsUrl: (wsUrl: string | null) => void;
+  reset: () => void;
+}
+
+export const useSessionStore = create<SessionState>((set) => ({
+  status: "idle",
+  message: "",
+  remote: null,
+  player: null,
+  wsUrl: null,
+
+  setStatus: (status, message = "") => set({ status, message }),
+  setSession: (remote, player) => set({ remote, player }),
+  setWsUrl: (wsUrl) => set({ wsUrl }),
+  reset: () =>
+    set({ status: "idle", message: "", remote: null, player: null }),
+}));

--- a/demos/realtime_motion_graph_web/web/store/useUiStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useUiStore.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { create } from "zustand";
+
+interface UiState {
+  configOpen: boolean;
+  setConfigOpen: (v: boolean) => void;
+  toggleConfig: () => void;
+}
+
+export const useUiStore = create<UiState>((set) => ({
+  configOpen: false,
+  setConfigOpen: (v) => set({ configOpen: v }),
+  toggleConfig: () => set((s) => ({ configOpen: !s.configOpen })),
+}));

--- a/demos/realtime_motion_graph_web/web/tsconfig.json
+++ b/demos/realtime_motion_graph_web/web/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext", "WebWorker"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/demos/realtime_motion_graph_web/web/types/curves.ts
+++ b/demos/realtime_motion_graph_web/web/types/curves.ts
@@ -1,0 +1,79 @@
+// Curve-based parameter scheduling types. A "curve" is a sequence of
+// control points along the track timeline that drives a slider param's
+// value as the audio plays. Drawn in ScheduleCurvesOverlay, applied by
+// useScheduledCurves at rAF cadence.
+
+/** Per-point interpolation mode. The curve renderer chooses how to
+ *  bridge from THIS point to the NEXT one based on this point's mode:
+ *  - smooth: Catmull-Rom spline (default, organic feel)
+ *  - linear: straight line
+ *  - step:   value held flat until the next point */
+export type CurveInterpMode = "smooth" | "linear" | "step";
+
+export interface CurvePoint {
+  /** 0..1 along the track duration. Endpoints pinned at 0 and 1. */
+  x: number;
+  /** 0..1 normalised. Mapped to param min/max (always 0..meta.max)
+   *  via `SLIDER_META[param]` at apply time. */
+  y: number;
+  mode: CurveInterpMode;
+}
+
+export interface CurveState {
+  /** When false, the curve is drawn but doesn't drive the param —
+   *  manual sliders / MIDI behave as if no curve existed. */
+  enabled: boolean;
+  /** Always ≥ 2 points; first.x === 0 and last.x === 1. */
+  points: CurvePoint[];
+}
+
+/** The curated FIXED param set the schedule-curves overlay always
+ *  exposes as tabs. LoRA strengths are dynamic (loaded from the
+ *  engine's catalog at runtime) and added on top via
+ *  loraCurveParam(id) — see ScheduleCurvesOverlay's tab build. */
+export const SCHEDULEABLE_PARAMS = [
+  "denoise",
+  "hint_strength",
+  "feedback",
+  "shift",
+  "noise_share",
+  "ode_noise",
+] as const;
+
+export type ScheduleableParam = (typeof SCHEDULEABLE_PARAMS)[number];
+
+/** Build the curve-store key for a LoRA's strength param. Mirrors the
+ *  `lora_str_<id>` convention used by SLIDER_META at runtime. */
+export function loraCurveParam(id: string): string {
+  return `lora_str_${id}`;
+}
+
+/** Max number of LoRA tabs in the schedule overlay. Capped because
+ *  the tab strip is finite real estate and most users automate at
+ *  most a couple of LoRAs. */
+export const MAX_LORA_CURVES = 2;
+
+/** Display label shown in the tab strip. CSS uppercases via
+ *  text-transform; we store natural case so screen readers and tooltips
+ *  read sensibly. Mirrors the labels in MainTile / EngineTile / HUD so
+ *  users see the same names everywhere ("Remix strength", not the
+ *  internal `denoise` key). */
+export const SCHEDULEABLE_PARAM_LABEL: Record<ScheduleableParam, string> = {
+  denoise: "Remix strength",
+  hint_strength: "Structure strength",
+  feedback: "Feedback",
+  shift: "Shift",
+  noise_share: "Noise share",
+  ode_noise: "ODE noise",
+};
+
+/** Default curve: a flat line at midrange. Two points, both `smooth`. */
+export function defaultCurveState(): CurveState {
+  return {
+    enabled: false,
+    points: [
+      { x: 0, y: 0.5, mode: "smooth" },
+      { x: 1, y: 0.5, mode: "smooth" },
+    ],
+  };
+}

--- a/demos/realtime_motion_graph_web/web/types/engine.ts
+++ b/demos/realtime_motion_graph_web/web/types/engine.ts
@@ -1,0 +1,88 @@
+// Slider definitions and engine-side knobs. Mirrors the SLIDER_META and
+// CONFIG.controls shape from DEMON's static/app.js.
+
+export interface SliderMeta {
+  /** Maximum value (slider top). */
+  max: number;
+  /** Arrow-key step. */
+  step: number;
+  /** Hide from the simple Main tile; live in pro/advanced areas. */
+  pro?: boolean;
+}
+
+/** Standard non-LoRA sliders. LoRA sliders (`lora_str_<id>`) get added at
+ * runtime when the catalog arrives — they aren't listed here. */
+export const SLIDER_META: Record<string, SliderMeta> = {
+  denoise: { max: 1.0, step: 0.1 },
+  hint_strength: { max: 2.0, step: 0.2 },
+
+  feedback: { max: 1.0, step: 0.1, pro: true },
+  shift: { max: 1.0, step: 0.1, pro: true },
+  noise_share: { max: 1.0, step: 0.1, pro: true },
+  ode_noise: { max: 0.5, step: 0.05, pro: true },
+
+  ch_g0: { max: 3.0, step: 0.15, pro: true },
+  ch_g1: { max: 3.0, step: 0.15, pro: true },
+  ch_g2: { max: 3.0, step: 0.15, pro: true },
+  ch_g3: { max: 3.0, step: 0.15, pro: true },
+  ch_g4: { max: 3.0, step: 0.15, pro: true },
+  ch_g5: { max: 3.0, step: 0.15, pro: true },
+  ch_g6: { max: 3.0, step: 0.15, pro: true },
+  ch_g7: { max: 3.0, step: 0.15, pro: true },
+
+  ch13: { max: 3.0, step: 0.15, pro: true },
+  ch14: { max: 3.0, step: 0.15, pro: true },
+  ch19: { max: 3.0, step: 0.15, pro: true },
+  ch23: { max: 3.0, step: 0.15, pro: true },
+  ch29: { max: 3.0, step: 0.15, pro: true },
+  ch56: { max: 3.0, step: 0.15, pro: true },
+
+  // DCW (wavelet-domain post-step correction). Numeric knobs only; the
+  // boolean ON/OFF + mode + wavelet choices live in their own panel state.
+  dcw_scaler: { max: 0.2, step: 0.02, pro: true },
+  dcw_high_scaler: { max: 0.1, step: 0.01, pro: true },
+};
+
+export const DCW_MODES = ["low", "high", "double", "pix"] as const;
+export const DCW_WAVELETS = ["haar", "db4", "sym8", "db8"] as const;
+export type DcwMode = (typeof DCW_MODES)[number];
+export type DcwWavelet = (typeof DCW_WAVELETS)[number];
+
+export const LORA_SLIDER_MAX = 2.0;
+export const LORA_SLIDER_STEP = 0.2;
+
+/** Default LoRA strength as a fraction of LORA_SLIDER_MAX. Used in two
+ * places that must agree: the catalog seeder (when the server doesn't
+ * ship a per-LoRA strength) and the side-bar empty-state visual (no
+ * LoRA bound yet). Both reading the same constant keeps the ribbon's
+ * canvas fill, the hint's head position, and ARIA aria-valuenow in
+ * lock-step. */
+export const LORA_DEFAULT_STRENGTH_FRACTION = 0.7;
+
+/** Visibility floor for the side-bar (LoRA) ribbon. Shared by:
+ *   - the canvas in engine/render/ribbons.ts (so the writhe never
+ *     fully disappears at strength=0)
+ *   - the RemixHint head position in DesktopEdgeDrag.tsx (so the
+ *     hint sits at the visible head, not below it)
+ * Without sharing the same floor, drags below this threshold leave
+ * the hint floating below the ribbon's visible end. */
+export const LORA_SIDE_VISIBLE_FLOOR = 0.25;
+
+export type DisplayMode = "graph" | "video";
+
+/** Full keyscale set the model accepts (mirrors VALID_KEYSCALES in app.js). */
+const NOTES = ["A", "B", "C", "D", "E", "F", "G"] as const;
+const ACCIDENTALS = ["", "#", "b", "♯", "♭"] as const;
+const MODES = ["major", "minor"] as const;
+
+export const VALID_KEYSCALES: string[] = (() => {
+  const out: string[] = [];
+  for (const note of NOTES) {
+    for (const acc of ACCIDENTALS) {
+      for (const mode of MODES) {
+        out.push(`${note}${acc} ${mode}`);
+      }
+    }
+  }
+  return out;
+})();

--- a/demos/realtime_motion_graph_web/web/types/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/types/protocol.ts
@@ -1,0 +1,114 @@
+// WS wire protocol shapes. Mirrors the Python side
+// (DEMON/demos/realtime_motion_graph_web/protocol.py + backend.py).
+
+export interface LoraCatalogEntry {
+  id: string;
+  name?: string;
+  path?: string;
+  state?: string;
+  strength?: number;
+  materialized_bytes?: number;
+}
+
+/** Sent by the client at session start (config phase). */
+export interface SessionConfig {
+  sde?: boolean;
+  lora?: boolean;
+  depth?: number;
+  vae_window?: number;
+  crop?: number;
+  steps?: number;
+  fast_vae?: boolean;
+  key?: string;
+  enabled_loras?: string[];
+  prompt?: string;
+  lora_strengths?: Record<string, number>;
+  // Allow extras — pyproject's config object is permissive.
+  [k: string]: unknown;
+}
+
+/** First JSON the server returns once the audio upload is in. */
+export interface ReadyMessage {
+  type: "ready";
+  duration: number;
+  channels: number;
+  sample_rate: number;
+  lora_catalog?: LoraCatalogEntry[];
+  lora_dir?: string;
+  bpm?: number | null;
+  key?: string | null;
+}
+
+/** Structured init failure from the server. */
+export interface ServerErrorMessage {
+  type: "error";
+  code?: string;
+  message?: string;
+  build_command?: string;
+}
+
+export interface ParamsUpdateMessage {
+  type: "params_update";
+  params: Record<string, number>;
+}
+
+export interface PromptAppliedMessage {
+  type: "prompt_applied";
+  tags?: string;
+}
+
+export interface LoraCatalogMessage {
+  type: "lora_catalog";
+  catalog: LoraCatalogEntry[];
+}
+
+export interface SwapReadyMessage {
+  type: "swap_ready";
+  duration: number;
+  channels: number;
+  key?: string;
+}
+
+export interface SwapFailedMessage {
+  type: "swap_failed";
+  error?: string;
+}
+
+export type ServerJsonMessage =
+  | ReadyMessage
+  | ServerErrorMessage
+  | ParamsUpdateMessage
+  | PromptAppliedMessage
+  | LoraCatalogMessage
+  | SwapReadyMessage
+  | SwapFailedMessage
+  | { type: string; [k: string]: unknown };
+
+/** Parsed binary slice from the server. */
+export interface AudioSlice {
+  flags: number;
+  startSample: number;
+  numSamples: number;
+  channels: number;
+  /** Per-generation engine time in ms. */
+  tickMs: number;
+  /** Decoder latency in ms. */
+  decMs: number;
+  /** Number of generation calls represented by this slice. */
+  numGens: number;
+  /** Decoded float32 PCM, interleaved. */
+  audio: Float32Array;
+}
+
+/** Detail payload for `swap_ready` events on RemoteBackend. */
+export interface SwapReadyDetail extends SwapReadyMessage {
+  interleaved: Float32Array;
+}
+
+export const SAMPLE_RATE = 48000;
+/** 60 s of audio at 25 fps latents. */
+export const T = 1500;
+export const CROSSFADE_SECONDS = 0.05;
+export const SLICE_HDR_SIZE = 23; // 1+4+4+2+4+4+4
+export const SLICE_FLAG_RAW = 0;
+export const SLICE_FLAG_DELTA = 1;


### PR DESCRIPTION
## Summary

Replaces the Vite-scaffold-on-shared-package approach (the previous version of this PR) with a self-contained Next.js app. The full UI source — components, engine adapter, hooks, stores, types, styles — is inlined under `demos/realtime_motion_graph_web/web/`. No external package dependency, no git-URL pinning, no lockfile churn to ship UI changes.

## What's new

- `web/` — Next.js 16 + React 19 + zustand app. Self-contained.
  - `app/` — App Router (layout, page, RTMGBoot for engine URL wiring)
  - `components/`, `engine/`, `hooks/`, `store/`, `types/`, `lib/` — full UI source
  - `next.config.ts` — rewrites `/api/*`, `/fixtures/*`, `/loras/*`, `/videos/*` → `http://localhost:8765`
  - `.env.development` — `NEXT_PUBLIC_POD_BASE_URL=http://localhost:8765` (WebSocket bypasses Next rewrites)
  - `public/audio-worklet.js` — copied from existing `static/`
- `run.py` — launcher that starts the Python backend on `:8765` and `next dev` on `:3000` together, with combined `[backend]` / `[web]`-prefixed output. Ctrl-C tears both down. First run auto-installs `web/node_modules`.

## How to run

```bash
uv run python -u -m demos.realtime_motion_graph_web.run
# forward backend args after `--`:
uv run python -u -m demos.realtime_motion_graph_web.run -- --accel eager
```

Open `http://localhost:3000`.

The legacy single-port mode (`python -m demos.realtime_motion_graph_web`) is unchanged — useful for Vast.ai-style deploys where binding two ports isn't an option. The vanilla static client under `static/` is left intact.

## Test plan

- [ ] `uv run python -u -m demos.realtime_motion_graph_web.run` boots both processes; `[backend]` and `[web]` lines interleave cleanly.
- [ ] First run installs `web/node_modules` automatically (Node.js 20+).
- [ ] `http://localhost:3000` loads the Performance UI.
- [ ] Click **Play** → fixture loads from the backend and audio streams.
- [ ] HUD canvas + graph canvas render; advanced drawer opens; sliders dispatch param updates.
- [ ] Ctrl-C shuts down both backend and Next.js dev server cleanly.