### PR TITLE
feat: keep text encoder resident on GPU by default

### DIFF
--- a/acestep/engine/model_context.py
+++ b/acestep/engine/model_context.py
@@ -54,6 +54,7 @@ class ModelContext:
         use_flash_attention: bool = False,
         offload_to_cpu: bool = False,
         offload_dit_to_cpu: bool = False,
+        offload_text_encoder: bool = False,
         quantization: Optional[str] = None,
         prefer_source: Optional[str] = None,
         skip_decoder: bool = False,
@@ -86,6 +87,7 @@ class ModelContext:
             compile_decoder=compile_decoder,
             compile_vae=compile_vae,
             use_flash_attention=use_flash_attention,
+            offload_text_encoder=offload_text_encoder,
             prefer_source=prefer_source,
             skip_decoder=skip_decoder,
             skip_vae=skip_vae,
@@ -138,6 +140,7 @@ class ModelContext:
         compile_decoder: bool,
         compile_vae: bool,
         use_flash_attention: bool,
+        offload_text_encoder: bool,
         prefer_source: Optional[str],
         skip_decoder: bool,
         skip_vae: bool,
@@ -229,13 +232,13 @@ class ModelContext:
             self.vae = torch.compile(self.vae, dynamic=True)
 
         # --- 3. Load text encoder / tokenizer ------------------------------
-        self._offload_text_encoder = skip_decoder
+        self._offload_text_encoder = offload_text_encoder
         text_enc_path = os.path.join(checkpoint_dir, "Qwen3-Embedding-0.6B")
         if not os.path.exists(text_enc_path):
             raise FileNotFoundError(f"Text encoder not found at {text_enc_path}")
         self.text_tokenizer = AutoTokenizer.from_pretrained(text_enc_path)
         self.text_encoder = AutoModel.from_pretrained(text_enc_path)
-        if not self.offload_to_cpu and not skip_decoder:
+        if not self.offload_to_cpu and not self._offload_text_encoder:
             self.text_encoder = self.text_encoder.to(device).to(self.dtype)
         else:
             self.text_encoder = self.text_encoder.to("cpu").to(self.dtype)

--- a/acestep/engine/session.py
+++ b/acestep/engine/session.py
@@ -160,6 +160,7 @@ class Session:
         vae_backend: str = "eager",
         use_flash_attention: bool = True,
         offload_to_cpu: bool = False,
+        offload_text_encoder: bool = False,
         quantization: Optional[str] = None,
         trt_engines: Optional[dict[str, str]] = None,
         vae_window: float = 0.0,
@@ -180,6 +181,9 @@ class Session:
             trt_engines: Engine paths, used iff a *_backend is "tensorrt".
                 Keys: "decoder", "vae_encode", "vae_decode". Use
                 acestep.paths.default_trt_engines() for the canonical paths.
+            offload_text_encoder: Override text encoder placement policy.
+                Defaults to ``False`` so prompt edits do not pay CPU/GPU
+                transfer cost. Set ``True`` for lower steady VRAM usage.
         """
         from acestep.engine.model_context import ModelContext
         from acestep.engine.runtime_init import (
@@ -208,6 +212,7 @@ class Session:
             device=device,
             use_flash_attention=use_flash_attention,
             offload_to_cpu=offload_to_cpu,
+            offload_text_encoder=offload_text_encoder,
             quantization=quantization,
             **ctx_flags,
         )

--- a/acestep/nodes/model_nodes.py
+++ b/acestep/nodes/model_nodes.py
@@ -25,6 +25,8 @@ class LoadModel(BaseNode):
             and no dict is provided, ``acestep.paths.default_trt_engines()``
             is used.
         offload_to_cpu: Whether to offload models when not in use.
+        offload_text_encoder: Whether to offload the text encoder between
+            prompt encodes to reduce steady VRAM at the cost of prompt latency.
         quantization: Quantization type (None, "int8_weight_only", etc.).
 
     The ``compile_decoder`` / ``compile_vae`` flags are still accepted for
@@ -79,6 +81,11 @@ class LoadModel(BaseNode):
                 NodeParam(
                     name="offload_to_cpu", type="boolean", default=False,
                     description="Offload to CPU when idle",
+                    hidden=True,
+                ),
+                NodeParam(
+                    name="offload_text_encoder", type="boolean", default=False,
+                    description="Offload text encoder between prompt encodes",
                     hidden=True,
                 ),
                 NodeParam(
@@ -149,6 +156,7 @@ class LoadModel(BaseNode):
             device=kwargs.get("device", "auto"),
             use_flash_attention=kwargs.get("use_flash_attention", False),
             offload_to_cpu=kwargs.get("offload_to_cpu", False),
+            offload_text_encoder=kwargs.get("offload_text_encoder", False),
             quantization=kwargs.get("quantization", None),
             **ctx_flags,
         )

--- a/demos/realtime_motion_graph_web/README.md
+++ b/demos/realtime_motion_graph_web/README.md
@@ -62,6 +62,10 @@ uv run python -u -m demos.realtime_motion_graph_web.run -- \
     --accel tensorrt --vae-accel eager
 ```
 
+The text encoder stays resident in VRAM by default so live prompt edits do not
+pay CPU/GPU transfer cost. Add `--offload-text-encoder` on lower-VRAM GPUs to
+restore the previous lower-memory behavior.
+
 `--checkpoint <name>` selects which DiT checkpoint to load. The name
 must match a directory under `<checkpoints_dir>/` (auto-downloaded from
 HF on first use). Currently `acestep-v15-turbo` (default, 2B) is the

--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -306,10 +306,12 @@ def handle_client(
     decoder_backend: str = "tensorrt",
     vae_backend: str = "tensorrt",
     checkpoint: str = "acestep-v15-turbo",
+    offload_text_encoder: bool = False,
 ):
     print(
         f"[Server] Client connected "
-        f"(decoder={decoder_backend}, vae={vae_backend}, ckpt={checkpoint})"
+        f"(decoder={decoder_backend}, vae={vae_backend}, ckpt={checkpoint}, "
+        f"text_encoder={'offload' if offload_text_encoder else 'resident'})"
     )
 
     # Disable Nagle on the connection socket. Param frames are tiny (<1 KB
@@ -495,6 +497,7 @@ def handle_client(
         config_path=checkpoint,
         decoder_backend=decoder_backend,
         vae_backend=vae_backend,
+        offload_text_encoder=offload_text_encoder,
         trt_engines=trt_engines,
         vae_window=vae_window,
     )

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -300,6 +300,7 @@ def main():
 
     args = sys.argv[1:]
     no_backend = "--no-backend" in args or "--ui-only" in args
+    offload_text_encoder = "--offload-text-encoder" in args
     if "--host" in args:
         idx = args.index("--host")
         host = args[idx + 1]
@@ -376,6 +377,7 @@ def main():
                 decoder_backend=decoder_accel,
                 vae_backend=vae_accel,
                 checkpoint=checkpoint,
+                offload_text_encoder=offload_text_encoder,
             )
 
     print(f"[Server] Starting HTTP+WS on :{port}")
@@ -396,6 +398,8 @@ def main():
     extras = [f"mode={default_mode}"]
     if kiosk:
         extras.append("kiosk")
+    if offload_text_encoder:
+        extras.append("text_encoder=offload")
     extras.append(f"ckpt={checkpoint}")
     extra_str = " " + " ".join(f"[{e}]" for e in extras)
     if decoder_accel == vae_accel:


### PR DESCRIPTION
supersedes #26 

this is marcos work, rebased on main sans benchmark code. 

Add explicit offload_text_encoder parameter to ModelContext / Session (default False), decoupled from skip_decoder. Previously the realtime web demo's TRT decoder path implicitly offloaded the text encoder to CPU, so every prompt re-encode paid a CPU/GPU transfer plus a cuda.synchronize and empty_cache. That stall could outrun the VAE decode window and let the unmodified source audio bleed through during prompt changes.

Pinning the text encoder on GPU costs ~1.2 GB of steady VRAM. Pass --offload-text-encoder to the web server (or the same flag on Session / LoadModel) to restore the lower-VRAM, higher-latency behavior.