### PR TITLE
realtime_motion_graph_web: graph sparks → constant leftward party trails

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
@@ -92,10 +92,17 @@ interface History {
   filled: number;
 }
 
-// Beat-triggered confetti sparks (cursor.ts vocabulary). Spawned in
-// starburst patterns from each satellite on the rising edge of `pulse`,
-// then aged + simulated under gravity until they fade out. Stateful
-// across frames; capped at MAX_SPARKS so dense music can't run away.
+// Confetti sparks (cursor.ts vocabulary). Each line fires on its own
+// jittered ~250ms schedule, independent of audio, so the cluster reads
+// as a constant party — there's almost always a burst in flight from
+// somewhere. `pulse` modulates burst *intensity* (more sparks per
+// burst on loud moments) rather than gating triggers, so the graph
+// still responds to music without going silent in quiet sections.
+//
+// All sparks fly leftward (toward the past, away from the playhead's
+// "now"). The result reads as a chromatic comet trail behind the
+// playhead — sparks streak across the rendered line history in their
+// line's color, reinforcing the "time is flowing past you" cue.
 interface Spark {
   x: number;
   y: number;
@@ -108,33 +115,29 @@ interface Spark {
   b: number;
 }
 
-// Spark size + physics lifted from engine/cursor.ts confetti — same
-// disc, same speed range, same gravity, same life. Direction is
-// different though: a cursor click is stationary, so confetti goes
-// radial-random; a satellite is moving along its orbit, so sparks shed
-// in its direction of motion (tangent ± a narrow cone) → reads as a
-// comet trail rather than a puff. Gravity arcs the trail downward
-// naturally, no upward bias needed.
-const SPARK_GRAVITY = 0.16; // matches GRAVITY in cursor.ts
+// Spark physics. Disc size still matches cursor.ts confetti (2px), but
+// trails are tuned longer + flatter than the cursor click: faster
+// speeds, lower gravity, longer life — the playhead leaves a chromatic
+// streak behind it rather than a tight burst.
+const SPARK_GRAVITY = 0.10; // was 0.16 (cursor confetti); reduced for flatter trails
 const SPARK_RADIUS = 2; // matches SPARK_RADIUS in cursor.ts (4px diameter)
-const SPARK_MIN_SPEED = 3.2; // matches CONFETTI_MIN_SPEED
-const SPARK_MAX_SPEED = 7.0; // matches CONFETTI_MAX_SPEED
-const SPARK_LIFE_MS = 900; // matches CONFETTI_LIFE_MS (±100ms jitter applied per spark)
-const SPARK_CONE_RAD = Math.PI / 7; // ~25° spread around the satellite's tangent
-const SPARKS_PER_BEAT = 8;
-const MAX_SPARKS = 240;
-const BEAT_THRESH = 0.4; // pulse threshold for "kick is happening"
+const SPARK_MIN_SPEED = 4.5; // was 3.2; faster baseline → longer trails
+const SPARK_MAX_SPEED = 8.5; // was 7.0; faster ceiling for the loud-moment streaks
+const SPARK_LIFE_MS = 1100; // was 900; longer fade so the trail extends visibly farther
+const SPARK_CONE_RAD = Math.PI / 5; // ~36° spread around the leftward axis
+const LEFT_ANGLE = Math.PI; // 180° — pure leftward, toward the past
 
-// Per-line firing gate. Each beat, every line independently rolls
-// against `fireProb`, which scales linearly with the kick's peak
-// strength: soft kicks fire only ~40% of lines (sparse, syncopated),
-// peak kicks fire ~100% (full swarm). After firing, a line is muted
-// for COOLDOWN_MIN..COOLDOWN_MAX ms — independent across lines, so
-// dense music desyncs naturally instead of repeating in lockstep.
-const FIRE_PROB_AT_THRESHOLD = 0.4;
-const FIRE_PROB_AT_PEAK = 1.0;
-const COOLDOWN_MIN_MS = 100;
-const COOLDOWN_MAX_MS = 400;
+// Per-line burst scheduler. Every line picks its own next-fire time
+// in [BURST_INTERVAL_MIN_MS, BURST_INTERVAL_MAX_MS] after its last
+// burst — independent across lines, so the cluster fires constantly
+// but desynced. `pulse` doesn't gate firing; it just bumps the burst's
+// spark count via SPARKS_PER_BURST_PULSE so loud moments visibly
+// thicken without quiet moments going silent.
+const SPARKS_PER_BURST_BASE = 6;
+const SPARKS_PER_BURST_PULSE = 6; // up to +6 more sparks at peak pulse
+const MAX_SPARKS = 400; // raised — constant firing × 8+ lines × ~1s life sustains a higher steady state
+const BURST_INTERVAL_MIN_MS = 150;
+const BURST_INTERVAL_MAX_MS = 350;
 
 export class GraphRenderer {
   readonly canvas: HTMLCanvasElement;
@@ -142,17 +145,10 @@ export class GraphRenderer {
   private readonly histories: Map<string, History> = new Map();
   private readonly _resizeObs: ResizeObserver;
   private readonly _sparks: Spark[] = [];
-  // Cooldown timestamps per line — `now`-domain wall-clock millis after
-  // which the line is eligible to fire again.
-  private readonly _lineCooldowns: Map<string, number> = new Map();
-  // Beat detection state — track whether pulse is currently above
-  // threshold and the peak it's hit during this above-threshold span.
-  // Firing on the falling edge (when pulse drops back below threshold)
-  // means we know the kick's actual peak strength, not just the
-  // rising-edge value (always ≈ threshold). ~50–100ms of perceptual
-  // latency from kick onset; well within sync tolerance.
-  private _aboveThresh = false;
-  private _peakPulse = 0;
+  // Per-line `now`-domain wall-clock millis at which the line's next
+  // burst should fire. Initialized lazily on first fire so freshly
+  // added lines join the party immediately.
+  private readonly _nextFireAt: Map<string, number> = new Map();
   private _lastNow = 0;
   private w = 1;
   private h = 1;
@@ -285,40 +281,19 @@ export class GraphRenderer {
     // at different rates, in different directions, on different shells.
     //
     // Orbits are time-driven so the cluster never freezes between data
-    // samples. When an audio kick happens, each satellite has an
-    // independent chance to fire a comet trail of palette-colored
-    // sparks along its tangent — chance scales with the kick's peak
-    // strength (soft kicks: sparse syncopation, peak kicks: full
-    // swarm), gated by a per-line cooldown so dense music desyncs
-    // organically instead of marching in lockstep. Sparks live in
+    // samples. Each line fires a leftward comet trail on its own
+    // jittered ~250ms schedule (independent across lines), so the
+    // graph reads as a constant chromatic party flowing past the
+    // playhead. `pulse` doesn't gate the trigger — it just thickens
+    // each burst (more sparks) on loud moments. Sparks live in
     // `this._sparks`, capped at MAX_SPARKS.
     {
       const dt = this._lastNow ? Math.min(50, now - this._lastNow) : 16;
       this._lastNow = now;
       const dtScale = dt / 16;
 
-      // Falling-edge peak detection: arm when pulse crosses threshold,
-      // track the max while above, fire on the frame that drops back
-      // below. `beatPulse` is the peak strength observed during the
-      // above-threshold span — used to scale per-line fire probability.
-      let beat = false;
-      let beatPulse = 0;
-      if (pulse > BEAT_THRESH) {
-        this._aboveThresh = true;
-        if (pulse > this._peakPulse) this._peakPulse = pulse;
-      } else if (this._aboveThresh) {
-        beat = true;
-        beatPulse = this._peakPulse;
-        this._aboveThresh = false;
-        this._peakPulse = 0;
-      }
-      const fireProb =
-        FIRE_PROB_AT_THRESHOLD +
-        (FIRE_PROB_AT_PEAK - FIRE_PROB_AT_THRESHOLD) *
-          Math.min(
-            1,
-            Math.max(0, (beatPulse - BEAT_THRESH) / (1 - BEAT_THRESH)),
-          );
+      const burstCount =
+        SPARKS_PER_BURST_BASE + Math.round(SPARKS_PER_BURST_PULSE * pulse);
 
       const orbitTheta = (now / 1800) * Math.PI * 2; // ~1.8s base period
       const baseOrbitR = 6 * (1 + 0.4 * pulse);
@@ -369,27 +344,25 @@ export class GraphRenderer {
         ctx.arc(satX, satY, 2.5, 0, Math.PI * 2);
         ctx.fill();
 
-        // Beat → comet trail shed from the satellite along its tangent.
-        // Tangent direction is perpendicular to the radial, signed by
-        // orbit `dir`, so sparks always fly in the direction of motion.
-        // Narrow ±25° cone keeps them tightly behind the satellite
-        // instead of fanning out; gravity arcs the trail downward.
-        //
-        // Two gates layer here: per-line probability (scales with kick
-        // strength via fireProb) and an independent cooldown so a line
-        // that just fired doesn't immediately re-fire on the next beat.
-        // Together they break the unison and add organic syncopation.
-        const eligibleAt = this._lineCooldowns.get(name) ?? 0;
-        if (beat && now >= eligibleAt && Math.random() < fireProb) {
-          this._lineCooldowns.set(
+        // Per-line burst: fire whenever the wall clock passes the
+        // line's scheduled next-fire time, then reschedule with fresh
+        // jitter. Independent across lines so the cluster fires
+        // constantly but desynced — there's almost always a trail in
+        // flight from somewhere on the graph. Direction is fixed
+        // leftward (LEFT_ANGLE = π) so the trail streaks toward the
+        // past instead of orbiting outward — reads as the playhead
+        // shedding history behind itself as time flows.
+        const nextFireAt = this._nextFireAt.get(name) ?? 0;
+        if (now >= nextFireAt) {
+          this._nextFireAt.set(
             name,
-            now + COOLDOWN_MIN_MS + Math.random() * (COOLDOWN_MAX_MS - COOLDOWN_MIN_MS),
+            now +
+              BURST_INTERVAL_MIN_MS +
+              Math.random() * (BURST_INTERVAL_MAX_MS - BURST_INTERVAL_MIN_MS),
           );
-          const tangentAngle = angle + dir * (Math.PI / 2);
-          for (let i = 0; i < SPARKS_PER_BEAT; i++) {
+          for (let i = 0; i < burstCount; i++) {
             if (this._sparks.length >= MAX_SPARKS) this._sparks.shift();
-            const sa =
-              tangentAngle + (Math.random() - 0.5) * 2 * SPARK_CONE_RAD;
+            const sa = LEFT_ANGLE + (Math.random() - 0.5) * 2 * SPARK_CONE_RAD;
             const sp =
               SPARK_MIN_SPEED +
               Math.random() * (SPARK_MAX_SPEED - SPARK_MIN_SPEED);

--- a/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
@@ -273,20 +273,13 @@ export class GraphRenderer {
       ctx.stroke();
     }
 
-    // Whimsical orbital dots + beat-triggered sparks. Each signal gets
-    // a colored disc anchored on the line at the playhead, plus a
-    // colored satellite orbiting it. Speed and radius are hashed from
-    // the line name (cursor.ts:47-50 PARTICLE_CONFIG vocabulary) so the
-    // cluster reads as a flock, not a metronome — different lines orbit
-    // at different rates, in different directions, on different shells.
-    //
-    // Orbits are time-driven so the cluster never freezes between data
-    // samples. Each line fires a leftward comet trail on its own
-    // jittered ~250ms schedule (independent across lines), so the
-    // graph reads as a constant chromatic party flowing past the
-    // playhead. `pulse` doesn't gate the trigger — it just thickens
-    // each burst (more sparks) on loud moments. Sparks live in
-    // `this._sparks`, capped at MAX_SPARKS.
+    // Per-line dot at the playhead intersection + leftward confetti
+    // trails shed from the dot. Each line fires on its own jittered
+    // ~250ms schedule (independent across lines) so the graph reads as
+    // a constant chromatic party flowing past the playhead. `pulse`
+    // doesn't gate the trigger — it just thickens each burst (more
+    // sparks) on loud moments. Sparks live in `this._sparks`, capped
+    // at MAX_SPARKS.
     {
       const dt = this._lastNow ? Math.min(50, now - this._lastNow) : 16;
       this._lastNow = now;
@@ -295,8 +288,6 @@ export class GraphRenderer {
       const burstCount =
         SPARKS_PER_BURST_BASE + Math.round(SPARKS_PER_BURST_PULSE * pulse);
 
-      const orbitTheta = (now / 1800) * Math.PI * 2; // ~1.8s base period
-      const baseOrbitR = 6 * (1 + 0.4 * pulse);
       const pxPerSample = w / (VISIBLE_SAMPLES - 1);
       const samplesFromHead = Math.round((w - playheadX) / pxPerSample);
 
@@ -313,35 +304,10 @@ export class GraphRenderer {
         const yAtHead = h - Y_PAD - v * (h - 2 * Y_PAD);
         const [r, g, b] = _colorFor(name);
 
-        // Hash → phase, spin direction, speed mul ∈ [0.7, 1.4],
-        // radius mul ∈ [0.85, 1.15]. Different bits feed each so a
-        // small name change scrambles all four — no two signals end up
-        // visually paired by accident.
-        let hash = 0;
-        for (let i = 0; i < name.length; i++) {
-          hash = (hash * 31 + name.charCodeAt(i)) | 0;
-        }
-        const phase = ((Math.abs(hash) % 1000) / 1000) * Math.PI * 2;
-        const dir = hash & 1 ? 1 : -1;
-        const speedMul = 0.7 + ((Math.abs(hash >> 5) % 1000) / 1000) * 0.7;
-        const radiusMul =
-          0.85 + ((Math.abs(hash >> 11) % 1000) / 1000) * 0.3;
-
-        const orbitR = baseOrbitR * radiusMul;
-        const angle = phase + dir * orbitTheta * speedMul;
-        const satX = playheadX + Math.cos(angle) * orbitR;
-        const satY = yAtHead + Math.sin(angle) * orbitR;
-
-        // Disc anchored on the line.
+        // Disc anchored on the line at the playhead.
         ctx.fillStyle = `rgb(${r},${g},${b})`;
         ctx.beginPath();
         ctx.arc(playheadX, yAtHead, 3, 0, Math.PI * 2);
-        ctx.fill();
-
-        // Colored satellite head (slightly larger than the line disc so
-        // it reads as the lead element of the pair).
-        ctx.beginPath();
-        ctx.arc(satX, satY, 2.5, 0, Math.PI * 2);
         ctx.fill();
 
         // Per-line burst: fire whenever the wall clock passes the
@@ -350,8 +316,8 @@ export class GraphRenderer {
         // constantly but desynced — there's almost always a trail in
         // flight from somewhere on the graph. Direction is fixed
         // leftward (LEFT_ANGLE = π) so the trail streaks toward the
-        // past instead of orbiting outward — reads as the playhead
-        // shedding history behind itself as time flows.
+        // past, reading as the playhead shedding history behind itself
+        // as time flows.
         const nextFireAt = this._nextFireAt.get(name) ?? 0;
         if (now >= nextFireAt) {
           this._nextFireAt.set(
@@ -367,8 +333,8 @@ export class GraphRenderer {
               SPARK_MIN_SPEED +
               Math.random() * (SPARK_MAX_SPEED - SPARK_MIN_SPEED);
             this._sparks.push({
-              x: satX,
-              y: satY,
+              x: playheadX,
+              y: yAtHead,
               vx: Math.cos(sa) * sp,
               vy: Math.sin(sa) * sp,
               age: 0,


### PR DESCRIPTION
## Summary

Reworks the per-line beat sparks shipped in #40 from beat-gated bursts into a constant leftward-streaking confetti trail behind the playhead. Goal: the graph should read as a non-stop chromatic party flowing past you, with the music modulating intensity rather than gating presence.

### Trigger
- **Was**: falling-edge peak detection on \`pulse\`, then per-line probability gate (40-100% scaled with peak strength) + 100-400ms cooldown. Result: bursts fire on beats only, in subsets of lines per beat.
- **Now**: per-line wall-clock scheduler. Each line picks its own next-fire time in [150ms, 350ms] after each burst. Independent across lines → cluster fires constantly but desynced. There's almost always a trail in flight from somewhere on the graph.

### Direction
- **Was**: tangent-direction (perpendicular to radial, signed by orbit \`dir\`), ±25° cone. Sparks shed in the direction of the satellite's spin.
- **Now**: fixed \`LEFT_ANGLE = π\` ± 36° cone. All sparks fly leftward toward the past side of the playhead. Reads as the playhead shedding chromatic history behind itself as time flows.

### Trail tuning
| Knob | Before | After |
| --- | --- | --- |
| \`SPARK_MIN_SPEED\` | 3.2 | **4.5** |
| \`SPARK_MAX_SPEED\` | 7.0 | **8.5** |
| \`SPARK_GRAVITY\` | 0.16 | **0.10** |
| \`SPARK_LIFE_MS\` | 900 | **1100** |
| \`SPARK_CONE_RAD\` | π/7 (~25°) | **π/5 (~36°)** |

Net: trails extend visibly farther and arc less steeply. Disc size still 2px (matches cursor.ts).

### Pulse coupling
\`pulse\` no longer gates triggers; it bumps each burst's spark count from \`SPARKS_PER_BURST_BASE = 6\` up to +6 more at peak pulse. Loud moments visibly thicken without quiet moments going silent.

\`MAX_SPARKS\` bumped 240 → 400 to absorb the higher steady-state in-flight count (8+ lines firing every ~250ms × ~1.1s life ≈ ~280 active).

### Removed
- \`BEAT_THRESH\`, \`FIRE_PROB_AT_THRESHOLD\`, \`FIRE_PROB_AT_PEAK\`, \`COOLDOWN_MIN_MS\`, \`COOLDOWN_MAX_MS\`, \`SPARKS_PER_BEAT\` constants
- \`_aboveThresh\`, \`_peakPulse\`, \`_lineCooldowns\` class fields
- Falling-edge peak detection logic + fireProb computation
- \`tangentAngle\` calculation (no longer needed; spawn direction is fixed)

Net diff: −87 / +60.

## Test plan

- [ ] \`npm run dev\`. Performance screen renders without console errors.
- [ ] Sparks fire constantly from every active line, even with audio paused — no longer gated on kicks.
- [ ] Every spark flies leftward (toward the rendered history), forming a chromatic streak behind the playhead.
- [ ] Loud kicks produce visibly thicker bursts (more sparks per burst), but quiet sections still produce the steady party.
- [ ] Different lines fire out-of-phase (no global pulsing/unison rhythm).
- [ ] Steady-state sparks-on-screen settles around the new \`MAX_SPARKS\` cap; no runaway growth.
- [ ] \`tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)