### PR TITLE
realtime_motion_graph_web: fix LoRA control responsiveness + clarity

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1225,7 +1225,7 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
 
 .lora-row {
   display: grid;
-  grid-template-columns: 32px 1fr auto;
+  grid-template-columns: 44px 1fr auto;
   grid-template-rows: auto auto;
   align-items: center;
   column-gap: 10px;
@@ -1247,38 +1247,45 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
 }
 .lora-row[data-state="disabled"] .lora-row-name { opacity: 0.55; }
 
-/* Toggle switch.  Sliding-pill style so the visual position alone
-   communicates state — no ON/OFF text needed (which would duplicate
-   the row name and confuse scan order). */
+/* Toggle as an explicit ON / OFF button.
+   Earlier this was a sliding pill; with 3+ LoRAs the thumb-position
+   signal was too subtle to scan a column quickly, and the user
+   couldn't tell whether a tap had actually flipped the state. The
+   literal text eliminates the ambiguity. The accent-fill ON state
+   matches the broader "outline + accent" button language used by
+   .seed-btn / .pause-btn / .send-prompt-btn elsewhere. */
 .lora-switch {
-  width: 28px; height: 16px;
+  width: 44px; height: 22px;
   padding: 0;
-  background: transparent;
-  border: 1px solid currentColor;
-  border-radius: 9px;
-  position: relative;
+  font: 600 10px/1 var(--font-mono);
+  letter-spacing: 0.08em;
+  background: var(--input-bg);
+  color: var(--text-dim);
+  border: 1px solid var(--frame-line);
+  border-radius: 11px;
   cursor: pointer;
-  opacity: 0.55;
-  transition: opacity 0.12s ease, background 0.18s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 0.14s ease,
+    color 0.14s ease,
+    border-color 0.14s ease,
+    box-shadow 0.18s ease;
 }
-.lora-switch:hover { opacity: 0.85; }
+.lora-switch:hover {
+  color: var(--text);
+  border-color: var(--accent-line);
+}
 .lora-switch[aria-checked="true"] {
-  opacity: 1;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--accent);
+  color: #ffffff;
+  border-color: var(--accent);
+  box-shadow: 0 0 10px var(--accent-glow);
 }
-.lora-switch-thumb {
-  position: absolute;
-  top: 1px; left: 1px;
-  width: 12px; height: 12px;
-  border-radius: 50%;
-  background: currentColor;
-  opacity: 0.5;
-  transition: transform 0.16s cubic-bezier(.3,1.3,.5,1), opacity 0.12s ease;
-  pointer-events: none;
-}
-.lora-switch[aria-checked="true"] .lora-switch-thumb {
-  transform: translateX(12px);
-  opacity: 1;
+.lora-switch[aria-checked="true"]:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 .lora-switch.midi-learning {
   outline: 1px dashed currentColor;
@@ -1295,11 +1302,14 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
 .lora-strength-track {
   position: relative;
   flex: 1;
-  height: 4px;
+  height: 6px;
   background: rgba(255, 255, 255, 0.08);
-  border-radius: 2px;
+  border-radius: 3px;
   cursor: pointer;
   transition: background 0.12s ease;
+  /* Vertical room for the 14px thumb knob without growing the row.
+     The track itself stays 6px tall; the thumb floats above and below. */
+  margin: 4px 7px;
 }
 .lora-strength-track:hover { background: rgba(255, 255, 255, 0.14); }
 .lora-strength-fill {
@@ -1308,8 +1318,31 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   width: 0%;
   background: currentColor;
   opacity: 0.75;
-  border-radius: 2px;
+  border-radius: 3px;
   transition: width 0.06s linear;
+}
+/* Visible draggable handle. Sits centered on the fill head so the
+   user has an obvious grab target — earlier the track was 4px tall
+   with no thumb, and operators reported the drag affordance was
+   easy to miss. Pointer events stay on the track so the handle
+   inherits the same pointermove pipeline. */
+.lora-strength-thumb {
+  position: absolute;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  margin-left: -7px;
+  margin-top: -7px;
+  border-radius: 50%;
+  background: var(--text-strong);
+  border: 2px solid currentColor;
+  opacity: 0.95;
+  pointer-events: none;
+  transition: left 0.06s linear, transform 0.12s ease, box-shadow 0.18s ease;
+}
+.lora-strength-track:hover .lora-strength-thumb {
+  transform: scale(1.15);
+  box-shadow: 0 0 8px var(--accent-glow);
 }
 .lora-strength-value {
   font-variant-numeric: tabular-nums;
@@ -1326,6 +1359,7 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   background: rgba(255, 255, 255, 0.04);
 }
 .lora-row[data-state="disabled"] .lora-strength-fill { opacity: 0.25; }
+.lora-row[data-state="disabled"] .lora-strength-thumb { opacity: 0.35; }
 .lora-row[data-state="disabled"] .lora-strength-value { opacity: 0.35; }
 
 /* ============================================================================

--- a/demos/realtime_motion_graph_web/web/components/Performance/DesktopEdgeDrag.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/DesktopEdgeDrag.tsx
@@ -157,43 +157,40 @@ export function DesktopEdgeDrag({ side }: Props) {
     if (!el) return;
 
     // Cache the host rect at pointerdown and reuse for the lifetime of
-    // the drag. Without this, every pointermove called
-    // getBoundingClientRect(), forcing a synchronous layout flush per
-    // event. RAF-coalesce the store write so a 60–120 evt/sec pointer
-    // stream commits at most once per frame.
+    // the drag — without this, every pointermove forced a synchronous
+    // layout flush via getBoundingClientRect.
+    //
+    // Earlier versions also RAF-coalesced the store write to once per
+    // frame. That introduced a 16-24 ms gap between cursor and committed
+    // value AND, for LoRA sides, only updated useLoraStore — so the
+    // 8 ms param-sync tick saw stale values, and the advanced panel's
+    // slider (which reads from usePerformanceStore.sliderTargets) never
+    // moved when the user dragged a side bar. We now commit on every
+    // pointermove like LibraryTile does, and we mirror writes into BOTH
+    // stores so the advanced-panel slider tracks the side-bar drag.
     let isDragging = false;
     let dragInitialValue = 0;
     let cachedRect: DOMRect | null = null;
-    let pendingClientX = 0;
-    let pendingClientY = 0;
-    let rafId = 0;
 
-    const commitValue = () => {
+    const commitFromClient = (clientX: number, clientY: number) => {
       if (!cachedRect) return;
       if (isTop) {
-        const t = (pendingClientX - cachedRect.left) / cachedRect.width;
+        const t = (clientX - cachedRect.left) / cachedRect.width;
         usePerformanceStore
           .getState()
           .setSlider(TOP_PARAM, Math.max(0, Math.min(1, t)) * TOP_MAX);
         return;
       }
-      const t = 1 - (pendingClientY - cachedRect.top) / cachedRect.height;
+      const t = 1 - (clientY - cachedRect.top) / cachedRect.height;
       const ids = Array.from(useLoraStore.getState().enabled);
       const id = ids[slotIndex];
       if (!id) return;
-      useLoraStore
-        .getState()
-        .setStrength(id, Math.max(0, Math.min(1, t)) * LORA_SLIDER_MAX);
-    };
-
-    const flush = () => {
-      rafId = 0;
-      if (!cachedRect) return;
-      if (isDragging) commitValue();
-    };
-
-    const schedule = () => {
-      if (rafId === 0) rafId = requestAnimationFrame(flush);
+      const v = Math.max(0, Math.min(1, t)) * LORA_SLIDER_MAX;
+      // Mirror into BOTH stores so the engine sees it (perf →
+      // param-sync) and the LibraryTile slider (which reads from
+      // sliderTargets) reflects the side-bar drag in real time.
+      usePerformanceStore.getState().setSlider(`lora_str_${id}`, v);
+      useLoraStore.getState().setStrength(id, v);
     };
 
     const onPointerDown = (e: PointerEvent) => {
@@ -205,25 +202,17 @@ export function DesktopEdgeDrag({ side }: Props) {
       setDragging(true);
       dragInitialValue = readCurrentValue();
       cachedRect = el.getBoundingClientRect();
-      pendingClientX = e.clientX;
-      pendingClientY = e.clientY;
       el.setPointerCapture(e.pointerId);
       // Commit immediately so a click-without-drag still moves the value.
-      commitValue();
+      commitFromClient(e.clientX, e.clientY);
     };
     const onPointerMove = (e: PointerEvent) => {
       if (!isDragging) return;
-      pendingClientX = e.clientX;
-      pendingClientY = e.clientY;
-      schedule();
+      commitFromClient(e.clientX, e.clientY);
     };
     const onPointerUp = (e: PointerEvent) => {
       if (!isDragging) return;
       isDragging = false;
-      if (rafId !== 0) {
-        cancelAnimationFrame(rafId);
-        rafId = 0;
-      }
       el.releasePointerCapture(e.pointerId);
       setDragging(false);
       // First successful (value-changing) drag dismisses the hint forever.
@@ -264,7 +253,6 @@ export function DesktopEdgeDrag({ side }: Props) {
     el.addEventListener("pointerenter", onPointerEnter);
     el.addEventListener("pointerleave", onPointerLeave);
     return () => {
-      if (rafId !== 0) cancelAnimationFrame(rafId);
       el.removeEventListener("pointerdown", onPointerDown);
       el.removeEventListener("pointermove", onPointerMove);
       el.removeEventListener("pointerup", onPointerUp);

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -116,7 +116,7 @@ function LoraRow({ id, name }: RowProps) {
         onClick={toggle}
         title={enabled ? "Disable" : "Enable"}
       >
-        <span className="lora-switch-thumb" aria-hidden="true" />
+        {enabled ? "ON" : "OFF"}
       </button>
       <span className="lora-row-name" title={id} onClick={toggle}>
         {name}
@@ -124,6 +124,11 @@ function LoraRow({ id, name }: RowProps) {
       <div className="lora-strength">
         <div className="lora-strength-track" ref={trackRef}>
           <div className="lora-strength-fill" style={{ width: `${pct}%` }} />
+          <div
+            className="lora-strength-thumb"
+            style={{ left: `${pct}%` }}
+            aria-hidden="true"
+          />
         </div>
         <span className="lora-strength-value">{value.toFixed(2)}</span>
       </div>


### PR DESCRIPTION
## Summary

Two bug fixes plus design tightening for the LoRA controls in the Performance UI. Reported by the operator using the advanced-panel + side-bar combo with 3+ active LoRAs:

- **Side-bar drags felt laggy** vs. the advanced-panel slider
- **Side-bar drags didn't move the advanced-panel slider** — the two readouts disagreed
- **Hard to scan toggle state** with multiple LoRAs (sliding-pill thumb-position too subtle)
- **Slider drag handle wasn't visible** (4px bar, no thumb)

## What changed

1. `DesktopEdgeDrag.tsx`: on every pointermove, mirror writes into BOTH `usePerformanceStore.setSlider("lora_str_<id>", v)` *and* `useLoraStore.setStrength(id, v)`. Previously the LoRA-side branch only wrote `useLoraStore`; `useParamSync` reads `sliderTargets` first, and `LibraryTile` reads `sliderTargets` for display. Mirroring makes both readouts share one source of truth.
2. `DesktopEdgeDrag.tsx`: drop the RAF coalesce around the store write — added 16-24 ms of latency for no real CPU win (store writes are O(1); `useParamSync` already throttles transmission to 8 ms ticks). Pointerdown rect cache kept (the real layout-flush optimization).
3. `.lora-switch` redesign: explicit ON / OFF text, accent-filled when on (`var(--accent)` + `var(--accent-glow)` shadow). Matches the existing "outline + accent" button language used by `.seed-btn` / `.pause-btn` / `.send-prompt-btn`. Sliding-pill replaced because thumb position is hard to scan in a column of 3+ rows.
4. `.lora-strength-thumb`: new 14 px circular handle at the fill head. Track height grows 4 → 6 px; vertical margin absorbs the thumb overflow so the row doesn't grow. Hover scales + glows.
5. Disabled-row cascade extends to the new thumb.

## What this PR doesn't do

- No protocol or store API changes.
- No fix for the enable/disable-vs-strength-via-param-sync race (separate WS frames). That's a separate follow-up — flagged in the original audit.
- No changes to side-bar (canvas-drawn ribbon) visuals — adding a thumb element there would conflict with the perimeter-ribbon design language.

## Test plan

- [ ] Open the advanced drawer with 3+ LoRAs enabled. Drag any LoRA's library-row slider — handle visible, fill follows pointer, value text updates. No lag.
- [ ] Drag the left or right side bar with a LoRA bound. The matching library-row slider in the advanced panel moves in real time.
- [ ] Toggle a LoRA off, then on. The button reads OFF / ON; on-state has accent fill + glow; off-state is dim outline against `--input-bg`.
- [ ] Disabled rows: thumb dims to ~35% opacity (matches existing fill / value dimming).
- [ ] No regressions on the top "Remix Strength" ribbon (denoise) — that path was untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)