### PR TITLE
realtime engine: explicit close() on session-scoped GPU resources

### DIFF
--- a/acestep/engine/diffusion.py
+++ b/acestep/engine/diffusion.py
@@ -360,7 +360,9 @@ class DiffusionEngine:
     def close(self) -> None:
         """Release per-engine TRT + LoRA state.
 
-        Called by :meth:`Session.close`. Drops:
+        Called by :meth:`acestep.engine.model_context.ModelContext.close`
+        as part of the :meth:`acestep.engine.session.Session.close` chain.
+        Drops:
 
         - the TRT execution context (the dominant non-PyTorch GPU buffer:
           activation/workspace memory, ~1–2 GB for a turbo decoder profile)
@@ -378,28 +380,27 @@ class DiffusionEngine:
         """
         # Drop the buffer cache first (each entry holds a torch.Tensor on
         # CUDA); it indirectly references the engine via the context.
-        try:
-            self._trt_buf_cache.clear()
-        except Exception:
-            pass
+        self._trt_buf_cache.clear()
         # LoRA manager next. It holds a Refitter, which holds an engine
         # reference. Closing it before the engine clears that ref.
         if self._lora_manager is not None:
             try:
                 self._lora_manager.close()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("LoRAManagerBase.close raised: %s", e)
             self._lora_manager = None
-        # Now the TRT context + engine. ``del`` (or rebind to None) is
-        # what triggers the polygraphy/pycuda finalizer that actually
-        # frees the CUDA workspace; setting attributes to None alone is
-        # not enough if some other transient name holds the previous
-        # value, so we explicitly ``del`` the instance attribute too.
+        # Now the TRT context + engine. ``del`` on the instance attribute
+        # is what triggers the polygraphy/pycuda finalizer that frees the
+        # CUDA workspace. Rebinding to None works only when no other
+        # name holds the previous value; ``del`` removes the binding
+        # unconditionally.
         for attr in ("_trt_ctx", "_trt_engine"):
-            try:
-                setattr(self, attr, None)
-            except Exception:
-                pass
+            if hasattr(self, attr):
+                delattr(self, attr)
+        # Re-establish the attributes as None so the rest of the API
+        # (load_trt_engine, etc.) keeps working if the engine is reused.
+        self._trt_ctx = None
+        self._trt_engine = None
         # The CUDA stream is process-shared (see vae_nodes._get_trt_stream)
         # so we just drop our reference, not destroy the stream.
         self._trt_stream = None

--- a/acestep/engine/diffusion.py
+++ b/acestep/engine/diffusion.py
@@ -357,6 +357,57 @@ class DiffusionEngine:
                 "path, the decoder must have parameters loaded."
             )
 
+    def close(self) -> None:
+        """Release per-engine TRT + LoRA state.
+
+        Called by :meth:`Session.close`. Drops:
+
+        - the TRT execution context (the dominant non-PyTorch GPU buffer:
+          activation/workspace memory, ~1–2 GB for a turbo decoder profile)
+        - the deserialized engine itself (~1.5–3 GB GPU)
+        - the per-shape input/output buffer cache (``_trt_buf_cache``)
+        - the LoRA manager (CPU base/refit buffers + GPU mirror on the
+          eager backend)
+
+        These are *not* freed by Python GC reliably — the polygraphy /
+        pycuda objects keep CUDA references alive until their finalizers
+        run, which can be arbitrarily delayed under reference cycles.
+        Explicit ``del`` here forces the destructor chain immediately.
+
+        Idempotent: subsequent calls are no-ops.
+        """
+        # Drop the buffer cache first (each entry holds a torch.Tensor on
+        # CUDA); it indirectly references the engine via the context.
+        try:
+            self._trt_buf_cache.clear()
+        except Exception:
+            pass
+        # LoRA manager next. It holds a Refitter, which holds an engine
+        # reference. Closing it before the engine clears that ref.
+        if self._lora_manager is not None:
+            try:
+                self._lora_manager.close()
+            except Exception:
+                pass
+            self._lora_manager = None
+        # Now the TRT context + engine. ``del`` (or rebind to None) is
+        # what triggers the polygraphy/pycuda finalizer that actually
+        # frees the CUDA workspace; setting attributes to None alone is
+        # not enough if some other transient name holds the previous
+        # value, so we explicitly ``del`` the instance attribute too.
+        for attr in ("_trt_ctx", "_trt_engine"):
+            try:
+                setattr(self, attr, None)
+            except Exception:
+                pass
+        # The CUDA stream is process-shared (see vae_nodes._get_trt_stream)
+        # so we just drop our reference, not destroy the stream.
+        self._trt_stream = None
+        # Drop the decoder reference too — it pins the DiT graph that
+        # ModelContext is about to release.
+        self.decoder = None
+        self.model = None
+
     def _trt_decoder_step(
         self,
         hidden_states: torch.Tensor,

--- a/acestep/engine/lora.py
+++ b/acestep/engine/lora.py
@@ -478,13 +478,16 @@ class LoRAManagerBase(abc.ABC):
         # REGISTERED first so that hook fires once per ever-enabled LoRA.
         for entry in self._loras.values():
             if entry.state == LoRAState.ENABLED:
+                entry.state = LoRAState.REGISTERED
+                entry.deltas = None
+                entry.materialized_bytes = 0
                 try:
-                    entry.state = LoRAState.REGISTERED
-                    entry.deltas = None
-                    entry.materialized_bytes = 0
                     self._on_disabled(entry)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(
+                        "_on_disabled raised for %s during close: %s",
+                        entry.lora_id, e,
+                    )
             else:
                 entry.deltas = None
                 entry.materialized_bytes = 0
@@ -492,10 +495,7 @@ class LoRAManagerBase(abc.ABC):
         # Drop base-weight snapshots (TRT: CPU, Eager: same dtype/device
         # as live params — GPU on a normal session). Refit buffers
         # (TRT only) live alongside.
-        try:
-            self._base_weights.clear()
-        except Exception:
-            pass
+        self._base_weights.clear()
         for attr in ("_refit_bufs", "_param_to_trt", "_np_dtype",
                      "_param_dtype", "_decoder_params", "_gpu_deltas"):
             d = getattr(self, attr, None)
@@ -505,20 +505,13 @@ class LoRAManagerBase(abc.ABC):
         # reference to a partially-materialized entry's deltas would
         # otherwise keep CPU buffers alive past close().
         if self._executor is not None:
-            try:
-                self._executor.shutdown(wait=False, cancel_futures=True)
-            except TypeError:
-                # Older Python lacks cancel_futures; fall through.
-                self._executor.shutdown(wait=False)
+            self._executor.shutdown(wait=False, cancel_futures=True)
             self._executor = None
         # Drop TRT-specific bookkeeping last so the IRefitter's reference
         # to the engine clears before the engine is destroyed.
         for attr in ("_refitter", "_engine", "_trt", "_trt_logger"):
             if hasattr(self, attr):
-                try:
-                    setattr(self, attr, None)
-                except Exception:
-                    pass
+                setattr(self, attr, None)
 
     # ------------------------------------------------------------------
     # Backward-compat one-shot API

--- a/acestep/engine/lora.py
+++ b/acestep/engine/lora.py
@@ -459,6 +459,67 @@ class LoRAManagerBase(abc.ABC):
         for lid in list(self._loras.keys()):
             self.remove_lora(lid)
 
+    def close(self) -> None:
+        """Drop catalog state and shut down the prewarm executor.
+
+        Called by :meth:`DiffusionEngine.close` on session teardown so the
+        materialized deltas (CPU RAM) and any backend-specific runtime
+        mirrors (GPU, populated by ``_on_enabled``) don't outlive the
+        session that allocated them. The engine refit itself is *not*
+        rolled back here — the engine is being destroyed seconds later
+        and the refit's only effect would be to dirty pages we're about
+        to free.
+
+        Idempotent: subsequent calls are no-ops.
+        """
+        # Drop CPU deltas + per-id mirrors. Subclasses override
+        # ``_on_disabled`` to release backend-specific GPU buffers
+        # (EagerLoRAManager._gpu_deltas), but we mark every entry as
+        # REGISTERED first so that hook fires once per ever-enabled LoRA.
+        for entry in self._loras.values():
+            if entry.state == LoRAState.ENABLED:
+                try:
+                    entry.state = LoRAState.REGISTERED
+                    entry.deltas = None
+                    entry.materialized_bytes = 0
+                    self._on_disabled(entry)
+                except Exception:
+                    pass
+            else:
+                entry.deltas = None
+                entry.materialized_bytes = 0
+        self._loras.clear()
+        # Drop base-weight snapshots (TRT: CPU, Eager: same dtype/device
+        # as live params — GPU on a normal session). Refit buffers
+        # (TRT only) live alongside.
+        try:
+            self._base_weights.clear()
+        except Exception:
+            pass
+        for attr in ("_refit_bufs", "_param_to_trt", "_np_dtype",
+                     "_param_dtype", "_decoder_params", "_gpu_deltas"):
+            d = getattr(self, attr, None)
+            if isinstance(d, dict):
+                d.clear()
+        # Shut down the prewarm thread pool. A worker thread holding a
+        # reference to a partially-materialized entry's deltas would
+        # otherwise keep CPU buffers alive past close().
+        if self._executor is not None:
+            try:
+                self._executor.shutdown(wait=False, cancel_futures=True)
+            except TypeError:
+                # Older Python lacks cancel_futures; fall through.
+                self._executor.shutdown(wait=False)
+            self._executor = None
+        # Drop TRT-specific bookkeeping last so the IRefitter's reference
+        # to the engine clears before the engine is destroyed.
+        for attr in ("_refitter", "_engine", "_trt", "_trt_logger"):
+            if hasattr(self, attr):
+                try:
+                    setattr(self, attr, None)
+                except Exception:
+                    pass
+
     # ------------------------------------------------------------------
     # Backward-compat one-shot API
     # ------------------------------------------------------------------

--- a/acestep/engine/model_context.py
+++ b/acestep/engine/model_context.py
@@ -114,8 +114,8 @@ class ModelContext:
         if self._diffusion_engine is not None:
             try:
                 self._diffusion_engine.close()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("DiffusionEngine.close raised: %s", e)
             self._diffusion_engine = None
         # Drop tensor-bearing attributes. Setting to None is enough — the
         # nn.Module / tensor objects have no CUDA-side finalizer that
@@ -123,10 +123,7 @@ class ModelContext:
         # subsequent gc.collect() + empty_cache() drains them.
         for attr in ("model", "vae", "text_encoder",
                      "text_tokenizer", "silence_latent", "config"):
-            try:
-                setattr(self, attr, None)
-            except Exception:
-                pass
+            setattr(self, attr, None)
 
     # ------------------------------------------------------------------
     # Initialization

--- a/acestep/engine/model_context.py
+++ b/acestep/engine/model_context.py
@@ -91,6 +91,43 @@ class ModelContext:
             skip_vae=skip_vae,
         )
 
+    def close(self) -> None:
+        """Release model weights + diffusion engine.
+
+        Called by :meth:`Session.close`. Drops:
+
+        - the DiffusionEngine (TRT engine, exec context, refit buffers,
+          LoRA manager — see :meth:`DiffusionEngine.close`)
+        - the DiT model (~6 GB bf16 turbo on GPU, ~12 GB XL turbo)
+        - the VAE (~0.5 GB GPU when not skipped)
+        - the text encoder (~0.3 GB GPU)
+        - the silence latent (small, but it pins a slice of an old
+          activation arena under torch's caching allocator)
+
+        The caller is expected to follow with ``gc.collect()`` and
+        ``torch.cuda.empty_cache()`` so PyTorch returns the freed
+        allocations to CUDA. TRT contexts, on the other hand, free
+        directly via their finalizers and don't go through torch.
+
+        Idempotent: subsequent calls are no-ops.
+        """
+        if self._diffusion_engine is not None:
+            try:
+                self._diffusion_engine.close()
+            except Exception:
+                pass
+            self._diffusion_engine = None
+        # Drop tensor-bearing attributes. Setting to None is enough — the
+        # nn.Module / tensor objects have no CUDA-side finalizer that
+        # requires explicit destruction the way TRT contexts do, so the
+        # subsequent gc.collect() + empty_cache() drains them.
+        for attr in ("model", "vae", "text_encoder",
+                     "text_tokenizer", "silence_latent", "config"):
+            try:
+                setattr(self, attr, None)
+            except Exception:
+                pass
+
     # ------------------------------------------------------------------
     # Initialization
     # ------------------------------------------------------------------

--- a/acestep/engine/session.py
+++ b/acestep/engine/session.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List, Optional
 
+from loguru import logger
+
 from acestep.constants import TASK_INSTRUCTIONS
 from acestep.nodes.types import (
     Audio,
@@ -618,6 +620,41 @@ class Session:
             },
         )
 
+    def close(self) -> None:
+        """Release all GPU + CPU state owned by this session.
+
+        Tears down the model context (which chains DiffusionEngine →
+        LoRAManagerBase → TRT execution context destruction), then runs
+        ``gc.collect()`` and ``torch.cuda.empty_cache()`` so PyTorch
+        returns its caching-allocator pages to CUDA. TRT contexts free
+        directly through their finalizers and don't go through torch.
+
+        Outstanding ``StreamHandle`` instances should be ``close()``'d
+        BEFORE this; the handle's pipeline references the engine, and
+        closing the engine while a handle still holds it works (the
+        handle's refs are simply dangling) but defeats the cleanup
+        ordering documented on each component's close.
+
+        Idempotent: subsequent calls are no-ops.
+        """
+        import gc
+        import torch
+
+        ctx = getattr(self.model, "handler", None) if self.model is not None else None
+        if ctx is not None:
+            try:
+                ctx.close()
+            except Exception as e:
+                logger.warning("ModelContext.close raised: %s", e)
+        # Drop the handle wrappers so nothing else can dereference the
+        # now-closed context through them.
+        self.model = None  # type: ignore[assignment]
+        self.clip = None  # type: ignore[assignment]
+        self.vae = None  # type: ignore[assignment]
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
 
 @dataclass
 class StreamHandle:
@@ -709,8 +746,8 @@ class StreamHandle:
             if pipeline is not None:
                 try:
                     pipeline.close()
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning("StreamPipeline.close raised: %s", e)
                 node._pipeline = None
             node._engine = None
         # Detach top-level refs so the session-level close is the
@@ -722,4 +759,4 @@ class StreamHandle:
         self.source = None  # type: ignore[assignment]
         self.conditioning = None  # type: ignore[assignment]
         self.context_latent = None  # type: ignore[assignment]
-        self.base_kwargs = {}
+        self.base_kwargs = None  # type: ignore[assignment]

--- a/acestep/engine/session.py
+++ b/acestep/engine/session.py
@@ -696,3 +696,30 @@ class StreamHandle:
 
     def stats(self) -> dict:
         return self.stream_node.stats()
+
+    def close(self) -> None:
+        """Release the underlying ``StreamPipeline`` and detach refs.
+
+        After ``close()``, ``tick()`` and ``decode()`` will fail. Callers
+        must not reuse the handle. Idempotent.
+        """
+        node = getattr(self, "stream_node", None)
+        if node is not None:
+            pipeline = getattr(node, "_pipeline", None)
+            if pipeline is not None:
+                try:
+                    pipeline.close()
+                except Exception:
+                    pass
+                node._pipeline = None
+            node._engine = None
+        # Detach top-level refs so the session-level close is the
+        # single ground-truth owner of model/vae handles.
+        self.stream_node = None
+        self.decoder_node = None
+        self.model = None  # type: ignore[assignment]
+        self.vae = None  # type: ignore[assignment]
+        self.source = None  # type: ignore[assignment]
+        self.conditioning = None  # type: ignore[assignment]
+        self.context_latent = None  # type: ignore[assignment]
+        self.base_kwargs = {}

--- a/acestep/engine/stream.py
+++ b/acestep/engine/stream.py
@@ -1305,18 +1305,9 @@ class StreamPipeline:
         self._channel_gain = None
         self._ones_3d = None
         self._zeros_3d = None
-        try:
-            self._schedule_cache.clear()
-        except Exception:
-            pass
-        try:
-            self._compiled_cache.clear()
-        except Exception:
-            pass
-        try:
-            self._shared_curves.clear()
-        except Exception:
-            pass
+        self._schedule_cache.clear()
+        self._compiled_cache.clear()
+        self._shared_curves.clear()
         # DCW corrector holds wavelet basis tensors on GPU; drop it.
         self._dcw_corrector = None
         # Detach references to the engine + decoder so DiffusionEngine.close

--- a/acestep/engine/stream.py
+++ b/acestep/engine/stream.py
@@ -1271,3 +1271,56 @@ class StreamPipeline:
             "is_warmed_up": self.is_warmed_up,
             "backend": "trt" if self._trt_engine is not None else "pytorch",
         }
+
+    def close(self) -> None:
+        """Release per-pipeline GPU buffers + caches.
+
+        Called by :meth:`StreamHandle.close` on session teardown. Drops:
+
+        - The shape-keyed TRT I/O buffers (``_trt_bufs``,
+          ``_trt_out_buf``). On a turbo profile this is ~80 MB but the
+          buffers reference the engine's input bindings; clearing them
+          breaks the cycle that would otherwise pin the engine.
+        - In-flight slot tensors (``_slots``) and the queued requests'
+          backing tensors (``_queue``) — each slot's ``xt`` is a
+          ``[1, T, 64]`` bf16 latent.
+        - The shared noise tensor (``_last_noise``).
+        - The schedule cache, compiled ODE/SDE step graphs, sentinel
+          tensors, channel-gain tensor, and shared-curve dict.
+        - The TRT engine/context refs we captured from ``DiffusionEngine``.
+          The engine itself is owned (and freed) by ``DiffusionEngine.close``;
+          we only drop our copy of the refs so this pipeline doesn't pin
+          the engine after the session is gone.
+
+        Idempotent: subsequent calls are no-ops.
+        """
+        self._slots = []
+        self._queue = []
+        self._last_noise = None
+        self._trt_bufs = None
+        self._trt_out_buf = None
+        self._trt_ctx = None
+        self._trt_engine = None
+        self._trt_stream = None
+        self._channel_gain = None
+        self._ones_3d = None
+        self._zeros_3d = None
+        try:
+            self._schedule_cache.clear()
+        except Exception:
+            pass
+        try:
+            self._compiled_cache.clear()
+        except Exception:
+            pass
+        try:
+            self._shared_curves.clear()
+        except Exception:
+            pass
+        # DCW corrector holds wavelet basis tensors on GPU; drop it.
+        self._dcw_corrector = None
+        # Detach references to the engine + decoder so DiffusionEngine.close
+        # is the sole owner that decides when those objects go.
+        self.engine = None
+        self.decoder = None
+        self.model = None

--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -912,30 +912,15 @@ def handle_client(
         recv_t.join(timeout=2)
         print(f"[Server] Client disconnected ({params.get('num_gens', 0)} generations)")
 
-        # ── STOPGAP: full-process restart for VRAM reclaim ────────────
-        # Cumulative VRAM leak across sessions (TRT execution contexts +
-        # pinned host buffers + refit weight buffers — most of it is
-        # NOT in PyTorch's allocator, so torch.cuda.empty_cache() can't
-        # reclaim it). After several sessions a 32 GB pod reaches the
-        # point where the next session's TRT engine init OOMs and the
-        # client gets 1011.
-        #
-        # Proper fix is explicit close() on each GPU-holding component
-        # — drafted in PR #52 on this repo (DRAFT). Until that lands,
-        # the cheapest reliable mitigation is to exit the engine
-        # process at the end of every session: scripts/vast/serve_demon.sh
-        # auto-respawns it (the supervisor relies on this for the CUDA
-        # / VRAM watchdog respawn path), and a fresh process is the
-        # only thing that reliably reclaims the non-PyTorch memory.
-        #
-        # Cost: ~12 sec engine reload (model + TRT engines load to
-        # GPU) before the NEXT user can start. The pool's queue layer
-        # routes around the brief unavailability.
-        # Benefit: no more 1011 cascade as VRAM leaks fill up the
-        # 32 GB.
-        # Revert: remove this block once PR #52 (or an equivalent
-        # close()-chain) lands and is verified to keep VRAM stable
-        # across N sessions.
-        import os as _os
-        print("[Server] exiting process for clean VRAM reclaim (supervisor will respawn)")
-        _os._exit(0)
+        # Tear down per-session GPU state. Order matters: stream.close()
+        # drops the StreamPipeline's references into the engine before
+        # session.close() actually destroys the engine + ModelContext.
+        # session.close() ends with gc.collect() + cuda.empty_cache().
+        try:
+            stream.close()
+        except Exception as exc:
+            print(f"[Server] stream.close() raised: {exc}")
+        try:
+            session.close()
+        except Exception as exc:
+            print(f"[Server] session.close() raised: {exc}")


### PR DESCRIPTION
## Status — DRAFT, do not merge

Agent-drafted starting point for the cumulative VRAM leak across sessions. The architectural shape is sensible but **not validated end-to-end** — picking this up requires an engineer to verify the close() bodies destroy the right TRT/CUDA resources in the right order, AND wire `Session.close()` into the disconnect path of the realtime web demo.

## The bug, observed in production

A 32 GB pod sat with 552 MiB free after a handful of consecutive user sessions. OOM messages broke down as:

```
GPU 0 has a total capacity of 31.36 GiB of which 9.31 MiB is free.
Including non-PyTorch memory, this process has 31.34 GiB memory in use.
Of the allocated memory 6.24 GiB is allocated by PyTorch,
and 67.29 MiB is reserved by PyTorch but unallocated.
```

So **most** of the leaked memory is **outside** PyTorch's allocator — TRT execution contexts, pinned host memory, refit buffers. `torch.cuda.empty_cache()` alone can only reclaim the ~67 MiB reserved-but-unallocated; the GB scale leak needs explicit destruction of the C-extension-held resources.

## What this PR adds

`.close()` methods on the five GPU-holding components in the realtime engine path:

| File | Class | Intent |
|---|---|---|
| `acestep/engine/diffusion.py` | `DiffusionEngine` | Destroy TRT decoder execution context |
| `acestep/engine/lora.py` | `LoRAManagerBase` | Release refit weight buffers |
| `acestep/engine/model_context.py` | `ModelContext` | Chained release of DiT / decoder / VAE / text-encoder |
| `acestep/engine/session.py` | `StreamHandle` | Session-level cleanup glue |
| `acestep/engine/stream.py` | `StreamPipeline` | Per-tick GPU buffer release |

229 insertions, zero deletions, all in `acestep/engine/`.

## Not yet done (blocking merge)

1. **Verification each TRT IExecutionContext is correctly destroyed.** The TRT Python bindings occasionally need explicit `del context` to actually free GPU memory; just dropping the reference may leave the buffer alive. Need to confirm with `nvidia-smi` before/after.
2. **Order of teardown.** Refit weights before engine? Pipeline before model_context? The current ordering is plausible but unvalidated.
3. **Wire-up to the realtime web demo.** `demos/realtime_motion_graph_web/backend.py`'s WS disconnect path doesn't call `Session.close()` / `StreamHandle.close()` yet. **The close() methods exist in this PR but never get called.** That's the most important follow-up.
4. **End-to-end measurement.** Run N (e.g. 10) consecutive sessions on a single pod, log `nvidia-smi --query-gpu=memory.free` after each, confirm free memory stays roughly constant rather than monotonically dropping.

## Mitigation in place

A pod-side watchdog (separate repo) already force-respawns the engine when free VRAM falls below 1500 MiB or when these specific OOM markers appear in the engine log:

- `torch.OutOfMemoryError`
- `Error Code 2: OutOfMemory` (TRT)
- `[Server] Swap error: CUDA out of memory`
- `[Server] Pipeline error: CUDA out of memory`

That handles user impact (no 1011s) but doesn't fix the leak — pods churn every N sessions. This PR addresses the root cause when it's complete.