### PR TITLE
realtime_motion_graph_web: source-first gate + reset/clear buttons + deathstep label

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1086,6 +1086,21 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   z-index: 8;
 }
 
+/* Prominent variant: applied to the top edge ribbon's hint while the
+   per-song "drag to start" gate is active, so it reads as the next
+   action a first-time user must take — not a passive label. Larger
+   type, brighter color, and a soft glow only (single text-shadow,
+   no filter chain — see PERFORMANCE.md). */
+.remix-hint--prominent {
+  font-size: 15px;
+  letter-spacing: 0.22em;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.92);
+  text-shadow:
+    0 0 6px rgba(255, 255, 255, 0.45),
+    0 0 14px rgba(255, 255, 255, 0.25);
+}
+
 /* Desktop drag overlays — transparent click targets sized to each HUD
    edge bar. Pointer-events fall through the SVG ribbons (which set
    pointer-events: none) so dragging anywhere along the bar updates the
@@ -4097,6 +4112,21 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   opacity: 0.85;
   transition: transform 120ms, color 120ms, filter 120ms;
   filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.6));
+}
+
+/* "Drag to start" gate on the mobile remix rail. The sideways stepper
+   label is too subtle to act as a prompt, so the up chevron itself
+   pulses to read as the next action. Cleared the moment the user
+   crosses denoise > 0 (component drops `data-gate`). */
+.stepper-rail-zone[data-gate="up"] .stepper-rail-chevron {
+  opacity: 1;
+  color: var(--accent);
+  filter: drop-shadow(0 0 12px var(--accent-glow));
+  animation: stepper-rail-gate-pulse 1.4s ease-in-out infinite;
+}
+@keyframes stepper-rail-gate-pulse {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-5px) scale(1.18); }
 }
 
 .stepper-rail-readout {

--- a/demos/realtime_motion_graph_web/web/components/Performance/DesktopEdgeDrag.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/DesktopEdgeDrag.tsx
@@ -61,6 +61,12 @@ export function DesktopEdgeDrag({ side }: Props) {
   // Reads the target (intent) so the visual responds immediately to the
   // drag, even when smooth-mode is on (sliderValues lags via tween).
   const denoise = usePerformanceStore((s) => s.sliderTargets[TOP_PARAM] ?? 0);
+  // Per-song "hear source first" gate. While false, the top ribbon
+  // shows a prominent "drag to start" affordance and the side-rail
+  // hints stay hidden. The first value-changing top drag flips it
+  // true (see onPointerUp below). Reset to false on every song load
+  // by useStartSession / useFixtureSwap.
+  const remixStarted = usePerformanceStore((s) => s.remixStarted);
 
   const isTop = side === "top";
   const orientation: "horizontal" | "vertical" = isTop
@@ -219,6 +225,14 @@ export function DesktopEdgeDrag({ side }: Props) {
         } catch {}
         setHintDismissed(true);
         document.dispatchEvent(new CustomEvent(HINT_DISMISSED_EVENT));
+        // Top ribbon's value-changing drag also flips the per-song
+        // "hear source first" gate, so the side-rail hints become
+        // eligible to show and the prominent "drag to start" copy
+        // gives way. Only count drags that actually moved off zero —
+        // a drag that ends back at 0 hasn't started the remix.
+        if (isTop && finalValue > 0) {
+          usePerformanceStore.getState().setRemixStarted(true);
+        }
       }
       cachedRect = null;
     };
@@ -248,11 +262,21 @@ export function DesktopEdgeDrag({ side }: Props) {
     };
   }, [readCurrentValue, isTop, slotIndex]);
 
-  // Always show the hint until dismissed — even for empty LoRA slots, so
-  // the user has a stable visual anchor through "connecting" / catalog
+  // Visibility:
+  //   - Top ribbon: shows whenever remix hasn't started this song —
+  //     this is a per-song functional gate, not a one-time tutorial,
+  //     so it overrides the localStorage `hintDismissed` flag.
+  //   - Side rails (LoRA-1/2): the existing one-time tutorial. Stay
+  //     hidden until the user has started the remix on this song,
+  //     and stay hidden forever after the first successful drag
+  //     anywhere (`hintDismissed`). Without the remixStarted gate,
+  //     a fresh user would see three competing hints stacked on
+  //     load; we want the top one alone first.
+  // Empty LoRA slots still render their hint (when eligible) so the
+  // user has a stable visual anchor through "connecting" / catalog
   // updates. Drag on an empty slot is a no-op (data-empty guards
-  // pointerdown), but the hint stays visible so nothing "disappears".
-  const showHint = !hintDismissed;
+  // pointerdown).
+  const showHint = isTop ? !remixStarted : remixStarted && !hintDismissed;
 
   return (
     <div
@@ -286,6 +310,8 @@ export function DesktopEdgeDrag({ side }: Props) {
                 ? "— vibe —"
                 : "— rave —"
           }
+          idleLabel={isTop ? "drag to start" : undefined}
+          prominent={isTop}
         />
       )}
     </div>

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef } from "react";
 
 import { listLoras } from "@/engine/lora/listLoras";
+import { displayLoraName } from "@/lib/loraLabels";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
@@ -159,7 +160,7 @@ export function LibraryTile() {
           <LoraRow
             key={entry.id}
             id={entry.id}
-            name={entry.name ?? entry.id}
+            name={displayLoraName(entry.id, entry.name)}
           />
         ))}
       </div>

--- a/demos/realtime_motion_graph_web/web/components/Performance/MobileStepperRail.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/MobileStepperRail.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef } from "react";
 
+import { displayLoraName } from "@/lib/loraLabels";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { SLIDER_META } from "@/types/engine";
@@ -51,6 +52,12 @@ interface Props {
   /** Visual writhe-fill orientation: when true, --fill = 1 - frac (top of
    *  rail bright when value is 0). Match the rail's `invert`. */
   invertFill?: boolean;
+  /** When true, marks the up chevron with `data-gate="up"` so CSS can
+   *  pulse it as a "do this" affordance. Used by the per-song "drag to
+   *  start" gate on the remix rail — the sideways stepper label isn't
+   *  visible enough to act as the prompt, so the chevron itself
+   *  becomes the cue. */
+  pulseUp?: boolean;
 }
 
 function vibrate(ms: number): void {
@@ -73,6 +80,7 @@ export function MobileStepperRail({
   sublabelBottom,
   invert = false,
   invertFill = false,
+  pulseUp = false,
 }: Props) {
   const value = usePerformanceStore((s) => s.sliderTargets[param] ?? 0);
   const setSlider = usePerformanceStore((s) => s.setSlider);
@@ -181,6 +189,7 @@ export function MobileStepperRail({
       <button
         type="button"
         className="stepper-rail-zone stepper-rail-zone--up"
+        data-gate={pulseUp ? "up" : undefined}
         aria-label={
           sublabelTop ? `${label} more ${sublabelTop}` : `Increase ${label}`
         }
@@ -251,12 +260,25 @@ export function MobileStepperRail({
 // reads that out for display.
 
 export function MobileRemixStepper() {
+  // Mobile equivalent of the desktop top-edge "drag to start" gate.
+  // The vertical sideways stepper label isn't visible enough to act as
+  // the prompt, so we pulse the up chevron itself as the "do this"
+  // affordance while remix hasn't started. Crossing denoise > 0 (via
+  // the up chevron, MIDI, or any other path) flips the gate true.
+  const remixStarted = usePerformanceStore((s) => s.remixStarted);
+  const denoise = usePerformanceStore((s) => s.sliderTargets["denoise"] ?? 0);
+  useEffect(() => {
+    if (!remixStarted && denoise > 0) {
+      usePerformanceStore.getState().setRemixStarted(true);
+    }
+  }, [remixStarted, denoise]);
   return (
     <MobileStepperRail
       side="left"
       param="denoise"
       max={1.0}
       label="Remix Strength"
+      pulseUp={!remixStarted}
     />
   );
 }
@@ -271,7 +293,7 @@ export function MobileLoraBlendStepper() {
     ids.push(next.id);
   }
   const nameOf = (id: string | undefined) =>
-    id ? catalog.find((c) => c.id === id)?.name ?? id : null;
+    id ? displayLoraName(id, catalog.find((c) => c.id === id)?.name) : null;
   // With invert=true: top button decreases blend → more LoRA A;
   // bottom button increases blend → more LoRA B. Pair the per-chevron
   // labels accordingly so the user reads "tap up to get more <A>".

--- a/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
@@ -7,6 +7,7 @@ import { togglePauseAndAudio } from "@/engine/audio/togglePauseAndAudio";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { useCurveStore } from "@/store/useCurveStore";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
+import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
 import { VALID_KEYSCALES } from "@/types/engine";
@@ -222,6 +223,19 @@ export function OperatorStrip() {
         onClick={toggleKbdHints}
       >
         KBD: {showKbdHints ? "ON" : "OFF"}
+      </button>
+      <button
+        type="button"
+        className="pause-btn"
+        title="Reset all sliders + LoRAs to defaults. Does NOT touch MIDI mapping, automation curves, or persisted UI prefs."
+        onClick={() => {
+          if (typeof window === "undefined") return;
+          if (!window.confirm("Reset sliders and LoRAs to defaults?")) return;
+          usePerformanceStore.getState().resetToDefaults();
+          useLoraStore.getState().reset();
+        }}
+      >
+        RESET
       </button>
       <RecordToggle />
       <button

--- a/demos/realtime_motion_graph_web/web/components/Performance/RemixHint.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RemixHint.tsx
@@ -56,6 +56,15 @@ interface Props {
   /** Copy shown while the user is actively dragging. Differs per slider
    * so each "string" has its own personality (rave / mosh / vibe). */
   draggingLabel?: string;
+  /** Override the idle copy. Used by the top ribbon's per-song "drag
+   * to start" gate, which is functional (not a one-time tutorial), so
+   * we want a stronger imperative than the default "drag →". */
+  idleLabel?: string;
+  /** Bump the hint to "do this" prominence — larger type, stronger
+   * weight, soft glow, brighter base opacity, and bigger bob. Used
+   * only by the top ribbon while the per-song remix gate is active,
+   * so a first-time user can't miss the affordance. */
+  prominent?: boolean;
 }
 
 export function RemixHint({
@@ -65,6 +74,8 @@ export function RemixHint({
   orientation,
   side = "left",
   draggingLabel = "— rave —",
+  idleLabel,
+  prominent = false,
 }: Props) {
   const [pulse, setPulse] = useState(0);
 
@@ -116,9 +127,14 @@ export function RemixHint({
     opacity = 0.9;
     bobAmt = 0;
   } else {
-    label = compose("drag", idleArrow);
-    opacity = 0.4 + pulse * 0.35;
-    bobAmt = pulse * 6;
+    // Idle. `idleLabel` overrides the default arrow-composed copy (the
+    // top ribbon's "drag to start" gate uses this). `prominent` bumps
+    // base opacity, bob amplitude, and tags the element so CSS can
+    // upsize/glow it — the gate is required to start the remix, so it
+    // needs to read as the next action, not a passive hint.
+    label = idleLabel ?? compose("drag", idleArrow);
+    opacity = prominent ? 0.75 + pulse * 0.25 : 0.4 + pulse * 0.35;
+    bobAmt = pulse * (prominent ? 12 : 6);
   }
 
   // Horizontal: hint below the bar at value's X, bobs down.
@@ -156,8 +172,11 @@ export function RemixHint({
     };
   }
 
+  const className = prominent
+    ? "remix-hint remix-hint--prominent"
+    : "remix-hint";
   return (
-    <div className="remix-hint" style={style}>
+    <div className={className} style={style}>
       {label}
     </div>
   );

--- a/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
@@ -12,6 +12,7 @@ import {
   computePeaks,
   drawPeaks,
 } from "@/engine/curves/waveformPeaks";
+import { displayLoraName } from "@/lib/loraLabels";
 import { useCurveStore } from "@/store/useCurveStore";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
@@ -147,9 +148,10 @@ export function ScheduleCurvesOverlay() {
     return ids.map((id) => ({
       id,
       param: loraCurveParam(id),
-      label:
-        loraCatalog.find((e) => e.id === id)?.name?.toUpperCase() ??
-        id.toUpperCase(),
+      label: displayLoraName(
+        id,
+        loraCatalog.find((e) => e.id === id)?.name,
+      ).toUpperCase(),
     }));
   })();
 
@@ -619,6 +621,18 @@ export function ScheduleCurvesOverlay() {
             </button>
           );
         })}
+        {/* Discoverable "clear current curve" — same effect as the
+            right-click → Reset path in the preset menu, but visible as
+            a button in the toolbar so users know it exists. Acts on the
+            currently-active (selected) tab. */}
+        <button
+          type="button"
+          className="schedule-curves-master"
+          onClick={() => resetCurve(activeCurve)}
+          title={`Clear the current curve (${labelFor(activeCurve)}) — flattens it back to the midline.`}
+        >
+          CLEAR
+        </button>
         {/* Master enable / kill switch — flips ALL curves off without
             losing per-curve drawings. The application loop checks this
             first; when off, no slider gets driven. */}

--- a/demos/realtime_motion_graph_web/web/hooks/useEdgeLoraBinding.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useEdgeLoraBinding.ts
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { displayLoraName } from "@/lib/loraLabels";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import {
@@ -65,7 +66,7 @@ function applyDesktopBindings(): void {
 
     if (labelEl) {
       const entry = catalog.find((e) => e.id === id);
-      labelEl.textContent = entry?.name ?? id;
+      labelEl.textContent = displayLoraName(id, entry?.name);
     }
 
     const strength = strengths[id] ?? 0;
@@ -116,7 +117,7 @@ function applyMobileRightEdge(
   const labelEl = edge.querySelector<HTMLElement>(".install-edge-label");
   const { catalog } = useLoraStore.getState();
   const nameOf = (id: string | null) =>
-    id ? catalog.find((e) => e.id === id)?.name ?? id : "—";
+    id ? displayLoraName(id, catalog.find((e) => e.id === id)?.name) : "—";
 
   edge.dataset.bar = "lora_blend";
   if (idA && idB) {

--- a/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
@@ -94,6 +94,12 @@ export function useFixtureSwap() {
         return;
       }
       lastSwappedTo.current = name;
+      // Each new track re-enters the "hear source first" gate: snap
+      // denoise to 0 and clear remixStarted so the top-edge ribbon
+      // shows "drag to start" again. Side-rail hints stay suppressed
+      // until the user drags the top ribbon up.
+      usePerformanceStore.getState().setSlider("denoise", 0);
+      usePerformanceStore.getState().setRemixStarted(false);
       setStatus("ready", "Playing");
     };
 

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -197,6 +197,13 @@ export function useStartSession() {
       useLoraStore.getState().setCatalog(remote.loraCatalog);
     }
 
+    // "Hear the source first" gate: every fresh session starts with
+    // denoise = 0 so the user hears the unmodified track. The top-edge
+    // ribbon's "drag to start" affordance prompts them to dial it up;
+    // the first value-changing drag flips remixStarted true.
+    usePerformanceStore.getState().setSlider("denoise", 0);
+    usePerformanceStore.getState().setRemixStarted(false);
+
     setSession(remote, player);
     setStatus("ready", "Playing");
   }, []);

--- a/demos/realtime_motion_graph_web/web/lib/loraLabels.ts
+++ b/demos/realtime_motion_graph_web/web/lib/loraLabels.ts
@@ -1,0 +1,13 @@
+// Client-side display overrides for LoRA names. The underlying lora id
+// (e.g. `"deathstep"`) stays untouched everywhere it crosses an engine
+// boundary — prompts, MIDI keys, curve storage, the catalog wire format —
+// only the user-visible label is rewritten. Looked up at every render
+// site that shows a LoRA name (LibraryTile, edge bars, mobile stepper,
+// curve scheduler tabs).
+const LORA_DISPLAY_OVERRIDES: Record<string, string> = {
+  deathstep: "DUBSTEP",
+};
+
+export function displayLoraName(id: string, fallback?: string): string {
+  return LORA_DISPLAY_OVERRIDES[id] ?? fallback ?? id;
+}

--- a/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
@@ -212,6 +212,13 @@ interface PerformanceState {
   kiosk: boolean;
   /** Pause flag (audio context state). */
   paused: boolean;
+  /** Per-session, non-persisted gate: when false, the user has loaded a
+   *  song but hasn't yet started the remix. Song-load hooks (start +
+   *  fixture swap) reset this to false so each new track plays the
+   *  source first; the top edge ribbon's first value-changing drag
+   *  flips it true. Drives the "drag to start" affordance and gates
+   *  the side-rail tutorial hints. */
+  remixStarted: boolean;
 
   /** DCW (wavelet-domain post-step correction) non-numeric state. The two
    * numeric knobs (dcw_scaler, dcw_high_scaler) live in sliderValues. */
@@ -251,6 +258,7 @@ interface PerformanceState {
   toggleKiosk: () => void;
   setPaused: (p: boolean) => void;
   togglePause: () => void;
+  setRemixStarted: (b: boolean) => void;
   setDcwEnabled: (b: boolean) => void;
   toggleDcw: () => void;
   setDcwMode: (m: DcwMode) => void;
@@ -292,6 +300,7 @@ export const usePerformanceStore = create<PerformanceState>((set) => ({
   mode: "graph",
   kiosk: false,
   paused: false,
+  remixStarted: false,
 
   dcwEnabled: true,
   dcwMode: "double",
@@ -378,6 +387,7 @@ export const usePerformanceStore = create<PerformanceState>((set) => ({
   toggleKiosk: () => set((s) => ({ kiosk: !s.kiosk })),
   setPaused: (p) => set({ paused: p }),
   togglePause: () => set((s) => ({ paused: !s.paused })),
+  setRemixStarted: (b) => set({ remixStarted: b }),
   setDcwEnabled: (b) => set({ dcwEnabled: b }),
   toggleDcw: () => set((s) => ({ dcwEnabled: !s.dcwEnabled })),
   setDcwMode: (m) => set({ dcwMode: m }),
@@ -423,6 +433,7 @@ export const usePerformanceStore = create<PerformanceState>((set) => ({
       sliderTargets: { ...DEFAULT_SLIDER_VALUES },
       seed: 0,
       blend: 0.4,
+      remixStarted: false,
     }));
   },
   resetSlider: (param) => {


### PR DESCRIPTION
## Summary

Four UX improvements to the live demo at `demos/realtime_motion_graph_web/web/`:

### 1. Hear the source song first
Today `denoise` defaults to `0.7` and stays there across initial load and fixture swaps, so users hear a remixed track immediately and have no signal that the colored ribbon "strings" are draggable. Now every song load (start + swap) snaps `denoise` to `0` so the user hears the original track first, and a per-session `remixStarted` gate suppresses the side-rail tutorial hints. The top edge ribbon shows a prominent "drag to start" hint (bigger type, brighter, soft glow, bigger bob) until the user's first value-changing top drag flips the gate. On mobile the up chevron pulses (color shift, ~18% scale up, 5px lift, 1.4s ease-in-out loop) as the equivalent affordance — the sideways stepper label is too subtle.

### 2. Reset button (OperatorStrip)
"RESET" button next to KBD toggle. Confirms via `window.confirm`, then calls existing `resetToDefaults()` + `useLoraStore.reset()` — same path the idle-reset hook already uses. Doesn't touch MIDI mapping, automation curves, or persisted UI prefs.

### 3. Clear curve button (ScheduleCurvesOverlay)
"CLEAR" button in the toolbar next to the master ON/OFF. Calls existing `resetCurve(activeCurve)` action that was only reachable via right-click context menu.

### 4. DEATHSTEP → DUBSTEP display label
Single client-side override (`lib/loraLabels.ts`) applied at the four user-facing render sites (`LibraryTile`, edge bar, mobile stepper, curve scheduler tabs). The underlying lora id stays `"deathstep"` everywhere it crosses an engine boundary — prompts, MIDI keys, curve storage, catalog wire format.

## Test plan

- [ ] Click play → audio plays unmodified source song. Top ribbon shows pulsing prominent "drag to start". Side hints absent.
- [ ] Drag top ribbon up → audio audibly transforms. Side hints appear (← mosh / vibe →) for first-time users.
- [ ] Switch tracks → new audio is un-remixed; top ribbon snaps to min; "drag to start" returns; side hints hidden until top drag.
- [ ] Mobile: up chevron on the remix rail pulses; first up-tap flips the gate.
- [ ] OperatorStrip "RESET": confirm prompt → sliders/seed/blend/LoRAs reset; MIDI map and curves untouched.
- [ ] Schedule curves "CLEAR": active curve flattens to midline.
- [ ] LoRA labeled "DUBSTEP" in LibraryTile, edge bar, mobile stepper, curve tabs. Engine params still reference `lora_str_deathstep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)