### PR TITLE
realtime_motion_graph_web: render-pipeline foundations (perf pass #4)

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -183,6 +183,15 @@ body.cursor-idle .cursor-canvas { opacity: 0; }
 #performance {
   position: fixed;
   inset: 0;
+  /* --bloom-amount is written here (not on :root) so style recalc on
+     every binned-kick change only walks this subtree, not the whole
+     document. `isolation: isolate` promotes the scene to its own
+     stacking context so the compositor can keep the rest of the page
+     (cursor, anything outside #performance) on a separate layer that
+     doesn't repaint when bloom changes. Avoiding `contain: paint`
+     because position:fixed/absolute descendants (modals, tooltips)
+     would get clipped. */
+  isolation: isolate;
 }
 
 #start-overlay {

--- a/demos/realtime_motion_graph_web/web/components/PerfOverlay.tsx
+++ b/demos/realtime_motion_graph_web/web/components/PerfOverlay.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { frameScheduler } from "@/engine/scheduler/FrameScheduler";
+
+// Dev-only perf overlay. Toggle with Shift+P. Renders a fixed-position
+// panel showing instantaneous frame time, p95 over the last 5 s, long-
+// task count, GC spikes (proxied as >50 ms dt jumps), and per-tick EMA
+// from the FrameScheduler. No-op in production builds — the entire
+// component returns null when NODE_ENV !== "development".
+//
+// Don't pull this into ad-hoc places. The whole point is one panel that
+// shows what every render-path tick costs in one place — when someone
+// adds work, they see it here, not three months later when Vibor reports
+// jitter.
+
+const REFRESH_HZ = 4; // panel updates 4× / s — enough to read, low cost
+
+export function PerfOverlay(): React.ReactElement | null {
+  const [visible, setVisible] = useState(false);
+  const [, force] = useState(0);
+  const ref = useRef({ tick: 0 });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onKey = (e: KeyboardEvent) => {
+      // Shift+P toggle. We require the modifier so plain "p" stays
+      // available for input fields. Match either side of Shift.
+      if (e.shiftKey && (e.key === "P" || e.key === "p")) {
+        e.preventDefault();
+        setVisible((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return;
+    let alive = true;
+    const intervalMs = 1000 / REFRESH_HZ;
+    const id = window.setInterval(() => {
+      if (!alive) return;
+      ref.current.tick++;
+      force(ref.current.tick);
+    }, intervalMs);
+    return () => {
+      alive = false;
+      window.clearInterval(id);
+    };
+  }, [visible]);
+
+  if (process.env.NODE_ENV !== "development") return null;
+  if (!visible) return null;
+
+  const stats = frameScheduler.getStats();
+  const budget = 16.6;
+  const p95Color =
+    stats.p95FrameMs < 0
+      ? "#888"
+      : stats.p95FrameMs <= 8
+        ? "#7ec47e"
+        : stats.p95FrameMs <= budget
+          ? "#e8b95c"
+          : "#e8615c";
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 8,
+        right: 8,
+        zIndex: 999999,
+        padding: "8px 10px",
+        background: "rgba(10,10,12,0.85)",
+        color: "#dcdcdc",
+        font: "11px ui-monospace, SFMono-Regular, monospace",
+        lineHeight: 1.4,
+        borderRadius: 6,
+        backdropFilter: "blur(6px)",
+        boxShadow: "0 2px 12px rgba(0,0,0,0.5)",
+        pointerEvents: "none",
+        minWidth: 220,
+        maxWidth: 320,
+      }}
+    >
+      <div
+        style={{ fontWeight: 600, color: "#fff", marginBottom: 4 }}
+      >
+        perf · Shift+P
+      </div>
+      <div>
+        last frame:{" "}
+        <span style={{ color: stats.lastFrameMs > budget ? "#e8615c" : "#7ec47e" }}>
+          {stats.lastFrameMs.toFixed(2)} ms
+        </span>
+      </div>
+      <div>
+        p95 (5s):{" "}
+        <span style={{ color: p95Color }}>
+          {stats.p95FrameMs < 0 ? "—" : `${stats.p95FrameMs.toFixed(2)} ms`}
+        </span>
+      </div>
+      <div>
+        long tasks: {stats.longTaskCount} · gc spikes: {stats.gcSpikeCount}
+      </div>
+      <div
+        style={{
+          height: 1,
+          background: "rgba(255,255,255,0.12)",
+          margin: "5px 0",
+        }}
+      />
+      {stats.ticks.length === 0 && <div style={{ opacity: 0.5 }}>no ticks registered</div>}
+      {stats.ticks.map((t) => {
+        const over = t.emaMs > t.budgetMs;
+        return (
+          <div key={t.name} style={{ display: "flex", justifyContent: "space-between" }}>
+            <span style={{ opacity: t.phase === "compute" ? 0.7 : 1 }}>
+              {t.phase === "compute" ? "·" : " "}
+              {t.name}
+            </span>
+            <span style={{ color: over ? "#e8615c" : "#dcdcdc" }}>
+              {t.emaMs.toFixed(2)} / {t.budgetMs}ms
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/engine/audio/AudioPlayer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/AudioPlayer.ts
@@ -17,6 +17,13 @@ export class AudioPlayer {
   swapCount = 0;
   channels = 2;
   frameCount = 0;
+  // Most recent kick (RMS over a 480-frame window, soft-clipped to [0,1]).
+  // Computed by the AudioWorklet on the audio thread and posted alongside
+  // position; the main render path reads it via getKick(). On the
+  // ScriptProcessor fallback path this stays 0 — kick reactivity degrades
+  // gracefully (no flashes on beats) rather than blocking the main thread
+  // with a per-frame RMS loop. See PERFORMANCE.md.
+  kick = 0;
 
   private _listeners: Set<MirrorListener> = new Set();
   private _mirror: Float32Array | null = null;
@@ -56,10 +63,16 @@ export class AudioPlayer {
       this.node = node;
 
       node.port.onmessage = (e: MessageEvent) => {
-        const msg = e.data as { type: string; positionSec?: number; swapCount?: number };
+        const msg = e.data as {
+          type: string;
+          positionSec?: number;
+          swapCount?: number;
+          kick?: number;
+        };
         if (msg.type === "position") {
           this.positionSec = msg.positionSec ?? 0;
           this.swapCount = msg.swapCount ?? this.swapCount;
+          if (typeof msg.kick === "number") this.kick = msg.kick;
         }
       };
 

--- a/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
@@ -1,12 +1,13 @@
 // Parameter-history graph display. Maintains a rolling buffer per signal
 // and renders glowing polylines + a playhead.
 //
-// Glow uses the GPU-accelerated shadowBlur path (not ctx.filter:blur,
-// which falls back to software in Skia). The glow pass is intentionally
-// dialed back from earlier iterations — at full pulse the bloom should
-// read as a gentle in-color smear, not an additive white flash. Tuning
-// knobs live in the per-line loop below; bump them in lockstep if the
-// pulse needs to read more aggressively again.
+// Beat energy reads through three channels: line width pulses with
+// kick, the playhead does an additive "lighter" glow stroke on strong
+// kicks, and the spark bursts (below) trail behind the playhead. The
+// pre-2026 implementation used per-line ctx.shadowBlur strokes scaled
+// by pulse — that defeats Skia's blur cache and was the dominant
+// per-frame cost during music. Don't add shadowBlur back without
+// reading PERFORMANCE.md first.
 //
 // Independently of pulse, each signal renders a small orbital dot at its
 // playhead intersection (a colored disc + a white satellite on a slow
@@ -109,23 +110,14 @@ interface History {
 // "now"). Reads as a chromatic streak behind the playhead — sparks
 // trail across the rendered line history in their line's color,
 // reinforcing the "time is flowing past you" cue.
-interface Spark {
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  age: number;
-  life: number;
-  // Wall-clock millis at which the spark "activates". Sparks with
-  // birthAt > now are skipped entirely — no aging, no rendering — so
-  // chorus bursts can stagger per line and read as a cascade across
-  // the cluster instead of one synchronized cloud. For non-staggered
-  // (baseline) sparks, set birthAt = now at spawn.
-  birthAt: number;
-  r: number;
-  g: number;
-  b: number;
-}
+//
+// Storage: struct-of-arrays in pre-allocated TypedArrays, slot reuse via
+// a ring pointer. Zero per-frame allocation, zero array shift/splice,
+// no per-spark fillStyle string. The pre-2026-perf-pass implementation
+// used a Spark[] with shift()/splice()/push() and built an `rgba(...)`
+// string per spark per frame; on chorus kicks (240 sparks alive) that
+// was the dominant per-frame allocator and cause of beat-correlated
+// jank. See PERFORMANCE.md for the full incident write-up.
 
 // Spark physics. Disc size matches cursor.ts confetti (2px); trails
 // are tuned long + flat so they extend visibly along the rendered
@@ -184,7 +176,26 @@ export class GraphRenderer {
   private readonly ctx: CanvasRenderingContext2D;
   private readonly histories: Map<string, History> = new Map();
   private readonly _resizeObs: ResizeObserver;
-  private readonly _sparks: Spark[] = [];
+  // Spark pool — SoA TypedArrays. Slot is alive when _spAlive[i] === 1.
+  // Allocation is a ring pointer: _spNextSlot advances on each spawn,
+  // overwriting whatever was there. With MAX_SPARKS sized for the worst
+  // chorus burst, this approximates "evict oldest" (the original Spark[]
+  // shift() semantic) without an O(n) scan.
+  private readonly _spX = new Float32Array(MAX_SPARKS);
+  private readonly _spY = new Float32Array(MAX_SPARKS);
+  private readonly _spVX = new Float32Array(MAX_SPARKS);
+  private readonly _spVY = new Float32Array(MAX_SPARKS);
+  private readonly _spAge = new Float32Array(MAX_SPARKS);
+  private readonly _spLife = new Float32Array(MAX_SPARKS);
+  private readonly _spBirth = new Float32Array(MAX_SPARKS);
+  private readonly _spColor = new Uint16Array(MAX_SPARKS);
+  private readonly _spAlive = new Uint8Array(MAX_SPARKS);
+  private _spNextSlot = 0;
+  // Per-line color cache: name → index into _colorTable. The table holds
+  // pre-built `rgb(r,g,b)` strings so the render loop sets fillStyle to a
+  // string we already own, never allocating a new one per spark.
+  private readonly _colorIdxByName: Map<string, number> = new Map();
+  private readonly _colorTable: string[] = [];
   // Wall-clock millis at which the most recent baseline burst fired,
   // and the line picked to fire it. `_baselineLine` is consumed (set
   // to null) inside the per-line loop once that line actually fires,
@@ -276,12 +287,13 @@ export class GraphRenderer {
       ctx.fillRect(0, 0, w, h);
     }
 
-    // Glow + crisp line per signal. Build the path once, stroke twice:
-    // first wide with shadowBlur (GPU-accelerated on Chromium/Safari's
-    // accelerated canvas), then thin and sharp on top. This replaces
-    // `ctx.filter = blur(...)`, which falls back to software in Skia
-    // and was eating 5–15 ms / frame during active music — exactly the
-    // "whole-page lag during beats" shape.
+    // One stroke per signal. The pre-2026-perf-pass implementation did a
+    // second wide stroke with `shadowBlur = 1 + 1.5 * pulse` for a glow
+    // halo whenever pulse > 0.1 — but per-stroke shadowBlur with a
+    // beat-driven radius defeats Skia's compositor cache (every frame is
+    // a fresh blur kernel) and was firing for every line on every frame
+    // of music. Beat energy still reads through the playhead glow below
+    // and the spark bursts; the per-line halo wasn't pulling its weight.
     for (const [name, hist] of this.histories) {
       const n = Math.min(hist.filled, VISIBLE_SAMPLES);
       if (n < 2) continue;
@@ -301,28 +313,16 @@ export class GraphRenderer {
         else ctx.lineTo(x, y);
       }
 
-      if (pulse > 0.1) {
-        ctx.save();
-        ctx.globalCompositeOperation = "lighter";
-        ctx.shadowColor = `rgba(${r},${g},${b},${0.25 + 0.25 * pulse})`;
-        ctx.shadowBlur = 1 + 1.5 * pulse;
-        ctx.shadowOffsetX = 0;
-        ctx.shadowOffsetY = 0;
-        ctx.strokeStyle = `rgba(${r},${g},${b},${0.3 + 0.4 * pulse})`;
-        ctx.lineWidth = 1.5 + 1.5 * pulse;
-        ctx.stroke();
-        ctx.restore();
-      }
-
-      ctx.shadowBlur = 0;
-      ctx.strokeStyle = `rgba(${r},${g},${b},1)`;
-      ctx.lineWidth = 1;
+      // Line widens slightly with pulse so beats still register on the
+      // line itself, but no shadowBlur — pure crisp stroke.
+      ctx.strokeStyle = `rgba(${r},${g},${b},${0.85 + 0.15 * pulse})`;
+      ctx.lineWidth = 1 + 0.5 * pulse;
       ctx.stroke();
     }
 
     // Per-line dot at the playhead + two-layer leftward confetti
-    // trails shed from the dot. Sparks live in `this._sparks`, capped
-    // at MAX_SPARKS.
+    // trails shed from the dot. Sparks live in the SoA pool above
+    // (_spX/_spY/...), capped at MAX_SPARKS, allocated via ring pointer.
     //
     // Layer 1 (baseline): on the falling edge of small/medium kicks
     // (peakPulse in [BEAT_THRESH, CHORUS_THRESH)), pick ONE random
@@ -445,64 +445,91 @@ export class GraphRenderer {
           this._baselineLine = null; // consumed
         }
 
-        for (let i = 0; i < burstCount; i++) {
-          if (this._sparks.length >= MAX_SPARKS) this._sparks.shift();
-          const sa = LEFT_ANGLE + (Math.random() - 0.5) * 2 * SPARK_CONE_RAD;
-          const sp =
-            SPARK_MIN_SPEED +
-            Math.random() * (SPARK_MAX_SPEED - SPARK_MIN_SPEED);
-          this._sparks.push({
-            x: playheadX,
-            y: sparkY,
-            vx: Math.cos(sa) * sp,
-            vy: Math.sin(sa) * sp,
-            age: 0,
-            life: SPARK_LIFE_MS - 150 + Math.random() * 300,
-            birthAt: burstBirthAt,
-            r,
-            g,
-            b,
-          });
+        if (burstCount > 0) {
+          // Resolve / cache this line's color-table index once outside
+          // the inner spawn loop. _colorTable holds pre-built `rgb(...)`
+          // strings; the render pass reuses them as fillStyle without
+          // ever building a per-spark string.
+          let colorIdx = this._colorIdxByName.get(name);
+          if (colorIdx === undefined) {
+            colorIdx = this._colorTable.length;
+            this._colorTable.push(`rgb(${r},${g},${b})`);
+            this._colorIdxByName.set(name, colorIdx);
+          }
+          for (let i = 0; i < burstCount; i++) {
+            const sa =
+              LEFT_ANGLE + (Math.random() - 0.5) * 2 * SPARK_CONE_RAD;
+            const sp =
+              SPARK_MIN_SPEED +
+              Math.random() * (SPARK_MAX_SPEED - SPARK_MIN_SPEED);
+            const slot = this._spNextSlot;
+            this._spNextSlot =
+              this._spNextSlot + 1 >= MAX_SPARKS ? 0 : this._spNextSlot + 1;
+            this._spX[slot] = playheadX;
+            this._spY[slot] = sparkY;
+            this._spVX[slot] = Math.cos(sa) * sp;
+            this._spVY[slot] = Math.sin(sa) * sp;
+            this._spAge[slot] = 0;
+            this._spLife[slot] = SPARK_LIFE_MS - 150 + Math.random() * 300;
+            this._spBirth[slot] = burstBirthAt;
+            this._spColor[slot] = colorIdx;
+            this._spAlive[slot] = 1;
+          }
         }
       }
 
-      // Sparks — physics + render + cull. Walking backwards so splice
-      // doesn't shift indices we still need to visit. Skip sparks that
-      // haven't reached their birthAt yet (pre-birth chorus stagger).
-      for (let i = this._sparks.length - 1; i >= 0; i--) {
-        const s = this._sparks[i];
-        if (now < s.birthAt) continue;
-        s.age += dt;
-        if (s.age >= s.life) {
-          this._sparks.splice(i, 1);
+      // Sparks — physics + render in a single pool walk. Alpha is
+      // applied via globalAlpha (one numeric assignment) instead of a
+      // per-spark `rgba(...)` string allocation; fillStyle changes only
+      // when the next alive spark belongs to a different line. fillRect
+      // skips the path tessellation cost of arc(); at 2.5 px in motion
+      // the visual is indistinguishable from circles.
+      let lastColorIdx = -1;
+      for (let i = 0; i < MAX_SPARKS; i++) {
+        if (!this._spAlive[i]) continue;
+        if (now < this._spBirth[i]) continue;
+        const age = this._spAge[i] + dt;
+        const life = this._spLife[i];
+        if (age >= life) {
+          this._spAlive[i] = 0;
           continue;
         }
-        s.vy += SPARK_GRAVITY * dtScale;
-        s.x += s.vx * dtScale;
-        s.y += s.vy * dtScale;
-        const f = s.age / s.life;
-        const alpha = 1 - f;
+        this._spAge[i] = age;
+        const newVY = this._spVY[i] + SPARK_GRAVITY * dtScale;
+        this._spVY[i] = newVY;
+        const x = this._spX[i] + this._spVX[i] * dtScale;
+        const y = this._spY[i] + newVY * dtScale;
+        this._spX[i] = x;
+        this._spY[i] = y;
+        const f = age / life;
         const radius = SPARK_RADIUS * (1 - f * 0.7);
         if (radius <= 0.1) continue;
-        ctx.fillStyle = `rgba(${s.r},${s.g},${s.b},${alpha.toFixed(3)})`;
-        ctx.beginPath();
-        ctx.arc(s.x, s.y, radius, 0, Math.PI * 2);
-        ctx.fill();
+        const colorIdx = this._spColor[i];
+        if (colorIdx !== lastColorIdx) {
+          ctx.fillStyle = this._colorTable[colorIdx];
+          lastColorIdx = colorIdx;
+        }
+        ctx.globalAlpha = 1 - f;
+        const d = radius + radius;
+        ctx.fillRect(x - radius, y - radius, d, d);
       }
+      ctx.globalAlpha = 1;
 
       ctx.restore();
     }
 
-    // Playhead — same shadowBlur trick. Glow halo + crisp 1px line.
-    if (pulse > 0.05) {
+    // Playhead glow. The pre-2026-perf-pass version used
+    // `shadowBlur = 4 * pulse` and fired whenever pulse > 0.05 —
+    // i.e. essentially every frame of any non-silent music, with a
+    // continuously varying blur radius (worst case for Skia's blur
+    // cache). Replaced with a wider semi-transparent stroke under
+    // "lighter" composite — visually similar at speed, no shadowBlur.
+    // Gated at pulse > 0.2 so it only fires on meaningful kicks.
+    if (pulse > 0.2) {
       ctx.save();
       ctx.globalCompositeOperation = "lighter";
-      ctx.shadowColor = `rgba(150, 180, 220, ${0.9 * pulse})`;
-      ctx.shadowBlur = 4 * pulse;
-      ctx.shadowOffsetX = 0;
-      ctx.shadowOffsetY = 0;
-      ctx.strokeStyle = `rgba(150, 180, 220, ${0.9 * pulse})`;
-      ctx.lineWidth = 2 + 5 * pulse;
+      ctx.strokeStyle = `rgba(150, 180, 220, ${0.45 * pulse})`;
+      ctx.lineWidth = 4 + 8 * pulse;
       ctx.beginPath();
       ctx.moveTo(playheadX + 0.5, 0);
       ctx.lineTo(playheadX + 0.5, h);
@@ -510,7 +537,7 @@ export class GraphRenderer {
       ctx.restore();
     }
 
-    ctx.shadowBlur = 0;
+
     ctx.strokeStyle = `rgba(255, 255, 255, ${0.6 + 0.4 * pulse})`;
     ctx.lineWidth = 1;
     ctx.beginPath();

--- a/demos/realtime_motion_graph_web/web/engine/scheduler/FrameScheduler.ts
+++ b/demos/realtime_motion_graph_web/web/engine/scheduler/FrameScheduler.ts
@@ -1,0 +1,209 @@
+// Single-rAF policy. Every per-frame callback in the codebase registers
+// here and runs in a defined phase order; the scheduler owns the only
+// `requestAnimationFrame` call. Goals:
+//
+//   - One rAF wakeup per vsync, not six. (Pre-2026-perf-pass we had
+//     useRenderLoop, tickTweens, useScheduledCurves, AmbientRenderer ×2,
+//     VideoLayer, and ScheduleCurvesOverlay all racing for the same
+//     vsync. The slowest gated the frame; the cursor felt sticky on
+//     beats because that's when all six had work.)
+//
+//   - Compute → Render phase ordering. Tweens and curves must update
+//     store state BEFORE useRenderLoop reads it; otherwise we render
+//     a frame behind. Phases enforce that without per-callback
+//     coordination.
+//
+//   - Per-tick instrumentation. The dev perf overlay reads `getStats()`
+//     to show which callback is consuming the budget. Without this,
+//     "the page feels slow" is unactionable.
+//
+// Don't add a new requestAnimationFrame call elsewhere — see
+// PERFORMANCE.md.
+
+export type TickFn = (now: number, dt: number) => void;
+
+export type TickPhase = "compute" | "render";
+
+interface RegisteredTick {
+  name: string;
+  phase: TickPhase;
+  fn: TickFn;
+  // EMA of per-tick wall time in ms. Updated every frame the tick runs.
+  // Surfaced via getStats() to the dev overlay so we can see who's
+  // eating the budget.
+  emaMs: number;
+  // Soft budget. When exceeded, the dev overlay flags this tick. No
+  // hard enforcement — we don't drop callbacks; we just surface them.
+  budgetMs: number;
+}
+
+const EMA_ALPHA = 0.1;
+
+export interface FrameStats {
+  // Most recent frame's total wall time across all ticks (ms).
+  lastFrameMs: number;
+  // Rolling p95 frame time over the last 5 s. -1 until first sample.
+  p95FrameMs: number;
+  // Per-tick stats, sorted by EMA descending so the slowest is first.
+  ticks: { name: string; phase: TickPhase; emaMs: number; budgetMs: number }[];
+  // Long-task count (>50 ms tasks) since last reset. PerformanceObserver
+  // owns this; FrameScheduler just exposes it.
+  longTaskCount: number;
+  // GC bars approximated as "frames where dt jumped > 50 ms". Browsers
+  // don't expose GC pauses directly, so this is the cheapest proxy.
+  gcSpikeCount: number;
+}
+
+class FrameScheduler {
+  private _ticks: RegisteredTick[] = [];
+  private _rafId: number | null = null;
+  private _lastNow = 0;
+  // Rolling 5 s window of frame durations for p95.
+  private readonly _frameMs: Float32Array = new Float32Array(300); // ~5s at 60fps
+  private _frameMsHead = 0;
+  private _frameMsCount = 0;
+  private _longTaskCount = 0;
+  private _gcSpikeCount = 0;
+  private _longTaskObs: PerformanceObserver | null = null;
+
+  /** Register a tick. Returns an unregister function (call in cleanup). */
+  register(
+    name: string,
+    fn: TickFn,
+    opts?: { phase?: TickPhase; budgetMs?: number },
+  ): () => void {
+    const tick: RegisteredTick = {
+      name,
+      phase: opts?.phase ?? "render",
+      fn,
+      emaMs: 0,
+      budgetMs: opts?.budgetMs ?? 8,
+    };
+    this._ticks.push(tick);
+    this._ensureRunning();
+    return () => {
+      const i = this._ticks.indexOf(tick);
+      if (i >= 0) this._ticks.splice(i, 1);
+      if (this._ticks.length === 0) this._stop();
+    };
+  }
+
+  /** Force-stop; useful for HMR teardown. Tests only. */
+  _stop(): void {
+    if (this._rafId !== null && typeof cancelAnimationFrame !== "undefined") {
+      cancelAnimationFrame(this._rafId);
+    }
+    this._rafId = null;
+    this._lastNow = 0;
+  }
+
+  getStats(): FrameStats {
+    const ticks = this._ticks
+      .map((t) => ({
+        name: t.name,
+        phase: t.phase,
+        emaMs: t.emaMs,
+        budgetMs: t.budgetMs,
+      }))
+      .sort((a, b) => b.emaMs - a.emaMs);
+    return {
+      lastFrameMs: this._lastFrameMs,
+      p95FrameMs: this._computeP95(),
+      ticks,
+      longTaskCount: this._longTaskCount,
+      gcSpikeCount: this._gcSpikeCount,
+    };
+  }
+
+  resetCounters(): void {
+    this._longTaskCount = 0;
+    this._gcSpikeCount = 0;
+    this._frameMsHead = 0;
+    this._frameMsCount = 0;
+  }
+
+  private _lastFrameMs = 0;
+
+  private _ensureRunning(): void {
+    if (this._rafId !== null) return;
+    if (typeof requestAnimationFrame === "undefined") return;
+    this._installLongTaskObserver();
+    this._rafId = requestAnimationFrame(this._tick);
+  }
+
+  private _installLongTaskObserver(): void {
+    if (this._longTaskObs) return;
+    if (typeof PerformanceObserver === "undefined") return;
+    try {
+      this._longTaskObs = new PerformanceObserver((list) => {
+        this._longTaskCount += list.getEntries().length;
+      });
+      this._longTaskObs.observe({ entryTypes: ["longtask"] });
+    } catch {
+      // longtask not supported in this browser — silently skip.
+      this._longTaskObs = null;
+    }
+  }
+
+  private _tick = (now: number): void => {
+    if (this._ticks.length === 0) {
+      this._rafId = null;
+      return;
+    }
+    const dt = this._lastNow === 0 ? 16 : Math.min(50, now - this._lastNow);
+    if (this._lastNow !== 0 && dt > 50) {
+      // Likely a GC pause or tab restoration. Count it.
+      this._gcSpikeCount++;
+    }
+    this._lastNow = now;
+
+    const frameStart = performance.now();
+
+    // Compute phase: tweens, curves, anything that updates store state.
+    for (let i = 0; i < this._ticks.length; i++) {
+      const tick = this._ticks[i];
+      if (tick.phase !== "compute") continue;
+      const t0 = performance.now();
+      try {
+        tick.fn(now, dt);
+      } catch (err) {
+        console.error(`[FrameScheduler] tick "${tick.name}" threw`, err);
+      }
+      const elapsed = performance.now() - t0;
+      tick.emaMs = tick.emaMs === 0 ? elapsed : tick.emaMs * (1 - EMA_ALPHA) + elapsed * EMA_ALPHA;
+    }
+
+    // Render phase: canvas draws, DOM mutations driven by latest state.
+    for (let i = 0; i < this._ticks.length; i++) {
+      const tick = this._ticks[i];
+      if (tick.phase !== "render") continue;
+      const t0 = performance.now();
+      try {
+        tick.fn(now, dt);
+      } catch (err) {
+        console.error(`[FrameScheduler] tick "${tick.name}" threw`, err);
+      }
+      const elapsed = performance.now() - t0;
+      tick.emaMs = tick.emaMs === 0 ? elapsed : tick.emaMs * (1 - EMA_ALPHA) + elapsed * EMA_ALPHA;
+    }
+
+    this._lastFrameMs = performance.now() - frameStart;
+    this._frameMs[this._frameMsHead] = this._lastFrameMs;
+    this._frameMsHead = (this._frameMsHead + 1) % this._frameMs.length;
+    if (this._frameMsCount < this._frameMs.length) this._frameMsCount++;
+
+    this._rafId = requestAnimationFrame(this._tick);
+  };
+
+  private _computeP95(): number {
+    if (this._frameMsCount === 0) return -1;
+    // Cheap p95: copy + sort the ring. ~300 entries, runs only when the
+    // overlay queries — not per frame.
+    const buf = this._frameMs.slice(0, this._frameMsCount);
+    const sorted = Array.from(buf).sort((a, b) => a - b);
+    const idx = Math.floor(sorted.length * 0.95);
+    return sorted[Math.min(idx, sorted.length - 1)];
+  }
+}
+
+export const frameScheduler = new FrameScheduler();

--- a/demos/realtime_motion_graph_web/web/hooks/useRenderLoop.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useRenderLoop.ts
@@ -3,8 +3,8 @@
 import { useEffect, type RefObject } from "react";
 
 import { tickActiveCursor } from "@/engine/cursor";
-import { kickRms } from "@/engine/render/audioFeatures";
 import { EffectsRenderer } from "@/engine/render/EffectsRenderer";
+import { frameScheduler } from "@/engine/scheduler/FrameScheduler";
 import { GraphRenderer } from "@/engine/render/GraphRenderer";
 import { HUD } from "@/engine/render/HUD";
 import { getConfig, subscribeConfig } from "@/lib/config";
@@ -51,7 +51,6 @@ export function useRenderLoop(refs: Refs) {
     if (!hudEl || !graphEl) return;
 
     let cancelled = false;
-    let raf = 0;
 
     const hud = new HUD(hudEl);
     const graph = new GraphRenderer(graphEl);
@@ -139,6 +138,13 @@ export function useRenderLoop(refs: Refs) {
     // that read --bloom-amount) from re-rastering on frames where the
     // binned kick hasn't actually changed.
     let lastBloom = -1;
+    // Bloom host: target the performance scene root so style recalc is
+    // scoped to the subtree that actually consumes --bloom-amount, not
+    // the whole document. Falls back to <html> if the element isn't
+    // mounted yet (e.g. very first frames before the scene exists).
+    // Cached per-frame: re-resolve when null so a delayed mount picks up,
+    // but stop walking the DOM once we have it.
+    let bloomHost: HTMLElement | null = null;
 
     function tick(now: number) {
       if (cancelled) return;
@@ -151,8 +157,23 @@ export function useRenderLoop(refs: Refs) {
         const dur = session.player.duration;
         const pos = session.player.positionSec;
         frac = dur > 0 ? Math.max(0, Math.min(1, pos / dur)) : 0;
-        const mirror = session.player.getMirror();
-        kick = kickRms(mirror, pos, dur, session.player.channels);
+        // Kick is computed in the AudioWorklet on the audio thread and
+        // posted with each position update (~21 ms cadence). Reading
+        // it here is a single field load — no per-frame audio buffer
+        // walk on the main thread. The ScriptProcessor fallback path
+        // leaves player.kick = 0 (graceful degradation; non-secure
+        // contexts only). See PERFORMANCE.md.
+        kick = session.player.kick;
+      }
+      // CI / devtools synthetic-kick override: set window.__PERF_STRESS_KICK__
+      // to a number in [0, 1] to drive the visuals as if a kick of that
+      // strength were happening continuously. Used by tests/perf/smoke.mjs
+      // to measure chorus-frame cost without needing real audio playback.
+      if (
+        typeof window !== "undefined" &&
+        typeof (window as { __PERF_STRESS_KICK__?: number }).__PERF_STRESS_KICK__ === "number"
+      ) {
+        kick = (window as { __PERF_STRESS_KICK__?: number }).__PERF_STRESS_KICK__ ?? kick;
       }
 
       // Bloom CSS var, rounded to 0.1 bins so the document doesn't
@@ -165,10 +186,12 @@ export function useRenderLoop(refs: Refs) {
       const bloom = Math.round(kick * 10) / 10;
       if (typeof document !== "undefined") {
         if (bloom !== lastBloom) {
-          document.documentElement.style.setProperty(
-            "--bloom-amount",
-            bloom.toString(),
-          );
+          if (!bloomHost) {
+            bloomHost =
+              (document.getElementById("performance") as HTMLElement | null) ??
+              document.documentElement;
+          }
+          bloomHost.style.setProperty("--bloom-amount", bloom.toString());
           lastBloom = bloom;
         }
       }
@@ -243,26 +266,26 @@ export function useRenderLoop(refs: Refs) {
       // glow halo pulses in lockstep with the perimeter ribbons without
       // either side needing to read a CSS variable.
       tickActiveCursor(now, bloom);
-
-      raf = requestAnimationFrame(tick);
     }
 
-    function onVisibility() {
-      if (document.hidden) {
-        if (raf) cancelAnimationFrame(raf);
-        raf = 0;
-      } else if (!raf && !cancelled) {
-        raf = requestAnimationFrame(tick);
-      }
-    }
-    document.addEventListener("visibilitychange", onVisibility);
-
-    raf = requestAnimationFrame(tick);
+    // Single-rAF policy: master render loop registers with FrameScheduler.
+    // Compute-phase callbacks (tweens, scheduled curves) run before this
+    // tick on the same frame, so the store state we read is up to date.
+    // When document.hidden, skip the work entirely — Chrome throttles
+    // rAF to 1 Hz on hidden tabs but we want zero work, not slow work.
+    const unregister = frameScheduler.register(
+      "render-loop",
+      (now) => {
+        if (cancelled) return;
+        if (typeof document !== "undefined" && document.hidden) return;
+        tick(now);
+      },
+      { phase: "render", budgetMs: 10 },
+    );
 
     return () => {
       cancelled = true;
-      if (raf) cancelAnimationFrame(raf);
-      document.removeEventListener("visibilitychange", onVisibility);
+      unregister();
       sessionUnsub();
       mirrorUnsub?.();
       unsubEffectsConfig?.();

--- a/demos/realtime_motion_graph_web/web/hooks/useScheduledCurves.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useScheduledCurves.ts
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 
 import { evaluateCurve } from "@/engine/curves/interp";
+import { frameScheduler } from "@/engine/scheduler/FrameScheduler";
 import {
   isManualOverrideActive,
   usePerformanceStore,
@@ -31,33 +32,27 @@ import { LORA_SLIDER_MAX, SLIDER_META } from "@/types/engine";
 // would just churn renders without any visible effect.
 export function useScheduledCurves(): void {
   useEffect(() => {
-    let raf = 0;
-    let cancelled = false;
-
-    const tick = () => {
-      if (cancelled) return;
-      const curveState = useCurveStore.getState();
-      // Master kill-switch: when disabled, no curve drives anything,
-      // regardless of per-curve enabled flags. The user's drawings are
-      // preserved; they just don't apply.
-      if (!curveState.scheduleEnabled) {
-        raf = requestAnimationFrame(tick);
-        return;
-      }
-      const session = useSessionStore.getState();
-      const player = session.player;
-      const remote = session.remote;
-      // Need both: player gives us positionSec, remote gives duration
-      // (audio length the engine is generating against). Skip cleanly
-      // when not playing.
-      if (player && remote && remote.duration > 0) {
+    // Compute-phase tick: writes sliderValues before useRenderLoop's
+    // render phase reads them. Bails cheaply when scheduleEnabled is
+    // false — it stays registered but does ~zero work each frame.
+    // Pre-2026 this was a self-scheduling rAF that woke up every vsync
+    // even when the master kill-switch was off; now it shares a single
+    // rAF with the rest of the render path.
+    const unregister = frameScheduler.register(
+      "scheduled-curves",
+      () => {
+        const curveState = useCurveStore.getState();
+        if (!curveState.scheduleEnabled) return;
+        const session = useSessionStore.getState();
+        const player = session.player;
+        const remote = session.remote;
+        if (!player || !remote || remote.duration <= 0) return;
         const t = Math.min(
           1,
           Math.max(0, player.positionSec / remote.duration),
         );
         const curves = curveState.curves;
-        const setSliderDirect =
-          usePerformanceStore.getState().setSliderDirect;
+        const setSliderDirect = usePerformanceStore.getState().setSliderDirect;
         for (const param of Object.keys(curves)) {
           const c = curves[param];
           if (!c.enabled) continue;
@@ -71,14 +66,9 @@ export function useScheduledCurves(): void {
             : (SLIDER_META[param]?.max ?? 1.0);
           setSliderDirect(param, yNorm * max);
         }
-      }
-      raf = requestAnimationFrame(tick);
-    };
-    raf = requestAnimationFrame(tick);
-
-    return () => {
-      cancelled = true;
-      cancelAnimationFrame(raf);
-    };
+      },
+      { phase: "compute", budgetMs: 1 },
+    );
+    return () => unregister();
   }, []);
 }

--- a/demos/realtime_motion_graph_web/web/public/audio-worklet.js
+++ b/demos/realtime_motion_graph_web/web/public/audio-worklet.js
@@ -14,6 +14,15 @@
 const CROSSFADE_SECONDS = 0.05;
 const SEAM_FADE_SECONDS = 0.05;  // loop-seam crossfade at end-of-buffer
 const REPORT_EVERY = 1024;  // frames between position reports
+// Kick / RMS window. 480 frames at 48 kHz is ~10 ms — long enough to
+// average a kick transient, short enough to track sub-beat dynamics.
+// Sliding sum-of-squares is maintained incrementally; periodic refresh
+// (every REFRESH frames) re-computes from the buffer to bound floating-
+// point drift. KICK_SOFT_GAIN matches the main-thread kickRms() the
+// worklet replaces (was: `rms * 1.6`, clamped to [0,1]).
+const KICK_WINDOW = 480;
+const KICK_REFRESH = 48000;  // ~1 s — drift is microscopic in float32 anyway
+const KICK_SOFT_GAIN = 1.6;
 
 class RealtimeBufferProcessor extends AudioWorkletProcessor {
   constructor() {
@@ -32,6 +41,14 @@ class RealtimeBufferProcessor extends AudioWorkletProcessor {
     this.seamFadeLen = Math.max(1, Math.floor(sampleRate * SEAM_FADE_SECONDS));
 
     this._framesSinceReport = 0;
+
+    // Kick state: ring of squared frame energies, running sum.
+    this._kickRing = new Float32Array(KICK_WINDOW);
+    this._kickHead = 0;
+    this._kickFilled = 0;
+    this._kickSumSq = 0;
+    this._lastKick = 0;
+    this._kickFramesSinceRefresh = 0;
 
     this.port.onmessage = (e) => this._onmessage(e.data);
   }
@@ -136,9 +153,44 @@ class RealtimeBufferProcessor extends AudioWorkletProcessor {
         }
       }
 
+      // Kick / RMS — sliding sum of squared frame energies. Frame energy
+      // is the mean of the output channels at this frame; squaring gives
+      // us the input to RMS. We update the ring incrementally (subtract
+      // oldest, add newest) so per-frame cost is O(1). Done here on the
+      // audio thread so the main render loop never has to read the audio
+      // buffer to derive a beat signal — a per-frame mirror walk used to
+      // cost a budget slice on every render frame.
+      let frameEnergy = 0;
+      for (let c = 0; c < outChannels; c++) frameEnergy += output[c][i];
+      frameEnergy /= outChannels;
+      const sq = frameEnergy * frameEnergy;
+      const oldSq = this._kickRing[this._kickHead];
+      this._kickSumSq += sq - oldSq;
+      this._kickRing[this._kickHead] = sq;
+      this._kickHead = (this._kickHead + 1) % KICK_WINDOW;
+      if (this._kickFilled < KICK_WINDOW) this._kickFilled++;
+
       this.position++;
       if (this.position >= nCur) this.position = seam;
     }
+
+    // Periodic refresh of _kickSumSq from the ring to bound float drift.
+    // At float32 precision over ~1 s of accumulation drift is well below
+    // perceptual threshold, but the recompute is cheap enough.
+    this._kickFramesSinceRefresh += frames;
+    if (this._kickFramesSinceRefresh >= KICK_REFRESH) {
+      this._kickFramesSinceRefresh = 0;
+      let s = 0;
+      for (let i = 0; i < this._kickFilled; i++) s += this._kickRing[i];
+      this._kickSumSq = s;
+    }
+
+    // Compute the kick value once per process() block, not per frame.
+    // The sliding window already smooths the signal; main-thread visuals
+    // poll this at rAF cadence. RMS, soft-clip, clamp.
+    const denom = this._kickFilled || 1;
+    const rms = Math.sqrt(Math.max(0, this._kickSumSq) / denom);
+    this._lastKick = Math.max(0, Math.min(1, rms * KICK_SOFT_GAIN));
 
     this._framesSinceReport += frames;
     if (this._framesSinceReport >= REPORT_EVERY) {
@@ -147,6 +199,7 @@ class RealtimeBufferProcessor extends AudioWorkletProcessor {
         type: "position",
         positionSec: this.position / sampleRate,
         swapCount: this.swapCount,
+        kick: this._lastKick,
       });
     }
 

--- a/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
@@ -2,6 +2,8 @@
 
 import { create } from "zustand";
 
+import { frameScheduler } from "@/engine/scheduler/FrameScheduler";
+
 import {
   SLIDER_META,
   type DcwMode,
@@ -74,13 +76,18 @@ interface Tween {
   startTime: number;
 }
 const tweens = new Map<string, Tween>();
-let rafId: number | null = null;
+// Active FrameScheduler registration handle, or null when no tweens are
+// running. We register on first tween, unregister when the map empties —
+// keeps the master rAF callback from doing dead work while idle.
+let tweenUnregister: (() => void) | null = null;
 
-function tickTweens(): void {
-  rafId = null;
+function tickTweens(now: number): void {
+  if (tweens.size === 0) {
+    // Defensive: scheduler keeps calling until we unregister, but we
+    // already unregister at the end of any frame that drains the map.
+    return;
+  }
   const state = usePerformanceStore.getState();
-  if (tweens.size === 0) return;
-  const now = performance.now();
   const durationMs = state.smoothMs;
   const updates: Record<string, number> = {};
   for (const [param, t] of tweens) {
@@ -101,8 +108,9 @@ function tickTweens(): void {
       sliderValues: { ...s.sliderValues, ...updates },
     }));
   }
-  if (tweens.size > 0 && typeof requestAnimationFrame !== "undefined") {
-    rafId = requestAnimationFrame(tickTweens);
+  if (tweens.size === 0 && tweenUnregister) {
+    tweenUnregister();
+    tweenUnregister = null;
   }
 }
 
@@ -116,8 +124,11 @@ function ensureTween(param: string): void {
     start: sliderValues[param] ?? 0,
     startTime: performance.now(),
   });
-  if (rafId === null && typeof requestAnimationFrame !== "undefined") {
-    rafId = requestAnimationFrame(tickTweens);
+  if (!tweenUnregister) {
+    tweenUnregister = frameScheduler.register("tweens", tickTweens, {
+      phase: "compute",
+      budgetMs: 1,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

Fourth perf pass on this demo. User-visible symptom: cursor lag and UI sluggishness on every audio kick. The compounding causes were five `--bloom-amount` consumers on `:root` cascading whole-document paint, six rAF loops fighting for vsync, per-spark `rgba(...)` string allocation on chorus frames, and `kickRms` running per-frame on the main thread.

Each fix below targets a different class of cost. Together they should take chorus frames from "visibly janks the cursor" to "imperceptible" on the consumer (demon-public-demo) end.

## Changes

- **`engine/scheduler/FrameScheduler.ts` (new).** Single-rAF policy with compute → render phase ordering and per-tick EMA stats. Owns the only `requestAnimationFrame` call in the codebase. Migrated `useRenderLoop`, `tickTweens` in `usePerformanceStore`, and `useScheduledCurves` to register via `frameScheduler.register(name, fn, { phase, budgetMs })`. `AmbientRenderer` and `VideoLayer` keep their own rAFs (lower contention; can migrate later).

- **`public/audio-worklet.js` + `engine/audio/AudioPlayer.ts`.** Kick/RMS computed in the worklet's `process()` over a 480-frame sliding window via incremental sum-of-squares (O(1) per frame). Posted alongside position updates (~21 ms cadence). Main thread reads `player.kick` — one field load instead of a per-rAF mirror walk. ScriptProcessor fallback leaves kick = 0 (graceful degradation; non-secure contexts only).

- **`engine/render/GraphRenderer.ts` spark renderer.** `Spark[]` with shift/splice/push (O(n) on overflow + GC pressure on every chorus frame) → struct-of-arrays `TypedArray`s with ring-pointer alloc. Pre-cached `rgb(r,g,b)` strings keyed by line. Render pass sets `fillStyle` once per color group, applies fade via `globalAlpha`. `fillRect` over `arc` — visually indistinguishable at 2.5 px in motion, skips path tessellation.

- **`engine/render/GraphRenderer.ts` shadowBlur strip.** Per-line `shadowBlur` strokes scaled by pulse defeated Skia's blur cache and fired every frame whenever `pulse > 0.1`. Removed; line width pulses with kick instead. Playhead glow rewritten as a single `globalCompositeOperation = "lighter"` stroke gated at `pulse > 0.2`, no shadowBlur.

- **`app/globals.css`.** `--bloom-amount` is now scoped to `#performance` (the perf-scene root) with `isolation: isolate`, not `documentElement`. Style recalc on each binned-kick change touches only the perf-scene subtree, not the whole document. Avoiding `contain: paint` because position:fixed descendants (modals, tooltips) would get clipped. The `useRenderLoop` writer caches the host-element lookup.

- **`components/PerfOverlay.tsx` (new).** Dev-only floating panel, **Shift+P** toggle. Reads `frameScheduler.getStats()` 4×/s. Shows last-frame ms, p95 over 5 s, long-task count, GC-spike proxy, and per-tick EMA against budget. `NODE_ENV`-gated; mounted from the consumer app's layout.

## Companion PR

The demon-public-demo PR (forthcoming, post-merge) adds:
- CI perf-smoke test (Puppeteer + `perf-budget.json`).
- `PerfOverlay` mounted in `app/layout.tsx`.
- `PERFORMANCE.md` rules doc.

## Test plan

- [ ] Existing demos boot in dev — no console errors on perf scene mount or unmount.
- [ ] `Shift+P` toggles the perf overlay; per-tick EMAs are reasonable (master render-loop budget is 10 ms).
- [ ] During music playback, `player.kick` updates smoothly (visible via the perf overlay or by watching bloom).
- [ ] Sparks still fire on chorus kicks (peak ≥ 0.5) — visual parity with pre-PR.
- [ ] `--bloom-amount` is now on `#performance` (not `:root`); the rest of the document doesn't repaint on bloom changes.
- [ ] On the ScriptProcessor fallback path (HTTP), the demo loads without errors and visuals work without kick reactivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)