### PR TITLE
realtime_motion_graph_web: STOPGAP — exit engine process on session end

### DIFF
--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -889,3 +889,31 @@ def handle_client(
         running[0] = False
         recv_t.join(timeout=2)
         print(f"[Server] Client disconnected ({params.get('num_gens', 0)} generations)")
+
+        # ── STOPGAP: full-process restart for VRAM reclaim ────────────
+        # Cumulative VRAM leak across sessions (TRT execution contexts +
+        # pinned host buffers + refit weight buffers — most of it is
+        # NOT in PyTorch's allocator, so torch.cuda.empty_cache() can't
+        # reclaim it). After several sessions a 32 GB pod reaches the
+        # point where the next session's TRT engine init OOMs and the
+        # client gets 1011.
+        #
+        # Proper fix is explicit close() on each GPU-holding component
+        # — drafted in PR #52 on this repo (DRAFT). Until that lands,
+        # the cheapest reliable mitigation is to exit the engine
+        # process at the end of every session: scripts/vast/serve_demon.sh
+        # auto-respawns it (the supervisor relies on this for the CUDA
+        # / VRAM watchdog respawn path), and a fresh process is the
+        # only thing that reliably reclaims the non-PyTorch memory.
+        #
+        # Cost: ~12 sec engine reload (model + TRT engines load to
+        # GPU) before the NEXT user can start. The pool's queue layer
+        # routes around the brief unavailability.
+        # Benefit: no more 1011 cascade as VRAM leaks fill up the
+        # 32 GB.
+        # Revert: remove this block once PR #52 (or an equivalent
+        # close()-chain) lands and is verified to keep VRAM stable
+        # across N sessions.
+        import os as _os
+        print("[Server] exiting process for clean VRAM reclaim (supervisor will respawn)")
+        _os._exit(0)


### PR DESCRIPTION
## Summary

**Stopgap mitigation** for the cumulative VRAM leak across sessions tracked in #52 (DRAFT). Single 3-line change at the end of `handle_client`'s outer try/finally:

```python
import os as _os
print("[Server] exiting process for clean VRAM reclaim (supervisor will respawn)")
_os._exit(0)
```

After every WS client disconnect, the engine process exits. The operator's supervisor (`serve_demon.sh`, in the deployment repo) respawns it cleanly. A fresh process is the only thing that reliably reclaims the non-PyTorch memory — TRT execution contexts, pinned host buffers, refit weight buffers — which makes up most of the leak surface. `torch.cuda.empty_cache()` doesn't help because the leaked memory is outside torch's allocator.

**Replace with #52's proper `close()`-chain once it lands and is verified.**

## Production observation that motivated this

A 32 GB 5090 pod reaches ~552 MiB free after several consecutive sessions, then the next session's TRT engine init OOMs (engine archive read needs ~3.3 GB contiguous) and the client receives 1011. Pods churning every ~5 sessions; users hitting connection failures.

```
[E] [engine.cpp::readEngineFromArchive::1175]
    Error Code 2: OutOfMemory (Requested size was 3269390336 bytes.)
torch.OutOfMemoryError: CUDA out of memory.
    GPU 0 has a total capacity of 31.36 GiB of which 9.31 MiB is free.
    Including non-PyTorch memory, this process has 31.34 GiB memory in use.
    Of the allocated memory 6.24 GiB is allocated by PyTorch,
    and 67.29 MiB is reserved by PyTorch but unallocated.
```

— most of the in-use memory is non-PyTorch.

## Cost

~12 sec engine reload (model + TRT engines load to GPU) before the NEXT user's session can start. Operator's pool / queue layer absorbs the brief unavailability — users don't see an error, just the Play loading state for those few seconds. **Net much better UX than today's 1011 cascade.**

## Why this is a stopgap, not a fix

Restarting the entire process to reclaim memory is a sledgehammer. The right answer (#52 draft) is explicit `close()` on each GPU-holding component — `DiffusionEngine`, `LoRAManagerBase`, `ModelContext`, `StreamHandle`, `StreamPipeline` — chained from a session-level teardown. That avoids the 12 sec reload cost and is a more defensible architecture.

This patch should be reverted as soon as #52 (or an equivalent) lands and has been verified to keep VRAM stable across N consecutive sessions.

## Test plan

- [ ] Confirm `[Server] exiting process for clean VRAM reclaim` log line appears immediately after `[Server] Client disconnected (...)`.
- [ ] Run 10 consecutive sessions on a 32 GB pod; confirm `nvidia-smi` shows ~30 GB free after each session ends and the supervisor respawn completes.
- [ ] Confirm the queue layer's "loading" UX masks the ~12 sec respawn for a follow-up user.