### PR TITLE
realtime_motion_graph_web: trim overlapping slice head before send

### DIFF
--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -417,6 +417,13 @@ EAGER_MAX_PIPELINE_DEPTH = 4
 # tick. Set to 0 to disable the pause entirely (always tick).
 IDLE_PAUSE_S = float(os.environ.get("DEMON_IDLE_PAUSE_S", "20"))
 
+# Carryover kept on the wire when trimming the overlapping head of a
+# windowed slice (on_audio_ready, windowed path). Sized to match the
+# runner's leading seam xfade in pipeline.py so the xfade landing zone
+# is rewritten on the next tick and any param-driven micro-deltas at
+# the immediate seam still propagate.
+OVERLAP_PAD_FRAMES = 1200  # 25 ms at 48 kHz
+
 
 def _compute_max_pipeline_depth(diffusion_engine) -> int:
     """Largest ``pipeline_depth`` the loaded backend can serve.
@@ -1391,20 +1398,27 @@ def handle_client(
         # Trim the leading edge of the slice when it overlaps with the
         # previous one. The runner re-decodes the entire vae_window every
         # tick (default 3 s) but only advances ~0.5 s, so ~80% of every
-        # window is audio the client already has. We keep an OVERLAP_PAD
-        # carryover so any param-driven micro-deltas in the immediate
-        # seam zone still propagate, and the runner's own xfade landing
-        # zone (1200 frames at win_start) gets one more rewrite from
-        # this same trimmed-overlap on the NEXT tick — so client/server
-        # divergence in that zone is bounded to one tick.
+        # window is audio the client already has. We keep an
+        # OVERLAP_PAD_FRAMES carryover so any param-driven micro-deltas
+        # in the immediate seam zone still propagate, and the runner's
+        # own xfade landing zone (at win_start) gets one more rewrite
+        # from this same trimmed-overlap on the NEXT tick — so client/
+        # server divergence in that zone is bounded to one tick.
         #
-        # Non-contiguous windows (loop wrap, source swap reset) skip the
-        # trim entirely and re-send the full slice from win_start.
+        # Trim only fires on the windowed path and only for a contiguous
+        # forward step (ss inside the previous range AND se past it).
+        # The full-buffer path, source swap (resets the cursor), and
+        # loop wrap (se lands at or before last_sent_end) all skip the
+        # trim and re-send the slice in full.
         last_sent_end = last_sent_end_ref[0]
-        if last_sent_end > 0 and ss < last_sent_end:
-            OVERLAP_PAD = 1200  # 25 ms at 48 kHz — matches runner xfade
-            new_ss = max(ss, last_sent_end - OVERLAP_PAD)
-            if new_ss < se:
+        if (win_start is not None
+                and last_sent_end > 0
+                and ss < last_sent_end < se):
+            new_ss = max(ss, last_sent_end - OVERLAP_PAD_FRAMES)
+            if new_ss > ss:
+                trim = new_ss - ss
+                region = region[trim:]
+                mirror_region = mirror_region[trim:]
                 ss = new_ss
         last_sent_end_ref[0] = se
 

--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -1249,6 +1249,11 @@ def handle_client(
     # wholesale on swap so deltas continue to be computed against the
     # buffer the client just crossfaded into.
     client_mirror_ref = [src_np.copy()]
+    # End frame (exclusive) of the last slice we transmitted. Used to trim
+    # off the overlapping head of subsequent slices: with vae_window ≈ 3 s
+    # and predictive advance ≈ 0.5 s, ~80% of every newly-decoded window
+    # repeats audio the client already has. Reset on source swap below.
+    last_sent_end_ref = [0]
     zctx = zstd.ZstdCompressor(level=1)
 
     # Source-swap rendezvous between the recv thread (sets pending) and
@@ -1382,6 +1387,26 @@ def handle_client(
         if not _first_slice[0]:
             _first_slice[0] = True
             _ms("first_generated_slice")
+
+        # Trim the leading edge of the slice when it overlaps with the
+        # previous one. The runner re-decodes the entire vae_window every
+        # tick (default 3 s) but only advances ~0.5 s, so ~80% of every
+        # window is audio the client already has. We keep an OVERLAP_PAD
+        # carryover so any param-driven micro-deltas in the immediate
+        # seam zone still propagate, and the runner's own xfade landing
+        # zone (1200 frames at win_start) gets one more rewrite from
+        # this same trimmed-overlap on the NEXT tick — so client/server
+        # divergence in that zone is bounded to one tick.
+        #
+        # Non-contiguous windows (loop wrap, source swap reset) skip the
+        # trim entirely and re-send the full slice from win_start.
+        last_sent_end = last_sent_end_ref[0]
+        if last_sent_end > 0 and ss < last_sent_end:
+            OVERLAP_PAD = 1200  # 25 ms at 48 kHz — matches runner xfade
+            new_ss = max(ss, last_sent_end - OVERLAP_PAD)
+            if new_ss < se:
+                ss = new_ss
+        last_sent_end_ref[0] = se
 
         # Delta = what server has now minus what client has
         delta = (region - mirror_region).astype(np.float16)
@@ -1996,6 +2021,9 @@ def handle_client(
             new_n_channels = new_src_np.shape[1] if new_src_np.ndim > 1 else 1
             n_channels_ref[0] = new_n_channels
             client_mirror_ref[0] = new_src_np.copy()
+            # Source changed — the next slice's win_start is unrelated to
+            # the previous track's end, so don't trim it.
+            last_sent_end_ref[0] = 0
             audio_eng.swap(new_src_np)
             audio_eng.position = 0
 


### PR DESCRIPTION
## Summary
Cuts the per-tick wire payload from the full `vae_window` (~3 s) down to roughly `advance + 25 ms` (~0.5–1 s).

## Problem
The runner re-decodes the entire `vae_window` (default 3 s, `backend.py:276`) every tick but only advances the predictive-decode head by `tick_ms + dec_ms` ≈ 0.5 s (`pipeline.py:381-390`). Each emitted slice is therefore ~80% audio the client already received — Ryan flagged it on the wire trace as 3–5 s of float16-delta payload per tick. zstd compresses the no-change overlap region OK, but param-driven micro-deltas in the overlap zone are non-zero, so we still pay 2 bytes per sample for ~80% of every slice.

## Fix
Trim the leading edge of the outgoing slice to `last_sent_end - OVERLAP_PAD` whenever the new window overlaps the previous one. The pad (1200 frames = 25 ms — same scale as the runner's seam xfade) ensures:
- any param-driven micro-deltas at the immediate seam still propagate,
- the runner's own leading-xfade landing zone (`pipeline.py:402-408`) gets one more rewrite on the next tick, so client/server divergence in that 25 ms zone is bounded to one tick (audibly negligible).

Non-contiguous windows — track loop wrap, post-swap fresh source — skip the trim and re-send the full slice from `win_start`. The `last_sent_end_ref[0] = 0` reset in the swap path makes that automatic.

## Files
- `backend.py` — three localized hunks: state init, trim before send, reset on swap.

## Test plan
- [ ] Start a session, watch wire payload sizes — should drop from ~3 s of audio per slice to ~`advance` + ~25 ms
- [ ] Audio sounds the same — no audible seam at the trim boundary
- [ ] Track loop boundary — first slice past the wrap is full-width, no audible glitch
- [ ] Mid-session source swap — first slice on the new track is full-width

## Risks
The leading 25 ms of every window (the runner's pre-xfade landing zone) is now never on the wire as a fresh value; the client retains the previous tick's values there until the next tick rewrites them. Drift is bounded to one tick. If params are changing fast and that 25 ms zone audibly diverges, increase `OVERLAP_PAD` (or set it to runner's actual xfade size if we want them to track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)