### PR TITLE
Restore static-app defaults: LoRA seeding, config.json, dblclick-reset

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/RTMGBoot.tsx
+++ b/demos/realtime_motion_graph_web/web/app/RTMGBoot.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { setEngineUrlBuilder } from "@/engine/rtmgConfig";
+import { applyConfig, loadConfig } from "@/lib/config";
 
 // Same-origin URL builder. The engine's HTTP routes (/api/*, /fixtures/*,
 // /loras/*, /videos/*) are proxied to the Python backend at :8765 by the
@@ -10,6 +11,14 @@ import { setEngineUrlBuilder } from "@/engine/rtmgConfig";
 // Configured at module load (top-level, not in useEffect) so it's ready
 // before any child component's mount-time fetch fires.
 setEngineUrlBuilder((path) => (path.startsWith("/") ? path : `/${path}`));
+
+// Fire the config fetch as early as possible so applyConfig() runs before
+// the user clicks Play (which is when buildConfig() snapshots the engine
+// fields). Stores ship with hardcoded defaults that match DEFAULT_CONFIG,
+// so first paint is correct even if this is still in flight.
+if (typeof window !== "undefined") {
+  void loadConfig().then(applyConfig);
+}
 
 export function RTMGBoot() {
   return null;

--- a/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
@@ -17,6 +17,7 @@ import { useRenderLoop } from "@/hooks/useRenderLoop";
 import { useScheduledCurves } from "@/hooks/useScheduledCurves";
 import { useStartSession } from "@/hooks/useStartSession";
 import { useVideoLayer } from "@/hooks/useVideoLayer";
+import { useConfig } from "@/lib/config";
 import { useCurveStore } from "@/store/useCurveStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
@@ -62,7 +63,8 @@ export function PerformanceShell() {
   useRecording();
   useFixtureSwap();
   useEdgeLoraBinding();
-  useIdleReset(0);
+  const config = useConfig();
+  useIdleReset(config.reset_seconds);
 
   const startSession = useStartSession();
   const status = useSessionStore((s) => s.status);

--- a/demos/realtime_motion_graph_web/web/components/Performance/SliderGroup.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/SliderGroup.tsx
@@ -87,6 +87,11 @@ export function SliderGroup({ param, label, max, kbd }: Props) {
     let engaged = false;
     let engageTimer: ReturnType<typeof setTimeout> | null = null;
     const ENGAGE_MS = 50;
+    // DAW-style double-click-to-reset. Tracking pointerdown timestamps
+    // ourselves (instead of leaning on the synthetic `dblclick` event) is
+    // reliable in the presence of pointer capture and cross-browser quirks.
+    let lastDownAt = 0;
+    const DBLCLICK_MS = 350;
 
     const commit = () => {
       if (!cachedRect) return;
@@ -110,6 +115,17 @@ export function SliderGroup({ param, label, max, kbd }: Props) {
     const onPointerDown = (e: PointerEvent) => {
       // Right-click reserved for MIDI-learn.
       if (e.button !== 0) return;
+      const now = performance.now();
+      if (now - lastDownAt < DBLCLICK_MS) {
+        // Second click within the dblclick window: reset and bail before
+        // any drag state is set. Coexists with the long-press reset on
+        // mobile (useTactileSlider) — operators can use whichever feels
+        // natural.
+        usePerformanceStore.getState().resetSlider(param);
+        lastDownAt = 0;
+        return;
+      }
+      lastDownAt = now;
       dragging = true;
       engaged = false;
       cachedRect = el.getBoundingClientRect();

--- a/demos/realtime_motion_graph_web/web/hooks/useRenderLoop.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useRenderLoop.ts
@@ -7,6 +7,7 @@ import { kickRms } from "@/engine/render/audioFeatures";
 import { EffectsRenderer } from "@/engine/render/EffectsRenderer";
 import { GraphRenderer } from "@/engine/render/GraphRenderer";
 import { HUD } from "@/engine/render/HUD";
+import { getConfig, subscribeConfig } from "@/lib/config";
 import {
   destroyHaloRibbon,
   destroyRibbons,
@@ -83,18 +84,24 @@ export function useRenderLoop(refs: Refs) {
       : null;
 
     let effects: EffectsRenderer | null = null;
+    let unsubEffectsConfig: (() => void) | null = null;
     if (effectsEl) {
       try {
-        effects = new EffectsRenderer(effectsEl);
-        // Sensible defaults; Phase 12 / future hooks may bind these to
-        // sliders. Static values are fine because the kick/time uniforms
-        // are the per-frame variation.
-        effects.setParallaxStrength(0.4);
-        effects.setBloomOnKick(0.3);
-        effects.setBloomThreshold(0.15);
-        effects.setWarpStrength(0.4);
-        effects.setDubstep(0);
-        effects.setDaftPunk(0);
+        const e = new EffectsRenderer(effectsEl);
+        effects = e;
+        e.setDubstep(0);
+        e.setDaftPunk(0);
+        // Effects values come from web/public/config.json. Re-apply on
+        // every applyConfig() so an async-arriving config or future
+        // "Reload config" affordance lands without a page refresh.
+        const applyFx = (c: ReturnType<typeof getConfig>) => {
+          e.setParallaxStrength(c.effects.parallax_strength);
+          e.setBloomOnKick(c.effects.bloom_on_kick);
+          e.setBloomThreshold(c.effects.bloom_threshold);
+          e.setWarpStrength(c.effects.warp_strength);
+        };
+        applyFx(getConfig());
+        unsubEffectsConfig = subscribeConfig(applyFx);
       } catch (e) {
         // WebGL2 unavailable → fall back to the raw <video> the canvas
         // overlays. App still works without bloom/parallax.
@@ -258,6 +265,7 @@ export function useRenderLoop(refs: Refs) {
       document.removeEventListener("visibilitychange", onVisibility);
       sessionUnsub();
       mirrorUnsub?.();
+      unsubEffectsConfig?.();
       hud.destroy();
       graph.destroy();
       effects?.destroy();

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -7,6 +7,7 @@ import { listFixtures, loadFixtureAudio } from "@/engine/audio/loadFixture";
 import { defaultWsUrl } from "@/engine/podUrl";
 import { RemoteBackend, SLICE_FLAG_DELTA } from "@/engine/protocol";
 import { getApiKey } from "@/engine/rtmgConfig";
+import { getConfig } from "@/lib/config";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
@@ -43,25 +44,26 @@ function resolveWsUrl(serverWsUrl: string | null): string {
 function buildConfig(fixtureName: string): SessionConfig {
   const perf = usePerformanceStore.getState();
   const lora = useLoraStore.getState();
+  const cfg = getConfig().engine;
   const enabledLoras = Array.from(lora.enabled);
   const loraStrengths: Record<string, number> = {};
   for (const id of enabledLoras) {
     const v = lora.strengths[id];
     if (typeof v === "number") loraStrengths[id] = v;
   }
+  // Engine fields come from web/public/config.json (overridable per
+  // installation). Default depth=4 over depth=8: ~½ VRAM, ~⅛ param
+  // latency, ~11.3/s vs 12.3/s throughput on a 32 GB card. The VRAM
+  // headroom is what unlocks longer audio uploads (cap lives in
+  // loadFixture.ts; depth=4 makes future bumps VRAM-safe).
   return {
-    sde: false,
-    lora: true,
-    // depth=4 over depth=8: ~½ VRAM, ~⅛ param latency, ~11.3/s vs 12.3/s
-    // throughput on a 32 GB card per Ryan's measurements. The VRAM
-    // headroom is what unlocks longer audio uploads (the user-facing
-    // cap is the WebSocket frame size in loadFixture.ts; depth=4
-    // makes future bumps to that cap VRAM-safe).
-    depth: 4,
-    vae_window: 6,
-    crop: 0,
-    steps: 8,
-    fast_vae: false,
+    sde: cfg.sde,
+    lora: cfg.lora,
+    depth: cfg.depth,
+    vae_window: cfg.vae_window,
+    crop: cfg.crop,
+    steps: cfg.steps,
+    fast_vae: cfg.fast_vae,
     key: perf.activeKey,
     enabled_loras: enabledLoras,
     prompt: perf.promptA,

--- a/demos/realtime_motion_graph_web/web/lib/config.ts
+++ b/demos/realtime_motion_graph_web/web/lib/config.ts
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import {
+  DCW_MODES,
+  DCW_WAVELETS,
+  type DcwMode,
+  type DcwWavelet,
+} from "@/types/engine";
+
+// Operator-editable startup config. Mirrors the static app's
+// static/config.json (now lost in the React port). Lives at
+// web/public/config.json so an installer can edit and refresh without a
+// rebuild — the Next.js dev/prod server serves it as-is, no caching.
+//
+// Boot order:
+//   1. RTMGBoot (module load) calls loadConfig() → applyConfig().
+//   2. applyConfig() pushes values into the relevant zustand stores
+//      (perf, lora) and notifies non-store subscribers (effects renderer,
+//      PerformanceShell's useConfig()).
+//   3. Stores already initialize with hardcoded defaults that match
+//      DEFAULT_CONFIG below, so first paint is correct even if the fetch
+//      is still in flight.
+
+export interface RtmgConfigEngine {
+  sde: boolean;
+  lora: boolean;
+  depth: number;
+  vae_window: number;
+  crop: number;
+  steps: number;
+  fast_vae: boolean;
+  key: string;
+  /** Filename stems to auto-enable on first catalog load. Empty falls
+   * back to the count-rule in useLoraStore (first two from the sorted
+   * catalog, with name-fallback per slot). */
+  enabled_loras: string[];
+}
+
+export interface RtmgConfigPrompts {
+  a: string;
+  b: string;
+  blend: number;
+}
+
+export interface RtmgConfigEffects {
+  parallax_strength: number;
+  bloom_on_kick: number;
+  bloom_threshold: number;
+  warp_strength: number;
+}
+
+/** controls.* — initial slider values plus the DCW companion controls
+ * (enabled / mode / wavelet) and lora_default_strength. Numeric entries
+ * seed sliderValues + sliderTargets; the named DCW entries drive the
+ * non-numeric DCW state. Unknown keys are ignored. */
+export type RtmgConfigControls = Record<string, number | boolean | string>;
+
+export interface RtmgConfig {
+  engine: RtmgConfigEngine;
+  prompts: RtmgConfigPrompts;
+  controls: RtmgConfigControls;
+  seed: number;
+  effects: RtmgConfigEffects;
+  reset_seconds: number;
+}
+
+export const DEFAULT_CONFIG: RtmgConfig = {
+  engine: {
+    sde: false,
+    lora: true,
+    depth: 4,
+    vae_window: 6,
+    crop: 0,
+    steps: 8,
+    fast_vae: false,
+    key: "G# minor",
+    enabled_loras: [],
+  },
+  prompts: {
+    a: "heavy dubstep, deathstep, afxdump, growl heavy bass distortion",
+    b: "daft punk style, beautiful, four to the floor, angelic",
+    blend: 0.4,
+  },
+  controls: {
+    denoise: 0.7,
+    hint_strength: 1.4,
+    feedback: 0.0,
+    shift: 0.5,
+    noise_share: 0.0,
+    ode_noise: 0.0,
+    ch_g0: 1.0,
+    ch_g1: 1.0,
+    ch_g2: 1.0,
+    ch_g3: 1.0,
+    ch_g4: 1.0,
+    ch_g5: 1.0,
+    ch_g6: 1.0,
+    ch_g7: 1.0,
+    ch13: 1.0,
+    ch14: 1.0,
+    ch19: 1.0,
+    ch23: 1.0,
+    ch29: 1.0,
+    ch56: 1.0,
+    dcw_scaler: 0.05,
+    dcw_high_scaler: 0.02,
+    dcw_enabled: true,
+    dcw_mode: "double",
+    dcw_wavelet: "haar",
+    lora_default_strength: 1.4,
+  },
+  seed: 0,
+  effects: {
+    parallax_strength: 0.4,
+    bloom_on_kick: 0.3,
+    bloom_threshold: 0.15,
+    warp_strength: 0.4,
+  },
+  reset_seconds: 0,
+};
+
+let _activeConfig: RtmgConfig = DEFAULT_CONFIG;
+const listeners = new Set<(c: RtmgConfig) => void>();
+
+/** Snapshot of the active config. Read at point-of-use by code paths
+ * that don't need re-render reactivity (e.g. useStartSession.buildConfig
+ * runs once per Play click). For reactive reads, use useConfig(). */
+export function getConfig(): RtmgConfig {
+  return _activeConfig;
+}
+
+/** Subscribe to applyConfig() calls. Returns an unsubscribe. Used by
+ * non-store consumers (the effects renderer in useRenderLoop) that need
+ * to re-apply settings when the config arrives async after their mount. */
+export function subscribeConfig(fn: (c: RtmgConfig) => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+/** React hook variant — subscribes the calling component to config
+ * changes so it re-renders when applyConfig() fires. */
+export function useConfig(): RtmgConfig {
+  const [c, setC] = useState(_activeConfig);
+  useEffect(() => subscribeConfig(setC), []);
+  return c;
+}
+
+function mergeConfig(
+  base: RtmgConfig,
+  override: Partial<RtmgConfig> | null | undefined,
+): RtmgConfig {
+  if (!override) return base;
+  return {
+    engine: { ...base.engine, ...(override.engine ?? {}) },
+    prompts: { ...base.prompts, ...(override.prompts ?? {}) },
+    controls: { ...base.controls, ...(override.controls ?? {}) },
+    seed: typeof override.seed === "number" ? override.seed : base.seed,
+    effects: { ...base.effects, ...(override.effects ?? {}) },
+    reset_seconds:
+      typeof override.reset_seconds === "number"
+        ? override.reset_seconds
+        : base.reset_seconds,
+  };
+}
+
+/** Fetch /config.json (no cache). Missing file or parse error → defaults
+ * silently — the bundled defaults already match the React port's current
+ * behavior, so a deploy without a config.json works unchanged. */
+export async function loadConfig(): Promise<RtmgConfig> {
+  try {
+    const res = await fetch(`/config.json?t=${Date.now()}`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return DEFAULT_CONFIG;
+    const json = (await res.json()) as Partial<RtmgConfig>;
+    return mergeConfig(DEFAULT_CONFIG, json);
+  } catch {
+    return DEFAULT_CONFIG;
+  }
+}
+
+function isDcwMode(v: unknown): v is DcwMode {
+  return typeof v === "string" && (DCW_MODES as readonly string[]).includes(v);
+}
+function isDcwWavelet(v: unknown): v is DcwWavelet {
+  return typeof v === "string" && (DCW_WAVELETS as readonly string[]).includes(v);
+}
+
+/** Push the supplied config into stores + non-store subscribers. Idempotent;
+ * safe to call multiple times. The only mid-session callers today are the
+ * boot path; future "Reload config" affordances would call this too. */
+export function applyConfig(c: RtmgConfig): void {
+  _activeConfig = c;
+
+  // Numeric controls land on sliderValues + sliderTargets so the slider
+  // UI and the param-sync tick agree.
+  const sliderUpdates: Record<string, number> = {};
+  for (const [k, v] of Object.entries(c.controls)) {
+    if (typeof v === "number") sliderUpdates[k] = v;
+  }
+
+  usePerformanceStore.setState((s) => ({
+    sliderValues: { ...s.sliderValues, ...sliderUpdates },
+    sliderTargets: { ...s.sliderTargets, ...sliderUpdates },
+    promptA: c.prompts.a,
+    promptB: c.prompts.b,
+    blend: c.prompts.blend,
+    activeKey: c.engine.key,
+    seed: c.seed,
+    dcwEnabled:
+      typeof c.controls.dcw_enabled === "boolean"
+        ? c.controls.dcw_enabled
+        : s.dcwEnabled,
+    dcwMode: isDcwMode(c.controls.dcw_mode) ? c.controls.dcw_mode : s.dcwMode,
+    dcwWavelet: isDcwWavelet(c.controls.dcw_wavelet)
+      ? c.controls.dcw_wavelet
+      : s.dcwWavelet,
+  }));
+
+  for (const fn of listeners) fn(c);
+}

--- a/demos/realtime_motion_graph_web/web/public/config.json
+++ b/demos/realtime_motion_graph_web/web/public/config.json
@@ -1,0 +1,69 @@
+{
+  "_comment": "Initial settings for the DEMON installation. Edit and refresh — no rebuild needed. Slider max/step lives in types/engine.ts (SLIDER_META); only the per-control starting value is set here. Schema and defaults: web/lib/config.ts.",
+
+  "engine": {
+    "sde": false,
+    "lora": true,
+    "depth": 4,
+    "vae_window": 6,
+    "crop": 0,
+    "steps": 8,
+    "fast_vae": false,
+    "key": "G# minor",
+    "_enabled_loras_help": "Filename stems (no .safetensors) to auto-enable on first catalog load. Empty = count-rule (first two from the sorted catalog, with name-fallback per slot — see useLoraStore.ts).",
+    "enabled_loras": []
+  },
+
+  "prompts": {
+    "a": "heavy dubstep, deathstep, afxdump, growl heavy bass distortion",
+    "b": "daft punk style, beautiful, four to the floor, angelic",
+    "blend": 0.4
+  },
+
+  "controls": {
+    "denoise": 0.7,
+    "_lora_default_strength_help": "Initial value applied to any LoRA strength slider whose server-reported strength is 0 (current Python backend behavior). Auto-enabled LoRAs land here on first paint.",
+    "lora_default_strength": 1.4,
+    "hint_strength": 1.4,
+
+    "feedback": 0.0,
+    "shift": 0.5,
+    "noise_share": 0.0,
+    "ode_noise": 0.0,
+
+    "ch_g0": 1.0,
+    "ch_g1": 1.0,
+    "ch_g2": 1.0,
+    "ch_g3": 1.0,
+    "ch_g4": 1.0,
+    "ch_g5": 1.0,
+    "ch_g6": 1.0,
+    "ch_g7": 1.0,
+
+    "ch13": 1.0,
+    "ch14": 1.0,
+    "ch19": 1.0,
+    "ch23": 1.0,
+    "ch29": 1.0,
+    "ch56": 1.0,
+
+    "dcw_enabled": true,
+    "dcw_mode": "double",
+    "dcw_scaler": 0.05,
+    "dcw_high_scaler": 0.02,
+    "dcw_wavelet": "haar"
+  },
+
+  "seed": 0,
+
+  "_effects_help": "Audio-reactive video shader pipeline (parallax + bloom-on-kick). Both effects pulse with the kick envelope; the perimeter ribbons + DEMON wordmark also pulse with kick via a CSS variable.",
+  "effects": {
+    "parallax_strength": 0.4,
+    "bloom_on_kick": 0.3,
+    "bloom_threshold": 0.15,
+    "warp_strength": 0.4
+  },
+
+  "_reset_seconds_help": "Idle timeout. After this many seconds of no interaction (pointer, key, or MIDI), every control reverts to the defaults above. Set to 0 to disable.",
+  "reset_seconds": 0
+}

--- a/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
@@ -2,6 +2,7 @@
 
 import { create } from "zustand";
 
+import { getConfig } from "@/lib/config";
 import {
   LORA_DEFAULT_STRENGTH_FRACTION,
   LORA_SLIDER_MAX,
@@ -12,14 +13,15 @@ import type { LoraCatalogEntry } from "@/types/protocol";
 // arrives via /api/loras (cheap filesystem scan, available before WS) and
 // is updated mid-session via the WS "lora_catalog" frame.
 
-// Preferred LoRA stems flipped on the first time the catalog arrives
-// populated. If a preferred stem isn't in the catalog (different LoRA
-// library locally), the slot falls back to the catalog entry at the
-// same index, then to the next unclaimed entry — so a fresh page-load
-// always lands with two LoRAs hot regardless of which files are on disk.
-// One-shot: a later WS lora_catalog re-broadcast won't re-enable a LoRA
-// the user has explicitly disabled.
-const PREFERRED_DEFAULT_LORAS = ["deathstep", "synthpop"] as const;
+// Hardcoded preferred-stems fallback used when the operator's
+// config.json leaves engine.enabled_loras empty. If a preferred stem
+// isn't in the catalog (different LoRA library locally), the slot
+// falls back to the catalog entry at the same index, then to the next
+// unclaimed entry — so a fresh page-load always lands with two LoRAs
+// hot regardless of which files are on disk. One-shot: a later WS
+// lora_catalog re-broadcast won't re-enable a LoRA the user has
+// explicitly disabled.
+const HARDCODED_PREFERRED_LORAS = ["deathstep", "synthpop"] as const;
 
 interface LoraState {
   catalog: LoraCatalogEntry[];
@@ -46,35 +48,46 @@ export const useLoraStore = create<LoraState>((set) => ({
 
   setCatalog: (catalog) =>
     set((s) => {
+      const cfg = getConfig();
+      const cfgStrength = cfg.controls.lora_default_strength;
+      const fallbackStrength =
+        typeof cfgStrength === "number" && cfgStrength > 0
+          ? cfgStrength
+          : LORA_DEFAULT_STRENGTH_FRACTION * LORA_SLIDER_MAX;
       // Seed missing strengths from the server's reported defaults so a
       // freshly-arrived LoRA picks up its on-disk default. The Python
       // backend currently echoes 0.0 for every entry, which we treat as
-      // "unset" and fall back to LORA_DEFAULT_STRENGTH_FRACTION so the
-      // slider lands at a useful initial level. A genuine non-zero
-      // server default still wins.
+      // "unset" and fall back to controls.lora_default_strength (from
+      // config.json) so the slider lands at a useful initial level. A
+      // genuine non-zero server default still wins.
       const next: Record<string, number> = { ...s.strengths };
       for (const entry of catalog) {
         if (!(entry.id in next)) {
           next[entry.id] =
             typeof entry.strength === "number" && entry.strength > 0
               ? entry.strength
-              : LORA_DEFAULT_STRENGTH_FRACTION * LORA_SLIDER_MAX;
+              : fallbackStrength;
         }
       }
       // First populated catalog: flip on the preferred default LoRAs so the
-      // demo plays with its intended sound out of the box. If a preferred
-      // stem isn't in the catalog, fall back to the catalog entry at that
-      // slot index (with dedup so two missing defaults don't both claim the
-      // first entry). Skipped on later re-broadcasts so disabling a seeded
-      // LoRA sticks.
+      // demo plays with its intended sound out of the box. Preference
+      // order is config.json's engine.enabled_loras, falling back to
+      // HARDCODED_PREFERRED_LORAS when the config leaves it empty. If a
+      // preferred stem isn't in the catalog, fall back to the catalog
+      // entry at that slot index (with dedup so two missing defaults
+      // don't both claim the first entry). Skipped on later re-broadcasts
+      // so disabling a seeded LoRA sticks.
       let enabled = s.enabled;
       let seeded = s._seeded;
       if (!s._seeded && catalog.length > 0) {
+        const cfgPreferred = cfg.engine.enabled_loras;
+        const preferredList: readonly string[] =
+          cfgPreferred.length > 0 ? cfgPreferred : HARDCODED_PREFERRED_LORAS;
         const nextEnabled = new Set(s.enabled);
         const present = new Set(catalog.map((e) => e.id));
         const claimed = new Set<string>();
-        for (let i = 0; i < PREFERRED_DEFAULT_LORAS.length; i++) {
-          const preferred = PREFERRED_DEFAULT_LORAS[i];
+        for (let i = 0; i < preferredList.length; i++) {
+          const preferred = preferredList[i];
           let pick: string | undefined;
           if (present.has(preferred) && !claimed.has(preferred)) {
             pick = preferred;

--- a/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
@@ -12,11 +12,14 @@ import type { LoraCatalogEntry } from "@/types/protocol";
 // arrives via /api/loras (cheap filesystem scan, available before WS) and
 // is updated mid-session via the WS "lora_catalog" frame.
 
-// LoRAs flipped on the first time the catalog arrives populated. Matches the
-// safetensors filename stems delivered by /api/loras (see scripts/loras.default.txt).
-// One-shot: a later WS lora_catalog re-broadcast won't re-enable a LoRA the
-// user has explicitly disabled.
-const DEFAULT_ENABLED_LORAS = new Set(["deathstep", "synthpop"]);
+// Preferred LoRA stems flipped on the first time the catalog arrives
+// populated. If a preferred stem isn't in the catalog (different LoRA
+// library locally), the slot falls back to the catalog entry at the
+// same index, then to the next unclaimed entry — so a fresh page-load
+// always lands with two LoRAs hot regardless of which files are on disk.
+// One-shot: a later WS lora_catalog re-broadcast won't re-enable a LoRA
+// the user has explicitly disabled.
+const PREFERRED_DEFAULT_LORAS = ["deathstep", "synthpop"] as const;
 
 interface LoraState {
   catalog: LoraCatalogEntry[];
@@ -44,28 +47,47 @@ export const useLoraStore = create<LoraState>((set) => ({
   setCatalog: (catalog) =>
     set((s) => {
       // Seed missing strengths from the server's reported defaults so a
-      // freshly-arrived LoRA picks up its on-disk default. If the server
-      // omits `strength` (current Python backend behavior), fall back to
-      // LORA_DEFAULT_STRENGTH_FRACTION so the slider lands at a useful
-      // initial level instead of silently sitting at 0.
+      // freshly-arrived LoRA picks up its on-disk default. The Python
+      // backend currently echoes 0.0 for every entry, which we treat as
+      // "unset" and fall back to LORA_DEFAULT_STRENGTH_FRACTION so the
+      // slider lands at a useful initial level. A genuine non-zero
+      // server default still wins.
       const next: Record<string, number> = { ...s.strengths };
       for (const entry of catalog) {
         if (!(entry.id in next)) {
           next[entry.id] =
-            typeof entry.strength === "number"
+            typeof entry.strength === "number" && entry.strength > 0
               ? entry.strength
               : LORA_DEFAULT_STRENGTH_FRACTION * LORA_SLIDER_MAX;
         }
       }
-      // First populated catalog: flip on the canonical default LoRAs so the
-      // demo plays with its intended sound out of the box. Skipped on later
-      // re-broadcasts so disabling a default LoRA sticks.
+      // First populated catalog: flip on the preferred default LoRAs so the
+      // demo plays with its intended sound out of the box. If a preferred
+      // stem isn't in the catalog, fall back to the catalog entry at that
+      // slot index (with dedup so two missing defaults don't both claim the
+      // first entry). Skipped on later re-broadcasts so disabling a seeded
+      // LoRA sticks.
       let enabled = s.enabled;
       let seeded = s._seeded;
       if (!s._seeded && catalog.length > 0) {
         const nextEnabled = new Set(s.enabled);
-        for (const entry of catalog) {
-          if (DEFAULT_ENABLED_LORAS.has(entry.id)) nextEnabled.add(entry.id);
+        const present = new Set(catalog.map((e) => e.id));
+        const claimed = new Set<string>();
+        for (let i = 0; i < PREFERRED_DEFAULT_LORAS.length; i++) {
+          const preferred = PREFERRED_DEFAULT_LORAS[i];
+          let pick: string | undefined;
+          if (present.has(preferred) && !claimed.has(preferred)) {
+            pick = preferred;
+          } else {
+            const slot = catalog[i]?.id;
+            pick = slot && !claimed.has(slot)
+              ? slot
+              : catalog.find((e) => !claimed.has(e.id))?.id;
+          }
+          if (pick) {
+            nextEnabled.add(pick);
+            claimed.add(pick);
+          }
         }
         enabled = nextEnabled;
         seeded = true;


### PR DESCRIPTION
DEPENDS UPON #39 

Three regressions from the static→React port, stacked on the fixture/lora picker fix.

- LoRA hardcoded defaults fall back to first/second from catalog. Previously hardcoded to `deathstep`/`synthpop`; libraries with different stems landed with zero LoRAs hot. Now: prefer the named defaults if present, else fill the slot with `catalog[i]` (deduped). Server's hardcoded `0.0` strength now falls through to the configured default instead of pinning sliders at 0.
- Restore startup-value `config.json`. The static app's `static/config.json` (operator-editable per-installation defaults: engine config, prompts, sliders, effects, idle reset, etc.) had no replacement in the React port. Restored as `web/public/config.json` with a typed loader (`web/lib/config.ts`); fetched on boot, applied to zustand stores. Edit-and-refresh, no rebuild. Bundled `DEFAULT_CONFIG` mirrors current React behavior so a deploy without the file works unchanged.
- Restore double-click-to-reset on faders. Standard DAW behavior; long-press reset (`useTactileSlider`) still works alongside.

Stacked on `ryanontheinside/fix/local-lora-fixture-fix`; the diff narrows once that lands.

## Test plan

- [ ] Local: top two LoRAs auto-enable at non-zero strength regardless of which `*.safetensors` files are in `~/.daydream-scope/models/demon/loras/`
- [ ] Edit `web/public/config.json` (e.g. change `seed` or a slider default), refresh browser, confirm change is reflected without rebuild
- [ ] Double-click any vertical fader, confirm it snaps to its default
- [ ] Long-press still resets faders on mobile
