### PR TITLE
demos/realtime_motion_graph_web: lower default audio upload cap to 60 s

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
@@ -103,12 +103,13 @@ export async function loadFixtureAudio(name: string): Promise<DecodedFixture> {
   return decodeArrayBuffer(bytes);
 }
 
-// Cap user-supplied audio at DEMON's largest TRT engine profile
-// (240 s; see acestep/paths.py:_TRT_ENGINE_PROFILES). Anything longer
-// would fail server-side at session init regardless of WS frame size.
-// The server's websockets.serve(max_size=...) is sized to fit this
-// duration with a comfortable margin.
-const MAX_FIXTURE_DURATION_S = 240;
+// Cap user-supplied audio at the smallest TRT engine profile (60 s; see
+// acestep/paths.py:_TRT_ENGINE_PROFILES). Larger profiles (120 s, 240 s)
+// require materially more VRAM at session init — we've been seeing 1011s
+// on cold-loads when the bigger profiles spin up. Operators that want
+// longer engines can raise this and the server's websockets.serve
+// max_size accordingly.
+const MAX_FIXTURE_DURATION_S = 60;
 
 function ensureFitsSwapLimit(decoded: DecodedFixture): void {
   const seconds = decoded.frames / decoded.sampleRate;


### PR DESCRIPTION
## Summary

Sets `MAX_FIXTURE_DURATION_S` in `web/engine/audio/loadFixture.ts` back to **60 s** (was 240). 60 s is the smallest registered TRT engine profile in `acestep/paths.py:_TRT_ENGINE_PROFILES`; larger profiles (120 s, 240 s) need materially more VRAM at session init and have been triggering 1011 close-frames on cold-loads. Operator decision — installations that want the longer engines can raise the constant (and the server's `websockets.serve(max_size=…)` to match).

Prior bump for context: #33 (136 s → 240 s).

## Test plan

- [ ] Upload a 50 s clip → accepts, session starts, plays through.
- [ ] Upload a 75 s clip → rejected client-side with `Track too long — 75s (max 60s). Trim it.`
- [ ] No regression on the bundled fixtures (all ≤ 60 s).