### PR TITLE
demos/realtime_motion_graph_web/web: trim decoded fixture to whole seconds

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
@@ -43,8 +43,29 @@ async function decodeArrayBuffer(bytes: ArrayBuffer): Promise<DecodedFixture> {
   // through, >2 → take front L/R only (Web Audio puts front-L=0,
   // front-R=1 for any layout).
   const srcChannels = audioBuffer.numberOfChannels;
-  const frames = audioBuffer.length;
+  const rawFrames = audioBuffer.length;
   const channels = 2;
+
+  // Length normalize: trim to a whole-second multiple. Browsers'
+  // decodeAudioData honours the mp3 encoder-padding header and returns
+  // a non-integer-second sample count for many real-world files (e.g.
+  // a 142.96 s mp3 with 23 ms of priming silence at the head). The
+  // server-side VAE encode then computes a latent count off that ragged
+  // tail and can underflow into a negative time dim — we saw
+  // `Trying to create tensor with negative dimension -1: [1, 128, -1]`
+  // on a track with exactly that shape. Whole-second alignment also
+  // matches what every TRT engine profile expects (60/120/240 s
+  // boundaries) and is what server-side fixture caches assume.
+  // Trimming the partial tail loses < 1 s of audio; padding with
+  // zeros would risk an audible click.
+  const sr = audioBuffer.sampleRate;
+  const frames = Math.floor(rawFrames / sr) * sr;
+  if (frames < sr) {
+    throw new Error(
+      `Audio too short — need ≥ 1 second, got ${(rawFrames / sr).toFixed(2)} s.`,
+    );
+  }
+
   const interleaved = new Float32Array(frames * channels);
 
   if (srcChannels === 1) {
@@ -63,7 +84,7 @@ async function decodeArrayBuffer(bytes: ArrayBuffer): Promise<DecodedFixture> {
     }
   }
 
-  return { interleaved, channels, frames, sampleRate: audioBuffer.sampleRate };
+  return { interleaved, channels, frames, sampleRate: sr };
 }
 
 export async function loadFixtureAudio(name: string): Promise<DecodedFixture> {


### PR DESCRIPTION
## Summary

`decodeArrayBuffer` in `web/engine/audio/loadFixture.ts` now trims the decoded sample buffer to a whole-second multiple before emitting interleaved PCM to the engine.

## Why

Browsers' `AudioContext.decodeAudioData` honours the mp3 encoder-padding header and returns a non-integer-second sample count for many real-world mp3s. Concrete example: a 142.96 s mp3 with 23 ms of priming silence at the head decodes to 6,861,888 samples (= 142.96 × 48 kHz). The server-side VAE encode then computes a latent count from that ragged tail and underflows into a negative time dim:

```
swap_failed: Trying to create tensor with negative dimension -1: [1, 128, -1]
```

Whole-second alignment is also what TRT engine profiles assume (60 / 120 / 240 s boundaries — see `acestep/paths.py:_TRT_ENGINE_PROFILES`) and what the server-side fixture caches use, so this fixes a class of bugs, not just the one specific mp3 that surfaced it.

## Trade-off

- Trimming the partial tail loses < 1 s of audio at most.
- Padding with zeros instead would risk an audible click at swap-and-loop boundaries.
- Refusing anything < 1 s with an explicit error beats letting it slip through and producing meaningless latents.

## Test plan

- [ ] Re-upload the failing mp3 (mp3 with non-zero `start_time` per ffprobe). `swap_failed: negative dimension` no longer fires; track plays end-to-end.
- [ ] Existing fixtures (already whole-second-aligned) — no behavioural change; `frames` returned matches what they returned before.
- [ ] Upload of a track shorter than 1 s — clean error message, no engine crash.
- [ ] Check that the decoded duration shown in the UI's status bar drops by < 1 s for trimmed mp3s (it'll show e.g. "142 s" instead of "142.96 s").