### PR TITLE
demos/realtime_motion_graph_web/web: depth=4 in default SessionConfig

### DIFF
--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -52,7 +52,12 @@ function buildConfig(): SessionConfig {
   return {
     sde: false,
     lora: true,
-    depth: 8,
+    // depth=4 over depth=8: ~½ VRAM, ~⅛ param latency, ~11.3/s vs 12.3/s
+    // throughput on a 32 GB card per Ryan's measurements. The VRAM
+    // headroom is what unlocks longer audio uploads (the user-facing
+    // cap is the WebSocket frame size in loadFixture.ts; depth=4
+    // makes future bumps to that cap VRAM-safe).
+    depth: 4,
     vae_window: 6,
     crop: 0,
     steps: 8,


### PR DESCRIPTION
## Summary

Flip the React UI's hardcoded `SessionConfig.depth` from 8 to 4 in `web/hooks/useStartSession.ts`. Per measurements on a 32 GB card, depth=4 wins ~½ VRAM and ~⅛ parameter latency vs depth=8, with throughput at ~11.3/s vs ~12.3/s — virtually free at the playback rate.

`static/config.json` (legacy single-port vanilla-JS client) is unaffected; the React UI under `web/` sends its own `SessionConfig` over the WebSocket and that's what production deploys use.

## Why now

Combined with the windowed-VAE win from #20, depth=4 gives meaningful VRAM headroom on 32 GB cards — useful both for stability at the current 240 s engine ceiling and for any future longer-audio profiles.

## Test plan

- [ ] Backend logs show `pipeline_depth=4` on session start.
- [ ] No regression in time-to-first-audio or perceptual quality.
- [ ] VRAM at session steady-state is materially lower on a 32 GB pod (vs a baseline depth=8 session with the same audio).
- [ ] Existing 32 GB pod handles 240 s audio without OOM (combined with windowed VAE).