### PR TITLE
realtime_motion_graph_web: fix KnobDef import path

### DIFF
--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -583,7 +583,7 @@ def handle_client(
                 # delta check (set_lora_strength only when the new value
                 # differs by > 0.02) doesn't immediately fire a redundant
                 # refit on tick 1.
-                from .client.knobs import KnobDef
+                from .knobs import KnobDef
                 virtual_knobs.add_knob(
                     f"lora_str_{lid}",
                     KnobDef(


### PR DESCRIPTION
## Summary

`enable_lora()` in `demos/realtime_motion_graph_web/backend.py:586` imports `KnobDef` from `.client.knobs`, but no `client` subpackage exists — `KnobDef` is defined at `demos/realtime_motion_graph_web/knobs.py:24`. The `ModuleNotFoundError` is swallowed three lines below at line 596:

```python
except Exception as e:
    print(f"[Server] enable_lora({lid}) failed: {e}")
```

so every LoRA enable raises, the knob slot for `lora_str_<lid>` is never registered with `virtual_knobs`, and the runner's slider-delta check has nothing to compare against.

The LoRAs themselves still get enabled at the engine level (the `engine_obj.enable_lora` call earlier in the try succeeds), but their strength can't be driven via the client params dict — which is why operators see LoRAs "stuck" at default strength after the first session of a pod.

Visible in pod logs as:

```
[Server] enable_lora(deathstep) failed: No module named 'demos.realtime_motion_graph_web.client'
[Server] enable_lora(synthpop) failed: No module named 'demos.realtime_motion_graph_web.client'
```

right after `Model loaded in 11.8s`, on every session that uses LoRAs.

## Fix

One line — drop the bogus `.client` segment:

```diff
-                from .client.knobs import KnobDef
+                from .knobs import KnobDef
```

`grep -rn "from .client" demos/realtime_motion_graph_web/` returns no other matches, so this was an isolated typo, not a missed package rename.

## Test plan

- [ ] Run a session with `enabled_loras: ['deathstep', 'synthpop']` (or any non-empty LoRA list) — pod logs no longer print `[Server] enable_lora(...) failed: No module named ...`.
- [ ] After enable, `virtual_knobs` has a slot named `lora_str_deathstep` / `lora_str_synthpop` registered with the strength the LoRA was enabled at.
- [ ] Slider for LoRA strength on the client actually moves the live strength on the engine.