### PR TITLE
realtime_motion_graph_web: drop stale slices across track swap

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/engine/protocol.ts
@@ -98,6 +98,14 @@ export class RemoteBackend extends EventTarget {
   // and postMessage is FIFO, so audio slices stay in order.
   private _decoderWorker: Worker | null = null;
   private _nextDecodeId = 1;
+  // Source-buffer epoch. Bumped right before the swap_ready event is
+  // dispatched, so any binary slice that arrives at the WS afterwards is
+  // tagged for the new buffer. Slices in flight from before the bump
+  // (queued in the WS handler ahead of the swap, or sitting in the
+  // decoder worker mid-decode) keep their old epoch and get dropped by
+  // the listener — without this they'd land in the new track and bleed
+  // chunks of the previous song through.
+  private _sliceEpoch = 0;
 
   constructor(
     url: string,
@@ -140,6 +148,7 @@ export class RemoteBackend extends EventTarget {
           decMs: msg.decMs,
           numGens: msg.numGens,
           audio: msg.audio,
+          epoch: msg.epoch,
         };
         this.dispatchEvent(new CustomEvent("slice", { detail: slice }));
       };
@@ -229,6 +238,14 @@ export class RemoteBackend extends EventTarget {
           this._pendingSwap = null;
           this.duration = meta.duration;
           this.channels = meta.channels;
+          // Bump epoch BEFORE the dispatch so that the synchronous
+          // `player.swap()` call inside the listener (which bumps
+          // AudioPlayer.swapCount in lockstep) and any subsequent
+          // binary slice the WS hands us are all aligned on the new
+          // buffer. Stale slices already queued in the worker still
+          // carry the previous epoch and will be dropped by the
+          // listener.
+          this._sliceEpoch++;
           this.dispatchEvent(
             new CustomEvent("swap_ready", {
               detail: { ...meta, interleaved },
@@ -273,13 +290,18 @@ export class RemoteBackend extends EventTarget {
         if (this._decoderWorker) {
           const buf = ev.data as ArrayBuffer;
           this._decoderWorker.postMessage(
-            { id: this._nextDecodeId++, buffer: buf },
+            {
+              id: this._nextDecodeId++,
+              buffer: buf,
+              epoch: this._sliceEpoch,
+            },
             [buf],
           );
         } else {
           try {
             const slice = this._parseSlice(ev.data as ArrayBuffer);
             if (slice) {
+              slice.epoch = this._sliceEpoch;
               this.dispatchEvent(new CustomEvent("slice", { detail: slice }));
             }
           } catch (e) {
@@ -356,6 +378,9 @@ export class RemoteBackend extends EventTarget {
       decMs,
       numGens,
       audio,
+      // Caller (the WS onmessage fallback path) overwrites this with the
+      // current source epoch right before dispatching.
+      epoch: 0,
     };
   }
 

--- a/demos/realtime_motion_graph_web/web/engine/workers/sliceDecoder.worker.ts
+++ b/demos/realtime_motion_graph_web/web/engine/workers/sliceDecoder.worker.ts
@@ -11,6 +11,10 @@ import { SLICE_FLAG_DELTA, SLICE_HDR_SIZE } from "@/types/protocol";
 interface DecodeRequest {
   id: number;
   buffer: ArrayBuffer;
+  /** Snapshot of the protocol's source-buffer epoch at WS-receipt time.
+   *  Echoed back unchanged on the response so the main thread can drop
+   *  slices whose source has since been swapped out. */
+  epoch: number;
 }
 
 interface DecodeResponse {
@@ -24,12 +28,14 @@ interface DecodeResponse {
   decMs: number;
   numGens: number;
   audio: Float32Array;
+  epoch: number;
 }
 
 interface DecodeError {
   id: number;
   ok: false;
   error: string;
+  epoch: number;
 }
 
 // Reusable scratch overlay for half-precision decode (one allocation, not
@@ -69,10 +75,15 @@ function float16ArrayToFloat32(u16: Uint16Array): Float32Array {
 }
 
 self.onmessage = (ev: MessageEvent<DecodeRequest>) => {
-  const { id, buffer } = ev.data;
+  const { id, buffer, epoch } = ev.data;
   try {
     if (buffer.byteLength < SLICE_HDR_SIZE) {
-      const err: DecodeError = { id, ok: false, error: "slice too short" };
+      const err: DecodeError = {
+        id,
+        ok: false,
+        error: "slice too short",
+        epoch,
+      };
       (self as unknown as Worker).postMessage(err);
       return;
     }
@@ -113,6 +124,7 @@ self.onmessage = (ev: MessageEvent<DecodeRequest>) => {
       decMs,
       numGens,
       audio,
+      epoch,
     };
     (self as unknown as Worker).postMessage(reply, [audio.buffer]);
   } catch (e) {
@@ -120,6 +132,7 @@ self.onmessage = (ev: MessageEvent<DecodeRequest>) => {
       id,
       ok: false,
       error: e instanceof Error ? e.message : String(e),
+      epoch,
     };
     (self as unknown as Worker).postMessage(err);
   }

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -137,6 +137,12 @@ export function useStartSession() {
       const detail = (e as CustomEvent<AudioSlice>).detail;
       const player = useSessionStore.getState().player;
       if (!player) return;
+      // Drop slices that were generated for a previous source. Without
+      // this, slices already in the WS queue (or mid-decode in the
+      // worker) at the moment the user swaps tracks would write into
+      // the new buffer — audible as chunks of the previous song
+      // bleeding through after a swap.
+      if (detail.epoch !== player.swapCount) return;
       const startFrame = Math.floor(detail.startSample);
       if (detail.flags === SLICE_FLAG_DELTA) {
         player.addDelta(startFrame, detail.audio);

--- a/demos/realtime_motion_graph_web/web/types/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/types/protocol.ts
@@ -98,6 +98,11 @@ export interface AudioSlice {
   numGens: number;
   /** Decoded float32 PCM, interleaved. */
   audio: Float32Array;
+  /** Source-buffer epoch this slice was received under. Increments on each
+   *  swap_ready. Consumers compare against `AudioPlayer.swapCount` to drop
+   *  slices that were generated for a previous track but only finished
+   *  decoding (or arrived) after the swap. */
+  epoch: number;
 }
 
 /** Detail payload for `swap_ready` events on RemoteBackend. */


### PR DESCRIPTION
## Summary
Fixes the "previous track bleeds into the new one after a swap" bug. After uploading a new fixture, users were hearing chunks of the old track for several seconds — proportional to how busy the worker decoder was at swap time.

## Root cause
Slice decoding runs in a worker. Binary slices already queued at the WS or sitting mid-decode in the worker when the user swaps still complete and dispatch on the main thread *after* the swap. The slice listener then writes their PCM into the new buffer at `startSample`, leaking old-track audio.

## Fix
Tag every binary slice with a `source-buffer epoch` at WS-receipt time. The protocol bumps `_sliceEpoch` right before dispatching `swap_ready`. The slice listener in `useStartSession` compares `slice.epoch` to `AudioPlayer.swapCount` (incremented in lockstep inside the swap_ready handler) and drops on mismatch.

Failure mode is safe-by-default: if anything desyncs, slices get dropped rather than written into the wrong buffer — silence beats bleed.

## Files
- `types/protocol.ts` — `AudioSlice.epoch: number`
- `engine/protocol.ts` — `_sliceEpoch` field, bump at swap_ready, tag worker dispatch + main-thread fallback
- `engine/workers/sliceDecoder.worker.ts` — pass-through `epoch` on request, response, and error
- `hooks/useStartSession.ts` — drop on epoch mismatch in the slice listener

## Test plan
- [ ] Build (`npm run build` in `demos/realtime_motion_graph_web/web/`) — clean
- [ ] Start a session, mid-generation upload a new track — no audible chunks of the previous track in the new buffer
- [ ] Swap several times rapidly — each swap is clean
- [ ] Single-track session (no swap) — slices apply normally (epoch 0 == swapCount 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)