### PR TITLE
realtime_motion_graph_web: friendlier WS close-error message (1011/1006)

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/engine/protocol.ts
@@ -326,13 +326,23 @@ export class RemoteBackend extends EventTarget {
         // If the socket closes before we finished the init handshake, the
         // connect() promise must reject — otherwise the launcher sits on
         // "Uploading..." forever when the server crashes mid-init.
+        //
+        // Tailor the message by close code: 1011 (server internal error)
+        // and 1006 (abnormal closure) are the two shapes operators see
+        // most often, both recoverable by reloading. The previous
+        // "Check the server console" tail was useless to end users and
+        // made the error feel scarier than it is.
         if (!this.ready) {
-          const reason = e.reason || `code ${e.code}`;
-          reject(
-            new Error(
-              `WebSocket closed before server sent 'ready' (${reason}). Check the server console.`,
-            ),
-          );
+          let msg: string;
+          if (e.code === 1011) {
+            msg = "Server restarted to clear memory — refresh the page to retry.";
+          } else if (e.code === 1006) {
+            msg = "Connection lost — refresh to retry.";
+          } else {
+            const reason = e.reason || `code ${e.code}`;
+            msg = `Connection failed (${reason}) — refresh to retry.`;
+          }
+          reject(new Error(msg));
         }
         this.dispatchEvent(new CustomEvent("close", { detail: e }));
       };


### PR DESCRIPTION
## Problem

Sessions ending mid-engine-respawn (cumulative-VRAM-leak workaround:
process exit per session, supervisor respawns) produce 1011 or 1006 on
the next user's WS handshake. Currently surfaced to end users as:

> WebSocket closed before server sent 'ready' (code 1011).
> Check the server console.

— long, scary, and tells end users to do something they can't.

## Fix

Tailor the close-handshake reject message by close code:

- \`1011\` → \`"Server restarted to clear memory — refresh the page to retry."\`
- \`1006\` → \`"Connection lost — refresh to retry."\`
- other → \`"Connection failed (<reason>) — refresh to retry."\`

Each tells the user the single action they can actually take (reload).

## Why this PR exists

Originally shipped as a vendor-only patch in
[daydreamlive/demon-public-demo#78](https://github.com/daydreamlive/demon-public-demo/pull/78)
(commit \`58dad69\`). That patch was wiped out by the next vendor sync
from DEMON main (\`8d0c2be\`) because the change never landed upstream.
This PR restores it the right way — at the source — so the next sync
preserves it.

CSS / no behavioural change beyond user-visible error text.

## Test plan

- [ ] Trigger a 1011 (server crash mid-init) — see the new "Server
      restarted…" message
- [ ] Trigger a 1006 (network drop pre-ready) — see the new "Connection
      lost…" message
- [ ] Other close codes still surface a sensible "Connection failed
      (<reason>)…" message
- [ ] Successful connection (ws.onclose after ready) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)