### PR TITLE
realtime_motion_graph_web: revert LoRA toggle to sliding pill, retint with accent

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1225,7 +1225,7 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
 
 .lora-row {
   display: grid;
-  grid-template-columns: 44px 1fr auto;
+  grid-template-columns: 26px 1fr auto;
   grid-template-rows: auto auto;
   align-items: center;
   column-gap: 10px;
@@ -1247,45 +1247,54 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
 }
 .lora-row[data-state="disabled"] .lora-row-name { opacity: 0.55; }
 
-/* Toggle as an explicit ON / OFF button.
-   Earlier this was a sliding pill; with 3+ LoRAs the thumb-position
-   signal was too subtle to scan a column quickly, and the user
-   couldn't tell whether a tap had actually flipped the state. The
-   literal text eliminates the ambiguity. The accent-fill ON state
-   matches the broader "outline + accent" button language used by
-   .seed-btn / .pause-btn / .send-prompt-btn elsewhere. */
+/* Toggle: compact sliding pill. The state difference is carried by
+   thumb-position (visual scan), thumb-color (dim → bright), and
+   track-fill (transparent → accent). Earlier the colors all inherited
+   from currentColor which made the difference washed-out — switching
+   to explicit tokens (--text-dim / --accent / --accent-glow) gives the
+   ON state real visual weight without growing the control. */
 .lora-switch {
-  width: 44px; height: 22px;
+  width: 22px; height: 12px;
   padding: 0;
-  font: 600 10px/1 var(--font-mono);
-  letter-spacing: 0.08em;
-  background: var(--input-bg);
-  color: var(--text-dim);
+  background: transparent;
   border: 1px solid var(--frame-line);
-  border-radius: 11px;
+  border-radius: 7px;
+  position: relative;
   cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
   transition:
-    background 0.14s ease,
-    color 0.14s ease,
+    background 0.18s ease,
     border-color 0.14s ease,
     box-shadow 0.18s ease;
 }
 .lora-switch:hover {
-  color: var(--text);
   border-color: var(--accent-line);
 }
 .lora-switch[aria-checked="true"] {
   background: var(--accent);
-  color: #ffffff;
   border-color: var(--accent);
-  box-shadow: 0 0 10px var(--accent-glow);
+  box-shadow: 0 0 6px var(--accent-glow);
 }
 .lora-switch[aria-checked="true"]:hover {
   background: var(--accent-hover);
   border-color: var(--accent-hover);
+}
+.lora-switch-thumb {
+  position: absolute;
+  top: 1px; left: 1px;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  transition:
+    transform 0.16s cubic-bezier(.3,1.3,.5,1),
+    background 0.14s ease;
+  pointer-events: none;
+}
+.lora-switch:hover .lora-switch-thumb {
+  background: var(--text);
+}
+.lora-switch[aria-checked="true"] .lora-switch-thumb {
+  transform: translateX(10px);
+  background: #ffffff;
 }
 .lora-switch.midi-learning {
   outline: 1px dashed currentColor;

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -116,7 +116,7 @@ function LoraRow({ id, name }: RowProps) {
         onClick={toggle}
         title={enabled ? "Disable" : "Enable"}
       >
-        {enabled ? "ON" : "OFF"}
+        <span className="lora-switch-thumb" aria-hidden="true" />
       </button>
       <span className="lora-row-name" title={id} onClick={toggle}>
         {name}


### PR DESCRIPTION
## Summary

Operator feedback on the previous PR's toggle redesign: the explicit ON/OFF text button (44 × 22 px, accent-filled) is too big — the pill shape was preferred, the issue was washed-out colors. This reverts to the sliding pill, **smaller** than the original (22 × 12 px vs 28 × 16 px), with explicit accent-token tinting so the ON state actually pops.

## What changed (vs previous merge)

- **Shape**: ON/OFF text button → sliding pill
- **Size**: smaller than the original pill — 22 × 12 px track, 8 px thumb, 10 px translate. Grid column 44 → 26 px to match.
- **Colors** (the real fix):
  - Off state: transparent track, `--frame-line` border, `--text-dim` thumb. Hover lifts border to `--accent-line`, thumb to `--text`.
  - On state: `--accent` track fill, `--accent` border, `0 0 6px var(--accent-glow)` halo, `#fff` thumb. Hover deepens to `--accent-hover`.

The off/on differentiation is now carried by **three simultaneous changes** (track fill transparent → accent, glow off → on, thumb dim → white) instead of one (thumb position alone). Same scannability the ON/OFF button gave; same compact footprint as the original pill.

`.lora-strength-thumb` (slider knob) and the `DesktopEdgeDrag` data-flow fix from the prior PR are unchanged.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] With 3+ LoRAs in the library, off/on differentiation is unmistakable at a glance — accent-orange filled tracks scan instantly against the dim outlined off rows
- [ ] Hover transitions on both states are smooth
- [ ] Glow halo on enabled rows isn't blown out against the row background

🤖 Generated with [Claude Code](https://claude.com/claude-code)