### PR TITLE
demos/realtime_motion_graph_web: enable fast_vae by default

### DIFF
--- a/demos/realtime_motion_graph_web/web/public/config.json
+++ b/demos/realtime_motion_graph_web/web/public/config.json
@@ -8,7 +8,7 @@
     "vae_window": 6,
     "crop": 0,
     "steps": 8,
-    "fast_vae": false,
+    "fast_vae": true,
     "key": "G# minor",
     "_enabled_loras_help": "Filename stems (no .safetensors) to auto-enable on first catalog load. Empty = count-rule (first two from the sorted catalog, with name-fallback per slot — see useLoraStore.ts).",
     "enabled_loras": []


### PR DESCRIPTION
## Summary

Flips `web/public/config.json`'s engine defaults so sessions send `fast_vae: true`. The flag selects DreamVAE (the distilled student decoder, drop-in for `vae_decode_fp16_*` and substantially lighter on VRAM) over the standard teacher decoder.

## Why

Engine selection is duration-driven: a >120s upload picks the 240s profile via `available_trt_engines`. With the standard VAE, 240s on a 32 GB card runs out of workspace at engine load (per `tests/benchmarks/vram_60s_vs_240s_results.md` — total ~37.3 GB just for decoder + standard vae_encode + standard vae_decode at 240s). Combining:

- depth=4 (already merged in #32)
- windowed vae_window (already wired)
- **DreamVAE decode** (this PR)

…brings the 240s session footprint comfortably under 32 GB.

## Pre-conditions for production

The dreamvae engines must be present in the operator's `trt_engines` directory:
- `dreamvae_decode_fp16_60s`, `_120s`, `_240s`, `_3to30s`

Build with:
```
acestep.engine.trt.build --all --duration 60 120 240 --decoder-mixed --decoder-refit --with-dreamvae
```

`available_dreamvae_decode_engine` falls back to the teacher decoder if a profile's dreamvae engine is missing, so this flip won't break operators who haven't built them yet — they'll just keep using the standard decoder.

## Test plan

- [ ] After merge, sessions show `fast_vae=true` in the WS config frame.
- [ ] Backend logs at session start show `dreamvae_decode_*` engine selected (not the standard `vae_decode_*`).
- [ ] 240s upload on a 32 GB card loads cleanly (no OOM at session init); audio streams.
- [ ] Operators without dreamvae engines built see no regression — fallback to teacher decoder works.