### PR TITLE
realtime_motion_graph_web: disable click-to-pause graph overlay on touch devices

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -630,6 +630,17 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
 #install-video-area #graph-wrap .graph-pause-overlay:focus-visible {
   outline: none;
 }
+/* Touch devices: every tap on the graph would call togglePauseAndAudio →
+   AudioContext.suspend(), and on Android that visibly blanks the audio-
+   driven render pipeline (analyser-fed bloom + FluidSim) for ~1 frame
+   while the ⏸/▶ glyph flashes in. The OperatorStrip play/pause button
+   is the canonical mobile control; leave the element in the DOM so the
+   one-shot discovery flash on first `ready` still surfaces. */
+@media (pointer: coarse) {
+  #install-video-area #graph-wrap .graph-pause-overlay {
+    pointer-events: none;
+  }
+}
 .graph-pause-overlay__glyph {
   position: absolute;
   top: 50%;


### PR DESCRIPTION
## Problem

On Android, every tap on the visible graph/video area showed a brief
black screen with a centred ⏸/▶ glyph flashing in, then the UI returned.
Reproduces in PWA standalone mode (no URL bar collapse) on every tap.

## Root cause

\`GraphPauseOverlay\` is a full-bleed transparent \`<button>\` (\`position:
absolute; inset: 0\`, \`globals.css\` rule \`#install-video-area #graph-wrap
.graph-pause-overlay\`) sitting on top of the entire graph canvas. Every
click calls \`togglePauseAndAudio()\`, which flips the store's \`paused\`
flag **and** suspends/resumes the \`AudioContext\`. On Android,
\`AudioContext.suspend()\` starves the analyser feed driving the render
pipeline (bloom amount, FluidSim), so the canvas visibly blanks for a
frame while the YouTube-style discovery glyph flashes in for 700 ms.
The user reads this as "black screen with a cursor on every touch".

Desktop is fine because mouse clicks are deliberate; mobile users tap
the canvas while exploring sliders / tiles and inadvertently pause every
time.

## Fix

Add a single \`@media (pointer: coarse)\` rule that sets
\`pointer-events: none\` on the overlay button. The element stays in the
DOM, so the one-shot discovery flash that fires on first \`ready\`
(GraphPauseOverlay.tsx \`useEffect\` for \`status === "ready"\`) still
surfaces on mobile as an affordance hint. The \`OperatorStrip\` play/pause
button is unaffected and remains the canonical pause control on touch
devices.

CSS-only — no React or hook changes.

## Test plan

- [ ] Desktop (mouse): click anywhere on the graph still pauses/resumes
      and flashes the glyph
- [ ] Desktop (mouse): keyboard / OperatorStrip pause still work
- [ ] Mobile (Android Chrome / PWA): tapping anywhere on the graph no
      longer toggles pause and no longer shows the black flash
- [ ] Mobile: OperatorStrip pause/play button still works
- [ ] Mobile: discovery flash on first \`ready\` still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)