### PR TITLE
rtmg/web: tune connection-unstable pill — relax thresholds, shift above curves overlay

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -4120,6 +4120,19 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   animation:
     network-indicator-fade-in 200ms cubic-bezier(.2, .8, .2, 1) forwards,
     start-whisper-breathe 2.6s ease-in-out infinite 200ms;
+  transition: bottom 240ms cubic-bezier(.2, .8, .2, 1);
+}
+/* Curve scheduler overlay docks its tab strip + close button against
+   the bottom of the viewport (≈48–56px tall). When that overlay is
+   open, hoist the pill above the tabs so it doesn't sit on top of the
+   curve tabs or the preset menus that grow upward from them. */
+.network-indicator[data-curves-open="true"] {
+  bottom: calc(
+    var(--drawer-handle-h, 28px) +
+    env(safe-area-inset-bottom, 0px) +
+    var(--curves-tab-strip-h, 64px) +
+    12px
+  );
 }
 .network-indicator__bars rect {
   fill: currentColor;

--- a/demos/realtime_motion_graph_web/web/components/Performance/NetworkIndicator.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/NetworkIndicator.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCurveStore } from "@/store/useCurveStore";
 import { useNetworkStore } from "@/store/useNetworkStore";
 
 // Subtle bottom-center pill that fades in when the user is likely
@@ -8,14 +9,20 @@ import { useNetworkStore } from "@/store/useNetworkStore";
 // fields don't re-render. pointer-events disabled so it never blocks
 // the canvas or the AdvancedDrawer handle behind it. aria-live polite
 // so screen readers announce the engagement once, not per eval tick.
+//
+// When the schedule-curves overlay is open, the pill shifts up so it
+// clears the curve tab strip at the overlay's bottom — handled via the
+// `data-curves-open` attribute and a CSS bottom-offset bump.
 export function NetworkIndicator() {
   const quality = useNetworkStore((s) => s.quality);
+  const curvesOpen = useCurveStore((s) => s.overlayOpen);
   if (quality === "healthy") return null;
 
   return (
     <div
       className="network-indicator"
       data-quality={quality}
+      data-curves-open={curvesOpen ? "true" : undefined}
       role="status"
       aria-live="polite"
     >

--- a/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
+++ b/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
@@ -60,19 +60,24 @@ const THRESHOLDS = {
    *  intervals don't false-positive on a high ratio. */
   JITTER_ABS_MS: 50,
   /** Server tickMs p95 as a fraction of the *measured* slice cadence.
-   *  >0.85 = ≤15% headroom = the buffer is the only thing saving you
-   *  from underrun. Self-calibrates: at a 100ms cadence this fires at
-   *  85ms; at a 24ms cadence at ~20ms. */
-  TICK_BUDGET_RATIO: 0.85,
+   *  >0.92 = ≤8% headroom = the buffer is genuinely the only thing
+   *  saving you from underrun. Self-calibrates: at a 100ms cadence this
+   *  fires at 92ms; at a 24ms cadence at ~22ms. Bumped from 0.85 in
+   *  2026-05 after the pill was firing too often on otherwise-fine
+   *  sessions — 15% headroom is normal scheduler noise. */
+  TICK_BUDGET_RATIO: 0.92,
   /** No slice received in this long → unstable, no matter the jitter.
-   *  Squarely in the VoIP/WebRTC convention for an audio-stream
-   *  timeout (1–2s). */
-  STALL_MS: 1500,
+   *  Upper end of the VoIP/WebRTC convention for an audio-stream
+   *  timeout (1–2s). Bumped from 1500ms in 2026-05 to absorb brief
+   *  GC/JIT stalls without alarming. */
+  STALL_MS: 2200,
 
-  /** Consecutive bad ticks before showing (3s @ 500ms). On the
-   *  conservative end of the Zoom/Meet "unstable" debounce range
-   *  (~1.5–3s). */
-  ESCALATE_TICKS: 6,
+  /** Consecutive bad ticks before showing (6s @ 500ms). Above the
+   *  Zoom/Meet "unstable" debounce range (~1.5–3s) — we lean cautious
+   *  because false alarms erode trust faster than missed ones in this
+   *  app, where the canvas itself visibly degrades during real
+   *  trouble. Bumped from 6 (3s) in 2026-05. */
+  ESCALATE_TICKS: 12,
   /** Consecutive clean ticks before hiding (8s @ 500ms). Asymmetric
    *  ~2.7× the show debounce: easy to dismiss, hard to summon. */
   RECOVERY_TICKS: 16,


### PR DESCRIPTION
Two small fixes to the "UNSTABLE CONNECTION" pill in the rtmg web app, both tracking field feedback that it was firing too often and overlapping the curve scheduler.

## What changed

**Thresholds — relax** (`engine/networkMonitor.ts`):

| Constant | Old | New | Why |
| --- | --- | --- | --- |
| `ESCALATE_TICKS` | 6 (3s) | 12 (6s) | Above Zoom/Meet debounce range; false alarms erode trust faster than missed ones here |
| `TICK_BUDGET_RATIO` | 0.85 | 0.92 | ≤15% headroom is normal scheduler noise; trigger at ≤8% instead |
| `STALL_MS` | 1500 | 2200 | Upper end of VoIP/WebRTC convention — absorbs GC/JIT pauses |
| `RECOVERY_TICKS` | 16 | 16 | Unchanged — easy to dismiss, hard to summon |

The canvas itself visibly degrades during real trouble, so leaning conservative on the pill is the right tradeoff.

**Curve-overlay collision — shift up** (`NetworkIndicator.tsx`, `app/globals.css`):

The pill sits bottom-center; the curve scheduler's tab strip + preset menus dock against the bottom of the same viewport. They were overlapping. Subscribed to `useCurveStore.overlayOpen` and gated a `data-curves-open` attribute. CSS bumps `bottom` by `var(--curves-tab-strip-h, 64px)` when set, 240ms eased so the move is felt, not jarring.

## Test plan

- [x] HMR compiles clean
- [ ] Visual: open curve scheduler, force `quality: "unstable"` in dev tools, confirm pill clears the tab strip and transitions smoothly when overlay opens/closes
- [ ] Live: monitor unstable-fire rate on prod after merge — should drop noticeably without missing real instability events