### PR TITLE
realtime_motion_graph_web: MIDI first-pair snap + recording preview auto-close

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/RecordingPreview.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RecordingPreview.tsx
@@ -91,6 +91,7 @@ export function RecordingPreview() {
     });
     triggerDownload(prepared.blob, prepared.filename);
     notifySaved(prepared, state.durationMs);
+    dismiss();
   }
 
   async function share() {

--- a/demos/realtime_motion_graph_web/web/components/Performance/RecordingPreview.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RecordingPreview.tsx
@@ -112,15 +112,18 @@ export function RecordingPreview() {
       if (nav.canShare?.(data)) {
         await nav.share(data);
         notifySaved(prepared, state.durationMs);
+        dismiss();
         return;
       }
     } catch (err) {
-      // User cancellation throws AbortError — just swallow.
+      // User cancellation throws AbortError — leave the preview open so
+      // they can try a different action (Save / different share target).
       if ((err as Error).name === "AbortError") return;
       console.warn("[RecordingPreview] share failed", err);
     }
     triggerDownload(prepared.blob, prepared.filename);
     notifySaved(prepared, state.durationMs);
+    dismiss();
   }
 
   const canShare =

--- a/demos/realtime_motion_graph_web/web/engine/midi/absoluteDelta.ts
+++ b/demos/realtime_motion_graph_web/web/engine/midi/absoluteDelta.ts
@@ -45,9 +45,18 @@ export function readKnob(cc: number, value: number): KnobReading {
   const last = lastValue.get(cc);
   lastValue.set(cc, value);
 
-  // Snap to extremes regardless of prior history. Without this, a fast
-  // sweep from mid-range to 0 might leave the slider at 0.07 because
-  // delta clamping limited each step.
+  // First message for this CC — record only, no slider movement. Without
+  // this gate, a knob parked at an extreme when the user maps it would
+  // hit the extreme-snap branch below and slam the slider to 0 or max
+  // on first contact — exactly the takeover bug this module exists to
+  // prevent. We can't tell "parked at extreme on first contact" from
+  // "swept into extreme during tracking" without a prior value, so we
+  // do nothing the first time and let delta tracking start on message 2.
+  if (last === undefined) return { absolute: null, delta: null };
+
+  // Snap to extremes once we ARE tracking. Without this, a fast sweep
+  // from mid-range to 0 might leave the slider at 0.07 because delta
+  // clamping limited each step.
   if (value <= EXTREME_LOW_THRESHOLD) {
     return { absolute: 0, delta: null };
   }
@@ -55,7 +64,6 @@ export function readKnob(cc: number, value: number): KnobReading {
     return { absolute: 127, delta: null };
   }
 
-  if (last === undefined) return { absolute: null, delta: null };
   const raw = value - last;
   // Clamp instead of drop. A fast sweep still produces motion in the
   // right direction; the next message refines.

--- a/demos/realtime_motion_graph_web/web/store/useMidiStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useMidiStore.ts
@@ -2,6 +2,7 @@
 
 import { create } from "zustand";
 
+import { resetKnobDelta } from "@/engine/midi/absoluteDelta";
 import {
   DEFAULT_MIDI_MAP,
   MIDI_STORAGE_KEY,
@@ -114,6 +115,12 @@ export const useMidiStore = create<MidiState>((set, get) => ({
         if (next.cc[k] === learn.target) delete next.cc[k];
       }
       next.cc[String(num)] = learn.target;
+      // Drop any cached prior value for this CC so the next message
+      // re-establishes a baseline. Without this, rebinding CC X from
+      // param A to param B would treat the first post-rebind message
+      // as a delta from A's last raw value, producing a wrong jump on
+      // B's slider.
+      resetKnobDelta(num);
     } else if (kind === "note") {
       // Action button learning a NOTE.
       for (const k of Object.keys(next.notes)) {


### PR DESCRIPTION
Two small UX fixes for the realtime motion graph web demo.

## 1. MIDI: don't snap to extreme on first CC after pair

`absoluteDelta.ts` existed precisely to prevent classic MIDI takeover snap, but its extreme-snap fallback ran unconditionally — so a knob parked at value `<=1` or `>=126` when the user mapped it would slam the slider to 0 or max on first contact, then "settle" via delta tracking on subsequent messages.

Most visible on `hint_strength` ("Structure strength", `max=2.0`). User-reported as "the slider jumps from 0 to a big number really quickly, but if you turn the dial a bit more it settles."

**Fix:** in `readKnob`, return `{ absolute: null, delta: null }` on the first message for a CC (when `last === undefined`), **before** checking for extreme snap. From message 2 onward the original behavior is unchanged — fast sweeps still land on bounds, delta clamping still applies.

Also call `resetKnobDelta(num)` inside `useMidiStore.applyLearn` for `cc` bindings, so rebinding the same CC from param A to param B doesn't carry A's last raw value forward into B's first delta.

Files:
- `engine/midi/absoluteDelta.ts`
- `store/useMidiStore.ts`

## 2. Recording: auto-dismiss preview after Save

Clicking Save in `RecordingPreview` downloaded the WAV but left the preview dialog mounted, so the operator had to click Discard before they could record the next clip. Now Save triggers the download and dismisses the preview (same path as the Discard button).

Files:
- `components/Performance/RecordingPreview.tsx`

## Test plan

MIDI:
- [ ] Park a hardware knob near max (≥126), right-click Structure → Learn, twist. Slider stays put on first post-learn message, then delta-tracks.
- [ ] Same with knob parked near min (≤1).
- [ ] Mid-range first-pair: should track smoothly (regression check).
- [ ] Existing mapping, fast-sweep mid → 0/127: slider lands exactly on bound.
- [ ] Bind CC X to denoise, twist; rebind CC X to hint_strength, twist slightly: hint_strength does not jump.

Recording:
- [ ] Record a clip, click Save: WAV downloads and preview dialog disappears.
- [ ] Record a clip, click Discard: preview disappears, no download.
- [ ] (Mobile/share-capable browsers) Share path is unchanged in this PR.