### PR TITLE
realtime_motion_graph_web: default to 60s low-fi fixture for first-time users

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 
-import { decodeAudioFile, listFixtures } from "@/engine/audio/loadFixture";
+import { decodeAudioFile, listFixtures, pickDefaultFixture } from "@/engine/audio/loadFixture";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
@@ -69,8 +69,9 @@ export function AudioSourceCrate() {
     void listFixtures()
       .then((names) => {
         setFixtures(names);
-        if (!usePerformanceStore.getState().fixture && names[0]) {
-          setFixture(names[0]);
+        const def = pickDefaultFixture(names);
+        if (!usePerformanceStore.getState().fixture && def) {
+          setFixture(def);
         }
       })
       .catch(() => setFixtures([]));

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import { decodeAudioFile, listFixtures } from "@/engine/audio/loadFixture";
+import { decodeAudioFile, listFixtures, pickDefaultFixture } from "@/engine/audio/loadFixture";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
@@ -58,8 +58,9 @@ export function LiteTrackCarousel() {
     void listFixtures()
       .then((names) => {
         setFixtures(names);
-        if (!usePerformanceStore.getState().fixture && names[0]) {
-          setFixture(names[0]);
+        const def = pickDefaultFixture(names);
+        if (!usePerformanceStore.getState().fixture && def) {
+          setFixture(def);
         }
       })
       .catch(() => setFixtures([]));

--- a/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import { decodeAudioFile, listFixtures } from "@/engine/audio/loadFixture";
+import { decodeAudioFile, listFixtures, pickDefaultFixture } from "@/engine/audio/loadFixture";
 import { togglePauseAndAudio } from "@/engine/audio/togglePauseAndAudio";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { useCurveStore } from "@/store/useCurveStore";
@@ -51,8 +51,9 @@ export function OperatorStrip() {
     void listFixtures()
       .then((names) => {
         setFixtures(names);
-        if (!usePerformanceStore.getState().fixture && names[0]) {
-          setFixture(names[0]);
+        const def = pickDefaultFixture(names);
+        if (!usePerformanceStore.getState().fixture && def) {
+          setFixture(def);
         }
       })
       .catch(() => setFixtures([]));

--- a/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
@@ -137,3 +137,13 @@ export async function listFixtures(): Promise<string[]> {
   const json = (await res.json()) as string[];
   return json;
 }
+
+// Preferred default the UI picks when no fixture is yet selected. Falls
+// back to names[0] if the catalog doesn't contain it (e.g. removed from
+// KNOWN_FIXTURES upstream).
+export const PREFERRED_DEFAULT_FIXTURE = "low_fi_Gm_loop_60s_gnm.wav";
+
+export function pickDefaultFixture(names: readonly string[]): string {
+  if (names.includes(PREFERRED_DEFAULT_FIXTURE)) return PREFERRED_DEFAULT_FIXTURE;
+  return names[0] ?? "";
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -3,7 +3,7 @@
 import { useCallback } from "react";
 
 import { AudioPlayer } from "@/engine/audio/AudioPlayer";
-import { listFixtures, loadFixtureAudio } from "@/engine/audio/loadFixture";
+import { listFixtures, loadFixtureAudio, pickDefaultFixture } from "@/engine/audio/loadFixture";
 import { defaultWsUrl } from "@/engine/podUrl";
 import { RemoteBackend, SLICE_FLAG_DELTA } from "@/engine/protocol";
 import { getApiKey } from "@/engine/rtmgConfig";
@@ -94,7 +94,7 @@ export function useStartSession() {
     if (!fixtureName) {
       try {
         const list = await listFixtures();
-        fixtureName = list[0] ?? "";
+        fixtureName = pickDefaultFixture(list);
         if (fixtureName) {
           usePerformanceStore.getState().setFixture(fixtureName);
         }


### PR DESCRIPTION
## Summary
- Adds `pickDefaultFixture(names)` in `engine/audio/loadFixture.ts`: returns `low_fi_Gm_loop_60s_gnm.wav` if the server catalog includes it, else falls back to `names[0]` (today's behavior).
- Wires it into the four sites that previously hardcoded `names[0]` / `list[0]`: `hooks/useStartSession.ts`, plus `AudioSourceCrate` / `OperatorStrip` / `LiteTrackCarousel`.

## Why
Today's first-time-user default is whatever sorts first alphabetically out of `KNOWN_FIXTURES` — currently `inside_confusion_loop_120s_gsm.wav`. The 60s low-fi loop is a better first-impression track. Existing users with a persisted fixture are unaffected: the `if (!fixture …)` guards only fire on empty store state. If the preferred fixture is ever removed from `KNOWN_FIXTURES`, the helper falls back to today's behavior.

## Test plan
- [ ] Fresh browser session (no persisted `fixture`): track placard, OperatorStrip dropdown, and LiteTrackCarousel all show `low_fi_Gm_loop_60s_gnm.wav` selected.
- [ ] Start a session: WebSocket `start` message's `fixture_name` equals `low_fi_Gm_loop_60s_gnm.wav`.
- [ ] Existing user (any persisted `fixture`): selection unchanged across reloads.
- [ ] Resilience: stub `listFixtures` to return a list without the preferred name → UI falls back to `names[0]` instead of breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)