### PR TITLE
realtime_motion_graph_web: harden kick pipeline against NaN + cap LoRA strength at 1.8

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
@@ -333,6 +333,11 @@ export class GraphRenderer {
   }
 
   draw(pulse = 0, now: number = performance.now()): void {
+    // Defense in depth: clamp must come BEFORE the Math.max/Math.min
+    // because those don't catch NaN. A single non-finite pulse value
+    // would otherwise propagate into baseAlpha and addColorStop, which
+    // throws `SyntaxError: rgba(...,NaN)` and kills the render loop.
+    if (!Number.isFinite(pulse)) pulse = 0;
     // ResizeObserver in the constructor already keeps {w, h} in sync,
     // including the display:none → block transition. The legacy
     // getBoundingClientRect() self-heal that used to live here forced a

--- a/demos/realtime_motion_graph_web/web/public/audio-worklet.js
+++ b/demos/realtime_motion_graph_web/web/public/audio-worklet.js
@@ -174,7 +174,15 @@ class RealtimeBufferProcessor extends AudioWorkletProcessor {
       let frameEnergy = 0;
       for (let c = 0; c < outChannels; c++) frameEnergy += output[c][i];
       frameEnergy /= outChannels;
-      const sq = frameEnergy * frameEnergy;
+      // Reject non-finite frames at the source. A single NaN sample
+      // (uninitialized buffer fragment, mid-swap zero-frame, etc.)
+      // poisons _kickSumSq permanently because the incremental update
+      // below propagates NaN forever — the consumer (main-thread
+      // useRenderLoop → GraphRenderer.draw → addColorStop) then crashes
+      // every frame with `rgba(...,NaN)`. Treating non-finite as silent
+      // (sq=0) keeps the ring valid and the visuals quiet for that
+      // sample, which is the right behaviour for a glitched frame.
+      const sq = Number.isFinite(frameEnergy) ? frameEnergy * frameEnergy : 0;
       const oldSq = this._kickRing[this._kickHead];
       this._kickSumSq += sq - oldSq;
       this._kickRing[this._kickHead] = sq;
@@ -201,7 +209,15 @@ class RealtimeBufferProcessor extends AudioWorkletProcessor {
     // poll this at rAF cadence. RMS, soft-clip, clamp.
     const denom = this._kickFilled || 1;
     const rms = Math.sqrt(Math.max(0, this._kickSumSq) / denom);
-    this._lastKick = Math.max(0, Math.min(1, rms * KICK_SOFT_GAIN));
+    const scaled = rms * KICK_SOFT_GAIN;
+    // Belt-and-suspenders: even with the per-sample NaN guard above,
+    // recompute every frame so a corrupted ring (e.g. from a hostile
+    // postMessage) can't keep posting NaN to the main thread. The
+    // standard Math.max/Math.min clamp does NOT fix NaN — both calls
+    // pass it through untouched.
+    this._lastKick = Number.isFinite(scaled)
+      ? Math.max(0, Math.min(1, scaled))
+      : 0;
 
     this._framesSinceReport += frames;
     if (this._framesSinceReport >= REPORT_EVERY) {

--- a/demos/realtime_motion_graph_web/web/types/engine.ts
+++ b/demos/realtime_motion_graph_web/web/types/engine.ts
@@ -51,7 +51,12 @@ export const DCW_WAVELETS = ["haar", "db4", "sym8", "db8"] as const;
 export type DcwMode = (typeof DCW_MODES)[number];
 export type DcwWavelet = (typeof DCW_WAVELETS)[number];
 
-export const LORA_SLIDER_MAX = 2.0;
+// Capped at 1.8 (was 2.0). Operator finding: most LoRAs we ship turn
+// to noise above ~1.7 (e.g. v5/discofunk noise at 2.0, hardrock noise
+// at 2.0). 1.8 still leaves room above the natural sweet spot for
+// every shipped LoRA without giving users a slider position that
+// reliably destroys the output.
+export const LORA_SLIDER_MAX = 1.8;
 export const LORA_SLIDER_STEP = 0.2;
 
 /** Default LoRA strength as a fraction of LORA_SLIDER_MAX. Used in two


### PR DESCRIPTION
## Summary

Two unrelated fixes for one operator pain-point cycle.

### (1) Kick pipeline NaN — render-loop crash in production

Production users hit a continuous render-loop crash:

\`\`\`
[FrameScheduler] tick "render-loop" threw SyntaxError:
  Failed to execute 'addColorStop' on 'CanvasGradient':
  The value provided ('rgba(61,182,190,NaN)') could not be parsed as a color.
      at GraphRenderer.draw
\`\`\`

NaN propagates from the audio-worklet's kick computation:
1. A single non-finite output sample (uninitialized buffer fragment, glitched mid-swap zero-frame, etc.) → \`frameEnergy = NaN\`
2. \`sq = frameEnergy * frameEnergy\` is NaN
3. \`_kickSumSq += sq - oldSq\` poisons the running sum **forever**
4. \`Math.max(0, Math.min(1, NaN * KICK_SOFT_GAIN))\` is **still NaN** — the standard min/max clamp does not catch non-finite values
5. \`_lastKick = NaN\` postMessage'd to main thread, \`graph.draw(NaN)\` → \`addColorStop(0, "rgba(...,NaN)")\` throws → render-loop dies

**Three layers of defense:**
- \`audio-worklet.js\`: skip non-finite frame energies at the source (\`sq = Number.isFinite(frameEnergy) ? frameEnergy*frameEnergy : 0\`) so the ring buffer can't be poisoned by a single bad sample
- \`audio-worklet.js\`: per-frame \`Number.isFinite(scaled) ? clamp : 0\` on the final kick value, so a worklet that's been running with a corrupted ring (from before this fix) recovers on the next clean frame
- \`GraphRenderer.draw()\`: early \`if (!Number.isFinite(pulse)) pulse=0\` so any future producer that posts NaN doesn't kill the canvas

The audio-worklet covers the ribbon / halo / effects tickers downstream of the same \`kick\` field too — they all read the same sanitised value via \`useRenderLoop\`.

### (2) Cap LORA_SLIDER_MAX at 1.8 (was 2.0)

Every style LoRA we ship (v5 / hardrock / bach) turns to noise above ~1.7 strength. The slider going to 2.0 gives users a reliable \"destroy the output\" position above the useful range. 1.8 leaves modest headroom above each LoRA's sweet spot without exposing the cliff.

\`LORA_SLIDER_STEP\` unchanged at 0.2; effective stops now 0 / 0.2 / 0.4 / 0.6 / 0.8 / 1.0 / 1.2 / 1.4 / 1.6 / 1.8.
\`LORA_DEFAULT_STRENGTH_FRACTION\` (0.7) unchanged — defaults to 1.26 absolute, still safe.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Reload production with the fix → no more \`addColorStop\` SyntaxErrors in the console after extended sessions
- [ ] LoRA strength sliders top out at 1.8, fill width still goes to 100% at the new max
- [ ] Default LoRA strength (when server-seeded) stays at 1.26 = 0.7 × 1.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)