### PR TITLE
realtime_motion_graph_web: gate drag-to-start on session-ready + smooth denoise drop

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/DesktopEdgeDrag.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/DesktopEdgeDrag.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
 import {
   LORA_DEFAULT_STRENGTH_FRACTION,
   LORA_SIDE_VISIBLE_FLOOR,
@@ -67,6 +68,12 @@ export function DesktopEdgeDrag({ side }: Props) {
   // true (see onPointerUp below). Reset to false on every song load
   // by useStartSession / useFixtureSwap.
   const remixStarted = usePerformanceStore((s) => s.remixStarted);
+  // Don't show ANY hints until the session is actually live (track
+  // decoded, WebSocket connected, audio playing). Otherwise the
+  // prompt flashes during the loading-fixture / connecting phase
+  // before the user can do anything with it.
+  const sessionStatus = useSessionStore((s) => s.status);
+  const sessionReady = sessionStatus === "ready";
 
   const isTop = side === "top";
   const orientation: "horizontal" | "vertical" = isTop
@@ -276,7 +283,9 @@ export function DesktopEdgeDrag({ side }: Props) {
   // user has a stable visual anchor through "connecting" / catalog
   // updates. Drag on an empty slot is a no-op (data-empty guards
   // pointerdown).
-  const showHint = isTop ? !remixStarted : remixStarted && !hintDismissed;
+  const showHint =
+    sessionReady &&
+    (isTop ? !remixStarted : remixStarted && !hintDismissed);
 
   return (
     <div

--- a/demos/realtime_motion_graph_web/web/components/Performance/MobileStepperRail.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/MobileStepperRail.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { displayLoraName } from "@/lib/loraLabels";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
 import { SLIDER_META } from "@/types/engine";
 
 // Vertical stepper rail for the screen edges on phones in landscape mode.
@@ -265,8 +266,11 @@ export function MobileRemixStepper() {
   // the prompt, so we pulse the up chevron itself as the "do this"
   // affordance while remix hasn't started. Crossing denoise > 0 (via
   // the up chevron, MIDI, or any other path) flips the gate true.
+  // Held off until the session is actually ready so the pulse doesn't
+  // flash during the loading / connecting phase.
   const remixStarted = usePerformanceStore((s) => s.remixStarted);
   const denoise = usePerformanceStore((s) => s.sliderTargets["denoise"] ?? 0);
+  const sessionReady = useSessionStore((s) => s.status === "ready");
   useEffect(() => {
     if (!remixStarted && denoise > 0) {
       usePerformanceStore.getState().setRemixStarted(true);
@@ -278,7 +282,7 @@ export function MobileRemixStepper() {
       param="denoise"
       max={1.0}
       label="Remix Strength"
-      pulseUp={!remixStarted}
+      pulseUp={sessionReady && !remixStarted}
     />
   );
 }

--- a/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
@@ -94,11 +94,12 @@ export function useFixtureSwap() {
         return;
       }
       lastSwappedTo.current = name;
-      // Each new track re-enters the "hear source first" gate: snap
-      // denoise to 0 and clear remixStarted so the top-edge ribbon
-      // shows "drag to start" again. Side-rail hints stay suppressed
-      // until the user drags the top ribbon up.
-      usePerformanceStore.getState().setSlider("denoise", 0);
+      // Each new track re-enters the "hear source first" gate: glide
+      // denoise smoothly down to 0 (so the ribbon visibly retreats
+      // rather than snapping) and clear remixStarted so the top-edge
+      // ribbon shows "drag to start" again. Side-rail hints stay
+      // suppressed until the user drags the top ribbon up.
+      usePerformanceStore.getState().animateSliderTo("denoise", 0, 700);
       usePerformanceStore.getState().setRemixStarted(false);
       setStatus("ready", "Playing");
     };

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -199,9 +199,11 @@ export function useStartSession() {
 
     // "Hear the source first" gate: every fresh session starts with
     // denoise = 0 so the user hears the unmodified track. The top-edge
-    // ribbon's "drag to start" affordance prompts them to dial it up;
-    // the first value-changing drag flips remixStarted true.
-    usePerformanceStore.getState().setSlider("denoise", 0);
+    // ribbon glides smoothly from its current value down to 0 (instead
+    // of snapping) so the user sees the ribbon retreat as the prompt
+    // appears. The "drag to start" affordance prompts them to dial it
+    // back up; the first value-changing drag flips remixStarted true.
+    usePerformanceStore.getState().animateSliderTo("denoise", 0, 700);
     usePerformanceStore.getState().setRemixStarted(false);
 
     setSession(remote, player);

--- a/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
@@ -67,7 +67,7 @@ function saveNum(key: string, n: number): void {
 // `sliderValues` chases `sliderTargets` along a cubic ease-out tween.
 //
 // Slider UIs read `sliderTargets` so dragging feels immediate. The
-// param-sync tick (hooks/useParamSync.ts, 8 ms) reads `sliderValues`
+// param-sync tick (hooks/useParamSync.ts, 33 ms) reads `sliderValues`
 // so the engine sees the smoothed curve. MIDI knobs hit bumpSlider
 // repeatedly; each bump retargets and the tween chases without stutter.
 
@@ -134,6 +134,64 @@ function ensureTween(param: string): void {
 
 function cancelTween(param: string): void {
   tweens.delete(param);
+  dropTweens.delete(param);
+}
+
+// ── One-shot drop tweens ───────────────────────────────────────────────
+// The regular `tweens` machinery only animates `sliderValues` (the engine
+// value), assuming `sliderTargets` was set to its final destination
+// immediately so the UI snaps to where the user pointed. The "hear source
+// first" gate has the opposite need: when a song loads and we drop denoise
+// to 0, the visual ribbon SHOULD slide down (not jump), and the engine
+// SHOULD get the smooth ramp too. This tier drives both fields together
+// over a per-tween duration, independent of the global `smooth` toggle.
+// Cancelled implicitly by setSlider/cancelTween if the user grabs the
+// ribbon mid-drop.
+interface DropTween {
+  start: number;
+  startTime: number;
+  target: number;
+  durationMs: number;
+}
+const dropTweens = new Map<string, DropTween>();
+let dropTweenUnregister: (() => void) | null = null;
+
+function tickDropTweens(now: number): void {
+  if (dropTweens.size === 0) return;
+  const updates: Record<string, number> = {};
+  for (const [param, t] of dropTweens) {
+    const elapsed = now - t.startTime;
+    if (elapsed >= t.durationMs) {
+      updates[param] = t.target;
+      dropTweens.delete(param);
+      continue;
+    }
+    const k = elapsed / t.durationMs;
+    // Same cubic ease-out as the regular tween — snappy start, soft
+    // landing on zero so the ribbon doesn't slam into the rail edge.
+    const eased = 1 - Math.pow(1 - k, 3);
+    updates[param] = t.start + (t.target - t.start) * eased;
+  }
+  if (Object.keys(updates).length > 0) {
+    usePerformanceStore.setState((s) => ({
+      sliderValues: { ...s.sliderValues, ...updates },
+      sliderTargets: { ...s.sliderTargets, ...updates },
+    }));
+  }
+  if (dropTweens.size === 0 && dropTweenUnregister) {
+    dropTweenUnregister();
+    dropTweenUnregister = null;
+  }
+}
+
+function ensureDropTweenRunning(): void {
+  if (!dropTweenUnregister) {
+    dropTweenUnregister = frameScheduler.register(
+      "drop-tweens",
+      tickDropTweens,
+      { phase: "compute", budgetMs: 1 },
+    );
+  }
 }
 
 // ── Manual-override timestamps ─────────────────────────────────────────
@@ -259,6 +317,15 @@ interface PerformanceState {
   setPaused: (p: boolean) => void;
   togglePause: () => void;
   setRemixStarted: (b: boolean) => void;
+  /** Animate a slider from its current value to `target` over `durationMs`
+   *  using a cubic ease-out, driving BOTH `sliderTargets` and
+   *  `sliderValues` together (the visual ribbon and the engine value
+   *  glide in lockstep). Used by the per-song "hear source first" gate
+   *  to slide denoise down to 0 on each song load. Cancelled implicitly
+   *  if the user drags the ribbon mid-drop. Does not stamp a
+   *  manual-override timestamp (this is a system action, not a user
+   *  touch — curves should not defer to it). */
+  animateSliderTo: (param: string, target: number, durationMs: number) => void;
   setDcwEnabled: (b: boolean) => void;
   toggleDcw: () => void;
   setDcwMode: (m: DcwMode) => void;
@@ -388,6 +455,27 @@ export const usePerformanceStore = create<PerformanceState>((set) => ({
   setPaused: (p) => set({ paused: p }),
   togglePause: () => set((s) => ({ paused: !s.paused })),
   setRemixStarted: (b) => set({ remixStarted: b }),
+  animateSliderTo: (param, target, durationMs) => {
+    cancelTween(param);
+    const current =
+      usePerformanceStore.getState().sliderTargets[param] ?? 0;
+    const clamped = clampToMeta(param, target);
+    if (current === clamped || durationMs <= 0) {
+      // No motion needed — write both fields to land at target instantly.
+      set((s) => ({
+        sliderValues: { ...s.sliderValues, [param]: clamped },
+        sliderTargets: { ...s.sliderTargets, [param]: clamped },
+      }));
+      return;
+    }
+    dropTweens.set(param, {
+      start: current,
+      startTime: performance.now(),
+      target: clamped,
+      durationMs,
+    });
+    ensureDropTweenRunning();
+  },
   setDcwEnabled: (b) => set({ dcwEnabled: b }),
   toggleDcw: () => set((s) => ({ dcwEnabled: !s.dcwEnabled })),
   setDcwMode: (m) => set({ dcwMode: m }),


### PR DESCRIPTION
## Summary

Two refinements to [#53](https://github.com/ryanontheinside/DEMON/pull/53)'s source-first gate, both reported by an operator after testing:

### 1. Hold the affordance off until the session is actually ready
Without this, the prompt + chevron pulse flash during the `loading-fixture` / `connecting` phase before the user can do anything with it. Now `DesktopEdgeDrag` and `MobileRemixStepper` subscribe to `useSessionStore.status` and only render the hint / pulse when `status === "ready"`.

### 2. Glide denoise to 0 instead of snapping
PR#53 used `setSlider("denoise", 0)`, which respects the global `smooth` toggle. Even with `smooth=on`, the regular tween only animates `sliderValues` (engine value) — `sliderTargets` is set instantly so dragging UIs don't lag the cursor. The visual ribbon reads `sliderTargets`, so it was snapping down on song load.

Added a separate "drop tween" tier that drives **both** fields together over a per-tween duration, independent of the global `smooth` toggle. New action: `animateSliderTo(param, target, durationMs)`. Cancelled implicitly if the user grabs the ribbon mid-drop (`cancelTween` clears both the regular and drop tween maps).

Both `useStartSession` and `useFixtureSwap` now call `animateSliderTo("denoise", 0, 700)` at the moment status flips ready, so the ribbon visibly retreats as the prompt fades in.

## Test plan

- [ ] Click play. During load: top ribbon stays at default, no prompt. The moment status flips to "ready", the ribbon glides smoothly from 0.7 → 0 (~700ms cubic ease-out) and the prominent "drag to start" hint appears.
- [ ] Switch tracks mid-session at denoise=0.6. On `swap_ready`: ribbon glides from 0.6 → 0; prompt re-appears.
- [ ] Grab the ribbon during the drop. The drop tween cancels, the user's drag wins immediately.
- [ ] Mobile: chevron pulse is absent during loading; appears only when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)