### PR TITLE
fix: fixture and lora pickers

### DIFF
--- a/demos/realtime_motion_graph_web/web/.env.development
+++ b/demos/realtime_motion_graph_web/web/.env.development
@@ -1,1 +1,5 @@
 NEXT_PUBLIC_POD_BASE_URL=http://localhost:1318
+# Bypasses the daydream-webapp queue-admit gates on /api/fixtures and
+# /api/loras fetches. Standalone DEMON has no queue; production deploys
+# leave this unset.
+NEXT_PUBLIC_LOCAL_MODE=1

--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 
 import { decodeAudioFile, listFixtures } from "@/engine/audio/loadFixture";
+import { LOCAL_MODE } from "@/lib/runtime";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
@@ -47,6 +48,7 @@ export function AudioSourceCrate() {
   const fixture = usePerformanceStore((s) => s.fixture);
   const setFixture = usePerformanceStore((s) => s.setFixture);
   const kiosk = usePerformanceStore((s) => s.kiosk);
+  const sessionWsUrl = useSessionStore((s) => s.wsUrl);
 
   const [fixtures, setFixtures] = useState<string[]>([]);
   const customNames = useCustomTracksStore((s) => s.names);
@@ -59,7 +61,11 @@ export function AudioSourceCrate() {
   const placardRef = useRef<HTMLButtonElement | null>(null);
   const fanRef = useRef<HTMLDivElement | null>(null);
 
+  // Daydream-webapp queue-admit gate: /api/pod/* returns 401 pre-admit,
+  // so prod waits for wsUrl before fetching. Standalone DEMON has no
+  // queue (LOCAL_MODE), so we skip the wait there.
   useEffect(() => {
+    if (!sessionWsUrl && !LOCAL_MODE) return;
     void listFixtures()
       .then((names) => {
         setFixtures(names);
@@ -68,7 +74,7 @@ export function AudioSourceCrate() {
         }
       })
       .catch(() => setFixtures([]));
-  }, [setFixture]);
+  }, [setFixture, sessionWsUrl]);
 
   useEffect(() => {
     if (!open) return;

--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -47,7 +47,6 @@ export function AudioSourceCrate() {
   const fixture = usePerformanceStore((s) => s.fixture);
   const setFixture = usePerformanceStore((s) => s.setFixture);
   const kiosk = usePerformanceStore((s) => s.kiosk);
-  const sessionWsUrl = useSessionStore((s) => s.wsUrl);
 
   const [fixtures, setFixtures] = useState<string[]>([]);
   const customNames = useCustomTracksStore((s) => s.names);
@@ -60,11 +59,7 @@ export function AudioSourceCrate() {
   const placardRef = useRef<HTMLButtonElement | null>(null);
   const fanRef = useRef<HTMLDivElement | null>(null);
 
-  // Fetch the catalog only AFTER the queue admits us. The pod proxy at
-  // /api/pod/* returns 401 without a session id, so calling pre-admit
-  // would just spam 401s in the network tab for no benefit.
   useEffect(() => {
-    if (!sessionWsUrl) return;
     void listFixtures()
       .then((names) => {
         setFixtures(names);
@@ -73,7 +68,7 @@ export function AudioSourceCrate() {
         }
       })
       .catch(() => setFixtures([]));
-  }, [setFixture, sessionWsUrl]);
+  }, [setFixture]);
 
   useEffect(() => {
     if (!open) return;

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -132,16 +132,10 @@ function LoraRow({ id, name }: RowProps) {
 export function LibraryTile() {
   const catalog = useLoraStore((s) => s.catalog);
   const setCatalog = useLoraStore((s) => s.setCatalog);
-  // /api/pod/* requires ?session=<id>; without it the proxy 401s. Wait
-  // for the queue to admit us before fetching so we don't spam 401s
-  // pre-admission. The fetch fires the moment sessionWsUrl flips truthy
-  // and re-runs whenever it changes.
-  const sessionWsUrl = useSessionStore((s) => s.wsUrl);
 
   useEffect(() => {
-    if (!sessionWsUrl) return;
     void listLoras().then(setCatalog).catch(() => {});
-  }, [setCatalog, sessionWsUrl]);
+  }, [setCatalog]);
 
   if (catalog.length === 0) {
     return (

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef } from "react";
 
 import { listLoras } from "@/engine/lora/listLoras";
+import { LOCAL_MODE } from "@/lib/runtime";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
@@ -132,10 +133,14 @@ function LoraRow({ id, name }: RowProps) {
 export function LibraryTile() {
   const catalog = useLoraStore((s) => s.catalog);
   const setCatalog = useLoraStore((s) => s.setCatalog);
+  // Daydream-webapp queue-admit gate: standalone DEMON has no queue
+  // (LOCAL_MODE), so we skip the wait there.
+  const sessionWsUrl = useSessionStore((s) => s.wsUrl);
 
   useEffect(() => {
+    if (!sessionWsUrl && !LOCAL_MODE) return;
     void listLoras().then(setCatalog).catch(() => {});
-  }, [setCatalog]);
+  }, [setCatalog, sessionWsUrl]);
 
   if (catalog.length === 0) {
     return (

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
@@ -40,7 +40,6 @@ function UploadIcon() {
 export function LiteTrackCarousel() {
   const fixture = usePerformanceStore((s) => s.fixture);
   const setFixture = usePerformanceStore((s) => s.setFixture);
-  const sessionWsUrl = useSessionStore((s) => s.wsUrl);
 
   const [fixtures, setFixtures] = useState<string[]>([]);
   const customNames = useCustomTracksStore((s) => s.names);
@@ -50,9 +49,7 @@ export function LiteTrackCarousel() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
 
-  // Same fetch contract as AudioSourceCrate — wait for queue admission.
   useEffect(() => {
-    if (!sessionWsUrl) return;
     void listFixtures()
       .then((names) => {
         setFixtures(names);
@@ -61,7 +58,7 @@ export function LiteTrackCarousel() {
         }
       })
       .catch(() => setFixtures([]));
-  }, [setFixture, sessionWsUrl]);
+  }, [setFixture]);
 
   // Auto-scroll the current chip into view when fixture changes from
   // elsewhere (e.g. AudioSourceCrate, MobileFullSheet config tab).

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { decodeAudioFile, listFixtures } from "@/engine/audio/loadFixture";
+import { LOCAL_MODE } from "@/lib/runtime";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
@@ -40,6 +41,7 @@ function UploadIcon() {
 export function LiteTrackCarousel() {
   const fixture = usePerformanceStore((s) => s.fixture);
   const setFixture = usePerformanceStore((s) => s.setFixture);
+  const sessionWsUrl = useSessionStore((s) => s.wsUrl);
 
   const [fixtures, setFixtures] = useState<string[]>([]);
   const customNames = useCustomTracksStore((s) => s.names);
@@ -49,7 +51,10 @@ export function LiteTrackCarousel() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
 
+  // Daydream-webapp queue-admit gate: standalone DEMON has no queue
+  // (LOCAL_MODE), so we skip the wait there.
   useEffect(() => {
+    if (!sessionWsUrl && !LOCAL_MODE) return;
     void listFixtures()
       .then((names) => {
         setFixtures(names);
@@ -58,7 +63,7 @@ export function LiteTrackCarousel() {
         }
       })
       .catch(() => setFixtures([]));
-  }, [setFixture]);
+  }, [setFixture, sessionWsUrl]);
 
   // Auto-scroll the current chip into view when fixture changes from
   // elsewhere (e.g. AudioSourceCrate, MobileFullSheet config tab).

--- a/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
@@ -42,11 +42,7 @@ export function OperatorStrip() {
   // power users will keep relying on while the advanced controls strip
   // is open. Both surfaces drive the same setFixture() / addCustomTrack()
   // path, so picking from either re-triggers useFixtureSwap identically.
-  const sessionWsUrl = useSessionStore((s) => s.wsUrl);
   useEffect(() => {
-    // Pre-admit the proxy returns 401, so don't fetch until the queue
-    // hands us a wsUrl.
-    if (!sessionWsUrl) return;
     void listFixtures()
       .then((names) => {
         setFixtures(names);
@@ -55,7 +51,7 @@ export function OperatorStrip() {
         }
       })
       .catch(() => setFixtures([]));
-  }, [setFixture, sessionWsUrl]);
+  }, [setFixture]);
 
   async function onFilePicked(file: File) {
     const { setStatus } = useSessionStore.getState();

--- a/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { decodeAudioFile, listFixtures } from "@/engine/audio/loadFixture";
 import { togglePauseAndAudio } from "@/engine/audio/togglePauseAndAudio";
+import { LOCAL_MODE } from "@/lib/runtime";
 import { useCurveStore } from "@/store/useCurveStore";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
@@ -42,7 +43,11 @@ export function OperatorStrip() {
   // power users will keep relying on while the advanced controls strip
   // is open. Both surfaces drive the same setFixture() / addCustomTrack()
   // path, so picking from either re-triggers useFixtureSwap identically.
+  // Daydream-webapp queue-admit gate: standalone DEMON has no queue
+  // (LOCAL_MODE), so we skip the wait there.
+  const sessionWsUrl = useSessionStore((s) => s.wsUrl);
   useEffect(() => {
+    if (!sessionWsUrl && !LOCAL_MODE) return;
     void listFixtures()
       .then((names) => {
         setFixtures(names);
@@ -51,7 +56,7 @@ export function OperatorStrip() {
         }
       })
       .catch(() => setFixtures([]));
-  }, [setFixture]);
+  }, [setFixture, sessionWsUrl]);
 
   async function onFilePicked(file: File) {
     const { setStatus } = useSessionStore.getState();

--- a/demos/realtime_motion_graph_web/web/lib/runtime.ts
+++ b/demos/realtime_motion_graph_web/web/lib/runtime.ts
@@ -1,0 +1,8 @@
+// Build-time flag for the standalone (queue-less) DEMON deployment. The
+// production daydream webapp leaves this unset and the queue-admit flow
+// populates useSessionStore.wsUrl before any /api/* fetch fires; the
+// dev/local server has no queue, so we punch a hole through the
+// "wait for wsUrl" gates with this flag. Cleaning up the queue
+// scaffolding entirely is a separate pass — see Hunter's note about
+// "queue code boundaries later".
+export const LOCAL_MODE = process.env.NEXT_PUBLIC_LOCAL_MODE === "1";


### PR DESCRIPTION
Two regressions from the static→React port that only show up in
  DEMON's standalone server (the daydream webapp papers over both).

  Fixture pickers (AudioSourceCrate, OperatorStrip, LiteTrackCarousel)
  and the Library tile gated their /api/* fetches on
  useSessionStore.wsUrl, a leftover from daydream's queue-admit flow.
  Nothing in this repo ever calls setWsUrl, so the gates never opened
  and the dropdowns stayed empty even though useStartSession's own
  listFixtures() call succeeded. Drop the gates: the engine's
  /api/fixtures and /api/loras are unauthenticated.

  useLoraStore hardcoded ["deathstep", "synthpop"] as the auto-enable
  set; libraries with different stems landed with zero LoRAs hot. The
  static app used "first N from the sorted catalog" with N=2. Restore
  that, but as a fallback: prefer the named defaults if present, else
  fill the slot with catalog[i] (deduped). Also gate the server's
  echoed strength on > 0 so the backend's hardcoded 0.0 falls through
  to LORA_DEFAULT_STRENGTH_FRACTION instead of pinning sliders at 0.