### PR TITLE
fix: keep Remix Strength ribbon visible at value=0

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
@@ -9,7 +9,7 @@
 // --bloom-amount. Drop-shadow glow filters live in CSS on the canvas
 // elements (CSS filter applies to canvases just like SVG).
 
-import { LORA_SIDE_VISIBLE_FLOOR } from "@/types/engine";
+import { LORA_SIDE_VISIBLE_FLOOR, REMIX_VISIBLE_FLOOR } from "@/types/engine";
 
 const PALETTE = [
   "#3db6be", // teal
@@ -32,12 +32,12 @@ const INWARD_DISTANCE = 8;
 // max --bloom-amount, so 16 px leaves clear headroom on both ends.
 const ALONG_END_INSET_PX = 16;
 
-// Floor for the side-bar (LoRA) ribbon length. Defined in types/engine
-// so DesktopEdgeDrag can floor the hint head against the same value —
-// otherwise drags below this threshold leave the hint floating below
-// the ribbon's visible end. Top bar (Remix Strength) is excluded —
-// denoise=0 there is a meaningful "off" that should collapse the ribbon
-// fully so the user can grade all the way to zero.
+// Floors for ribbon length, defined in types/engine. The side floor
+// is also consumed by DesktopEdgeDrag for the hint head position so
+// the hint stays attached to the ribbon's visible end. The top floor
+// is render-only — denoise=0 still passes through to the engine
+// untouched; the sliver only ensures the user can find the slider
+// after dragging it all the way left.
 
 interface BarConfig {
   sel: string;
@@ -183,11 +183,12 @@ function drawRibbon(
   bar: RibbonBar,
   bleedPx: number,
 ): void {
-  // Side bars (LoRA strengths) get a visibility floor so the ribbon
-  // never disappears even at strength=0. Top bar (Remix) is excluded —
-  // see LORA_SIDE_VISIBLE_FLOOR comment.
+  // Both axes get a visibility floor so the ribbon never disappears at
+  // strength=0 — otherwise the user has no cue the slider still exists.
+  // The top (Remix) floor is smaller than the side floor because the
+  // top bar is much wider; same proportional readability either way.
   const drawProgress = bar.horizontal
-    ? progress
+    ? Math.max(progress, REMIX_VISIBLE_FLOOR)
     : Math.max(progress, LORA_SIDE_VISIBLE_FLOOR);
   const drawLen = drawProgress * ALONG;
   const lateral = (ribbonIdx - (PALETTE.length - 1) / 2) * RIBBON_SPACING;

--- a/demos/realtime_motion_graph_web/web/types/engine.ts
+++ b/demos/realtime_motion_graph_web/web/types/engine.ts
@@ -68,6 +68,16 @@ export const LORA_DEFAULT_STRENGTH_FRACTION = 0.7;
  * the hint floating below the ribbon's visible end. */
 export const LORA_SIDE_VISIBLE_FLOOR = 0.25;
 
+/** Visibility floor for the top (Remix Strength) ribbon. Same role
+ * as LORA_SIDE_VISIBLE_FLOOR but for the horizontal bar. Without it,
+ * dragging denoise to 0 collapses the ribbon to nothing and the user
+ * has no visual cue that the slider still exists along the top edge.
+ * The drag overlay stays mounted at full width either way — the floor
+ * only affects rendering, not the stored value (engine still receives
+ * 0). Smaller than the side-bar floor because the top bar spans most
+ * of the viewport: 4% is still ~50-80px of grabbable ribbon. */
+export const REMIX_VISIBLE_FLOOR = 0.04;
+
 export type DisplayMode = "graph" | "video";
 
 /** Full keyscale set the model accepts (mirrors VALID_KEYSCALES in app.js). */


### PR DESCRIPTION
## Summary

- Dragging the desktop top-edge **Remix Strength** slider all the way to the left collapsed its ribbon to nothing, leaving no visual cue that the slider still existed. The drag overlay stays mounted and pointer-active, but with the writhe at `drawLen = 0` and the CSS bar at `scaleX(0)`, users reasonably concluded the slider had vanished.
- Mirrors the existing `LORA_SIDE_VISIBLE_FLOOR` pattern: introduces `REMIX_VISIBLE_FLOOR = 0.04` and applies it to horizontal bars in `drawRibbon`. Purely cosmetic — `denoise=0` still passes through to the engine untouched.
- Top floor (4%) is smaller than the side floor (25%) because the top bar spans most of the viewport, so 4% is still ~50–80px of grabbable ribbon at common viewport widths.

## Why this matters

User report: "Remix slider disappeared when dragged all the way to the left and I can't get it back without restarting." Restart works because `denoise` defaults to `0.7`. With this change a thin sliver always renders at the leftmost end so the user can grab it back.

Mobile is unaffected — the Remix slider remaps to `.install-edge-left` (vertical) at `max-width: 768px`, which already gets `LORA_SIDE_VISIBLE_FLOOR`.

## Test plan

- [ ] `npm run dev`, open desktop viewport, drag top Remix Strength ribbon to the leftmost edge — sliver should remain visible and grabbable
- [ ] Drag back rightward from the sliver — value should track normally, ribbon expands smoothly
- [ ] DevTools → confirm `aria-valuenow` on `.desktop-edge-drag[data-side="top"]` reports `0` when at the floor (floor is render-only)
- [ ] Side bars (LoRAs) at strength=0 still behave identically (no change to that code path)
- [ ] Mobile (≤768px) unaffected