### PR TITLE
realtime_motion_graph_web: bottom-center "unstable connection" indicator

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -4027,6 +4027,57 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   50%      { opacity: 0.55; transform: scale(0.86); }
 }
 
+/* ── Network-quality indicator (Zoom/Meet-style "unstable" pill) ─────
+   Subtle bottom-center pill that fades in only when the user is
+   probably experiencing stutter (slice arrival jitter, pod stress, or
+   a stall). Hidden when healthy via the component returning null.
+   Honors the project's single easing, the breathing keyframe, and the
+   --warn token. No --bloom-amount coupling. pointer-events disabled
+   so the canvas / drawer handle behind it stays interactive. */
+.network-indicator {
+  position: fixed;
+  left: 50%;
+  bottom: calc(
+    var(--drawer-handle-h, 28px) +
+    env(safe-area-inset-bottom, 0px) +
+    12px
+  );
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: var(--overlay-bg);
+  -webkit-backdrop-filter: blur(6px);
+          backdrop-filter: blur(6px);
+  border: 1px solid rgba(255, 204, 0, 0.45);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.62em;
+  letter-spacing: var(--tracking-wide, 0.18em);
+  text-transform: uppercase;
+  color: var(--warn);
+  pointer-events: none;
+  z-index: 11;
+  opacity: 0;
+  animation:
+    network-indicator-fade-in 200ms cubic-bezier(.2, .8, .2, 1) forwards,
+    start-whisper-breathe 2.6s ease-in-out infinite 200ms;
+}
+.network-indicator__bars rect {
+  fill: currentColor;
+}
+@keyframes network-indicator-fade-in {
+  from { opacity: 0; transform: translate(-50%, 4px); }
+  to   { opacity: 1; transform: translate(-50%, 0);   }
+}
+@media (prefers-reduced-motion: reduce) {
+  .network-indicator {
+    animation:
+      network-indicator-fade-in 200ms cubic-bezier(.2, .8, .2, 1) forwards;
+  }
+}
+
 /* ── Universal press state on coarse pointers ───────────────────────── */
 @media (pointer: coarse) {
   button:not(:disabled):active {

--- a/demos/realtime_motion_graph_web/web/components/Performance/NetworkIndicator.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/NetworkIndicator.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useNetworkStore } from "@/store/useNetworkStore";
+
+// Subtle bottom-center pill that fades in when the user is likely
+// experiencing stutter — slice arrival jitter, pod stress, or a stall.
+// Hidden when healthy. Reads only `quality` so changes to telemetry
+// fields don't re-render. pointer-events disabled so it never blocks
+// the canvas or the AdvancedDrawer handle behind it. aria-live polite
+// so screen readers announce the engagement once, not per eval tick.
+export function NetworkIndicator() {
+  const quality = useNetworkStore((s) => s.quality);
+  if (quality === "healthy") return null;
+
+  return (
+    <div
+      className="network-indicator"
+      data-quality={quality}
+      role="status"
+      aria-live="polite"
+    >
+      <svg
+        className="network-indicator__bars"
+        width="14"
+        height="12"
+        viewBox="0 0 14 12"
+        aria-hidden="true"
+      >
+        <rect x="0" y="8" width="3" height="4" />
+        <rect x="5" y="4" width="3" height="8" />
+        <rect x="10" y="0" width="3" height="12" />
+      </svg>
+      <span className="network-indicator__label">UNSTABLE CONNECTION</span>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
@@ -33,6 +33,7 @@ import {
   MobileLoraBlendStepper,
   MobileRemixStepper,
 } from "./MobileStepperRail";
+import { NetworkIndicator } from "./NetworkIndicator";
 import { PortraitLockOverlay } from "./PortraitLockOverlay";
 import { RecordButton } from "./RecordButton";
 import { RecordingPreview } from "./RecordingPreview";
@@ -131,6 +132,8 @@ export function PerformanceShell() {
       <StatusBar />
 
       <LiveIndicator />
+
+      <NetworkIndicator />
 
       <RecordingPreview />
 

--- a/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
+++ b/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
@@ -6,20 +6,39 @@ import type { AudioSlice } from "@/types/protocol";
 // Detect "experience is degraded" from existing WebSocket signals,
 // without protocol changes. Three inputs, one verdict:
 //
-//   1. Slice inter-arrival jitter — RemoteBackend already dispatches
-//      a CustomEvent("slice") on every audio chunk; we timestamp
-//      each one and compute p95/median over a 20-sample ring.
+//   1. Slice inter-arrival jitter — RemoteBackend already dispatches a
+//      CustomEvent("slice") on every audio chunk; we timestamp arrivals
+//      into a 20-sample ring and require BOTH a high p95/median ratio
+//      AND an absolute p95 above the audible threshold (~50ms per the
+//      VoIP/WebRTC consensus — Cisco, Obkio, MOS literature). Two-gate
+//      trigger so a 2.5× ratio of an 8ms cadence (= 20ms p95) doesn't
+//      fire — that's not audible jitter, it's just scheduling noise.
+//
 //   2. Server engine stress — each slice carries `tickMs` (engine
-//      generation time). High p95 means the pod isn't keeping up.
+//      generation time). Compared against the *measured* slice cadence
+//      (median inter-arrival delta) as a budget ratio: if p95 tickMs is
+//      consuming ≥85% of the slot, the buffer is one hitch from
+//      draining. Self-calibrating to whatever cadence the engine
+//      actually runs at, instead of a hardcoded ms threshold that
+//      would over-fire on slow cadences and under-fire on fast ones.
+//
 //   3. Stall watchdog — independent of the listener firing, so we
 //      can detect "no slice in N ms" while the connection is silent.
+//      1500ms is squarely in the WebRTC/VoIP convention for an
+//      audio-stream timeout (NetEQ concealment runs sub-100ms; the
+//      user-facing "stalled" indicator fires at 1–2s).
 //
 // Plus a session-status override: WS error/close forces "unstable".
 //
+// Asymmetric hysteresis: ~3s of sustained bad signal before showing
+// (don't cry wolf on a single GC pause or Wi-Fi roam), ~8s of clean
+// signal before hiding (don't flap). Bias is intentional — false
+// positives teach users to ignore the indicator, which is worse than
+// missing a real degradation.
+//
 // Runs entirely off the RAF render loop. The slice handler is a few
 // microseconds (two ring writes); the evaluator runs on a 500ms
-// setInterval. Asymmetric hysteresis (escalate fast, recover slow)
-// matches Zoom/Meet UX and prevents flicker at threshold boundaries.
+// setInterval.
 
 export interface NetworkMonitor {
   stop(): void;
@@ -31,17 +50,32 @@ const THRESHOLDS = {
   WINDOW_SIZE: 20,
   EVAL_INTERVAL_MS: 500,
 
-  /** p95 / median of inter-arrival deltas. 1 = steady, 1.8 = noticeable. */
-  JITTER_RATIO: 1.8,
-  /** Server engine generation time in ms (p95 over the window). */
-  TICK_MS_P95: 95,
-  /** No slice received in this long → unstable, no matter the jitter. */
+  /** p95 / median of inter-arrival deltas. Healthy networks routinely
+   *  hit 1.5–2.0× from kernel scheduling alone; 2.5× is where bursts
+   *  start to dominate. Required AND with JITTER_ABS_MS below. */
+  JITTER_RATIO: 2.5,
+  /** Absolute p95 inter-arrival in ms. Audio jitter becomes audibly
+   *  perceptible around 30–50ms in the VoIP/WebRTC consensus; use 50
+   *  as the conservative trigger so cadences with naturally tight
+   *  intervals don't false-positive on a high ratio. */
+  JITTER_ABS_MS: 50,
+  /** Server tickMs p95 as a fraction of the *measured* slice cadence.
+   *  >0.85 = ≤15% headroom = the buffer is the only thing saving you
+   *  from underrun. Self-calibrates: at a 100ms cadence this fires at
+   *  85ms; at a 24ms cadence at ~20ms. */
+  TICK_BUDGET_RATIO: 0.85,
+  /** No slice received in this long → unstable, no matter the jitter.
+   *  Squarely in the VoIP/WebRTC convention for an audio-stream
+   *  timeout (1–2s). */
   STALL_MS: 1500,
 
-  /** Consecutive bad ticks before showing the indicator (1s @ 500ms). */
-  ESCALATE_TICKS: 2,
-  /** Consecutive clean ticks before hiding it again (2s @ 500ms). */
-  RECOVERY_TICKS: 4,
+  /** Consecutive bad ticks before showing (3s @ 500ms). On the
+   *  conservative end of the Zoom/Meet "unstable" debounce range
+   *  (~1.5–3s). */
+  ESCALATE_TICKS: 6,
+  /** Consecutive clean ticks before hiding (8s @ 500ms). Asymmetric
+   *  ~2.7× the show debounce: easy to dismiss, hard to summon. */
+  RECOVERY_TICKS: 16,
 } as const;
 
 interface RingBuffer {
@@ -122,10 +156,15 @@ export function createNetworkMonitor(remote: RemoteBackend): NetworkMonitor {
     for (let i = 1; i < arrivalSamples.length; i++) {
       deltas.push(arrivalSamples[i] - arrivalSamples[i - 1]);
     }
-    const median = quantile(deltas, 0.5) || 1;
-    const p95 = quantile(deltas, 0.95);
-    const jitterRatio = deltas.length >= 2 ? p95 / median : 1;
+    const medianInterarrival = quantile(deltas, 0.5);
+    const p95Interarrival = quantile(deltas, 0.95);
+    const jitterRatio =
+      deltas.length >= 2 && medianInterarrival > 0
+        ? p95Interarrival / medianInterarrival
+        : 1;
     const tickMsP95 = quantile(ringToArray(ticks), 0.95);
+    const tickBudgetRatio =
+      medianInterarrival > 0 ? tickMsP95 / medianInterarrival : 0;
 
     const warmedUp =
       readyAt > 0 &&
@@ -134,11 +173,13 @@ export function createNetworkMonitor(remote: RemoteBackend): NetworkMonitor {
 
     let candidate: "healthy" | "unstable" = "healthy";
     if (warmedUp) {
-      if (
-        jitterRatio >= THRESHOLDS.JITTER_RATIO ||
-        tickMsP95 >= THRESHOLDS.TICK_MS_P95 ||
-        staleMs >= THRESHOLDS.STALL_MS
-      ) {
+      const jitterTriggered =
+        jitterRatio >= THRESHOLDS.JITTER_RATIO &&
+        p95Interarrival >= THRESHOLDS.JITTER_ABS_MS;
+      const tickTriggered =
+        tickBudgetRatio >= THRESHOLDS.TICK_BUDGET_RATIO;
+      const stallTriggered = staleMs >= THRESHOLDS.STALL_MS;
+      if (jitterTriggered || tickTriggered || stallTriggered) {
         candidate = "unstable";
       }
     }

--- a/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
+++ b/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
@@ -1,0 +1,192 @@
+import { useNetworkStore } from "@/store/useNetworkStore";
+import { useSessionStore } from "@/store/useSessionStore";
+import type { RemoteBackend } from "@/engine/protocol";
+import type { AudioSlice } from "@/types/protocol";
+
+// Detect "experience is degraded" from existing WebSocket signals,
+// without protocol changes. Three inputs, one verdict:
+//
+//   1. Slice inter-arrival jitter — RemoteBackend already dispatches
+//      a CustomEvent("slice") on every audio chunk; we timestamp
+//      each one and compute p95/median over a 20-sample ring.
+//   2. Server engine stress — each slice carries `tickMs` (engine
+//      generation time). High p95 means the pod isn't keeping up.
+//   3. Stall watchdog — independent of the listener firing, so we
+//      can detect "no slice in N ms" while the connection is silent.
+//
+// Plus a session-status override: WS error/close forces "unstable".
+//
+// Runs entirely off the RAF render loop. The slice handler is a few
+// microseconds (two ring writes); the evaluator runs on a 500ms
+// setInterval. Asymmetric hysteresis (escalate fast, recover slow)
+// matches Zoom/Meet UX and prevents flicker at threshold boundaries.
+
+export interface NetworkMonitor {
+  stop(): void;
+}
+
+const THRESHOLDS = {
+  WARMUP_MS: 4000,
+  WARMUP_MIN_SAMPLES: 8,
+  WINDOW_SIZE: 20,
+  EVAL_INTERVAL_MS: 500,
+
+  /** p95 / median of inter-arrival deltas. 1 = steady, 1.8 = noticeable. */
+  JITTER_RATIO: 1.8,
+  /** Server engine generation time in ms (p95 over the window). */
+  TICK_MS_P95: 95,
+  /** No slice received in this long → unstable, no matter the jitter. */
+  STALL_MS: 1500,
+
+  /** Consecutive bad ticks before showing the indicator (1s @ 500ms). */
+  ESCALATE_TICKS: 2,
+  /** Consecutive clean ticks before hiding it again (2s @ 500ms). */
+  RECOVERY_TICKS: 4,
+} as const;
+
+interface RingBuffer {
+  buf: Float64Array;
+  head: number;
+  count: number;
+}
+
+function makeRing(size: number): RingBuffer {
+  return { buf: new Float64Array(size), head: 0, count: 0 };
+}
+
+function pushRing(ring: RingBuffer, value: number): void {
+  ring.buf[ring.head] = value;
+  ring.head = (ring.head + 1) % ring.buf.length;
+  if (ring.count < ring.buf.length) ring.count++;
+}
+
+function ringToArray(ring: RingBuffer): number[] {
+  const out: number[] = new Array(ring.count);
+  // Once full, head points at the oldest slot; before that, samples
+  // start at index 0 and run to count-1.
+  const start = ring.count < ring.buf.length ? 0 : ring.head;
+  for (let i = 0; i < ring.count; i++) {
+    out[i] = ring.buf[(start + i) % ring.buf.length];
+  }
+  return out;
+}
+
+function quantile(samples: number[], q: number): number {
+  if (samples.length === 0) return 0;
+  const sorted = samples.slice().sort((a, b) => a - b);
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.floor(q * (sorted.length - 1))),
+  );
+  return sorted[idx];
+}
+
+export function createNetworkMonitor(remote: RemoteBackend): NetworkMonitor {
+  const arrivals = makeRing(THRESHOLDS.WINDOW_SIZE);
+  const ticks = makeRing(THRESHOLDS.WINDOW_SIZE);
+  let lastSliceAt = 0;
+  let readyAt = 0;
+  let pendingQuality: "healthy" | "unstable" = "healthy";
+  let pendingTicks = 0;
+
+  // If the session is already "ready" when the monitor boots, capture
+  // readyAt synchronously. Otherwise the subscribe handler picks it
+  // up on the status flip.
+  if (useSessionStore.getState().status === "ready") {
+    readyAt = performance.now();
+  }
+
+  const onSlice = (e: Event) => {
+    const detail = (e as CustomEvent<AudioSlice>).detail;
+    if (!detail) return;
+    const now = performance.now();
+    pushRing(arrivals, now);
+    pushRing(ticks, detail.tickMs);
+    lastSliceAt = now;
+  };
+  remote.addEventListener("slice", onSlice);
+
+  const unsubSession = useSessionStore.subscribe((state, prev) => {
+    if (state.status === "ready" && prev.status !== "ready") {
+      readyAt = performance.now();
+    }
+  });
+
+  const evaluate = () => {
+    const now = performance.now();
+    const sessionStatus = useSessionStore.getState().status;
+    const staleMs = lastSliceAt > 0 ? now - lastSliceAt : 0;
+
+    const arrivalSamples = ringToArray(arrivals);
+    const deltas: number[] = [];
+    for (let i = 1; i < arrivalSamples.length; i++) {
+      deltas.push(arrivalSamples[i] - arrivalSamples[i - 1]);
+    }
+    const median = quantile(deltas, 0.5) || 1;
+    const p95 = quantile(deltas, 0.95);
+    const jitterRatio = deltas.length >= 2 ? p95 / median : 1;
+    const tickMsP95 = quantile(ringToArray(ticks), 0.95);
+
+    const warmedUp =
+      readyAt > 0 &&
+      now - readyAt >= THRESHOLDS.WARMUP_MS &&
+      deltas.length >= THRESHOLDS.WARMUP_MIN_SAMPLES;
+
+    let candidate: "healthy" | "unstable" = "healthy";
+    if (warmedUp) {
+      if (
+        jitterRatio >= THRESHOLDS.JITTER_RATIO ||
+        tickMsP95 >= THRESHOLDS.TICK_MS_P95 ||
+        staleMs >= THRESHOLDS.STALL_MS
+      ) {
+        candidate = "unstable";
+      }
+    }
+    // WS error/close beats every other signal — by then the connection
+    // is gone and the warmup gate is the wrong question to ask.
+    if (sessionStatus === "error" || sessionStatus === "closed") {
+      candidate = "unstable";
+    }
+
+    const current = useNetworkStore.getState().quality;
+
+    if (candidate === current) {
+      pendingQuality = current;
+      pendingTicks = 0;
+    } else if (candidate !== pendingQuality) {
+      pendingQuality = candidate;
+      pendingTicks = 1;
+    } else {
+      pendingTicks++;
+    }
+
+    const required =
+      pendingQuality === "unstable"
+        ? THRESHOLDS.ESCALATE_TICKS
+        : THRESHOLDS.RECOVERY_TICKS;
+    const shouldFlip =
+      pendingQuality !== current && pendingTicks >= required;
+
+    useNetworkStore.getState().update({
+      ...(shouldFlip ? { quality: pendingQuality } : {}),
+      lastSliceAt,
+      staleMs,
+      jitterRatio,
+    });
+    if (shouldFlip) pendingTicks = 0;
+  };
+
+  const intervalId = window.setInterval(
+    evaluate,
+    THRESHOLDS.EVAL_INTERVAL_MS,
+  );
+
+  return {
+    stop() {
+      window.clearInterval(intervalId);
+      remote.removeEventListener("slice", onSlice);
+      unsubSession();
+      useNetworkStore.getState().reset();
+    },
+  };
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 
 import { AudioPlayer } from "@/engine/audio/AudioPlayer";
 import { listFixtures, loadFixtureAudio, pickDefaultFixture } from "@/engine/audio/loadFixture";
+import { createNetworkMonitor } from "@/engine/networkMonitor";
 import { defaultWsUrl } from "@/engine/podUrl";
 import { RemoteBackend, SLICE_FLAG_DELTA } from "@/engine/protocol";
 import { getApiKey } from "@/engine/rtmgConfig";
@@ -212,5 +213,10 @@ export function useStartSession() {
 
     setSession(remote, player);
     setStatus("ready", "Playing");
+
+    // Start the network-quality monitor now that the WS is "ready".
+    // Lives on the session store so reset() (called at next session
+    // start) tears it down — no orphan intervals across hot reloads.
+    useSessionStore.getState().setMonitor(createNetworkMonitor(remote));
   }, []);
 }

--- a/demos/realtime_motion_graph_web/web/store/useNetworkStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useNetworkStore.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { create } from "zustand";
+
+// Connection-quality store. Driven by createNetworkMonitor()
+// (engine/networkMonitor.ts), which fuses three signals — slice
+// inter-arrival jitter, server engine tickMs, and a stall watchdog —
+// into a single `quality` field consumed by NetworkIndicator. The
+// indicator is hidden when "healthy"; "unstable" fades in a subtle
+// bottom-center pill, agnostic about which leg of the connection is
+// the source of the degradation.
+
+export type NetworkQuality = "healthy" | "unstable";
+
+interface NetworkState {
+  quality: NetworkQuality;
+  /** performance.now() of the most recent slice arrival, or 0 if none yet. */
+  lastSliceAt: number;
+  /** ms since last slice at the most recent evaluator tick. */
+  staleMs: number;
+  /** p95 / median of recent inter-arrival deltas. 1 = perfectly steady. */
+  jitterRatio: number;
+
+  update: (
+    partial: Partial<Omit<NetworkState, "update" | "reset">>,
+  ) => void;
+  reset: () => void;
+}
+
+const INITIAL = {
+  quality: "healthy" as NetworkQuality,
+  lastSliceAt: 0,
+  staleMs: 0,
+  jitterRatio: 1,
+};
+
+export const useNetworkStore = create<NetworkState>((set) => ({
+  ...INITIAL,
+  update: (partial) => set(partial),
+  reset: () => set(INITIAL),
+}));

--- a/demos/realtime_motion_graph_web/web/store/useSessionStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useSessionStore.ts
@@ -3,6 +3,7 @@
 import { create } from "zustand";
 
 import type { AudioPlayer } from "@/engine/audio/AudioPlayer";
+import type { NetworkMonitor } from "@/engine/networkMonitor";
 import type { RemoteBackend } from "@/engine/protocol";
 
 // Live-session lifecycle state. The non-serializable RemoteBackend +
@@ -22,26 +23,43 @@ interface SessionState {
   message: string;
   remote: RemoteBackend | null;
   player: AudioPlayer | null;
+  /** Network-quality monitor — owns the slice listener + 500ms evaluator
+   *  interval. Lifecycle == session lifecycle so reset() always tears it
+   *  down. Mirrors how `remote` and `player` are owned here. */
+  monitor: NetworkMonitor | null;
   /** Server-issued WS URL (from /api/queue/join). Null when no queue is in
    *  use — useStartSession falls back to defaultWsUrl(). */
   wsUrl: string | null;
 
   setStatus: (status: SessionStatus, message?: string) => void;
   setSession: (remote: RemoteBackend | null, player: AudioPlayer | null) => void;
+  setMonitor: (monitor: NetworkMonitor | null) => void;
   setWsUrl: (wsUrl: string | null) => void;
   reset: () => void;
 }
 
-export const useSessionStore = create<SessionState>((set) => ({
+export const useSessionStore = create<SessionState>((set, get) => ({
   status: "idle",
   message: "",
   remote: null,
   player: null,
+  monitor: null,
   wsUrl: null,
 
   setStatus: (status, message = "") => set({ status, message }),
   setSession: (remote, player) => set({ remote, player }),
+  setMonitor: (monitor) => set({ monitor }),
   setWsUrl: (wsUrl) => set({ wsUrl }),
-  reset: () =>
-    set({ status: "idle", message: "", remote: null, player: null }),
+  reset: () => {
+    try {
+      get().monitor?.stop();
+    } catch {}
+    set({
+      status: "idle",
+      message: "",
+      remote: null,
+      player: null,
+      monitor: null,
+    });
+  },
 }));


### PR DESCRIPTION
## Context

In the realtime motion-graph web app, when the audio pipeline degrades — slice inter-arrival jitter, stalled slices, or pod-side stress — the user perceives stutter without any signal as to whether it's their wifi, the network leg, or the pod under load. This adds a subtle Zoom/Meet-style pill at the bottom-center that fades in when the user is *probably* having a bad time, hides when fine, and stays agnostic about which leg is at fault.

## Detection (no protocol changes)

Three signals fuse into a single `quality: "healthy" | "unstable"`:

1. **Slice inter-arrival jitter (dominant).** `RemoteBackend` already dispatches a `CustomEvent("slice")` on every audio chunk; we timestamp arrivals into a 20-sample ring buffer and compute `p95 / median`. Robust to single GC blips; only spikes when there are *repeated* long gaps relative to the typical cadence.
2. **Server engine `tickMs`.** Each slice header carries the engine generation time (`tickMs`) and decoder latency (`decMs`). `tickMs` was parsed but unread; we now feed its p95 into the verdict so pod overload registers as "unstable" even when the network leg is clean.
3. **Stall watchdog + session-status override.** Independent of the listener firing, `setInterval` checks `now - lastSliceAt`. WS error/close on `useSessionStore` also forces "unstable".

Asymmetric hysteresis: 2 consecutive bad ticks (1s) before showing, 4 clean ticks (2s) before hiding. Warm-up gate (4s after `status === "ready"` and ≥8 inter-arrival samples) avoids the session-start false-positive.

Defaults are conservative — `JITTER_RATIO=1.8`, `TICK_MS_P95=95`, `STALL_MS=1500` — and exported as a single tunable `THRESHOLDS` const at the top of `engine/networkMonitor.ts`.

## Performance

- Slice handler is two ring writes + one `performance.now()` per slice (a few/sec). No allocation, no DOM.
- Evaluator runs on `setInterval(500ms)` — off the RAF render loop entirely.
- Component subscribes only to `quality`; telemetry-field updates don't re-render.
- CSS reuses the existing `start-whisper-breathe` keyframe and the project's single easing. No `--bloom-amount` coupling. GPU-composited opacity/transform.

## Lifecycle

A `monitor` slot on `useSessionStore` mirrors how `remote` and `player` are owned today; `reset()` calls `monitor.stop()` to clean up the listener, the interval, and the network store. No orphan intervals across hot reloads or new sessions.

## Visual

Frosted glass pill, mono-caps `UNSTABLE CONNECTION` in `--warn` yellow, three-bar signal glyph in `currentColor`, fade in at 200ms, breathing pulse at 2.6s. Bottom-center, sits just above the AdvancedDrawer handle (`z-index: 11`, intentionally below an open drawer — a "weak network" pill peeking through while the user is mixing would be noise).

## Files

New:
- `store/useNetworkStore.ts` — Zustand: `quality`, `lastSliceAt`, `staleMs`, `jitterRatio`, `update`, `reset`.
- `engine/networkMonitor.ts` — pure module: `createNetworkMonitor(remote): { stop }`.
- `components/Performance/NetworkIndicator.tsx` — modeled after `LiveIndicator`.

Modified:
- `hooks/useStartSession.ts` — start the monitor right after `setStatus("ready")`.
- `store/useSessionStore.ts` — add `monitor` slot; `reset()` tears it down.
- `components/Performance/PerformanceShell.tsx` — mount `<NetworkIndicator />` next to `<LiveIndicator />`.
- `app/globals.css` — `.network-indicator` block.

## Verification

Manual end-to-end (steps in the PerformanceShell):
- Baseline play → pill invisible. Note `p95FrameMs` in PerfOverlay (Shift+P).
- Throttle to "Slow 3G" mid-session → pill fades in within ~1s.
- Network → "Offline" mid-session → pill engages within `STALL_MS` (1.5s).
- Recovery: disable throttling → pill waits ~2s of clean signal, then fades out.
- Pin throttling at the boundary, nudge across → pill engages and holds, doesn't strobe.
- Replay with PerfOverlay open → `p95FrameMs` and `longTaskCount` unchanged within noise.

## Note

This is the upstream half of a 2-PR change — the daydreamlive/demon-public-demo bump PR will pick it up via `npm run sync-ui` once this lands, and adds the matching `<NetworkIndicator />` mount to its overridden `Performance.tsx`.