### PR TITLE
realtime_motion_graph_web: unwrap DecodeFileResult in RefControl upload path

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/RefControl.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RefControl.tsx
@@ -170,7 +170,13 @@ export function RefControl({ kind }: { kind: RefKind }) {
     setBusy(true);
     setStatus("ready", `Loading ${bind.statusPrefix} ${file.name}…`);
     try {
-      const decoded = await decodeAudioFile(file);
+      // decodeAudioFile now returns { decoded, wasTrimmed } since the
+      // soft-trim-to-MAX_FIXTURE_DURATION_S feature landed. Unwrap before
+      // passing to add() / bind.send(), which still expect a bare
+      // DecodedFixture. wasTrimmed is informational only here — the
+      // ref-track upload UX doesn't surface a trim warning the way the
+      // main AudioSourceCrate flow does.
+      const { decoded } = await decodeAudioFile(file);
       // Mirror AudioSourceCrate's de-dup naming so uploads land in the
       // shared "your tracks" pool without colliding.
       const baseName = file.name;


### PR DESCRIPTION
## Summary

Incomplete refactor cleanup. \`decodeAudioFile()\` now returns \`DecodeFileResult { decoded, wasTrimmed }\` since the soft-trim-to-\`MAX_FIXTURE_DURATION_S\` feature landed. The main upload call sites were updated, but \`RefControl.tsx\` was missed and still treats the return value as a bare \`DecodedFixture\`.

\`next build\` runs strict TypeScript checks, so the omission breaks downstream builds (caught by demon-public-demo's Vercel preview):

\`\`\`
./vendor/demon-ui/components/Performance/RefControl.tsx:182:51
Type error: Argument of type 'DecodeFileResult' is not assignable to parameter of type 'DecodedFixture'.
  Type 'DecodeFileResult' is missing the following properties from type 'DecodedFixture': interleaved, channels, frames, sampleRate
\`\`\`

## Fix

Destructure \`{ decoded }\` from the awaited result. Comment explains the shape change. \`wasTrimmed\` is intentionally ignored here — the ref-track upload UX doesn't surface a trim warning the way AudioSourceCrate's main upload flow does, and adding one is out of scope.

## Test plan

- [x] \`npx tsc --noEmit\` clean for this file
- [ ] Smoke: ref-track upload still works end-to-end (upload an mp3 via RefControl, see it added to the custom-tracks pool, swap-source send succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)