### PR TITLE
demos/realtime_motion_graph_web: restore audio upload cap to 240 s

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
@@ -115,13 +115,12 @@ export async function loadFixtureAudio(name: string): Promise<DecodedFixture> {
   return decodeArrayBuffer(bytes);
 }
 
-// Cap user-supplied audio at the smallest TRT engine profile (60 s; see
-// acestep/paths.py:_TRT_ENGINE_PROFILES). Larger profiles (120 s, 240 s)
-// require materially more VRAM at session init — we've been seeing 1011s
-// on cold-loads when the bigger profiles spin up. Operators that want
-// longer engines can raise this and the server's websockets.serve
-// max_size accordingly.
-const MAX_FIXTURE_DURATION_S = 60;
+// Cap user-supplied audio at DEMON's largest TRT engine profile
+// (240 s; see acestep/paths.py:_TRT_ENGINE_PROFILES). Anything longer
+// would fail server-side at session init regardless of WS frame size.
+// The server's websockets.serve(max_size=...) is sized to fit this
+// duration with a comfortable margin.
+const MAX_FIXTURE_DURATION_S = 240;
 
 function ensureFitsSwapLimit(decoded: DecodedFixture): void {
   const seconds = decoded.frames / decoded.sampleRate;


### PR DESCRIPTION
## Summary
- Reverts the 240 s → 60 s upload cap from #48 by setting `MAX_FIXTURE_DURATION_S = 240` in `web/engine/audio/loadFixture.ts`.
- The cold-load 1011s that motivated the lower cap have since been addressed elsewhere (DEMON #55's `os._exit` VRAM reclaim, plus the bake#5 image rolled out across the warm-pool fleet). The upload cap shouldn't be the workaround anymore.
- Operators want longer tracks to upload again — the full 240 s TRT engine profile is registered and works.

## Test plan
- [ ] `npm run build` cleanly in `demos/realtime_motion_graph_web/web/`
- [ ] Upload a >60 s, ≤240 s track in the webapp — accepted, session starts
- [ ] Upload a >240 s track — still rejected with the existing "track too long" error
- [ ] No server-side change needed (`websockets.serve(max_size=...)` is already sized for 240 s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)