### PR TITLE
demos/realtime_motion_graph_web: raise audio upload cap to 240 s

### DIFF
--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -408,7 +408,10 @@ def main():
         ws_handler,
         host,
         port,
-        max_size=50 * 1024 * 1024,
+        # Sized to fit the React UI's MAX_FIXTURE_DURATION_S (240 s)
+        # at 48 kHz stereo Float32 (~88 MiB) with comfortable headroom.
+        # See web/engine/audio/loadFixture.ts.
+        max_size=100 * 1024 * 1024,
         process_request=_process_request,
     )
     ws_thread = threading.Thread(target=srv.serve_forever, daemon=True)

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1998,7 +1998,14 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   text-transform: uppercase;
   color: rgba(255, 255, 255, 0.72);
   z-index: 11;
-  white-space: nowrap;
+  /* Long messages (e.g. "Track too long — 322s (max 240s). Trim it.")
+     wrap onto multiple lines. The bar is centered and clamped at a
+     readable width; line-height gives the wrapped lines breathing room.
+     overflow-wrap: anywhere covers pathological inputs (URLs, hashes). */
+  max-width: min(80vw, 520px);
+  white-space: normal;
+  overflow-wrap: anywhere;
+  line-height: 1.5;
   pointer-events: none;
   opacity: 0;
   transition:

--- a/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
@@ -82,25 +82,18 @@ export async function loadFixtureAudio(name: string): Promise<DecodedFixture> {
   return decodeArrayBuffer(bytes);
 }
 
-// DEMON's WebSocket server caps incoming frames at ~50 MiB
-// (websockets.serve(max_size=…)). swap_source sends an 8-byte header +
-// interleaved Float32 PCM, so the decoded buffer must fit under that cap.
-// Practical limit at 48 kHz stereo Float32 (8 B/frame) ≈ 130 s of audio.
-const MAX_SWAP_SOURCE_BYTES = 50 * 1024 * 1024;
-const SWAP_SOURCE_HEADER_BYTES = 8;
+// Cap user-supplied audio at DEMON's largest TRT engine profile
+// (240 s; see acestep/paths.py:_TRT_ENGINE_PROFILES). Anything longer
+// would fail server-side at session init regardless of WS frame size.
+// The server's websockets.serve(max_size=...) is sized to fit this
+// duration with a comfortable margin.
+const MAX_FIXTURE_DURATION_S = 240;
 
 function ensureFitsSwapLimit(decoded: DecodedFixture): void {
-  const totalBytes = decoded.interleaved.byteLength + SWAP_SOURCE_HEADER_BYTES;
-  if (totalBytes <= MAX_SWAP_SOURCE_BYTES) return;
   const seconds = decoded.frames / decoded.sampleRate;
-  const bytesPerSecond = decoded.sampleRate * decoded.channels * 4;
-  const maxSeconds = Math.floor(
-    (MAX_SWAP_SOURCE_BYTES - SWAP_SOURCE_HEADER_BYTES) / bytesPerSecond,
-  );
+  if (seconds <= MAX_FIXTURE_DURATION_S) return;
   throw new Error(
-    `Track too long for the engine — ${Math.round(seconds)} s decoded ` +
-      `(${(totalBytes / 1024 / 1024).toFixed(1)} MB), engine accepts ` +
-      `up to ~${maxSeconds} s. Trim the file or pick a shorter clip.`,
+    `Track too long — ${Math.round(seconds)}s (max ${MAX_FIXTURE_DURATION_S}s). Trim it.`,
   );
 }
 


### PR DESCRIPTION
## Summary

The React UI rejected user-supplied audio longer than ~136 s, but the TRT engine profiles in `acestep/paths.py` (`_TRT_ENGINE_PROFILES`) register up to 240 s. The user-facing cap was a tighter bound than the engine actually requires — driven by the 50 MiB `websockets.serve(max_size=…)` rather than any engine limit.

Line up the cap with the engine ceiling:

- **`web/engine/audio/loadFixture.ts`** — validate by duration (`MAX_FIXTURE_DURATION_S = 240`) directly, not bytes. Anything longer than the largest registered TRT profile would fail at session init anyway, so reject it client-side with a clear short message: `Track too long — Ns (max 240s). Trim it.` (was a 3-line error referencing MB / MiB and 'WebSocket frame'-style internals).
- **`server.py`** — bump `max_size` from 50 MiB to 100 MiB. 240 s × 48 kHz stereo Float32 ≈ 88 MiB, plus comfortable headroom.
- **`web/app/globals.css`** — `.status-bar` was `white-space: nowrap` so any longer error message overflowed off the viewport. Now wraps at `min(80vw, 520px)` with `line-height: 1.5` and `overflow-wrap: anywhere` for pathological inputs (URLs, hashes).

Going beyond 240 s would require a new TRT engine profile baked (`acestep.engine.trt.build --duration <N>`); out of scope.

## Test plan

- [ ] Upload a 200 s clip → accepts, session starts, plays through.
- [ ] Upload a 245 s clip → rejected client-side with `Track too long — 245s (max 240s). Trim it.` rendered fully visible (wraps if needed) inside the StatusBar.
- [ ] No regression on short clips (60 s, 120 s) — they sit on the smallest fitting TRT profile as before (per `smallest_fitting_profile_duration_s`).
- [ ] Backend log on a 235 s session shows the 240 s engine selected without OOM on a 32 GB card.