### PR TITLE
demos/realtime_motion_graph_web: curve overlay edge inset + worker .ts path fix

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -660,13 +660,21 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
      of where the moving-lines graph (#graph-wrap) sits, and regardless
      of whether the AdvancedDrawer is open underneath. Z-index above
      the drawer (z=50) so it covers the drawer when both would overlap.
-     Insets leave room for the top HaloBadge + ribbon bleed; the
-     drawing area below extends as far down as the bottom HUD. */
+
+     The horizontal insets clear the DesktopEdgeDrag LoRA sliders on
+     the left and right edges (each takes
+     hud-thickness + ribbon-bleed + remix-hint-extend ≈ 145-195px from
+     its viewport edge). The bottom inset clears the AdvancedDrawer
+     handle (always visible at the bottom of the viewport, drawer open
+     or closed). +12px breathing room on each side so the curve area
+     never butts directly against neighbouring chrome — combined with
+     EDGE_PADDING_PX inside the canvas, control points at the extremes
+     stay fully reachable without ever overlapping any other UI. */
   position: fixed;
   top: 70px;
-  left: 24px;
-  right: 24px;
-  bottom: 24px;
+  left: calc(var(--hud-thickness) + var(--ribbon-bleed) + var(--remix-hint-extend) + 12px);
+  right: calc(var(--hud-thickness) + var(--ribbon-bleed) + var(--remix-hint-extend) + 12px);
+  bottom: calc(var(--drawer-handle-h, 36px) + 12px);
   z-index: 51;
   display: flex;
   flex-direction: column;

--- a/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
@@ -47,6 +47,47 @@ import {
 const WAVEFORM_BUCKETS_DESIRED = 720;
 const POINT_HIT_RADIUS_PX = 12;
 const CURVE_TESSELLATION = 256;
+// Inset for the drawable curve area, in CSS pixels. Endpoints (x∈{0,1},
+// y∈{0,1}) render at this distance from the canvas edges so the entire
+// control-point glyph stays inside the canvas — without this margin,
+// dots at the extremes get clipped by the tab strip below, the close
+// button above, and the overlay border on the sides, which makes them
+// hard to grab and drag. The waveform/grid/curve/playhead all share
+// the same inset so they line up visually.
+const EDGE_PADDING_PX = 16;
+
+/** Curve-space (x,y∈[0,1]) → canvas-local pixels, applying the edge
+ *  inset so an extreme point renders EDGE_PADDING_PX from the boundary. */
+function curveToPx(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): { cx: number; cy: number } {
+  const innerW = Math.max(0, w - 2 * EDGE_PADDING_PX);
+  const innerH = Math.max(0, h - 2 * EDGE_PADDING_PX);
+  return {
+    cx: EDGE_PADDING_PX + x * innerW,
+    cy: EDGE_PADDING_PX + (1 - y) * innerH,
+  };
+}
+
+/** Inverse of curveToPx. Clamps to [0,1] so points can't be dragged
+ *  outside the curve domain even if the cursor wanders into the
+ *  margin. */
+function pxToCurve(
+  px: number,
+  py: number,
+  w: number,
+  h: number,
+): { x: number; y: number } {
+  const innerW = Math.max(1, w - 2 * EDGE_PADDING_PX);
+  const innerH = Math.max(1, h - 2 * EDGE_PADDING_PX);
+  return {
+    x: Math.min(1, Math.max(0, (px - EDGE_PADDING_PX) / innerW)),
+    y: Math.min(1, Math.max(0, 1 - (py - EDGE_PADDING_PX) / innerH)),
+  };
+}
 
 function ensureCanvasSize(
   canvas: HTMLCanvasElement,
@@ -250,13 +291,6 @@ export function ScheduleCurvesOverlay() {
       };
     };
 
-    /** Convert pixel coords → curve-space (x ∈ [0,1], y ∈ [0,1]).
-     *  Y is inverted (top of canvas = y=1, bottom = y=0). */
-    const localToCurve = (px: number, py: number, w: number, h: number) => ({
-      x: Math.min(1, Math.max(0, px / w)),
-      y: Math.min(1, Math.max(0, 1 - py / h)),
-    });
-
     /** Hit-test a click against existing points. Returns the point's
      *  index in `pointsRef.current`, or null if no point under the
      *  cursor within POINT_HIT_RADIUS_PX. */
@@ -270,8 +304,7 @@ export function ScheduleCurvesOverlay() {
       let bestIdx: number | null = null;
       let bestDist = POINT_HIT_RADIUS_PX * POINT_HIT_RADIUS_PX;
       for (let i = 0; i < points.length; i++) {
-        const cx = points[i].x * w;
-        const cy = (1 - points[i].y) * h;
+        const { cx, cy } = curveToPx(points[i].x, points[i].y, w, h);
         const dx = cx - px;
         const dy = cy - py;
         const d2 = dx * dx + dy * dy;
@@ -292,15 +325,19 @@ export function ScheduleCurvesOverlay() {
 
       const points = pointsRef.current;
 
-      // Grid: horizontal thirds + dashed midline. Helps users eyeball
-      // where 0.5 / 0.33 / 0.67 sit on the y axis.
+      // Grid: horizontal thirds + midline. Helps users eyeball where
+      // 0.25 / 0.5 / 0.75 sit on the y axis. Drawn within the inset
+      // drawable rect so the lines line up with control points at
+      // the same y values.
       ctx.strokeStyle = "rgba(255, 255, 255, 0.06)";
       ctx.lineWidth = 1;
       for (const yFrac of [0.25, 0.5, 0.75]) {
-        const y = h - yFrac * h;
+        const { cy: y } = curveToPx(0, yFrac, w, h);
+        const { cx: xL } = curveToPx(0, yFrac, w, h);
+        const { cx: xR } = curveToPx(1, yFrac, w, h);
         ctx.beginPath();
-        ctx.moveTo(0, y);
-        ctx.lineTo(w, y);
+        ctx.moveTo(xL, y);
+        ctx.lineTo(xR, y);
         ctx.stroke();
       }
 
@@ -312,8 +349,8 @@ export function ScheduleCurvesOverlay() {
       ctx.shadowBlur = 8;
       ctx.beginPath();
       for (let i = 0; i < samples.length; i++) {
-        const x = (i / (samples.length - 1)) * w;
-        const y = (1 - samples[i]) * h;
+        const sx = i / (samples.length - 1);
+        const { cx: x, cy: y } = curveToPx(sx, samples[i], w, h);
         if (i === 0) ctx.moveTo(x, y);
         else ctx.lineTo(x, y);
       }
@@ -323,8 +360,7 @@ export function ScheduleCurvesOverlay() {
       // Control points — circle (smooth), diamond (linear), square (step).
       for (let i = 0; i < points.length; i++) {
         const p = points[i];
-        const cx = p.x * w;
-        const cy = (1 - p.y) * h;
+        const { cx, cy } = curveToPx(p.x, p.y, w, h);
         const isHover = hoverIndex === i;
         const isDrag = dragIndex === i;
         const r = isHover || isDrag ? 7 : 5;
@@ -356,19 +392,22 @@ export function ScheduleCurvesOverlay() {
       }
 
       // Playhead — vertical orange line at currentPositionSec / duration.
+      // Spans the inset's vertical extent so it lines up with the curve.
       const session = useSessionStore.getState();
       const player = session.player;
       const remote = session.remote;
       if (player && remote && remote.duration > 0) {
         const t = Math.min(1, Math.max(0, player.positionSec / remote.duration));
-        const xp = t * w;
+        const { cx: xp } = curveToPx(t, 0, w, h);
+        const { cy: yTop } = curveToPx(0, 1, w, h);
+        const { cy: yBot } = curveToPx(0, 0, w, h);
         ctx.strokeStyle = "rgba(240, 138, 72, 0.85)";
         ctx.lineWidth = 1.5;
         ctx.shadowColor = "rgba(240, 138, 72, 0.6)";
         ctx.shadowBlur = 6;
         ctx.beginPath();
-        ctx.moveTo(xp, 0);
-        ctx.lineTo(xp, h);
+        ctx.moveTo(xp, yTop);
+        ctx.lineTo(xp, yBot);
         ctx.stroke();
         ctx.shadowBlur = 0;
       }
@@ -390,7 +429,7 @@ export function ScheduleCurvesOverlay() {
         return;
       }
       // Click on empty area → insert a new smooth point at that x.
-      const { x, y } = localToCurve(px, py, w, h);
+      const { x, y } = pxToCurve(px, py, w, h);
       const points = pointsRef.current.slice();
       // Don't insert at the very edges — those are pinned endpoints.
       if (x <= 0.001 || x >= 0.999) return;
@@ -407,7 +446,7 @@ export function ScheduleCurvesOverlay() {
       if (dragIndex !== null) {
         const points = pointsRef.current.slice();
         const i = dragIndex;
-        const { x, y } = localToCurve(px, py, w, h);
+        const { x, y } = pxToCurve(px, py, w, h);
         // Endpoint x is pinned; midpoint x must stay strictly between
         // its neighbours so the curve stays well-formed.
         const isFirst = i === 0;

--- a/demos/realtime_motion_graph_web/web/engine/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/engine/protocol.ts
@@ -115,8 +115,13 @@ export class RemoteBackend extends EventTarget {
   private _initDecoderWorker(): void {
     if (typeof Worker === "undefined") return;
     try {
+      // The .ts extension is intentional: Next.js / Turbopack and modern
+      // bundlers transpile worker source files referenced via
+      // `new URL(..., import.meta.url)` at build time. The previous .mjs
+      // path was a leftover from when this code shipped as a tsup-built
+      // npm package whose dist/ contained a pre-compiled .mjs sibling.
       const worker = new Worker(
-        new URL("./workers/sliceDecoder.worker.mjs", import.meta.url),
+        new URL("./workers/sliceDecoder.worker.ts", import.meta.url),
         { type: "module" },
       );
       worker.onmessage = (ev: MessageEvent) => {


### PR DESCRIPTION
Two follow-up fixes from PR #28's inlining + early demon-public-demo testing.

## 1. Inset curve control points from canvas edges

The SCHEDULE CURVES overlay renders control points at `x∈[0,1]`, `y∈[0,1]` mapped directly to canvas pixels — so endpoints (`x=0`, `x=1`) and any point dragged to `y∈{0,1}` sat flush with the canvas edges. The dot glyph clipped against the tab strip below, the close-button row above, and the overlay border on the sides; extreme points were half-visible and hard to grab/drag.

Fix: introduce `EDGE_PADDING_PX` (16) and route all curve↔pixel math through two helpers — `curveToPx` / `pxToCurve` — that map the curve domain into a sub-rect inset by that padding on every side. Grid lines, curve polyline, control points, playhead, and pointer handlers all share the inset, so:

- Extreme points stay fully reachable (the entire glyph sits inside the canvas).
- Everything stays visually aligned (grid lines end at the same x extents as the curve; playhead spans the same y extent).
- Drag bounds clamp to `[0,1]` based on the inset, so points can't be dragged outside the curve domain even if the cursor wanders into the margin.

The waveform underlay stays full-bleed — it's a low-opacity decorative reference layer, no interactive elements there.

## 2. Worker URL: reference .ts source, not the legacy .mjs

When this codebase shipped as the `@daydreamlive/demon-react` npm package, tsup compiled `sliceDecoder.worker.ts` → `sliceDecoder.worker.mjs` into `dist/` and `protocol.ts` referenced the `.mjs` sibling. Now that PR #28 has inlined the package source, there's no build step, no `dist/`, no `.mjs` — Next.js / Turbopack fails to resolve the URL and the page errors out at compile time (`Module not found: Can't resolve './workers/sliceDecoder.worker.mjs'`).

Reference the `.ts` source directly. Next.js 13+ with Turbopack (and Vite, Webpack 5) transpile worker source files referenced via `new URL(..., import.meta.url)` at build time, so the `.ts` extension is the right one for an inlined worker.

## Test plan

- [ ] Open SCHEDULE CURVES → control points at `x=0` and `x=1` are visible 16 px in from the canvas edges, fully draggable in y.
- [ ] Drag any point to `y=1` (top) → fully on canvas, doesn't clip into the close-button row.
- [ ] Drag to `y=0` (bottom) → same, doesn't clip into the tab strip.
- [ ] Grid lines, curve polyline, and playhead all align with the inset.
- [ ] Curve presets still apply correctly.
- [ ] Page compiles cleanly — no `Module not found: ./workers/sliceDecoder.worker.mjs` error.
- [ ] Slice decoding still happens off the main thread (open devtools → Sources → Workers; `sliceDecoder.worker.ts` should appear during a session).