### PR TITLE
rtmg/web: UI feedback pass — network pill, upload, ribbon ends, advanced coachmark

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3726,6 +3726,9 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
      the seam reads as one 1px frame-line (the upload button drops its
      left border to avoid doubling). */
   border-radius: var(--radius-md) 0 0 var(--radius-md);
+  /* Clip the gradient ::before strip to the rounded corners. Without
+     this the 1px-tall strip overshoots the top-left curve. */
+  overflow: hidden;
   font-family: var(--font-mono);
   display: flex;
   flex-direction: row;
@@ -3771,6 +3774,8 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   border-left: none; /* the placard's right border is the seam */
   border-top: none;  /* gradient strip ::before owns the top edge */
   border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  /* Clip the gradient ::before strip to the rounded top-right corner. */
+  overflow: hidden;
   color: var(--text-dim);
   cursor: pointer;
   /* Drop-shadow lives on the .audio-source-dock parent so it traces

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -4415,6 +4415,18 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   top: calc(100% + 8px);
   transform: translateX(-50%) translateY(-4px);
 }
+/* Wide variant for descriptive tooltips (param explanations etc.).
+   Allows wrapping and caps the width so long sentences don't bleed
+   across the viewport like the default nowrap labels would. */
+[data-dd-tooltip][data-dd-tooltip-wide]::after {
+  white-space: normal;
+  max-width: 280px;
+  line-height: 1.45;
+  padding: 7px 11px 6px;
+  text-transform: none;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+}
 [data-dd-tooltip]:hover::after,
 [data-dd-tooltip]:focus-visible::after {
   opacity: 1;

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3660,9 +3660,10 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
    ============================================================================ */
 
 /* Bottom-left dock holding the now-playing placard + always-visible
-   upload icon button. The dock owns the fixed position; placard and
-   upload button are flex children so they share a baseline and
-   resize cleanly with the placard's variable width. */
+   upload icon button. The dock owns the fixed position AND the
+   collective hover-lift; the placard and upload button merge into a
+   single visual frame (no gap, no border between them, only the
+   placard carries the brand gradient strip + radii). */
 .audio-source-dock {
   position: fixed;
   /* Float above the bottom HUD bar, mirroring the turntable's right-side
@@ -3673,7 +3674,19 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  gap: 6px;
+  gap: 0;
+  transition: transform 140ms cubic-bezier(.2, .8, .2, 1);
+}
+/* Hover anywhere on the pair lifts the whole widget together so the
+   placard + upload read as one unit, not two. :has() supported in
+   all modern evergreen browsers we target. */
+.audio-source-dock:has(.audio-source-crate:hover),
+.audio-source-dock:has(.audio-source-upload-btn:hover) {
+  transform: translateY(-1px);
+}
+.audio-source-dock:has(.audio-source-crate:active),
+.audio-source-dock:has(.audio-source-upload-btn:active) {
+  transform: translateY(0);
 }
 .audio-source-crate {
   min-width: 140px;
@@ -3683,7 +3696,11 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   -webkit-backdrop-filter: blur(6px);
           backdrop-filter: blur(6px);
   border: 1px solid var(--frame-line);
-  border-radius: var(--radius-md);
+  /* Right edge is the shared seam with the upload button — flatten that
+     corner so the two pieces sit flush, and keep the right border so
+     the seam reads as one 1px frame-line (the upload button drops its
+     left border to avoid doubling). */
+  border-radius: var(--radius-md) 0 0 var(--radius-md);
   font-family: var(--font-mono);
   display: flex;
   flex-direction: row;
@@ -3695,14 +3712,15 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
      pulses subtly with the audio kick — no canvas needed. */
   filter: drop-shadow(0 0 calc(1px + var(--bloom-amount, 0) * 6px) var(--accent-glow));
   transition:
-    transform 140ms cubic-bezier(.2, .8, .2, 1),
     background 160ms,
     border-color 160ms,
     filter 200ms;
 }
-/* Always-visible upload icon button. Visually attached to the placard
-   (matching height, gradient top-edge, blur/border treatment) so the
-   pair reads as one widget — two ways to pick audio. */
+/* Always-visible upload icon button. Sits flush against the placard's
+   right edge — same height, same blur background, same bloom-coupled
+   drop-shadow, no separate gradient strip — so the pair reads as one
+   frame with an internal seam. The placard owns the brand gradient and
+   the left radii; the upload owns the right radii. */
 .audio-source-upload-btn {
   position: relative;
   flex: 0 0 auto;
@@ -3714,39 +3732,25 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   -webkit-backdrop-filter: blur(6px);
           backdrop-filter: blur(6px);
   border: 1px solid var(--frame-line);
-  border-radius: var(--radius-md);
+  border-left: none; /* the placard's right border is the seam */
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
   color: var(--text-dim);
   cursor: pointer;
   filter: drop-shadow(0 0 calc(1px + var(--bloom-amount, 0) * 6px) var(--accent-glow));
   transition:
-    transform 140ms cubic-bezier(.2, .8, .2, 1),
     background 160ms,
     border-color 160ms,
     color 160ms,
     filter 200ms;
 }
-.audio-source-upload-btn::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: var(--dd-gradient);
-  pointer-events: none;
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
-}
 .audio-source-upload-btn:hover {
-  transform: translateY(-1px);
   background: rgba(6, 6, 12, 0.85);
   border-color: var(--accent-line);
   color: var(--accent-hover);
 }
-.audio-source-upload-btn:active { transform: translateY(0); }
 .audio-source-upload-btn:disabled {
   opacity: 0.5;
   cursor: progress;
-  transform: none;
 }
 .audio-source-marquee-rows {
   display: flex;
@@ -3782,11 +3786,9 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   border-radius: var(--radius-md) var(--radius-md) 0 0;
 }
 .audio-source-crate:hover {
-  transform: translateY(-1px);
   background: rgba(6, 6, 12, 0.85);
   border-color: var(--accent-line);
 }
-.audio-source-crate:active { transform: translateY(0); }
 .audio-source-crate--open {
   border-color: var(--accent-line);
   background: rgba(6, 6, 12, 0.88);

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3298,7 +3298,7 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
    color shift. */
 .turntable-caption {
   position: absolute;
-  top: 62px; /* 2px below disc bottom */
+  top: 66px; /* 6px below disc bottom — gives the label visual breathing room */
   left: 3px;
   width: 54px; /* same x-extent as the disc; centered text below it */
   text-align: center;
@@ -3466,11 +3466,13 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   transform: rotate(5deg);
 }
 
-/* Live timer — coral monospace text below the disc. Doesn't rotate. */
+/* Live timer — coral monospace text below the disc. Doesn't rotate.
+   Matches the .turntable-caption "REC" position so the two occupy the
+   same visual slot with the same breathing-room from the disc. */
 .turntable-time {
   position: absolute;
   left: 0;
-  bottom: -2px;
+  bottom: -6px;
   width: 60px;
   text-align: center;
   font-family: var(--font-mono);

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3681,20 +3681,11 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
      gradient seam, no separate shadow halos. */
   filter: drop-shadow(0 0 calc(1px + var(--bloom-amount, 0) * 6px) var(--accent-glow));
 }
-.audio-source-dock::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: var(--dd-gradient);
-  pointer-events: none;
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
-  /* Sit above both children's backgrounds so the strip reads as the
-     unified top edge. */
-  z-index: 1;
-}
+/* Brand gradient strip — split into two pseudo-elements (one per
+   child) so each piece pins to its own child's positioning context.
+   Since --dd-gradient is a 180deg gradient compressed into 1px, both
+   strips show the same top-stop color and visually meet seamlessly at
+   the placard/upload seam. */
 /* Hover anywhere on the pair lifts the whole widget together so the
    placard + upload read as one unit, not two. :has() supported in
    all modern evergreen browsers we target. */
@@ -3707,6 +3698,7 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   transform: translateY(0);
 }
 .audio-source-crate {
+  position: relative; /* positioning context for the brand gradient ::before */
   min-width: 140px;
   max-width: 260px;
   padding: 7px 12px 7px 14px;
@@ -3726,11 +3718,24 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   gap: 10px;
   cursor: pointer;
   text-align: left;
-  /* Drop-shadow + gradient strip live on the .audio-source-dock parent
-     so they span placard + upload as one unit. */
+  /* Drop-shadow lives on the .audio-source-dock parent so it traces
+     the merged outline; gradient strip lives on this ::before. */
   transition:
     background 160ms,
     border-color 160ms;
+}
+.audio-source-crate::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--dd-gradient);
+  pointer-events: none;
+  /* Top-left radius only — the right edge meets the upload's strip,
+     which owns the top-right radius. */
+  border-radius: var(--radius-md) 0 0 0;
 }
 /* Always-visible upload icon button. Sits flush against the placard's
    right edge — same height, same blur background, same bloom-coupled
@@ -3752,11 +3757,24 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   border-radius: 0 var(--radius-md) var(--radius-md) 0;
   color: var(--text-dim);
   cursor: pointer;
-  /* Drop-shadow + gradient strip live on the .audio-source-dock parent. */
+  /* Drop-shadow lives on the .audio-source-dock parent so it traces
+     the merged outline; gradient strip lives on this ::before. */
   transition:
     background 160ms,
     border-color 160ms,
     color 160ms;
+}
+.audio-source-upload-btn::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--dd-gradient);
+  pointer-events: none;
+  /* Top-right radius only — the left edge meets the placard's strip. */
+  border-radius: 0 var(--radius-md) 0 0;
 }
 .audio-source-upload-btn:hover {
   background: rgba(6, 6, 12, 0.85);

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -4120,6 +4120,19 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   animation:
     network-indicator-fade-in 200ms cubic-bezier(.2, .8, .2, 1) forwards,
     start-whisper-breathe 2.6s ease-in-out infinite 200ms;
+  transition: bottom 240ms cubic-bezier(.2, .8, .2, 1);
+}
+/* Curve scheduler overlay docks its tab strip + close button against
+   the bottom of the viewport (≈48–56px tall). When that overlay is
+   open, hoist the pill above the tabs so it doesn't sit on top of the
+   curve tabs or the preset menus that grow upward from them. */
+.network-indicator[data-curves-open="true"] {
+  bottom: calc(
+    var(--drawer-handle-h, 28px) +
+    env(safe-area-inset-bottom, 0px) +
+    var(--curves-tab-strip-h, 64px) +
+    12px
+  );
 }
 .network-indicator__bars rect {
   fill: currentColor;

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3594,13 +3594,23 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
    dropdown + upload icon for power users who prefer the dropdown.
    ============================================================================ */
 
-.audio-source-crate {
+/* Bottom-left dock holding the now-playing placard + always-visible
+   upload icon button. The dock owns the fixed position; placard and
+   upload button are flex children so they share a baseline and
+   resize cleanly with the placard's variable width. */
+.audio-source-dock {
   position: fixed;
   /* Float above the bottom HUD bar, mirroring the turntable's right-side
      anchor on the left. 24px gap above the bar matches the turntable. */
   bottom: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-bottom, 0px));
   left: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-left, 0px));
   z-index: 8;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 6px;
+}
+.audio-source-crate {
   min-width: 140px;
   max-width: 260px;
   padding: 7px 12px 7px 14px;
@@ -3624,6 +3634,54 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
     background 160ms,
     border-color 160ms,
     filter 200ms;
+}
+/* Always-visible upload icon button. Visually attached to the placard
+   (matching height, gradient top-edge, blur/border treatment) so the
+   pair reads as one widget — two ways to pick audio. */
+.audio-source-upload-btn {
+  position: relative;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  background: rgba(6, 6, 12, 0.72);
+  -webkit-backdrop-filter: blur(6px);
+          backdrop-filter: blur(6px);
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-md);
+  color: var(--text-dim);
+  cursor: pointer;
+  filter: drop-shadow(0 0 calc(1px + var(--bloom-amount, 0) * 6px) var(--accent-glow));
+  transition:
+    transform 140ms cubic-bezier(.2, .8, .2, 1),
+    background 160ms,
+    border-color 160ms,
+    color 160ms,
+    filter 200ms;
+}
+.audio-source-upload-btn::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--dd-gradient);
+  pointer-events: none;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+.audio-source-upload-btn:hover {
+  transform: translateY(-1px);
+  background: rgba(6, 6, 12, 0.85);
+  border-color: var(--accent-line);
+  color: var(--accent-hover);
+}
+.audio-source-upload-btn:active { transform: translateY(0); }
+.audio-source-upload-btn:disabled {
+  opacity: 0.5;
+  cursor: progress;
+  transform: none;
 }
 .audio-source-marquee-rows {
   display: flex;
@@ -3872,7 +3930,11 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
     max-width: none;
   }
   .audio-source-crate {
-    max-width: calc(100vw - 32px);
+    /* Leave room for the upload button + gap (38 + 6 + dock's own left
+       inset). The dock's inset is the same `var(--hud-thickness) + 24px`
+       used for the right margin, so cap at viewport width minus that
+       plus the button. */
+    max-width: calc(100vw - 32px - 44px);
   }
 }
 
@@ -4048,7 +4110,7 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
 
 /* ── Hide AudioSourceCrate when the mobile Lite drawer is open ──────── */
 @media (max-width: 768px) {
-  body.drawer-open .audio-source-crate,
+  body.drawer-open .audio-source-dock,
   body.drawer-open .audio-source-fan {
     display: none !important;
   }

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1025,15 +1025,14 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   top: 0;
   /* Bookended on BOTH sides by corner anchors. Right inset terminates
      before the halo badge (right: hud + 24, width 44 → left edge at
-     hud + 68; 12px gap = hud + 80). Left inset reserves room for the
-     downstream consumer's brand anchor — currently demon-public-demo's
-     DAYDREAM wordmark at ~30px tall × ~160px wide (888×167 PNG scaled
-     to 30px), anchored at `hud + 24`. The 200px inset clears the
-     wordmark + breathing room (24 anchor + 160 wordmark + 16 gap).
-     Reduce to 144px if the consumer reverts to a smaller anchor
-     like the previous LibraryButton cassette (64px wide). With no
-     consumer mounted, the slot is simply blank. */
-  left: calc(var(--hud-thickness) + 200px);
+     hud + 68; 12px gap = hud + 80). Left inset reserves room for an
+     anchor of comparable scale to the halo plus a generous 64px breathing
+     gap before the ribbon begins (left: hud + 144). The asymmetric gap
+     accommodates a downstream consumer with a hard-edged rectangular
+     anchor — demon-public-demo's saved-sessions Library cassette —
+     where the halo's soft writhing ring needs less air than a tilted
+     rectangle. With no consumer mounted, the slot is simply blank. */
+  left: calc(var(--hud-thickness) + 144px);
   right: calc(var(--hud-thickness) + 80px);
   height: var(--hud-thickness);
 }

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1534,6 +1534,71 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   background: var(--frame-line);
 }
 
+/* First-run coachmark — floats above the drawer handle to teach new
+   users that more controls live behind it. pointer-events: none so a
+   click on the coachmark falls through to the handle underneath (the
+   document-level pointerdown handler in <AdvancedCoachmark> dismisses
+   the callout while the same click opens the drawer). Single keyframe
+   chain (fade-in forwards → bob loop) — no filter, no backdrop-filter,
+   per PERFORMANCE.md "no unnecessary effects on idle UI". */
+.advanced-coachmark {
+  position: fixed;
+  left: 50%;
+  /* Sit just above the closed-drawer handle peek. When the drawer opens,
+     the parent dismisses the coachmark — no need to track --drawer-h. */
+  bottom: calc(var(--drawer-handle-h, 28px) + 14px);
+  transform: translateX(-50%);
+  pointer-events: none;
+  z-index: 12;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.72em;
+  letter-spacing: var(--tracking-wide, 0.18em);
+  text-transform: uppercase;
+  color: var(--text-strong);
+  text-shadow:
+    0 0 6px rgba(0, 0, 0, 0.55),
+    0 0 14px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  animation:
+    advanced-coachmark-fade-in 320ms cubic-bezier(.2, .8, .2, 1) forwards,
+    advanced-coachmark-bob 2.4s ease-in-out infinite 320ms;
+}
+.advanced-coachmark-text { display: inline-block; }
+.advanced-coachmark kbd {
+  display: inline-block;
+  padding: 0 5px;
+  margin: 0 2px;
+  border: 1px solid var(--accent-line, rgba(255, 255, 255, 0.35));
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 0.95em;
+  color: var(--accent, currentColor);
+  background: rgba(255, 255, 255, 0.06);
+}
+.advanced-coachmark-arrow {
+  color: var(--accent, currentColor);
+  font-size: 14px;
+  line-height: 1;
+}
+@keyframes advanced-coachmark-fade-in {
+  from { opacity: 0; transform: translate(-50%, 8px); }
+  to   { opacity: 1; transform: translate(-50%, 0);   }
+}
+@keyframes advanced-coachmark-bob {
+  0%, 100% { transform: translate(-50%, 0); }
+  50%      { transform: translate(-50%, -4px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .advanced-coachmark {
+    animation: advanced-coachmark-fade-in 320ms cubic-bezier(.2, .8, .2, 1) forwards;
+  }
+}
+
 /* Drawer body — vertical stack: operator strip across the top, then a
    wrap-flex grid of mixer tiles below. Tiles wrap to the next row before
    anything overflows horizontally — no sideways scrolling. */

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1025,14 +1025,15 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   top: 0;
   /* Bookended on BOTH sides by corner anchors. Right inset terminates
      before the halo badge (right: hud + 24, width 44 → left edge at
-     hud + 68; 12px gap = hud + 80). Left inset reserves room for an
-     anchor of comparable scale to the halo plus a generous 64px breathing
-     gap before the ribbon begins (left: hud + 144). The asymmetric gap
-     accommodates a downstream consumer with a hard-edged rectangular
-     anchor — demon-public-demo's saved-sessions Library cassette —
-     where the halo's soft writhing ring needs less air than a tilted
-     rectangle. With no consumer mounted, the slot is simply blank. */
-  left: calc(var(--hud-thickness) + 144px);
+     hud + 68; 12px gap = hud + 80). Left inset reserves room for the
+     downstream consumer's brand anchor — currently demon-public-demo's
+     DAYDREAM wordmark at ~30px tall × ~160px wide (888×167 PNG scaled
+     to 30px), anchored at `hud + 24`. The 200px inset clears the
+     wordmark + breathing room (24 anchor + 160 wordmark + 16 gap).
+     Reduce to 144px if the consumer reverts to a smaller anchor
+     like the previous LibraryButton cassette (64px wide). With no
+     consumer mounted, the slot is simply blank. */
+  left: calc(var(--hud-thickness) + 200px);
   right: calc(var(--hud-thickness) + 80px);
   height: var(--hud-thickness);
 }

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3313,8 +3313,12 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
 .turntable:hover .turntable-caption {
   color: var(--accent-hover);
 }
-.turntable--recording .turntable-caption {
-  color: var(--accent);
+/* Hide the REC label while recording — the .turntable-time elapsed
+   counter renders in the same vertical slot and the two would stack.
+   Fade for continuity with the surrounding state changes. */
+.turntable--recording .turntable-caption,
+.turntable--paused .turntable-caption {
+  opacity: 0;
 }
 
 /* Disc — the rotating element. Holds platter, grooves, label, spindle. */

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -4358,6 +4358,81 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   }
 }
 
+/* ── Custom tooltip (replaces native `title=` for hover-visible UI) ──
+   Opt-in via `data-dd-tooltip="..."`. The element must have
+   `position: relative` (most of our chrome already does because of
+   per-element ::before strips) for the pseudo to anchor correctly.
+
+   Default placement: ABOVE the element. Override per-element with
+   `data-dd-tooltip-pos="below"` when the element lives at the top
+   of the viewport (LibraryButton, HaloBadge, etc.) where a tooltip
+   above would clip off-screen.
+
+   Accessibility: keep `aria-label` on the element alongside
+   `data-dd-tooltip` — screen readers read the aria-label; this
+   pseudo is decorative (aria-hidden by virtue of being a pseudo).
+
+   Design: same vocabulary as .halo-menu / .audio-source-fan —
+   sheet bg, frame-line border, top brand-gradient hairline, mono
+   caps with --tracking-wide. Single project easing. 200ms hover
+   delay so the tooltip doesn't flicker on accidental cursor passes. */
+[data-dd-tooltip]::after {
+  content: attr(data-dd-tooltip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  padding: 5px 10px 4px;
+  background: var(--sheet-bg);
+  border: 1px solid var(--frame-line);
+  border-top: 2px solid transparent;
+  background-image:
+    linear-gradient(var(--sheet-bg), var(--sheet-bg)),
+    var(--dd-gradient);
+  background-origin: padding-box, border-box;
+  background-clip: padding-box, border-box;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--text-strong);
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 100;
+  opacity: 0;
+  visibility: hidden;
+  box-shadow:
+    0 6px 18px rgba(0, 0, 0, 0.45),
+    0 0 14px rgba(240, 138, 72, 0.15);
+  transition:
+    opacity 140ms cubic-bezier(.2, .8, .2, 1),
+    visibility 0s linear 140ms,
+    transform 140ms cubic-bezier(.2, .8, .2, 1);
+}
+[data-dd-tooltip][data-dd-tooltip-pos="below"]::after {
+  bottom: auto;
+  top: calc(100% + 8px);
+  transform: translateX(-50%) translateY(-4px);
+}
+[data-dd-tooltip]:hover::after,
+[data-dd-tooltip]:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+  /* 200ms delay so accidental passes don't flicker the tooltip. */
+  transition:
+    opacity 140ms cubic-bezier(.2, .8, .2, 1) 200ms,
+    visibility 0s linear 200ms,
+    transform 140ms cubic-bezier(.2, .8, .2, 1) 200ms;
+}
+/* Disable on touch — no real hover, and the active state ::after
+   would briefly flash on tap. Accessibility-equivalent info is in
+   the element's aria-label. */
+@media (pointer: coarse) {
+  [data-dd-tooltip]::after { display: none !important; }
+}
+
 /* ── Universal press state on coarse pointers ───────────────────────── */
 @media (pointer: coarse) {
   button:not(:disabled):active {

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3290,6 +3290,33 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   box-shadow: 0 0 0 2px var(--accent), 0 6px 22px rgba(0, 0, 0, 0.6);
 }
 
+/* Tactful word label beneath the disc — names the object without
+   competing with the skeuomorphic vinyl. Sits in the existing
+   container's free space below the disc (disc ends at y=60 of a 70px
+   container) and centered on the disc's x (left:3, w:54 → center 30).
+   Uses --accent-hover on hover/recording to match the disc's own
+   color shift. */
+.turntable-caption {
+  position: absolute;
+  top: 62px; /* 2px below disc bottom */
+  left: 3px;
+  width: 54px; /* same x-extent as the disc; centered text below it */
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--text-dim);
+  pointer-events: none;
+  transition: color 160ms;
+}
+.turntable:hover .turntable-caption {
+  color: var(--accent-hover);
+}
+.turntable--recording .turntable-caption {
+  color: var(--accent);
+}
+
 /* Disc — the rotating element. Holds platter, grooves, label, spindle. */
 .turntable-disc {
   position: absolute;
@@ -3868,6 +3895,11 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   background: var(--sheet-bg);
   border: 1px solid var(--frame-line);
   border-radius: var(--radius-lg);
+  /* Clip the ::before gradient strip to the rounded corners — see
+     the design-language Decision Rule on decorative strips. The fan's
+     own scrollable child handles its own overflow, and box-shadow
+     renders outside the clip box, so the outer glow stays intact. */
+  overflow: hidden;
   padding: 6px;
   display: flex;
   flex-direction: column;

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3676,6 +3676,24 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   align-items: stretch;
   gap: 0;
   transition: transform 140ms cubic-bezier(.2, .8, .2, 1);
+  /* Brand gradient strip + bloom drop-shadow live on the dock so they
+     span placard + upload as one continuous element — no per-child
+     gradient seam, no separate shadow halos. */
+  filter: drop-shadow(0 0 calc(1px + var(--bloom-amount, 0) * 6px) var(--accent-glow));
+}
+.audio-source-dock::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--dd-gradient);
+  pointer-events: none;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  /* Sit above both children's backgrounds so the strip reads as the
+     unified top edge. */
+  z-index: 1;
 }
 /* Hover anywhere on the pair lifts the whole widget together so the
    placard + upload read as one unit, not two. :has() supported in
@@ -3708,13 +3726,11 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   gap: 10px;
   cursor: pointer;
   text-align: left;
-  /* Bloom drop-shadow ties the placard to the perimeter ribbons so it
-     pulses subtly with the audio kick — no canvas needed. */
-  filter: drop-shadow(0 0 calc(1px + var(--bloom-amount, 0) * 6px) var(--accent-glow));
+  /* Drop-shadow + gradient strip live on the .audio-source-dock parent
+     so they span placard + upload as one unit. */
   transition:
     background 160ms,
-    border-color 160ms,
-    filter 200ms;
+    border-color 160ms;
 }
 /* Always-visible upload icon button. Sits flush against the placard's
    right edge — same height, same blur background, same bloom-coupled
@@ -3736,12 +3752,11 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   border-radius: 0 var(--radius-md) var(--radius-md) 0;
   color: var(--text-dim);
   cursor: pointer;
-  filter: drop-shadow(0 0 calc(1px + var(--bloom-amount, 0) * 6px) var(--accent-glow));
+  /* Drop-shadow + gradient strip live on the .audio-source-dock parent. */
   transition:
     background 160ms,
     border-color 160ms,
-    color 160ms,
-    filter 200ms;
+    color 160ms;
 }
 .audio-source-upload-btn:hover {
   background: rgba(6, 6, 12, 0.85);
@@ -3773,17 +3788,6 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
 .audio-source-crate--open .audio-source-crate-caret {
   color: var(--accent);
   transform: rotate(180deg);
-}
-.audio-source-crate::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: var(--dd-gradient);
-  pointer-events: none;
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
 }
 .audio-source-crate:hover {
   background: rgba(6, 6, 12, 0.85);

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -979,16 +979,25 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   left: 0;
   width: 100%;
   height: calc(100% + var(--ribbon-bleed));
-  -webkit-mask-image: linear-gradient(to right, transparent var(--ribbon-along-inset), black calc(var(--ribbon-along-inset) + var(--ribbon-tail-fade)), black 100%);
-          mask-image: linear-gradient(to right, transparent var(--ribbon-along-inset), black calc(var(--ribbon-along-inset) + var(--ribbon-tail-fade)), black 100%);
+  /* Symmetric fade at BOTH ends — the trailing edge (left) where the
+     ribbon writhe begins AND the far edge (right) where the gray
+     "track" ribbons terminate at the bar's outer end. Same
+     ribbon-tail-fade width on each side so the bar reads as
+     symmetric. */
+  -webkit-mask-image: linear-gradient(to right, transparent var(--ribbon-along-inset), black calc(var(--ribbon-along-inset) + var(--ribbon-tail-fade)), black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
+          mask-image: linear-gradient(to right, transparent var(--ribbon-along-inset), black calc(var(--ribbon-along-inset) + var(--ribbon-tail-fade)), black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
 }
 .install-edge-left .install-ribbons {
   top: 0;
   left: 0;
   width: calc(100% + var(--ribbon-bleed));
   height: 100%;
-  -webkit-mask-image: linear-gradient(to bottom, black 0, black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
-          mask-image: linear-gradient(to bottom, black 0, black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
+  /* Fade BOTH ends: the trailing edge (bottom, where the writhe
+     begins) and the far edge (top, where the gray "track" ribbons
+     terminate at the bar's outer end). flipAlong=true means
+     "along=ALONG" maps to canvas top. */
+  -webkit-mask-image: linear-gradient(to bottom, transparent var(--ribbon-along-inset), black calc(var(--ribbon-along-inset) + var(--ribbon-tail-fade)), black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
+          mask-image: linear-gradient(to bottom, transparent var(--ribbon-along-inset), black calc(var(--ribbon-along-inset) + var(--ribbon-tail-fade)), black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
 }
 .install-edge-right .install-ribbons {
   top: 0;
@@ -998,8 +1007,10 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   left: calc(-1 * var(--ribbon-bleed));
   width: calc(100% + var(--ribbon-bleed));
   height: 100%;
-  -webkit-mask-image: linear-gradient(to bottom, black 0, black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
-          mask-image: linear-gradient(to bottom, black 0, black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
+  /* Fade BOTH ends — same as left bar (mirrored layout, same mask
+     applies). */
+  -webkit-mask-image: linear-gradient(to bottom, transparent var(--ribbon-along-inset), black calc(var(--ribbon-along-inset) + var(--ribbon-tail-fade)), black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
+          mask-image: linear-gradient(to bottom, transparent var(--ribbon-along-inset), black calc(var(--ribbon-along-inset) + var(--ribbon-tail-fade)), black calc(100% - var(--ribbon-along-inset) - var(--ribbon-tail-fade)), transparent calc(100% - var(--ribbon-along-inset)));
 }
 .install-edge.install-edge-pulse .install-edge-bar { opacity: 1; }
 .install-edge.install-edge-pulse .install-edge-label {
@@ -3706,6 +3717,10 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   -webkit-backdrop-filter: blur(6px);
           backdrop-filter: blur(6px);
   border: 1px solid var(--frame-line);
+  /* The brand gradient ::before IS the top edge — no separate top
+     border, otherwise hover (which repaints border to --accent-line)
+     would stack a colored 1px line beneath the gradient strip. */
+  border-top: none;
   /* Right edge is the shared seam with the upload button — flatten that
      corner so the two pieces sit flush, and keep the right border so
      the seam reads as one 1px frame-line (the upload button drops its
@@ -3754,6 +3769,7 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
           backdrop-filter: blur(6px);
   border: 1px solid var(--frame-line);
   border-left: none; /* the placard's right border is the seam */
+  border-top: none;  /* gradient strip ::before owns the top edge */
   border-radius: 0 var(--radius-md) var(--radius-md) 0;
   color: var(--text-dim);
   cursor: pointer;

--- a/demos/realtime_motion_graph_web/web/components/Performance/AdvancedCoachmark.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AdvancedCoachmark.tsx
@@ -2,19 +2,56 @@
 
 import { useEffect } from "react";
 
-// First-run coachmark that points at the .install-drawer-handle to teach
-// users that more controls live behind it. Mounts only on desktop (mobile
-// has the LiteControls strip + "All controls" link, so the gap is
-// desktop-shaped), only after the session is ready, and only the first
-// time per user (dismissal persisted in localStorage).
+// ─────────────────────────────────────────────────────────────────────
+// HINT SEQUENCE — canonical doc. KEEP THIS COMMENT IN SYNC when adding
+// new coaching steps.
+// ─────────────────────────────────────────────────────────────────────
 //
-// Dismissed by: any pointerdown anywhere, Esc key, the drawer opening,
-// or an 8-second auto-hide. Whichever fires first writes the localStorage
-// flag so the coachmark never reappears.
+// First-time users get a cascade of UI hints. Each stage waits on the
+// previous one (or on an explicit engagement signal) so we never fire
+// two attention-grabbers simultaneously — that's the bug this sequence
+// exists to prevent.
 //
-// Parent (AdvancedDrawer) owns the visibility gate and the dismiss
-// handler; this component just renders the callout and wires the
-// document-level dismiss listeners.
+//   Stage A — Pre-session
+//     Trigger: initial page load (no session yet)
+//     Shows:   <StartOverlay/> "click to begin"
+//     Exits:   user clicks → session boots
+//
+//   Stage B — Session ready / new song
+//     Trigger: useSessionStore.status === "ready"
+//              AND usePerformanceStore.remixStarted === false
+//              (the latter resets per fixture swap, so every song gets
+//              its own gated entry)
+//     Shows:   Top-ribbon <RemixHint prominent/> — "drag to start"
+//              The gated next-action; the user MUST drag this ribbon
+//              to engage the remix engine. Owned by <DesktopEdgeDrag/>.
+//     Exits:   user drags the top ribbon → remixStarted := true
+//
+//   Stage C — Remix gate cleared
+//     Trigger: remixStarted := true (first top-ribbon drag this song)
+//     Shows:   Side-ribbon <RemixHint/> on left + right LoRA ribbons
+//              (idle pulse, contextual — not prominent)
+//     Exits:   each side hint dismisses on first drag of that slider
+//
+//   Stage D — User engaged
+//     Trigger: Stage C completed at least once this session
+//              AND ~12s have passed since remixStarted first flipped
+//              AND the advanced drawer is still closed
+//     Shows:   <AdvancedCoachmark/> — "Drag up for more controls"
+//     Dismiss: pointerdown anywhere, Esc, drawer open, or 8s auto-hide
+//     Persist: dd:advanced-coachmark-dismissed = "1" in localStorage
+//     Owned by: <AdvancedDrawer/> (this component is just the view)
+//
+// Adding a new coaching step? Slot it into the sequence above, pick a
+// trigger that waits on a real engagement signal (not just session-
+// ready), and update this comment. Audio-source / upload do NOT need
+// coachmarks — their copy + always-visible icon are the affordances.
+// ─────────────────────────────────────────────────────────────────────
+//
+// This file: the Stage-D view. The visibility gate, dismissal
+// persistence, and remix-gate-clear timing all live in
+// <AdvancedDrawer/>. This component just renders the callout and
+// wires the document-level dismiss listeners.
 
 export const advancedCoachmarkStorageKey = "dd:advanced-coachmark-dismissed";
 const AUTO_HIDE_MS = 8000;

--- a/demos/realtime_motion_graph_web/web/components/Performance/AdvancedCoachmark.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AdvancedCoachmark.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect } from "react";
+
+// First-run coachmark that points at the .install-drawer-handle to teach
+// users that more controls live behind it. Mounts only on desktop (mobile
+// has the LiteControls strip + "All controls" link, so the gap is
+// desktop-shaped), only after the session is ready, and only the first
+// time per user (dismissal persisted in localStorage).
+//
+// Dismissed by: any pointerdown anywhere, Esc key, the drawer opening,
+// or an 8-second auto-hide. Whichever fires first writes the localStorage
+// flag so the coachmark never reappears.
+//
+// Parent (AdvancedDrawer) owns the visibility gate and the dismiss
+// handler; this component just renders the callout and wires the
+// document-level dismiss listeners.
+
+export const advancedCoachmarkStorageKey = "dd:advanced-coachmark-dismissed";
+const AUTO_HIDE_MS = 8000;
+
+interface Props {
+  visible: boolean;
+  onDismiss: () => void;
+}
+
+export function AdvancedCoachmark({ visible, onDismiss }: Props) {
+  // Auto-hide after AUTO_HIDE_MS even without explicit dismissal so we
+  // don't nag once the user has had a chance to notice it.
+  useEffect(() => {
+    if (!visible) return;
+    const t = window.setTimeout(onDismiss, AUTO_HIDE_MS);
+    return () => window.clearTimeout(t);
+  }, [visible, onDismiss]);
+
+  // Pointer / Esc dismissal. We listen at the document level so any
+  // interaction at all counts as acknowledgement — clicks on the
+  // coachmark itself fall through (pointer-events: none in CSS) and
+  // hit whatever's underneath, so the user can click the handle to
+  // both dismiss + open in one motion.
+  useEffect(() => {
+    if (!visible) return;
+    const onPointer = () => onDismiss();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onDismiss();
+    };
+    document.addEventListener("pointerdown", onPointer, { once: true });
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onPointer);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [visible, onDismiss]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="advanced-coachmark" role="status" aria-live="polite">
+      <span className="advanced-coachmark-text">
+        Drag up for more controls — Press <kbd>O</kbd> to toggle
+      </span>
+      <span className="advanced-coachmark-arrow" aria-hidden="true">
+        ▾
+      </span>
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
@@ -162,7 +162,7 @@ export function AdvancedDrawer() {
           className={`install-drawer-handle${started ? "" : " install-drawer-handle--disabled"}`}
           aria-label="Toggle advanced controls drawer"
           aria-disabled={!started}
-          title={started ? "Advanced Controls (o)" : "Press Play to enable"}
+          data-dd-tooltip={started ? "Advanced Controls (o)" : "Press Play to enable"}
           onClick={() => {
             if (!started) return;
             setOpen((v) => !v);

--- a/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useCurveStore } from "@/store/useCurveStore";
@@ -79,13 +79,18 @@ export function AdvancedDrawer() {
     };
   }, [open]);
 
-  // First-run coachmark: show once per user on desktop, the first time
-  // the session reaches "ready". Mobile already has the LiteControls
-  // strip + "All controls" link, so the discoverability gap is desktop-
-  // shaped. Dismissal is persisted in localStorage; the actual hide
-  // (any pointerdown / Esc / 8s auto-hide) is wired inside the
-  // coachmark component, which calls back into handleCoachmarkDismiss.
+  // ─── HINT SEQUENCE — Stage D: advanced-controls coachmark ─────────
+  // See AdvancedCoachmark.tsx for the full multi-stage hint contract.
+  // tl;dr — don't fire on session-ready (would compete with the
+  // top-ribbon RemixHint, which is Stage B). Wait until the user
+  // clears the per-song remix gate (drags the top ribbon — Stage C
+  // signal: usePerformanceStore.remixStarted flips true), THEN delay
+  // ~12s so the side-ribbon RemixHints land + get noticed without our
+  // coachmark crowding them.
+  const remixStarted = usePerformanceStore((s) => s.remixStarted);
+  const remixGateClearedAt = useRef<number | null>(null);
   const [coachmarkVisible, setCoachmarkVisible] = useState(false);
+
   const handleCoachmarkDismiss = useCallback(() => {
     setCoachmarkVisible(false);
     try {
@@ -96,18 +101,47 @@ export function AdvancedDrawer() {
       // worth crashing the drawer over.
     }
   }, []);
+
+  // Capture the timestamp when the remix gate first clears this
+  // session. remixStarted resets to false per fixture swap (so each
+  // new song re-shows the "drag to start" hint), but the coachmark
+  // shouldn't get a second chance — once cleared, leave the
+  // timestamp pinned for the lifetime of the page.
+  useEffect(() => {
+    if (remixStarted && remixGateClearedAt.current === null) {
+      remixGateClearedAt.current = Date.now();
+    }
+  }, [remixStarted]);
+
+  // Schedule the coachmark once the gate + delay are satisfied.
   useEffect(() => {
     if (isMobile) return;
     if (status !== "ready") return;
     if (open) return; // user already discovered the drawer some other way
+    if (remixGateClearedAt.current === null) return; // remix gate not yet cleared
     try {
       if (localStorage.getItem(advancedCoachmarkStorageKey) === "1") return;
     } catch {
       // If we can't read localStorage, treat the user as first-run;
       // showing the coachmark once is friendlier than never showing it.
     }
-    setCoachmarkVisible(true);
-  }, [isMobile, status, open]);
+    const DELAY_MS = 12_000;
+    const elapsed = Date.now() - remixGateClearedAt.current;
+    if (elapsed >= DELAY_MS) {
+      setCoachmarkVisible(true);
+      return;
+    }
+    const t = window.setTimeout(() => {
+      // Re-check `open` at fire-time — user might have opened the
+      // drawer during the delay window.
+      if (useSessionStore.getState().status !== "ready") return;
+      // Note: we don't have access to `open` here without re-reading,
+      // but the next effect (open → dismiss) will catch that race.
+      setCoachmarkVisible(true);
+    }, DELAY_MS - elapsed);
+    return () => window.clearTimeout(t);
+  }, [isMobile, status, open, remixStarted]);
+
   // If the user opens the drawer some other way (keyboard, click on
   // the handle, future custom event), retire the coachmark.
   useEffect(() => {

--- a/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useOneShotTooltip } from "@/hooks/useOneShotTooltip";
 import { useCurveStore } from "@/store/useCurveStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
@@ -157,23 +158,7 @@ export function AdvancedDrawer() {
         className={`install-sheet${open ? " open" : ""}${isMobile ? " install-sheet--mobile" : ""}`}
         aria-hidden={!open}
       >
-        <button
-          id="install-adv-handle"
-          className={`install-drawer-handle${started ? "" : " install-drawer-handle--disabled"}`}
-          aria-label="Toggle advanced controls drawer"
-          aria-disabled={!started}
-          data-dd-tooltip={started ? "Advanced Controls (o)" : "Press Play to enable"}
-          onClick={() => {
-            if (!started) return;
-            setOpen((v) => !v);
-          }}
-          disabled={!started}
-          type="button"
-        >
-          <span className="install-drawer-handle-grip" aria-hidden="true" />
-          <span className="install-drawer-handle-label">Advanced Controls</span>
-          <span className="install-drawer-handle-grip" aria-hidden="true" />
-        </button>
+        <DrawerHandle started={started} open={open} setOpen={setOpen} />
 
         <div className="install-sheet-body">
           {isMobile ? (
@@ -217,5 +202,44 @@ export function AdvancedDrawer() {
         onDismiss={handleCoachmarkDismiss}
       />
     </>
+  );
+}
+
+// Extracted so useOneShotTooltip lives in its own component scope —
+// keeps AdvancedDrawer's hook list clean (it already runs five effects
+// + four store subscriptions) and avoids any chance of conditionally
+// calling the hook based on `started` early-returns. The tooltip only
+// applies the [data-dd-tooltip] attribute the first time a user hovers
+// the handle; afterwards the persistent label + the AdvancedCoachmark
+// (Stage D) carry the affordance.
+interface DrawerHandleProps {
+  started: boolean;
+  open: boolean;
+  setOpen: (fn: (v: boolean) => boolean) => void;
+}
+function DrawerHandle({ started, open, setOpen }: DrawerHandleProps) {
+  const tipProps = useOneShotTooltip(
+    "advanced-drawer",
+    started ? "Advanced Controls (o)" : "Press Play to enable",
+  );
+  void open; // accepted but no longer needed in this body — kept in signature for clarity
+  return (
+    <button
+      id="install-adv-handle"
+      className={`install-drawer-handle${started ? "" : " install-drawer-handle--disabled"}`}
+      aria-label="Toggle advanced controls drawer"
+      aria-disabled={!started}
+      {...tipProps}
+      onClick={() => {
+        if (!started) return;
+        setOpen((v) => !v);
+      }}
+      disabled={!started}
+      type="button"
+    >
+      <span className="install-drawer-handle-grip" aria-hidden="true" />
+      <span className="install-drawer-handle-label">Advanced Controls</span>
+      <span className="install-drawer-handle-grip" aria-hidden="true" />
+    </button>
   );
 }

--- a/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useCurveStore } from "@/store/useCurveStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
 
+import {
+  AdvancedCoachmark,
+  advancedCoachmarkStorageKey,
+} from "./AdvancedCoachmark";
 import { ChannelGainsTile } from "./ChannelGainsTile";
 import { ChannelsTile } from "./ChannelsTile";
 import { DcwTile } from "./DcwTile";
@@ -75,6 +79,43 @@ export function AdvancedDrawer() {
     };
   }, [open]);
 
+  // First-run coachmark: show once per user on desktop, the first time
+  // the session reaches "ready". Mobile already has the LiteControls
+  // strip + "All controls" link, so the discoverability gap is desktop-
+  // shaped. Dismissal is persisted in localStorage; the actual hide
+  // (any pointerdown / Esc / 8s auto-hide) is wired inside the
+  // coachmark component, which calls back into handleCoachmarkDismiss.
+  const [coachmarkVisible, setCoachmarkVisible] = useState(false);
+  const handleCoachmarkDismiss = useCallback(() => {
+    setCoachmarkVisible(false);
+    try {
+      localStorage.setItem(advancedCoachmarkStorageKey, "1");
+    } catch {
+      // localStorage may be unavailable (private browsing, quota). The
+      // worst case is the user sees the coachmark next session; not
+      // worth crashing the drawer over.
+    }
+  }, []);
+  useEffect(() => {
+    if (isMobile) return;
+    if (status !== "ready") return;
+    if (open) return; // user already discovered the drawer some other way
+    try {
+      if (localStorage.getItem(advancedCoachmarkStorageKey) === "1") return;
+    } catch {
+      // If we can't read localStorage, treat the user as first-run;
+      // showing the coachmark once is friendlier than never showing it.
+    }
+    setCoachmarkVisible(true);
+  }, [isMobile, status, open]);
+  // If the user opens the drawer some other way (keyboard, click on
+  // the handle, future custom event), retire the coachmark.
+  useEffect(() => {
+    if (open && coachmarkVisible) {
+      handleCoachmarkDismiss();
+    }
+  }, [open, coachmarkVisible, handleCoachmarkDismiss]);
+
   return (
     <>
       <aside
@@ -136,6 +177,11 @@ export function AdvancedDrawer() {
           onClose={() => setAllOpen(false)}
         />
       )}
+
+      <AdvancedCoachmark
+        visible={coachmarkVisible}
+        onDismiss={handleCoachmarkDismiss}
+      />
     </>
   );
 }

--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -32,12 +32,12 @@ interface TrackOption {
   kind: "fixture" | "custom";
 }
 
-function UploadIcon() {
+function UploadIcon({ size = 14 }: { size?: number }) {
   return (
     <svg
       viewBox="0 0 16 16"
-      width={14}
-      height={14}
+      width={size}
+      height={size}
       fill="none"
       stroke="currentColor"
       strokeWidth={1.4}
@@ -76,6 +76,7 @@ export function AudioSourceCrate() {
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const placardRef = useRef<HTMLButtonElement | null>(null);
+  const uploadBtnRef = useRef<HTMLButtonElement | null>(null);
   const fanRef = useRef<HTMLDivElement | null>(null);
 
   // Daydream-webapp queue-admit gate: /api/pod/* returns 401 pre-admit,
@@ -100,6 +101,7 @@ export function AudioSourceCrate() {
       const t = e.target as Node | null;
       if (!t) return;
       if (placardRef.current?.contains(t)) return;
+      if (uploadBtnRef.current?.contains(t)) return;
       if (fanRef.current?.contains(t)) return;
       setOpen(false);
     }
@@ -178,30 +180,46 @@ export function AudioSourceCrate() {
 
   return (
     <>
-      <button
-        ref={placardRef}
-        type="button"
-        className={`audio-source-crate${open ? " audio-source-crate--open" : ""}`}
-        onClick={() => setOpen((v) => !v)}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        aria-label={`Pick audio track. Current: ${displayedName}`}
-        title={`Audio source: ${displayedName}`}
-      >
-        <span className="audio-source-marquee-rows">
-          <span className="audio-source-marquee-label">
-            {open ? "Pick a track" : "▶ Now playing"}
+      <div className="audio-source-dock">
+        <button
+          ref={placardRef}
+          type="button"
+          className={`audio-source-crate${open ? " audio-source-crate--open" : ""}`}
+          onClick={() => setOpen((v) => !v)}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label={`Pick audio track. Current: ${displayedName}`}
+          title={`Audio source: ${displayedName}`}
+        >
+          <span className="audio-source-marquee-rows">
+            <span className="audio-source-marquee-label">
+              {open ? "Pick a track" : "▶ Now playing"}
+            </span>
+            <span className="audio-source-marquee-name" title={displayedName}>
+              {open ? "or upload your own" : displayedName}
+            </span>
           </span>
-          <span className="audio-source-marquee-name" title={displayedName}>
-            {open ? "or upload your own" : displayedName}
+          <span className="audio-source-crate-caret" aria-hidden="true">
+            <svg viewBox="0 0 10 10" width={10} height={10} fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M2 6.5L5 3.5L8 6.5" />
+            </svg>
           </span>
-        </span>
-        <span className="audio-source-crate-caret" aria-hidden="true">
-          <svg viewBox="0 0 10 10" width={10} height={10} fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
-            <path d="M2 6.5L5 3.5L8 6.5" />
-          </svg>
-        </span>
-      </button>
+        </button>
+        {/* Always-visible upload affordance. Discoverability beats the
+            "Upload your own" sleeve hidden inside the fan — same handler,
+            same dialog gate, just one click closer. */}
+        <button
+          ref={uploadBtnRef}
+          type="button"
+          className="audio-source-upload-btn"
+          disabled={uploading}
+          onClick={() => fileInputRef.current?.click()}
+          aria-label="Upload your own audio track"
+          title={uploading ? "Decoding…" : "Upload your own audio track"}
+        >
+          <UploadIcon size={16} />
+        </button>
+      </div>
 
       {open && (
         <div ref={fanRef} className="audio-source-fan" role="menu">

--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -189,7 +189,7 @@ export function AudioSourceCrate() {
           aria-haspopup="menu"
           aria-expanded={open}
           aria-label={`Pick audio track. Current: ${displayedName}`}
-          title={`Audio source: ${displayedName}`}
+          data-dd-tooltip={`Audio source: ${displayedName}`}
         >
           <span className="audio-source-marquee-rows">
             <span className="audio-source-marquee-label">
@@ -215,7 +215,7 @@ export function AudioSourceCrate() {
           disabled={uploading}
           onClick={() => fileInputRef.current?.click()}
           aria-label="Upload your own audio track"
-          title={uploading ? "Decoding…" : "Upload your own audio track"}
+          data-dd-tooltip={uploading ? "Decoding…" : "Upload your own audio track"}
         >
           <UploadIcon size={16} />
         </button>
@@ -262,7 +262,7 @@ export function AudioSourceCrate() {
             className="audio-source-sleeve audio-source-sleeve--upload"
             disabled={uploading}
             onClick={() => fileInputRef.current?.click()}
-            title="Upload your own audio track"
+            data-dd-tooltip="Upload your own audio track"
           >
             <span
               className="audio-source-sleeve-art audio-source-sleeve-art--upload"

--- a/demos/realtime_motion_graph_web/web/components/Performance/DcwTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/DcwTile.tsx
@@ -38,7 +38,7 @@ export function DcwTile() {
             type="button"
             className={`dcw-toggle${dcwEnabled ? " active" : ""}`}
             data-role="dcw-enabled"
-            title="Toggle DCW (T)"
+            data-dd-tooltip="Toggle DCW (T)"
             onClick={toggleDcw}
           >
             DCW: {dcwEnabled ? "ON" : "OFF"}

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
@@ -179,7 +179,7 @@ export function LiteTrackCarousel() {
           className="lite-track-chip lite-track-chip--upload"
           disabled={uploading}
           onClick={() => fileInputRef.current?.click()}
-          title="Upload audio track"
+          data-dd-tooltip="Upload audio track"
           aria-label="Upload audio track"
         >
           <span className="lite-track-chip-icon" aria-hidden="true">

--- a/demos/realtime_motion_graph_web/web/components/Performance/MidiBadge.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/MidiBadge.tsx
@@ -11,7 +11,7 @@ export function MidiBadge() {
   const status = useMidiStore((s) => s.status);
   const cls = `midi-badge midi-${status.tone}`;
   return (
-    <div className={cls} title="MIDI status — right-click any slider to learn">
+    <div className={cls} data-dd-tooltip="MIDI status — right-click any slider to learn">
       {status.message}
     </div>
   );

--- a/demos/realtime_motion_graph_web/web/components/Performance/NetworkIndicator.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/NetworkIndicator.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCurveStore } from "@/store/useCurveStore";
 import { useNetworkStore } from "@/store/useNetworkStore";
 
 // Subtle bottom-center pill that fades in when the user is likely
@@ -8,14 +9,20 @@ import { useNetworkStore } from "@/store/useNetworkStore";
 // fields don't re-render. pointer-events disabled so it never blocks
 // the canvas or the AdvancedDrawer handle behind it. aria-live polite
 // so screen readers announce the engagement once, not per eval tick.
+//
+// When the schedule-curves overlay is open, the pill shifts up so it
+// clears the curve tab strip at the overlay's bottom — handled via the
+// `data-curves-open` attribute and a CSS bottom-offset bump.
 export function NetworkIndicator() {
   const quality = useNetworkStore((s) => s.quality);
+  const curvesOpen = useCurveStore((s) => s.overlayOpen);
   if (quality === "healthy") return null;
 
   return (
     <div
       className="network-indicator"
       data-quality={quality}
+      data-curves-open={curvesOpen ? "true" : undefined}
       role="status"
       aria-live="polite"
     >

--- a/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
@@ -198,7 +198,7 @@ export function OperatorStrip() {
       <button
         type="button"
         className="pause-btn"
-        title={uploading ? "Decoding…" : "Upload audio track"}
+        data-dd-tooltip={uploading ? "Decoding…" : "Upload audio track"}
         aria-label="Upload audio track"
         disabled={uploading}
         onClick={() => fileInputRef.current?.click()}
@@ -315,7 +315,7 @@ export function OperatorStrip() {
         id="kiosk-toggle"
         className={`pause-btn${kiosk ? " active" : ""}`}
         data-midi-learn="kiosk_toggle"
-        title="Toggle kiosk mode — auto-hide cursor + idle reset (right-click to MIDI-learn)"
+        data-dd-tooltip="Toggle kiosk mode — auto-hide cursor + idle reset (right-click to MIDI-learn)"
         type="button"
         onClick={toggleKiosk}
       >
@@ -325,7 +325,7 @@ export function OperatorStrip() {
         type="button"
         className={`pause-btn${overlayOpen ? " active" : ""}`}
         data-midi-learn="schedule_curves_toggle"
-        title="Open the curve scheduler — draw param automation against the track (right-click to MIDI-learn)"
+        data-dd-tooltip="Open the curve scheduler — draw param automation against the track (right-click to MIDI-learn)"
         onClick={toggleOverlay}
       >
         SCHEDULE CURVES
@@ -336,7 +336,7 @@ export function OperatorStrip() {
       <button
         type="button"
         className={`pause-btn${smooth ? " active" : ""}`}
-        title={
+        data-dd-tooltip={
           smooth
             ? `Smooth slider transitions over ${smoothMs} ms — click to disable`
             : "Smooth slider transitions: slider drags + MIDI knob movement glide to their target over the chosen duration. The visual stays instant."
@@ -362,7 +362,7 @@ export function OperatorStrip() {
       <button
         type="button"
         className={`pause-btn${lufsOn ? " active" : ""}`}
-        title={
+        data-dd-tooltip={
           lufsOn
             ? "Loudness match ON — quieter passages are boosted to match the loudest seen (peak-clamped at –1 dBTP). Resets on track change. Click to disable."
             : "Loudness match: continuously meter LUFS, track the running max, boost quieter passages so they hit the loudest level seen this track. Never attenuates."
@@ -375,7 +375,7 @@ export function OperatorStrip() {
       <button
         type="button"
         className={`pause-btn${showKbdHints ? " active" : ""}`}
-        title="Show keyboard-shortcut hints under each slider"
+        data-dd-tooltip="Show keyboard-shortcut hints under each slider"
         aria-pressed={showKbdHints}
         onClick={toggleKbdHints}
       >
@@ -384,7 +384,7 @@ export function OperatorStrip() {
       <button
         type="button"
         className="pause-btn"
-        title="Reset all sliders + LoRAs to defaults. Does NOT touch MIDI mapping, automation curves, or persisted UI prefs."
+        data-dd-tooltip="Reset all sliders + LoRAs to defaults. Does NOT touch MIDI mapping, automation curves, or persisted UI prefs."
         onClick={async () => {
           const ok = await confirm({
             title: "Reset",
@@ -404,7 +404,7 @@ export function OperatorStrip() {
         type="button"
         className="pause-btn pause-btn--right"
         data-midi-learn="seek_start"
-        title="Seek to beginning (right-click to MIDI-learn)"
+        data-dd-tooltip="Seek to beginning (right-click to MIDI-learn)"
         aria-label="Seek to beginning"
         onClick={() => {
           const p = useSessionStore.getState().player;
@@ -417,7 +417,7 @@ export function OperatorStrip() {
         id="pause-btn"
         className="pause-btn"
         data-midi-learn="pause"
-        title="Pause/Resume (right-click to MIDI-learn)"
+        data-dd-tooltip="Pause/Resume (right-click to MIDI-learn)"
         type="button"
         onClick={togglePauseAndAudio}
       >
@@ -427,7 +427,7 @@ export function OperatorStrip() {
         type="button"
         className={`pause-btn${loopOn ? " active" : ""}`}
         data-midi-learn="loop_toggle"
-        title={
+        data-dd-tooltip={
           loopOn
             ? "Loop ON — playhead wraps at end-of-buffer (right-click to MIDI-learn)"
             : "Loop OFF — playback stops at end-of-buffer; click ⏮ to restart"

--- a/demos/realtime_motion_graph_web/web/components/Performance/PromptsTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/PromptsTile.tsx
@@ -69,7 +69,7 @@ export function PromptsTile() {
           id="send-prompt"
           className="send-prompt-btn"
           data-midi-learn="send_prompt"
-          title="Send prompt — Enter (out of textarea) or ⌘/Ctrl + Enter (in textarea); right-click to MIDI-learn"
+          data-dd-tooltip="Send prompt — Enter (out of textarea) or ⌘/Ctrl + Enter (in textarea); right-click to MIDI-learn"
           type="button"
           onClick={sendPrompt}
         >

--- a/demos/realtime_motion_graph_web/web/components/Performance/RecordButton.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RecordButton.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { useOneShotTooltip } from "@/hooks/useOneShotTooltip";
 import { isRecordingSupported } from "@/hooks/useRecording";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import {
@@ -74,6 +75,12 @@ export function RecordButton() {
             ? "Saving…"
             : "Record (R)";
 
+  // One-shot tooltip — shows the first time, never again. The
+  // permanent "REC" caption beneath the disc carries the affordance
+  // once the user has seen the tooltip; repeated tooltips become
+  // noise during active performance.
+  const tipProps = useOneShotTooltip("record", label);
+
   return (
     <div className="turntable-wrap">
       {warning && (
@@ -88,9 +95,9 @@ export function RecordButton() {
       disabled={busy}
       aria-label={label}
       // Custom tooltip pattern — see [data-dd-tooltip] in globals.css.
-      // Default position is ABOVE, which is what the turntable wants
-      // (bottom-right of viewport).
-      data-dd-tooltip={label}
+      // One-shot via useOneShotTooltip: tipProps supplies the tooltip
+      // attr only the first time.
+      {...tipProps}
     >
       {/* Disc — platter, audio-reactive grooves, label, spindle. The whole
           disc rotates while recording (CSS animation on .turntable-disc). */}

--- a/demos/realtime_motion_graph_web/web/components/Performance/RecordButton.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RecordButton.tsx
@@ -41,13 +41,31 @@ export function RecordButton() {
     prevKind.current = state.kind;
   }, [state.kind]);
 
-  const supported = isRecordingSupported();
-  if (!supported) return null;
-  if (status === "idle" || kiosk) return null;
-
+  // Derive everything we need from state UP FRONT so the one-shot
+  // tooltip hook below stays above the early returns (Rules of Hooks
+  // — hooks must run in the same order on every render).
   const active = isActive(state);
   const busy = state.kind === "arming" || state.kind === "finalizing";
   const elapsed = state.kind === "recording" ? elapsedMs(state, now) : 0;
+  const label =
+    state.kind === "recording"
+      ? `Stop recording (${fmtTime(elapsed)})`
+      : state.kind === "paused"
+        ? "Resume recording"
+        : state.kind === "arming"
+          ? "Starting…"
+          : state.kind === "finalizing"
+            ? "Saving…"
+            : "Record (R)";
+  // One-shot tooltip — shows the first time, never again. The
+  // permanent "REC" caption beneath the disc carries the affordance
+  // once the user has seen the tooltip; repeated tooltips become
+  // noise during active performance.
+  const tipProps = useOneShotTooltip("record", label);
+
+  const supported = isRecordingSupported();
+  if (!supported) return null;
+  if (status === "idle" || kiosk) return null;
 
   const onClick = () => {
     if (busy) return;
@@ -63,23 +81,6 @@ export function RecordButton() {
   ]
     .filter(Boolean)
     .join(" ");
-
-  const label =
-    state.kind === "recording"
-      ? `Stop recording (${fmtTime(elapsed)})`
-      : state.kind === "paused"
-        ? "Resume recording"
-        : state.kind === "arming"
-          ? "Starting…"
-          : state.kind === "finalizing"
-            ? "Saving…"
-            : "Record (R)";
-
-  // One-shot tooltip — shows the first time, never again. The
-  // permanent "REC" caption beneath the disc carries the affordance
-  // once the user has seen the tooltip; repeated tooltips become
-  // noise during active performance.
-  const tipProps = useOneShotTooltip("record", label);
 
   return (
     <div className="turntable-wrap">

--- a/demos/realtime_motion_graph_web/web/components/Performance/RecordButton.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RecordButton.tsx
@@ -97,6 +97,10 @@ export function RecordButton() {
         <span className="turntable-label" />
         <span className="turntable-spindle" />
       </span>
+      {/* Small caption beneath the disc — tactful word label so first-time
+          visitors don't have to hover to learn what the turntable does.
+          Same mono+caps+wide-tracking treatment used everywhere else. */}
+      <span className="turntable-caption" aria-hidden="true">REC</span>
 
       {/* Tonearm — sits to the upper-right of the disc. Idle: parked,
           rotated up-right; recording: dropped onto the outer groove. The

--- a/demos/realtime_motion_graph_web/web/components/Performance/RecordButton.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RecordButton.tsx
@@ -87,7 +87,10 @@ export function RecordButton() {
       onClick={onClick}
       disabled={busy}
       aria-label={label}
-      title={label}
+      // Custom tooltip pattern — see [data-dd-tooltip] in globals.css.
+      // Default position is ABOVE, which is what the turntable wants
+      // (bottom-right of viewport).
+      data-dd-tooltip={label}
     >
       {/* Disc — platter, audio-reactive grooves, label, spindle. The whole
           disc rotates while recording (CSS animation on .turntable-disc). */}

--- a/demos/realtime_motion_graph_web/web/components/Performance/RecordToggle.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RecordToggle.tsx
@@ -80,7 +80,7 @@ export function RecordToggle() {
       }}
       disabled={busy}
       aria-label={active ? "Stop recording" : "Record audio"}
-      title={active ? "Stop recording (R)" : "Record audio (R)"}
+      data-dd-tooltip={active ? "Stop recording (R)" : "Record audio (R)"}
     >
       {state.kind === "recording" && (
         <span className="rec-btn-dot" aria-hidden="true" />

--- a/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
@@ -629,7 +629,7 @@ export function ScheduleCurvesOverlay() {
           type="button"
           className="schedule-curves-master"
           onClick={() => resetCurve(activeCurve)}
-          title={`Clear the current curve (${labelFor(activeCurve)}) — flattens it back to the midline.`}
+          data-dd-tooltip={`Clear the current curve (${labelFor(activeCurve)}) — flattens it back to the midline.`}
         >
           CLEAR
         </button>
@@ -643,7 +643,7 @@ export function ScheduleCurvesOverlay() {
             (scheduleEnabled ? " schedule-curves-master--on" : "")
           }
           onClick={toggleScheduleEnabled}
-          title={
+          data-dd-tooltip={
             scheduleEnabled
               ? "Curves are driving sliders. Click to pause all automation."
               : "All curves paused. Click to resume."
@@ -656,7 +656,8 @@ export function ScheduleCurvesOverlay() {
           className="schedule-curves-close"
           onClick={closeOverlay}
           aria-label="Close schedule curves"
-          title="Close (Esc)"
+          data-dd-tooltip="Close (Esc)"
+          data-dd-tooltip-pos="below"
         >
           ×
         </button>

--- a/demos/realtime_motion_graph_web/web/components/Performance/SeedTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/SeedTile.tsx
@@ -13,7 +13,7 @@ export function SeedTile() {
           id="seed-btn"
           className="seed-btn"
           data-midi-learn="seed"
-          title="Randomize seed (right-click to MIDI-learn)"
+          data-dd-tooltip="Randomize seed (right-click to MIDI-learn)"
           type="button"
           onClick={randomize}
           aria-label="Randomize seed"

--- a/demos/realtime_motion_graph_web/web/components/Performance/SliderGroup.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/SliderGroup.tsx
@@ -7,6 +7,8 @@ import { useTactileSlider } from "@/hooks/useTactileSlider";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { SLIDER_META } from "@/types/engine";
 
+import { tooltipFor } from "./SliderTile";
+
 // Vertical slider matching DEMON's CSS layout (.slider-track + .slider-fill
 // + .slider-thumb). Click + drag on the track to set; the value reads from
 // usePerformanceStore. LoRA sliders (param starting with `lora_str_`)
@@ -180,9 +182,23 @@ export function SliderGroup({ param, label, max, kbd }: Props) {
 
   const tintStyle = { "--slider-tint": tintAt(fraction) } as CSSProperties;
 
+  // Descriptive tooltip on the LABEL only — hovering the track during
+  // drag would otherwise trigger the tooltip mid-interaction. Label is
+  // the natural "what is this?" hover target. data-dd-tooltip-wide
+  // wraps the longer copy across multiple lines (vs the default nowrap
+  // chrome tooltips).
+  const tooltip = tooltipFor(param);
+
   return (
     <div className="slider-group" data-param={param} style={tintStyle}>
-      <div className="slider-label">{label}</div>
+      <div
+        className="slider-label"
+        {...(tooltip
+          ? { "data-dd-tooltip": tooltip, "data-dd-tooltip-wide": "" }
+          : {})}
+      >
+        {label}
+      </div>
       <div className="slider-track" ref={trackRef}>
         <div className="slider-fill" style={{ height: `${pct}%` }} />
         <div className="slider-thumb" style={{ bottom: `${pct}%` }} />

--- a/demos/realtime_motion_graph_web/web/components/Performance/SliderTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/SliderTile.tsx
@@ -20,69 +20,62 @@ const DISPLAY_NAMES: Record<string, string> = {
 };
 
 // Tooltip copy for each tweakable param, surfaced via the slider label's
-// hover tooltip in SliderGroup. Concepts here map to the DEMON paper
-// (Diffusion Engine for Musical Orchestrated Noise) — paper sections
-// are noted in parens where applicable so future readers can find the
-// source. Keep these short enough to read in 1–2 seconds; use
-// data-dd-tooltip-wide rendering (white-space: normal, max-width 280px).
+// hover tooltip in SliderGroup. Aim: a 1–2 second read that tells the
+// user WHEN to reach for this knob — what musical outcome it produces,
+// not the diffusion-process plumbing underneath. Renders via
+// data-dd-tooltip-wide (white-space: normal, max-width 280px).
 const PARAM_TOOLTIPS: Record<string, string> = {
-  // ── Main remix controls (paper §3.5: denoise is the single most
-  //    impactful generation control; §3.6: semantic + timbre hints
-  //    feed the multi-condition architecture) ──
+  // ── Main remix controls ──
   denoise:
-    "Remix depth. How much of the model's transformation is applied to the source — 0 keeps the source mostly untouched, 1 fully replaces it. The single most impactful control; takes ~650ms to fully propagate through the ring buffer at depth 8.",
+    "How much the model reshapes the source audio. Keep it low for a subtle remix that stays close to the original; push it high to fully transform the track into something new. The most expressive knob — try sweeping it during playback.",
   hint_strength:
-    "How strongly the model follows the source's structural cues (sections, rhythm, dynamics, prompt-hint embeddings). Higher = more faithful to the original arrangement; lower = the model invents more freely.",
+    "How closely the model follows the original song's structure — sections, rhythm, dynamics. Crank it up to keep the arrangement intact; drop it to let the model rearrange more freely.",
   timbre_strength:
-    "How strongly the source's timbre (instrument character, tone color) bleeds into the output. Independent of structure — keep the rhythm but change the instruments, or vice versa.",
+    "How much of the source's instrument character (tone, color) carries into the output. High keeps the original instruments recognizable; low frees the model to swap them for whatever fits the prompt.",
 
-  // ── Engine internals (paper §3.2: per-slot scheduling + variance-
-  //    preserving noise interpolation; §3.6: per-frame ODE noise
-  //    injection) ──
+  // ── Engine internals ──
   feedback:
-    "Noise carryover between sequential generations. 0 = each generation independent; 1 = nearly identical noise across generations (variations of each other). 0.3–0.5 provides continuity without collapsing diversity.",
+    "How similar each new generation is to the previous one. Low values give you variety on every refresh; higher values give you a continuous evolution where each generation flows into the next. 0.3–0.5 is the sweet spot for smooth continuity without everything sounding the same.",
   shift:
-    "Timestep-schedule shift. Compresses or expands the denoising trajectory — the turbo model is built around shift=3.0. Lower values spread denoising evenly across steps; higher values concentrate action in early steps.",
+    "Advanced: changes where the model concentrates its work across denoising. The default is tuned for the turbo engine and works well in most cases — leave it alone unless you're chasing a specific feel.",
   noise_share:
-    "Per-frame noise correlation across generations — finer-grained sibling of FEEDBACK. Controls how much initial noise is shared frame-by-frame rather than as one scalar across the whole 60s generation.",
+    "Fine-grained sibling of FEEDBACK. Where FEEDBACK is one number for the whole generation, this lets the noise-sharing vary across the timeline. Leave at 0 unless you want detailed control over how successive generations evolve.",
   ode_noise:
-    "Stochastic noise injected after each ODE denoising step. Adds controlled creativity to an otherwise deterministic path. Modest values (~0.1) introduce subtle variation; higher values create 'creativity bursts'.",
+    "Adds a touch of randomness during generation. Bump it up if the model feels too deterministic — small values add subtle variation, higher values produce surprising bursts of creativity. Zero keeps generation fully predictable.",
 
-  // ── DCW (paper §3.4 / Active Research: wavelet-domain post-step
-  //    correction; two numeric scalers, plus mode + wavelet choice
-  //    selectors elsewhere in the tile) ──
+  // ── DCW ──
   dcw_scaler:
-    "DCW low-band scaler. Wavelet-domain post-step correction targeting low-frequency content (bass, body). Boosts or attenuates the model's low-frequency velocity output before the next step.",
+    "Boost or attenuate the model's low end (bass, body). Push positive if the output feels thin; pull negative if the bass is overpowering. The range is small on purpose — these are fine adjustments.",
   dcw_high_scaler:
-    "DCW high-band scaler. Wavelet-domain post-step correction targeting high-frequency content (transients, brightness, air).",
+    "Boost or attenuate the model's high end (transients, brightness, air). Push up for crispness and snap; pull down to round off harsh tops.",
 };
 
-// Per-channel gain tooltips — same concept (paper §6 Active Research:
-// Latent channel semantics — empirical characterization of ACE-Step
-// 1.5's 64-channel VAE latent space). Generated programmatically so
-// the channel index appears in the copy without 14 hand-written
-// repetitions.
+// Per-channel tooltips. The 64-channel latent space hasn't been fully
+// mapped to perceptual qualities yet, so the copy frames each channel
+// as something to discover by ear — not a labeled knob with a known
+// purpose. Generated programmatically to avoid 14 near-identical
+// hand-written strings.
 const CHANNEL_GAINS = ["ch_g0", "ch_g1", "ch_g2", "ch_g3", "ch_g4", "ch_g5", "ch_g6", "ch_g7"] as const;
 const NAMED_CHANNELS = ["ch13", "ch14", "ch19", "ch23", "ch29", "ch56"] as const;
 for (const [i, p] of CHANNEL_GAINS.entries()) {
   PARAM_TOOLTIPS[p] =
-    `Latent channel ${i} gain. Scales channel ${i} of the 64-dim VAE latent before decode. Different channels correlate with different perceptual axes (frequency band, dynamics, transients) — under active characterization.`;
+    `Experimental — adjusts the strength of one of the model's internal audio channels (channel ${i}). Each channel encodes a different aspect of the sound (frequency band, dynamics, transients); the exact mapping is still being explored. Sweep it to discover what it does for your source.`;
 }
 for (const p of NAMED_CHANNELS) {
   const idx = p.slice(2);
   PARAM_TOOLTIPS[p] =
-    `Latent channel ${idx} scaler. Adjusts the strength of channel ${idx} in the 64-dim VAE latent. Hand-picked channels with empirically characterized perceptual effects (paper §6 Active Research).`;
+    `Experimental — a hand-picked internal audio channel (#${idx}) that produces a noticeable perceptual change. Sweep it to hear what this specific channel controls for your source.`;
 }
 
 export function tooltipFor(param: string): string | undefined {
   // LoRA strength sliders (param like `lora_str_<id>`) get a generic
-  // tooltip rather than per-LoRA copy — the row already carries the
+  // tooltip rather than per-LoRA copy — the row already shows the
   // LoRA's name as its visible label.
   if (param.startsWith("lora_str_")) {
-    return "LoRA strength. Hot-swaps and additively blends this LoRA into the running TensorRT engine (paper §3.4 runtime LoRA refit). Multiple LoRAs stack with independent strengths.";
+    return "How strongly this LoRA shapes the output. LoRAs are little style packs — set a low value for a subtle flavor, crank past 1.0 to make this LoRA dominate the sound. Multiple LoRAs stack — turn several on at once for combined styles.";
   }
   if (param === "lora_blend") {
-    return "LoRA A / LoRA B crossfade. 0 = LoRA A only, 1 = LoRA B only, 0.5 = both at half strength. Sibling sliders below show the individual strengths.";
+    return "Crossfade between LoRA A and LoRA B. 0 = A only, 1 = B only, 0.5 = both at half strength. Use this to morph between two styles smoothly.";
   }
   return PARAM_TOOLTIPS[param];
 }

--- a/demos/realtime_motion_graph_web/web/components/Performance/SliderTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/SliderTile.tsx
@@ -19,6 +19,74 @@ const DISPLAY_NAMES: Record<string, string> = {
   dcw_high_scaler: "DCW high",
 };
 
+// Tooltip copy for each tweakable param, surfaced via the slider label's
+// hover tooltip in SliderGroup. Concepts here map to the DEMON paper
+// (Diffusion Engine for Musical Orchestrated Noise) — paper sections
+// are noted in parens where applicable so future readers can find the
+// source. Keep these short enough to read in 1–2 seconds; use
+// data-dd-tooltip-wide rendering (white-space: normal, max-width 280px).
+const PARAM_TOOLTIPS: Record<string, string> = {
+  // ── Main remix controls (paper §3.5: denoise is the single most
+  //    impactful generation control; §3.6: semantic + timbre hints
+  //    feed the multi-condition architecture) ──
+  denoise:
+    "Remix depth. How much of the model's transformation is applied to the source — 0 keeps the source mostly untouched, 1 fully replaces it. The single most impactful control; takes ~650ms to fully propagate through the ring buffer at depth 8.",
+  hint_strength:
+    "How strongly the model follows the source's structural cues (sections, rhythm, dynamics, prompt-hint embeddings). Higher = more faithful to the original arrangement; lower = the model invents more freely.",
+  timbre_strength:
+    "How strongly the source's timbre (instrument character, tone color) bleeds into the output. Independent of structure — keep the rhythm but change the instruments, or vice versa.",
+
+  // ── Engine internals (paper §3.2: per-slot scheduling + variance-
+  //    preserving noise interpolation; §3.6: per-frame ODE noise
+  //    injection) ──
+  feedback:
+    "Noise carryover between sequential generations. 0 = each generation independent; 1 = nearly identical noise across generations (variations of each other). 0.3–0.5 provides continuity without collapsing diversity.",
+  shift:
+    "Timestep-schedule shift. Compresses or expands the denoising trajectory — the turbo model is built around shift=3.0. Lower values spread denoising evenly across steps; higher values concentrate action in early steps.",
+  noise_share:
+    "Per-frame noise correlation across generations — finer-grained sibling of FEEDBACK. Controls how much initial noise is shared frame-by-frame rather than as one scalar across the whole 60s generation.",
+  ode_noise:
+    "Stochastic noise injected after each ODE denoising step. Adds controlled creativity to an otherwise deterministic path. Modest values (~0.1) introduce subtle variation; higher values create 'creativity bursts'.",
+
+  // ── DCW (paper §3.4 / Active Research: wavelet-domain post-step
+  //    correction; two numeric scalers, plus mode + wavelet choice
+  //    selectors elsewhere in the tile) ──
+  dcw_scaler:
+    "DCW low-band scaler. Wavelet-domain post-step correction targeting low-frequency content (bass, body). Boosts or attenuates the model's low-frequency velocity output before the next step.",
+  dcw_high_scaler:
+    "DCW high-band scaler. Wavelet-domain post-step correction targeting high-frequency content (transients, brightness, air).",
+};
+
+// Per-channel gain tooltips — same concept (paper §6 Active Research:
+// Latent channel semantics — empirical characterization of ACE-Step
+// 1.5's 64-channel VAE latent space). Generated programmatically so
+// the channel index appears in the copy without 14 hand-written
+// repetitions.
+const CHANNEL_GAINS = ["ch_g0", "ch_g1", "ch_g2", "ch_g3", "ch_g4", "ch_g5", "ch_g6", "ch_g7"] as const;
+const NAMED_CHANNELS = ["ch13", "ch14", "ch19", "ch23", "ch29", "ch56"] as const;
+for (const [i, p] of CHANNEL_GAINS.entries()) {
+  PARAM_TOOLTIPS[p] =
+    `Latent channel ${i} gain. Scales channel ${i} of the 64-dim VAE latent before decode. Different channels correlate with different perceptual axes (frequency band, dynamics, transients) — under active characterization.`;
+}
+for (const p of NAMED_CHANNELS) {
+  const idx = p.slice(2);
+  PARAM_TOOLTIPS[p] =
+    `Latent channel ${idx} scaler. Adjusts the strength of channel ${idx} in the 64-dim VAE latent. Hand-picked channels with empirically characterized perceptual effects (paper §6 Active Research).`;
+}
+
+export function tooltipFor(param: string): string | undefined {
+  // LoRA strength sliders (param like `lora_str_<id>`) get a generic
+  // tooltip rather than per-LoRA copy — the row already carries the
+  // LoRA's name as its visible label.
+  if (param.startsWith("lora_str_")) {
+    return "LoRA strength. Hot-swaps and additively blends this LoRA into the running TensorRT engine (paper §3.4 runtime LoRA refit). Multiple LoRAs stack with independent strengths.";
+  }
+  if (param === "lora_blend") {
+    return "LoRA A / LoRA B crossfade. 0 = LoRA A only, 1 = LoRA B only, 0.5 = both at half strength. Sibling sliders below show the individual strengths.";
+  }
+  return PARAM_TOOLTIPS[param];
+}
+
 // Map slider param → keyboard hint shown beneath the slider. Mirrors the
 // chord layout in hooks/useKeyboardShortcuts.ts; if you change one, change
 // the other.

--- a/demos/realtime_motion_graph_web/web/engine/cursor.ts
+++ b/demos/realtime_motion_graph_web/web/engine/cursor.ts
@@ -21,7 +21,7 @@
 // and double the per-frame draw surface. Caller renders
 // <canvas class="cursor-canvas"> (see <CustomCursor />).
 
-const ORBIT_RADIUS = 9;
+const ORBIT_RADIUS = 6;
 const SPRING_K = 0.18;
 const DAMPING = 0.78;
 const ROTATION_SPEED = 0.0004;
@@ -52,9 +52,15 @@ const PARTICLE_CONFIG: Array<{
 
 // Spark / confetti tuning. Gravity is per-frame at ~60fps; the loop scales
 // physics by dt / 16 so motion stays steady on uneven frame timing.
+//
+// SPARK_LIFE_MS + SPARK_MIN_SPEED tuned 2026-05 in response to user
+// feedback that the sparks felt like "glitter" and were annoying —
+// life dropped from 700ms (visible long trails) to 420ms (sparks
+// fade before the trail visually extends), and min-speed raised from
+// 3.2 to 5 so idle micro-jitter doesn't emit sparks at all.
 const GRAVITY = 0.16;
-const SPARK_LIFE_MS = 700;
-const SPARK_MIN_SPEED = 3.2;
+const SPARK_LIFE_MS = 420;
+const SPARK_MIN_SPEED = 5;
 const SPARK_PER_FRAME_CAP = 1;
 const CONFETTI_LIFE_MS = 900;
 const CONFETTI_COUNT = 16;

--- a/demos/realtime_motion_graph_web/web/engine/cursor.ts
+++ b/demos/realtime_motion_graph_web/web/engine/cursor.ts
@@ -22,8 +22,14 @@
 // <canvas class="cursor-canvas"> (see <CustomCursor />).
 
 const ORBIT_RADIUS = 6;
-const SPRING_K = 0.18;
-const DAMPING = 0.78;
+// Spring physics for the orbital cluster. Tuned 2026-05 in response
+// to feedback that the cluster "lagged the cursor then bounced to it"
+// — classic underdamped spring. Bumped K (stiffer pull toward target)
+// and lowered DAMPING (more friction per frame — DAMPING is a velocity
+// multiplier, so smaller = more decay). Result: cluster tracks the
+// cursor tightly with minimal overshoot.
+const SPRING_K = 0.42;
+const DAMPING = 0.60;
 const ROTATION_SPEED = 0.0004;
 const ATTRACTOR_RANGE = 140;
 const ATTRACTOR_GAIN = 0.4;

--- a/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
+++ b/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
@@ -60,19 +60,24 @@ const THRESHOLDS = {
    *  intervals don't false-positive on a high ratio. */
   JITTER_ABS_MS: 50,
   /** Server tickMs p95 as a fraction of the *measured* slice cadence.
-   *  >0.85 = ≤15% headroom = the buffer is the only thing saving you
-   *  from underrun. Self-calibrates: at a 100ms cadence this fires at
-   *  85ms; at a 24ms cadence at ~20ms. */
-  TICK_BUDGET_RATIO: 0.85,
+   *  >0.92 = ≤8% headroom = the buffer is genuinely the only thing
+   *  saving you from underrun. Self-calibrates: at a 100ms cadence this
+   *  fires at 92ms; at a 24ms cadence at ~22ms. Bumped from 0.85 in
+   *  2026-05 after the pill was firing too often on otherwise-fine
+   *  sessions — 15% headroom is normal scheduler noise. */
+  TICK_BUDGET_RATIO: 0.92,
   /** No slice received in this long → unstable, no matter the jitter.
-   *  Squarely in the VoIP/WebRTC convention for an audio-stream
-   *  timeout (1–2s). */
-  STALL_MS: 1500,
+   *  Upper end of the VoIP/WebRTC convention for an audio-stream
+   *  timeout (1–2s). Bumped from 1500ms in 2026-05 to absorb brief
+   *  GC/JIT stalls without alarming. */
+  STALL_MS: 2200,
 
-  /** Consecutive bad ticks before showing (3s @ 500ms). On the
-   *  conservative end of the Zoom/Meet "unstable" debounce range
-   *  (~1.5–3s). */
-  ESCALATE_TICKS: 6,
+  /** Consecutive bad ticks before showing (6s @ 500ms). Above the
+   *  Zoom/Meet "unstable" debounce range (~1.5–3s) — we lean cautious
+   *  because false alarms erode trust faster than missed ones in this
+   *  app, where the canvas itself visibly degrades during real
+   *  trouble. Bumped from 6 (3s) in 2026-05. */
+  ESCALATE_TICKS: 12,
   /** Consecutive clean ticks before hiding (8s @ 500ms). Asymmetric
    *  ~2.7× the show debounce: easy to dismiss, hard to summon. */
   RECOVERY_TICKS: 16,

--- a/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
@@ -17,6 +17,15 @@ const PALETTE = [
   "#f08a48", // orange
   "#e84f3d", // coral
 ];
+// rgb triplets parsed once at module load — used to build per-frame
+// linear-gradient strokeStyles that fade each ribbon's leading end to
+// alpha 0. Kept in sync with PALETTE by index.
+const PALETTE_RGB: ReadonlyArray<readonly [number, number, number]> = [
+  [0x3d, 0xb6, 0xbe],
+  [0xc7, 0xb5, 0x66],
+  [0xf0, 0x8a, 0x48],
+  [0xe8, 0x4f, 0x3d],
+];
 
 const ALONG = 1000;
 const ACROSS = 100;
@@ -32,35 +41,31 @@ const INWARD_DISTANCE = 8;
 // max --bloom-amount, so 16 px leaves clear headroom on both ends.
 const ALONG_END_INSET_PX = 16;
 
-// "Filled" colored ribbons converge onto a shared meeting point in the
-// last HEAD_CONVERGE_START fraction of their writhe, then each ribbon's
-// path continues into a polar wrap around the halo center — so the four
-// ribbons LITERALLY become the halo at the slider's value position.
-// No separate halo draw call; the wrap is the halo.
-const HEAD_CONVERGE_START = 0.85;
-const HEAD_HALO_BASE_R_PX = 9;
-const HEAD_HALO_KICK_R_PX = 4;
-const HEAD_HALO_RADIAL_SPREAD_PX = 1.1;
-const HEAD_HALO_NOISE_AMP_BASE_PX = 0.9;
-const HEAD_HALO_NOISE_AMP_KICK_PX = 1.6;
-const HEAD_HALO_WRAP_STEPS = 28;
-// Wrap covers ~340° so the ribbon ends just shy of closing back on
-// itself — implies a coil at the thumb position without a visible seam.
-const HEAD_HALO_WRAP_SPAN = Math.PI * 2 * 0.95;
-const HEAD_HALO_FAN_FRACTION = 0.25; // radial offset ramps from 0 over first 25% of wrap
+// Half-revolution curl at each ribbon's leading edge — same geometry
+// as the pre-2026-05 version, restored after the per-ribbon coil and
+// halo-wrap variants were tried and rejected.
+const HEAD_CURL_STEPS = 8;
+const HEAD_CURL_BASE_R = 7;
+const HEAD_CURL_KICK_R = 3;
 
-// Gray "track" ribbons drawn full-length-minus-fill behind the colored
-// fill, so the slider reads as a traditional fill-up-to-value control
-// — but the track is itself moving ribbons, so it's cohesive with the
-// fill rather than a different visual language.
+// Leading-end fade — mirrors the trailing-end's CSS mask fade but
+// tracks the value position. Implemented via a createLinearGradient()
+// strokeStyle so it's a single stroke per ribbon (no sub-stroke alpha
+// juggling). Fade region: from FADE_START_T × drawLen (still full
+// color) → drawLen + FADE_END_EXTRA_PX (transparent), which makes
+// the visible ribbon look ~10% shorter than its drawLen + the curl
+// dissolves cleanly past the fade.
+const LEAD_FADE_START_T = 0.82;
+const LEAD_FADE_END_EXTRA_PX = 18;
+
+// Gray "track" ribbons drawn drawLen..ALONG behind the colored fill so
+// the slider reads as a traditional fill-up-to-value control — but the
+// track is itself moving ribbons, cohesive with the fill rather than a
+// different visual language.
 const TRACK_COLOR = "#5a5a60";
 // Multiplier on the canvas-wide alpha for the track pass — keeps the
 // track subordinate while still letting it breathe with --bloom-amount.
 const TRACK_ALPHA_MUL = 0.42;
-// How long the gray track fans out from the convergence point as the
-// along axis moves away from the halo. Mirrors HEAD_CONVERGE_START so
-// the track's start lines up with where the fill's wrap began.
-const TRACK_FAN_FRACTION = 0.15;
 
 // Floors for ribbon length, defined in types/engine. The side floor
 // is also consumed by DesktopEdgeDrag for the hint head position so
@@ -240,20 +245,11 @@ function viewBoxToCanvas(
   return { x: t.acrossOffset + across * t.sx, y: t.alongOffset + y * t.sy };
 }
 
-/** Unit vector (in canvas-pixel space) the ribbon travels as `along`
- *  increases. The "outboard" direction the halo center sits relative
- *  to the convergence point. */
-function travelDir(bar: RibbonBar): { dx: number; dy: number } {
-  if (bar.horizontal) {
-    return bar.flipAlong ? { dx: -1, dy: 0 } : { dx: 1, dy: 0 };
-  }
-  return bar.flipAlong ? { dx: 0, dy: -1 } : { dx: 0, dy: 1 };
-}
-
-/** Colored "fill" ribbon — 0..drawLen along the bar, converging
- *  laterally at the head, then continuing as a polar wrap around the
- *  halo center so the ribbon literally becomes the halo (no abrupt end,
- *  no separate halo-draw call). One ribbon = one stroked path. */
+/** Colored "fill" ribbon — 0..drawLen along the bar, terminating in
+ *  the original half-revolution curl. Stroked with a per-frame linear
+ *  gradient strokeStyle so the leading end fades to alpha 0 — mirrors
+ *  the trailing-end CSS mask fade but tracks the value position.
+ *  Single beginPath / stroke per ribbon. */
 function drawFillRibbon(
   ctx: CanvasRenderingContext2D,
   progress: number,
@@ -278,71 +274,112 @@ function drawFillRibbon(
     bar.innerSign > 0 ? ACROSS - INWARD_DISTANCE : INWARD_DISTANCE;
   const tform = barTransform(bar, bleedPx);
 
-  ctx.beginPath();
+  // ── Leading-end fade gradient ─────────────────────────────────────
+  // Build a linear gradient along the bar's along axis. Points where
+  // the path falls BEFORE the gradient's start get the first stop
+  // (full color); points AFTER the end get the last stop (transparent).
+  // So the writhe is full color from along=0 to ~82% of drawLen, then
+  // fades to 0 over the next ~18% + the curl extent.
+  const [cr, cg, cb] = PALETTE_RGB[ribbonIdx];
+  let g0x = 0, g0y = 0, g1x = 0, g1y = 0;
+  if (bar.horizontal) {
+    g0x = tform.alongOffset + drawLen * LEAD_FADE_START_T * tform.sx;
+    g1x = tform.alongOffset + drawLen * tform.sx + LEAD_FADE_END_EXTRA_PX;
+  } else if (bar.flipAlong) {
+    // Vertical bar, value end at TOP of canvas (small y).
+    g0y = tform.alongOffset + (ALONG - drawLen * LEAD_FADE_START_T) * tform.sy;
+    g1y = tform.alongOffset + (ALONG - drawLen) * tform.sy - LEAD_FADE_END_EXTRA_PX;
+  } else {
+    g0y = tform.alongOffset + drawLen * LEAD_FADE_START_T * tform.sy;
+    g1y = tform.alongOffset + drawLen * tform.sy + LEAD_FADE_END_EXTRA_PX;
+  }
+  const grad = ctx.createLinearGradient(g0x, g0y, g1x, g1y);
+  grad.addColorStop(0, `rgba(${cr},${cg},${cb},1)`);
+  grad.addColorStop(1, `rgba(${cr},${cg},${cb},0)`);
+  ctx.strokeStyle = grad;
 
-  // PHASE 1 — Writhe from along=0 → drawLen. Over the last
-  // (1 - HEAD_CONVERGE_START) of the writhe, both `lateral` and the
-  // writhe noise taper to 0, so all four ribbons land at exactly
-  // (drawLen, center) — a single shared convergence point.
+  // ── Writhe (full lateral spread, no convergence — pre-2026-05 look) ──
+  ctx.beginPath();
+  let prevVbX = 0,
+    prevVbY = 0,
+    lastVbX = 0,
+    lastVbY = 0;
   for (let i = 0; i <= SEGMENTS; i++) {
     const t = i / SEGMENTS;
     const along = t * drawLen;
     const noise =
       Math.sin(along * 0.012 + time * 1.3 + phase) * 0.7 +
       Math.sin(along * 0.025 - time * 0.9 + phase * 1.4) * 0.3;
-    const convergeT = t < HEAD_CONVERGE_START
-      ? 0
-      : (t - HEAD_CONVERGE_START) / (1 - HEAD_CONVERGE_START);
-    const lateralFactor = 1 - convergeT;
-    const writheFactor = 1 - convergeT; // → 0 at convergence: clean meeting point
-    const across =
-      center + lateral * lateralFactor + noise * writheAmp * writheFactor;
-    const { x, y } = viewBoxToCanvas(bar, tform, along, across);
-    if (i === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
+    const across = center + lateral + noise * writheAmp;
+
+    let vbX: number, vbY: number;
+    if (bar.horizontal) {
+      vbX = along;
+      vbY = across;
+    } else {
+      vbX = across;
+      vbY = bar.flipAlong ? ALONG - along : along;
+    }
+    const px = bar.horizontal
+      ? tform.alongOffset + vbX * tform.sx
+      : tform.acrossOffset + vbX * tform.sx;
+    const py = bar.horizontal
+      ? vbY * tform.sy
+      : tform.alongOffset + vbY * tform.sy;
+    if (i > 0) {
+      prevVbX = lastVbX;
+      prevVbY = lastVbY;
+    }
+    if (i === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
+    lastVbX = vbX;
+    lastVbY = vbY;
   }
 
-  // PHASE 2 — Polar wrap around the halo center. The halo sits
-  // HEAD_HALO radius units outboard of the convergence point, so the
-  // convergence lies on the halo's back perimeter; the ribbon
-  // continues from there, fanning OUT to its concentric radial slot
-  // over the first HEAD_HALO_FAN_FRACTION of the wrap. No moveTo —
-  // same path as phase 1, so the visual transition has no seam.
+  // ── Half-revolution curl at the leading edge (original) ──
+  // Tangent from the writhe's last segment defines the curl plane;
+  // altSign / innerSign alternation gives adjacent ribbons opposite
+  // curl handedness. The gradient strokeStyle fades the curl out as
+  // it extends past drawLen, since the canvas position falls past
+  // the gradient's last stop.
   if (drawLen > 8) {
-    const conv = viewBoxToCanvas(bar, tform, drawLen, center);
-    const dir = travelDir(bar);
-    const haloR = HEAD_HALO_BASE_R_PX + kick * HEAD_HALO_KICK_R_PX;
-    const haloCx = conv.x + dir.dx * haloR;
-    const haloCy = conv.y + dir.dy * haloR;
-    // Angle from halo center pointing BACK at the convergence point.
-    const entryAngle = Math.atan2(-dir.dy, -dir.dx);
-    const radialSlot =
-      (ribbonIdx - (PALETTE.length - 1) / 2) * HEAD_HALO_RADIAL_SPREAD_PX;
-    const wrapWritheAmp =
-      HEAD_HALO_NOISE_AMP_BASE_PX + kick * HEAD_HALO_NOISE_AMP_KICK_PX;
-    const wrapPhase = ribbonIdx * 0.7;
-    const tw = time * 1.3;
-    for (let j = 1; j <= HEAD_HALO_WRAP_STEPS; j++) {
-      const wrapT = j / HEAD_HALO_WRAP_STEPS;
-      const theta = entryAngle + wrapT * HEAD_HALO_WRAP_SPAN;
-      const fanT = Math.min(1, wrapT / HEAD_HALO_FAN_FRACTION);
-      const noise =
-        Math.sin(theta * 3 + tw + wrapPhase) * 0.7 +
-        Math.sin(theta * 7 - tw * 0.7 + wrapPhase * 1.4) * 0.3;
-      const r = haloR + radialSlot * fanT + noise * wrapWritheAmp * fanT;
-      const x = haloCx + r * Math.cos(theta);
-      const y = haloCy + r * Math.sin(theta);
-      ctx.lineTo(x, y);
+    const dx = lastVbX - prevVbX;
+    const dy = lastVbY - prevVbY;
+    const segLen = Math.hypot(dx, dy) || 1;
+    const ux = dx / segLen;
+    const uy = dy / segLen;
+    const altSign = ribbonIdx % 2 === 0 ? 1 : -1;
+    const sign = altSign * (bar.innerSign > 0 ? 1 : -1);
+    const pvx = -uy * sign;
+    const pvy = ux * sign;
+    const rCurl = HEAD_CURL_BASE_R + kick * HEAD_CURL_KICK_R;
+    const cx = lastVbX + pvx * rCurl;
+    const cy = lastVbY + pvy * rCurl;
+    for (let j = 1; j <= HEAD_CURL_STEPS; j++) {
+      const a = (j / HEAD_CURL_STEPS) * Math.PI;
+      const sa = Math.sin(a);
+      const ca = Math.cos(a);
+      const rx = -pvx * ca + ux * sa;
+      const ry = -pvy * ca + uy * sa;
+      const tipAlong = bar.horizontal ? cx + rx * rCurl : cy + ry * rCurl;
+      const tipAcross = bar.horizontal ? cy + ry * rCurl : cx + rx * rCurl;
+      const tipX = bar.horizontal
+        ? tform.alongOffset + tipAlong * tform.sx
+        : tform.acrossOffset + tipAcross * tform.sx;
+      const tipY = bar.horizontal
+        ? tipAcross * tform.sy
+        : tform.alongOffset + tipAlong * tform.sy;
+      ctx.lineTo(tipX, tipY);
     }
   }
   ctx.stroke();
 }
 
-/** Gray "track" ribbon — drawLen..ALONG along the bar, mirroring the
- *  fill ribbon's writhe math so the unfilled portion looks like the
- *  same four ribbons, just dim. Starts at the convergence point
- *  (where the halo lives) and fans BACK OUT to the normal lateral
- *  spread over the first TRACK_FAN_FRACTION of the track. */
+/** Gray "track" ribbon — drawLen..ALONG along the bar. Uses the
+ *  identical writhe math (same noise function, same lateral spread,
+ *  same phase) as drawFillRibbon, so where fill ends and track begins
+ *  the two share the SAME point — no visual seam at the value
+ *  boundary, no special fan-in/fan-out treatment needed. */
 function drawTrackRibbon(
   ctx: CanvasRenderingContext2D,
   progress: number,
@@ -364,9 +401,9 @@ function drawTrackRibbon(
   const center =
     bar.innerSign > 0 ? ACROSS - INWARD_DISTANCE : INWARD_DISTANCE;
   const tform = barTransform(bar, bleedPx);
-  // Density: one segment per ~4% of bar length, floored at 8 so even
-  // a near-maxed slider still has enough segments for the fan-out
-  // arc to look smooth.
+  // Density: roughly proportional to track length, floored at 8 so
+  // a near-maxed slider still has enough segments for the writhe to
+  // read smoothly past the curl region.
   const segs = Math.max(8, Math.round(SEGMENTS * (trackLen / ALONG)));
 
   ctx.beginPath();
@@ -376,10 +413,7 @@ function drawTrackRibbon(
     const noise =
       Math.sin(along * 0.012 + time * 1.3 + phase) * 0.7 +
       Math.sin(along * 0.025 - time * 0.9 + phase * 1.4) * 0.3;
-    const fanT = trackT < TRACK_FAN_FRACTION
-      ? trackT / TRACK_FAN_FRACTION
-      : 1;
-    const across = center + lateral * fanT + noise * writheAmp * fanT;
+    const across = center + lateral + noise * writheAmp;
     const { x, y } = viewBoxToCanvas(bar, tform, along, across);
     if (i === 0) ctx.moveTo(x, y);
     else ctx.lineTo(x, y);
@@ -421,14 +455,12 @@ export function tickRibbons(
       drawTrackRibbon(ctx, fill, i, time, kick, bar, bar.bleedPx);
     }
 
-    // PASS 2 — Colored fill ribbons (0..value), each ending in a
-    // polar wrap around the halo center. The four wraps overlay each
-    // other into a concentric multi-color ring — the slider's thumb
-    // — but it's literally part of each ribbon's path, so the
-    // morph from writhe → halo has no seam.
+    // PASS 2 — Colored fill ribbons (0..value), each terminating in
+    // the original half-revolution curl. Per-ribbon gradient
+    // strokeStyle (set inside drawFillRibbon) fades the leading end
+    // so the curl dissolves rather than ending abruptly.
     ctx.globalAlpha = alpha;
     for (let i = 0; i < PALETTE.length; i++) {
-      ctx.strokeStyle = PALETTE[i];
       drawFillRibbon(ctx, fill, i, time, kick, bar, bar.bleedPx);
     }
     ctx.restore();

--- a/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
@@ -32,18 +32,35 @@ const INWARD_DISTANCE = 8;
 // max --bloom-amount, so 16 px leaves clear headroom on both ends.
 const ALONG_END_INSET_PX = 16;
 
-// Fraction of the writhe along-axis over which the four ribbons collapse
-// onto a shared meeting point. At the meeting point a single multi-color
-// halo (drawConvergenceHalo) plays the role each ribbon's individual
-// "curl" used to — visually unifying the four into one terminator that
-// echoes the HaloBadge.
+// "Filled" colored ribbons converge onto a shared meeting point in the
+// last HEAD_CONVERGE_START fraction of their writhe, then each ribbon's
+// path continues into a polar wrap around the halo center — so the four
+// ribbons LITERALLY become the halo at the slider's value position.
+// No separate halo draw call; the wrap is the halo.
 const HEAD_CONVERGE_START = 0.85;
 const HEAD_HALO_BASE_R_PX = 9;
 const HEAD_HALO_KICK_R_PX = 4;
 const HEAD_HALO_RADIAL_SPREAD_PX = 1.1;
 const HEAD_HALO_NOISE_AMP_BASE_PX = 0.9;
 const HEAD_HALO_NOISE_AMP_KICK_PX = 1.6;
-const HEAD_HALO_SEGMENTS = 36;
+const HEAD_HALO_WRAP_STEPS = 28;
+// Wrap covers ~340° so the ribbon ends just shy of closing back on
+// itself — implies a coil at the thumb position without a visible seam.
+const HEAD_HALO_WRAP_SPAN = Math.PI * 2 * 0.95;
+const HEAD_HALO_FAN_FRACTION = 0.25; // radial offset ramps from 0 over first 25% of wrap
+
+// Gray "track" ribbons drawn full-length-minus-fill behind the colored
+// fill, so the slider reads as a traditional fill-up-to-value control
+// — but the track is itself moving ribbons, so it's cohesive with the
+// fill rather than a different visual language.
+const TRACK_COLOR = "#5a5a60";
+// Multiplier on the canvas-wide alpha for the track pass — keeps the
+// track subordinate while still letting it breathe with --bloom-amount.
+const TRACK_ALPHA_MUL = 0.42;
+// How long the gray track fans out from the convergence point as the
+// along axis moves away from the halo. Mirrors HEAD_CONVERGE_START so
+// the track's start lines up with where the fill's wrap began.
+const TRACK_FAN_FRACTION = 0.15;
 
 // Floors for ribbon length, defined in types/engine. The side floor
 // is also consumed by DesktopEdgeDrag for the hint head position so
@@ -187,7 +204,57 @@ export function destroyRibbons(bars: RibbonBar[]): void {
   }
 }
 
-function drawRibbon(
+/** Canvas-pixel transform for a bar's viewBox. Shared by drawFillRibbon
+ *  and drawTrackRibbon so both ribbons land in identical canvas space. */
+function barTransform(bar: RibbonBar, bleedPx: number) {
+  const alongSize = bar.horizontal ? bar.w : bar.h;
+  const acrossSize = bar.horizontal ? bar.h : bar.w;
+  const hostAcross = Math.max(1, acrossSize - bleedPx);
+  const acrossPerUnit = hostAcross / ACROSS;
+  const alongPerUnit = Math.max(1, alongSize - 2 * ALONG_END_INSET_PX) / ALONG;
+  // The canvas is bleedPx larger than the host on its bleedSide; only
+  // the "left" bleed (right-edge bar) needs an offset on the across
+  // axis. See drawFillRibbon's preserved comment in earlier revisions
+  // for the long version of why.
+  const acrossOffset = bar.bleedSide === "left" ? bleedPx : 0;
+  const alongOffset = ALONG_END_INSET_PX;
+  return {
+    sx: bar.horizontal ? alongPerUnit : acrossPerUnit,
+    sy: bar.horizontal ? acrossPerUnit : alongPerUnit,
+    acrossOffset,
+    alongOffset,
+  };
+}
+
+/** Map a (along, across) viewBox point to canvas-CSS-pixel coords. */
+function viewBoxToCanvas(
+  bar: RibbonBar,
+  t: ReturnType<typeof barTransform>,
+  along: number,
+  across: number,
+): { x: number; y: number } {
+  if (bar.horizontal) {
+    return { x: t.alongOffset + along * t.sx, y: across * t.sy };
+  }
+  const y = bar.flipAlong ? ALONG - along : along;
+  return { x: t.acrossOffset + across * t.sx, y: t.alongOffset + y * t.sy };
+}
+
+/** Unit vector (in canvas-pixel space) the ribbon travels as `along`
+ *  increases. The "outboard" direction the halo center sits relative
+ *  to the convergence point. */
+function travelDir(bar: RibbonBar): { dx: number; dy: number } {
+  if (bar.horizontal) {
+    return bar.flipAlong ? { dx: -1, dy: 0 } : { dx: 1, dy: 0 };
+  }
+  return bar.flipAlong ? { dx: 0, dy: -1 } : { dx: 0, dy: 1 };
+}
+
+/** Colored "fill" ribbon — 0..drawLen along the bar, converging
+ *  laterally at the head, then continuing as a polar wrap around the
+ *  halo center so the ribbon literally becomes the halo (no abrupt end,
+ *  no separate halo-draw call). One ribbon = one stroked path. */
+function drawFillRibbon(
   ctx: CanvasRenderingContext2D,
   progress: number,
   ribbonIdx: number,
@@ -209,111 +276,77 @@ function drawRibbon(
   const writheAmp = NOISE_AMP_BASE + kick * NOISE_AMP_KICK;
   const center =
     bar.innerSign > 0 ? ACROSS - INWARD_DISTANCE : INWARD_DISTANCE;
-
-  // The canvas is bleedPx larger than the host on its bleedSide. Map the
-  // viewBox so the ACROSS axis fills only the host content area; values
-  // past 0..ACROSS land in the bleed pixels (which is exactly where the
-  // writhing curls want to go).
-  const alongSize = bar.horizontal ? bar.w : bar.h;
-  const acrossSize = bar.horizontal ? bar.h : bar.w;
-  const hostAcross = Math.max(1, acrossSize - bleedPx);
-  const acrossPerUnit = hostAcross / ACROSS;
-  // Where viewBox across=0 maps to in canvas pixels. For "top" / "left" /
-  // "right", bleed lives on the inward side of the host, so across=0
-  // (the outer side) is at the canvas edge — except the right bar has
-  // its bleed on the left, so across=0 (bar's left = host's left edge,
-  // which is in the central gutter, beyond the inner side's bleed) needs
-  // to start at canvas_x = bleedPx, then increase toward the screen edge
-  // (across=100 = bar's right edge).
-  // ── wait: the right bar has innerSign=-1 (inner side at across=8), and
-  //    we want across=0 at the host's left edge (which IS the inner side
-  //    visually, in the central gutter). The CSS for .install-edge-right
-  //    pins the host with right:0, so the bar's right edge in CSS is the
-  //    screen's right edge (across=100 in viewBox), and the bar's left
-  //    edge (across=0 in viewBox) is hud-thickness inward. The canvas
-  //    extends LEFT of the bar by bleedPx — so canvas_x=0 is bleedPx
-  //    leftward of the bar's left edge (deeper into the central gutter).
-  //    Therefore across=0 → canvas_x = bleedPx. across=100 → canvas_x =
-  //    bleedPx + hostAcross = bar.w. across=-something (writhe curling
-  //    further inward) → canvas_x < bleedPx (into the bleed zone). ✓
-  const acrossOffset = bar.bleedSide === "left" ? bleedPx : 0;
-  // Same idea as acrossOffset but on the along axis: the writhe path's
-  // first and last points (along=0 and along=ALONG) would sit flush with
-  // the canvas bitmap edge, so the stroke half-width + drop-shadow halo
-  // get sliced. Inset both ends by ALONG_END_INSET_PX to give them room.
-  const hostAlong = Math.max(1, alongSize - 2 * ALONG_END_INSET_PX);
-  const alongPerUnit = hostAlong / ALONG;
-  const alongOffset = ALONG_END_INSET_PX;
-  const sx = bar.horizontal ? alongPerUnit : acrossPerUnit;
-  const sy = bar.horizontal ? acrossPerUnit : alongPerUnit;
+  const tform = barTransform(bar, bleedPx);
 
   ctx.beginPath();
+
+  // PHASE 1 — Writhe from along=0 → drawLen. Over the last
+  // (1 - HEAD_CONVERGE_START) of the writhe, both `lateral` and the
+  // writhe noise taper to 0, so all four ribbons land at exactly
+  // (drawLen, center) — a single shared convergence point.
   for (let i = 0; i <= SEGMENTS; i++) {
     const t = i / SEGMENTS;
     const along = t * drawLen;
     const noise =
       Math.sin(along * 0.012 + time * 1.3 + phase) * 0.7 +
       Math.sin(along * 0.025 - time * 0.9 + phase * 1.4) * 0.3;
-    // Converge the four ribbons toward a shared meeting point over the
-    // last ~15% of the bar so the per-ribbon `lateral` spread closes to
-    // zero at the head. Writhe amplitude also tapers so the meeting
-    // point reads as a clean focal point (the halo, drawn separately
-    // by drawConvergenceHalo, lives there).
     const convergeT = t < HEAD_CONVERGE_START
       ? 0
       : (t - HEAD_CONVERGE_START) / (1 - HEAD_CONVERGE_START);
     const lateralFactor = 1 - convergeT;
-    const writheFactor = 1 - convergeT * 0.85;
+    const writheFactor = 1 - convergeT; // → 0 at convergence: clean meeting point
     const across =
       center + lateral * lateralFactor + noise * writheAmp * writheFactor;
-
-    let x: number, y: number;
-    if (bar.horizontal) {
-      x = along;
-      y = across;
-    } else {
-      x = across;
-      y = bar.flipAlong ? ALONG - along : along;
-    }
-    // For horizontal bars, the across axis is y; for vertical bars, it's
-    // x. Apply the bleed offset to whichever one is the across axis (only
-    // matters when bleedSide === "left" → right-edge bar). The along
-    // offset packs the writhe inside ALONG_END_INSET_PX of margin on
-    // both ends so strokes don't get clipped at the canvas bitmap edge.
-    const px = bar.horizontal ? alongOffset + x * sx : acrossOffset + x * sx;
-    const py = bar.horizontal ? y * sy : alongOffset + y * sy;
-    if (i === 0) ctx.moveTo(px, py);
-    else ctx.lineTo(px, py);
+    const { x, y } = viewBoxToCanvas(bar, tform, along, across);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
   }
 
-  // No per-ribbon terminator here anymore — the four ribbons collapse
-  // toward a shared meeting point via the HEAD_CONVERGE_START taper in
-  // the loop above, and drawConvergenceHalo (called once per bar after
-  // all four palette passes) paints a single multi-color halo at that
-  // meeting point — same visual language as the HaloBadge, scaled down.
+  // PHASE 2 — Polar wrap around the halo center. The halo sits
+  // HEAD_HALO radius units outboard of the convergence point, so the
+  // convergence lies on the halo's back perimeter; the ribbon
+  // continues from there, fanning OUT to its concentric radial slot
+  // over the first HEAD_HALO_FAN_FRACTION of the wrap. No moveTo —
+  // same path as phase 1, so the visual transition has no seam.
+  if (drawLen > 8) {
+    const conv = viewBoxToCanvas(bar, tform, drawLen, center);
+    const dir = travelDir(bar);
+    const haloR = HEAD_HALO_BASE_R_PX + kick * HEAD_HALO_KICK_R_PX;
+    const haloCx = conv.x + dir.dx * haloR;
+    const haloCy = conv.y + dir.dy * haloR;
+    // Angle from halo center pointing BACK at the convergence point.
+    const entryAngle = Math.atan2(-dir.dy, -dir.dx);
+    const radialSlot =
+      (ribbonIdx - (PALETTE.length - 1) / 2) * HEAD_HALO_RADIAL_SPREAD_PX;
+    const wrapWritheAmp =
+      HEAD_HALO_NOISE_AMP_BASE_PX + kick * HEAD_HALO_NOISE_AMP_KICK_PX;
+    const wrapPhase = ribbonIdx * 0.7;
+    const tw = time * 1.3;
+    for (let j = 1; j <= HEAD_HALO_WRAP_STEPS; j++) {
+      const wrapT = j / HEAD_HALO_WRAP_STEPS;
+      const theta = entryAngle + wrapT * HEAD_HALO_WRAP_SPAN;
+      const fanT = Math.min(1, wrapT / HEAD_HALO_FAN_FRACTION);
+      const noise =
+        Math.sin(theta * 3 + tw + wrapPhase) * 0.7 +
+        Math.sin(theta * 7 - tw * 0.7 + wrapPhase * 1.4) * 0.3;
+      const r = haloR + radialSlot * fanT + noise * wrapWritheAmp * fanT;
+      const x = haloCx + r * Math.cos(theta);
+      const y = haloCy + r * Math.sin(theta);
+      ctx.lineTo(x, y);
+    }
+  }
   ctx.stroke();
 }
 
-/** Where the four ribbons converge, in viewBox (ALONG/ACROSS) units. */
-function convergencePoint(bar: RibbonBar, progress: number): { along: number; across: number } {
-  const drawProgress = bar.horizontal
-    ? Math.max(progress, REMIX_VISIBLE_FLOOR)
-    : Math.max(progress, LORA_SIDE_VISIBLE_FLOOR);
-  const drawLen = drawProgress * ALONG;
-  const center =
-    bar.innerSign > 0 ? ACROSS - INWARD_DISTANCE : INWARD_DISTANCE;
-  return { along: drawLen, across: center };
-}
-
-/** Single shared halo at the bar's leading edge — polar writhe in the
- *  same trig-noise language as HaloBadge, scaled to a small terminator
- *  ring that visually swallows the four ribbon ends. Drawn ONCE per
- *  bar after all four ribbons have been stroked. Radius/spread are in
- *  canvas CSS pixels (not viewBox units) so the ring stays circular
- *  regardless of the host's aspect ratio. */
-function drawConvergenceHalo(
+/** Gray "track" ribbon — drawLen..ALONG along the bar, mirroring the
+ *  fill ribbon's writhe math so the unfilled portion looks like the
+ *  same four ribbons, just dim. Starts at the convergence point
+ *  (where the halo lives) and fans BACK OUT to the normal lateral
+ *  spread over the first TRACK_FAN_FRACTION of the track. */
+function drawTrackRibbon(
   ctx: CanvasRenderingContext2D,
   progress: number,
+  ribbonIdx: number,
   time: number,
   kick: number,
   bar: RibbonBar,
@@ -322,53 +355,36 @@ function drawConvergenceHalo(
   const drawProgress = bar.horizontal
     ? Math.max(progress, REMIX_VISIBLE_FLOOR)
     : Math.max(progress, LORA_SIDE_VISIBLE_FLOOR);
-  if (drawProgress < 0.01) return;
+  const drawLen = drawProgress * ALONG;
+  const trackLen = ALONG - drawLen;
+  if (trackLen <= 1) return; // slider essentially maxed — no track to draw
+  const lateral = (ribbonIdx - (PALETTE.length - 1) / 2) * RIBBON_SPACING;
+  const phase = ribbonIdx * 0.8;
+  const writheAmp = NOISE_AMP_BASE + kick * NOISE_AMP_KICK;
+  const center =
+    bar.innerSign > 0 ? ACROSS - INWARD_DISTANCE : INWARD_DISTANCE;
+  const tform = barTransform(bar, bleedPx);
+  // Density: one segment per ~4% of bar length, floored at 8 so even
+  // a near-maxed slider still has enough segments for the fan-out
+  // arc to look smooth.
+  const segs = Math.max(8, Math.round(SEGMENTS * (trackLen / ALONG)));
 
-  const { along, across } = convergencePoint(bar, progress);
-
-  const alongSize = bar.horizontal ? bar.w : bar.h;
-  const acrossSize = bar.horizontal ? bar.h : bar.w;
-  const hostAcross = Math.max(1, acrossSize - bleedPx);
-  const acrossPerUnit = hostAcross / ACROSS;
-  const alongPerUnit = Math.max(1, alongSize - 2 * ALONG_END_INSET_PX) / ALONG;
-  const acrossOffset = bar.bleedSide === "left" ? bleedPx : 0;
-  const alongOffset = ALONG_END_INSET_PX;
-  const sx = bar.horizontal ? alongPerUnit : acrossPerUnit;
-  const sy = bar.horizontal ? acrossPerUnit : alongPerUnit;
-
-  // Map the convergence point from viewBox space to canvas CSS pixels
-  // using the same transform the writhe loop uses, so the halo lands
-  // exactly where the four ribbon ends do.
-  const cxPx = bar.horizontal
-    ? alongOffset + along * sx
-    : acrossOffset + across * sx;
-  const cyPx = bar.horizontal
-    ? across * sy
-    : alongOffset + along * sy;
-
-  const baseR = HEAD_HALO_BASE_R_PX + kick * HEAD_HALO_KICK_R_PX;
-  const writheAmp = HEAD_HALO_NOISE_AMP_BASE_PX + kick * HEAD_HALO_NOISE_AMP_KICK_PX;
-  const segs = HEAD_HALO_SEGMENTS;
-  for (let i = 0; i < PALETTE.length; i++) {
-    ctx.strokeStyle = PALETTE[i];
-    const phase = i * 0.7;
-    const radialOffset = (i - (PALETTE.length - 1) / 2) * HEAD_HALO_RADIAL_SPREAD_PX;
-    const t = time * 1.3;
-    ctx.beginPath();
-    for (let j = 0; j <= segs; j++) {
-      const theta = (j / segs) * Math.PI * 2;
-      const noise =
-        Math.sin(theta * 3 + t + phase) * 0.7 +
-        Math.sin(theta * 7 - t * 0.7 + phase * 1.4) * 0.3;
-      const r = baseR + radialOffset + noise * writheAmp;
-      const x = cxPx + r * Math.cos(theta);
-      const y = cyPx + r * Math.sin(theta);
-      if (j === 0) ctx.moveTo(x, y);
-      else ctx.lineTo(x, y);
-    }
-    ctx.closePath();
-    ctx.stroke();
+  ctx.beginPath();
+  for (let i = 0; i <= segs; i++) {
+    const trackT = i / segs;
+    const along = drawLen + trackT * trackLen;
+    const noise =
+      Math.sin(along * 0.012 + time * 1.3 + phase) * 0.7 +
+      Math.sin(along * 0.025 - time * 0.9 + phase * 1.4) * 0.3;
+    const fanT = trackT < TRACK_FAN_FRACTION
+      ? trackT / TRACK_FAN_FRACTION
+      : 1;
+    const across = center + lateral * fanT + noise * writheAmp * fanT;
+    const { x, y } = viewBoxToCanvas(bar, tform, along, across);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
   }
+  ctx.stroke();
 }
 
 export function tickRibbons(
@@ -393,15 +409,28 @@ export function tickRibbons(
     ctx.lineCap = "round";
     ctx.lineJoin = "round";
     ctx.lineWidth = lineWidthPx;
+
+    // PASS 1 — Gray track ribbons (unfilled portion of the slider).
+    // Painted FIRST so the colored fill + halo wrap render on top.
+    // Same four-ribbon writhe language as the fill, just dim; reads
+    // as "this is the rail of the slider," cohesive with the active
+    // portion.
+    ctx.globalAlpha = alpha * TRACK_ALPHA_MUL;
+    ctx.strokeStyle = TRACK_COLOR;
+    for (let i = 0; i < PALETTE.length; i++) {
+      drawTrackRibbon(ctx, fill, i, time, kick, bar, bar.bleedPx);
+    }
+
+    // PASS 2 — Colored fill ribbons (0..value), each ending in a
+    // polar wrap around the halo center. The four wraps overlay each
+    // other into a concentric multi-color ring — the slider's thumb
+    // — but it's literally part of each ribbon's path, so the
+    // morph from writhe → halo has no seam.
     ctx.globalAlpha = alpha;
     for (let i = 0; i < PALETTE.length; i++) {
       ctx.strokeStyle = PALETTE[i];
-      drawRibbon(ctx, fill, i, time, kick, bar, bar.bleedPx);
+      drawFillRibbon(ctx, fill, i, time, kick, bar, bar.bleedPx);
     }
-    // After all four palette passes: one shared multi-color halo at
-    // the convergence point, painted in the same pass so it inherits
-    // the same lineWidth / lineCap / globalAlpha context.
-    drawConvergenceHalo(ctx, fill, time, kick, bar, bar.bleedPx);
     ctx.restore();
   }
 }

--- a/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
@@ -272,7 +272,15 @@ function drawRibbon(
     lastY = y;
   }
 
-  // Curling arrowhead at the leading edge (in viewBox space, then scaled).
+  // Coiled tail at the leading edge — replaces the old half-revolution
+  // "arrowhead curl" with a near-full logarithmic spiral. Stays purely
+  // stroke-based (no filled disk) so it reads as ribbon-material that
+  // happens to be wrapping itself, not a separate UI part stuck on the
+  // end. A 315° sweep stops short of closing back on itself, and a mild
+  // inward radius taper makes the loop look like it's actually coiling
+  // around something graspable. Same audio-reactive r so the coil still
+  // breathes with the kick. altSign / innerSign alternation kept so
+  // adjacent ribbons coil opposite ways (each color gets its own thumb).
   if (drawLen > 8) {
     const dx = lastX - prevX;
     const dy = lastY - prevY;
@@ -286,18 +294,25 @@ function drawRibbon(
     const r = 7 + kick * 3;
     const cx = lastX + px * r;
     const cy = lastY + py * r;
-    const curlSteps = 8;
+    const curlSteps = 24;
+    const curlSweep = Math.PI * 1.75; // 315° — close-but-not-closed loop
     for (let j = 1; j <= curlSteps; j++) {
-      const a = (j / curlSteps) * Math.PI;
+      const t = j / curlSteps;
+      const a = t * curlSweep;
       const sa = Math.sin(a);
       const ca = Math.cos(a);
+      // Logarithmic inward taper: tip orbits cx,cy at a shrinking
+      // radius so the coil tightens as it wraps. 0.18 keeps the taper
+      // gentle enough that the loop's "almost-a-ring" silhouette
+      // survives at the smallest kick values.
+      const rEff = r * (1 - 0.18 * t);
       const rx = -px * ca + ux * sa;
       const ry = -py * ca + uy * sa;
-      // The arrowhead tip lives in viewBox space as (cx + rx*r, cy + ry*r).
+      // The coil tip lives in viewBox space as (cx + rx*rEff, cy + ry*rEff).
       // For a horizontal bar this is (along, across); for vertical bars it's
       // (across, along). Match the same axis-aware offset as above.
-      const tipAlong = bar.horizontal ? cx + rx * r : cy + ry * r;
-      const tipAcross = bar.horizontal ? cy + ry * r : cx + rx * r;
+      const tipAlong = bar.horizontal ? cx + rx * rEff : cy + ry * rEff;
+      const tipAcross = bar.horizontal ? cy + ry * rEff : cx + rx * rEff;
       const tipX = bar.horizontal
         ? alongOffset + tipAlong * sx
         : acrossOffset + tipAcross * sx;
@@ -306,8 +321,31 @@ function drawRibbon(
         : alongOffset + tipAlong * sy;
       ctx.lineTo(tipX, tipY);
     }
+    ctx.stroke();
+
+    // Kick-gated shimmer dot at the coil's geometric center. Implies
+    // mass / something graspable inside the loop, but only on strong
+    // hits so the resting state stays pure-ribbon. Cheap: one extra
+    // fill() per ribbon per high-kick frame; uses the same palette
+    // color the stroke already used.
+    if (kick > 0.55) {
+      const dotAlong = bar.horizontal ? cx : cy;
+      const dotAcross = bar.horizontal ? cy : cx;
+      const dotPxX = bar.horizontal
+        ? alongOffset + dotAlong * sx
+        : acrossOffset + dotAcross * sx;
+      const dotPxY = bar.horizontal
+        ? dotAcross * sy
+        : alongOffset + dotAlong * sy;
+      const dotR = r * 0.28 * Math.min(sx, sy);
+      ctx.beginPath();
+      ctx.arc(dotPxX, dotPxY, dotR, 0, Math.PI * 2);
+      ctx.fillStyle = ctx.strokeStyle as string;
+      ctx.fill();
+    }
+  } else {
+    ctx.stroke();
   }
-  ctx.stroke();
 }
 
 export function tickRibbons(

--- a/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
@@ -32,6 +32,19 @@ const INWARD_DISTANCE = 8;
 // max --bloom-amount, so 16 px leaves clear headroom on both ends.
 const ALONG_END_INSET_PX = 16;
 
+// Fraction of the writhe along-axis over which the four ribbons collapse
+// onto a shared meeting point. At the meeting point a single multi-color
+// halo (drawConvergenceHalo) plays the role each ribbon's individual
+// "curl" used to — visually unifying the four into one terminator that
+// echoes the HaloBadge.
+const HEAD_CONVERGE_START = 0.85;
+const HEAD_HALO_BASE_R_PX = 9;
+const HEAD_HALO_KICK_R_PX = 4;
+const HEAD_HALO_RADIAL_SPREAD_PX = 1.1;
+const HEAD_HALO_NOISE_AMP_BASE_PX = 0.9;
+const HEAD_HALO_NOISE_AMP_KICK_PX = 1.6;
+const HEAD_HALO_SEGMENTS = 36;
+
 // Floors for ribbon length, defined in types/engine. The side floor
 // is also consumed by DesktopEdgeDrag for the hint head position so
 // the hint stays attached to the ribbon's visible end. The top floor
@@ -235,17 +248,24 @@ function drawRibbon(
   const sy = bar.horizontal ? acrossPerUnit : alongPerUnit;
 
   ctx.beginPath();
-  let prevX = 0,
-    prevY = 0,
-    lastX = 0,
-    lastY = 0;
   for (let i = 0; i <= SEGMENTS; i++) {
     const t = i / SEGMENTS;
     const along = t * drawLen;
     const noise =
       Math.sin(along * 0.012 + time * 1.3 + phase) * 0.7 +
       Math.sin(along * 0.025 - time * 0.9 + phase * 1.4) * 0.3;
-    const across = center + lateral + noise * writheAmp;
+    // Converge the four ribbons toward a shared meeting point over the
+    // last ~15% of the bar so the per-ribbon `lateral` spread closes to
+    // zero at the head. Writhe amplitude also tapers so the meeting
+    // point reads as a clean focal point (the halo, drawn separately
+    // by drawConvergenceHalo, lives there).
+    const convergeT = t < HEAD_CONVERGE_START
+      ? 0
+      : (t - HEAD_CONVERGE_START) / (1 - HEAD_CONVERGE_START);
+    const lateralFactor = 1 - convergeT;
+    const writheFactor = 1 - convergeT * 0.85;
+    const across =
+      center + lateral * lateralFactor + noise * writheAmp * writheFactor;
 
     let x: number, y: number;
     if (bar.horizontal) {
@@ -262,88 +282,91 @@ function drawRibbon(
     // both ends so strokes don't get clipped at the canvas bitmap edge.
     const px = bar.horizontal ? alongOffset + x * sx : acrossOffset + x * sx;
     const py = bar.horizontal ? y * sy : alongOffset + y * sy;
-    if (i > 0) {
-      prevX = lastX;
-      prevY = lastY;
-    }
     if (i === 0) ctx.moveTo(px, py);
     else ctx.lineTo(px, py);
-    lastX = x;
-    lastY = y;
   }
 
-  // Coiled tail at the leading edge — replaces the old half-revolution
-  // "arrowhead curl" with a near-full logarithmic spiral. Stays purely
-  // stroke-based (no filled disk) so it reads as ribbon-material that
-  // happens to be wrapping itself, not a separate UI part stuck on the
-  // end. A 315° sweep stops short of closing back on itself, and a mild
-  // inward radius taper makes the loop look like it's actually coiling
-  // around something graspable. Same audio-reactive r so the coil still
-  // breathes with the kick. altSign / innerSign alternation kept so
-  // adjacent ribbons coil opposite ways (each color gets its own thumb).
-  if (drawLen > 8) {
-    const dx = lastX - prevX;
-    const dy = lastY - prevY;
-    const segLen = Math.hypot(dx, dy) || 1;
-    const ux = dx / segLen;
-    const uy = dy / segLen;
-    const altSign = ribbonIdx % 2 === 0 ? 1 : -1;
-    const sign = altSign * (bar.innerSign > 0 ? 1 : -1);
-    const px = -uy * sign;
-    const py = ux * sign;
-    const r = 7 + kick * 3;
-    const cx = lastX + px * r;
-    const cy = lastY + py * r;
-    const curlSteps = 24;
-    const curlSweep = Math.PI * 1.75; // 315° — close-but-not-closed loop
-    for (let j = 1; j <= curlSteps; j++) {
-      const t = j / curlSteps;
-      const a = t * curlSweep;
-      const sa = Math.sin(a);
-      const ca = Math.cos(a);
-      // Logarithmic inward taper: tip orbits cx,cy at a shrinking
-      // radius so the coil tightens as it wraps. 0.18 keeps the taper
-      // gentle enough that the loop's "almost-a-ring" silhouette
-      // survives at the smallest kick values.
-      const rEff = r * (1 - 0.18 * t);
-      const rx = -px * ca + ux * sa;
-      const ry = -py * ca + uy * sa;
-      // The coil tip lives in viewBox space as (cx + rx*rEff, cy + ry*rEff).
-      // For a horizontal bar this is (along, across); for vertical bars it's
-      // (across, along). Match the same axis-aware offset as above.
-      const tipAlong = bar.horizontal ? cx + rx * rEff : cy + ry * rEff;
-      const tipAcross = bar.horizontal ? cy + ry * rEff : cx + rx * rEff;
-      const tipX = bar.horizontal
-        ? alongOffset + tipAlong * sx
-        : acrossOffset + tipAcross * sx;
-      const tipY = bar.horizontal
-        ? tipAcross * sy
-        : alongOffset + tipAlong * sy;
-      ctx.lineTo(tipX, tipY);
-    }
-    ctx.stroke();
+  // No per-ribbon terminator here anymore — the four ribbons collapse
+  // toward a shared meeting point via the HEAD_CONVERGE_START taper in
+  // the loop above, and drawConvergenceHalo (called once per bar after
+  // all four palette passes) paints a single multi-color halo at that
+  // meeting point — same visual language as the HaloBadge, scaled down.
+  ctx.stroke();
+}
 
-    // Kick-gated shimmer dot at the coil's geometric center. Implies
-    // mass / something graspable inside the loop, but only on strong
-    // hits so the resting state stays pure-ribbon. Cheap: one extra
-    // fill() per ribbon per high-kick frame; uses the same palette
-    // color the stroke already used.
-    if (kick > 0.55) {
-      const dotAlong = bar.horizontal ? cx : cy;
-      const dotAcross = bar.horizontal ? cy : cx;
-      const dotPxX = bar.horizontal
-        ? alongOffset + dotAlong * sx
-        : acrossOffset + dotAcross * sx;
-      const dotPxY = bar.horizontal
-        ? dotAcross * sy
-        : alongOffset + dotAlong * sy;
-      const dotR = r * 0.28 * Math.min(sx, sy);
-      ctx.beginPath();
-      ctx.arc(dotPxX, dotPxY, dotR, 0, Math.PI * 2);
-      ctx.fillStyle = ctx.strokeStyle as string;
-      ctx.fill();
+/** Where the four ribbons converge, in viewBox (ALONG/ACROSS) units. */
+function convergencePoint(bar: RibbonBar, progress: number): { along: number; across: number } {
+  const drawProgress = bar.horizontal
+    ? Math.max(progress, REMIX_VISIBLE_FLOOR)
+    : Math.max(progress, LORA_SIDE_VISIBLE_FLOOR);
+  const drawLen = drawProgress * ALONG;
+  const center =
+    bar.innerSign > 0 ? ACROSS - INWARD_DISTANCE : INWARD_DISTANCE;
+  return { along: drawLen, across: center };
+}
+
+/** Single shared halo at the bar's leading edge — polar writhe in the
+ *  same trig-noise language as HaloBadge, scaled to a small terminator
+ *  ring that visually swallows the four ribbon ends. Drawn ONCE per
+ *  bar after all four ribbons have been stroked. Radius/spread are in
+ *  canvas CSS pixels (not viewBox units) so the ring stays circular
+ *  regardless of the host's aspect ratio. */
+function drawConvergenceHalo(
+  ctx: CanvasRenderingContext2D,
+  progress: number,
+  time: number,
+  kick: number,
+  bar: RibbonBar,
+  bleedPx: number,
+): void {
+  const drawProgress = bar.horizontal
+    ? Math.max(progress, REMIX_VISIBLE_FLOOR)
+    : Math.max(progress, LORA_SIDE_VISIBLE_FLOOR);
+  if (drawProgress < 0.01) return;
+
+  const { along, across } = convergencePoint(bar, progress);
+
+  const alongSize = bar.horizontal ? bar.w : bar.h;
+  const acrossSize = bar.horizontal ? bar.h : bar.w;
+  const hostAcross = Math.max(1, acrossSize - bleedPx);
+  const acrossPerUnit = hostAcross / ACROSS;
+  const alongPerUnit = Math.max(1, alongSize - 2 * ALONG_END_INSET_PX) / ALONG;
+  const acrossOffset = bar.bleedSide === "left" ? bleedPx : 0;
+  const alongOffset = ALONG_END_INSET_PX;
+  const sx = bar.horizontal ? alongPerUnit : acrossPerUnit;
+  const sy = bar.horizontal ? acrossPerUnit : alongPerUnit;
+
+  // Map the convergence point from viewBox space to canvas CSS pixels
+  // using the same transform the writhe loop uses, so the halo lands
+  // exactly where the four ribbon ends do.
+  const cxPx = bar.horizontal
+    ? alongOffset + along * sx
+    : acrossOffset + across * sx;
+  const cyPx = bar.horizontal
+    ? across * sy
+    : alongOffset + along * sy;
+
+  const baseR = HEAD_HALO_BASE_R_PX + kick * HEAD_HALO_KICK_R_PX;
+  const writheAmp = HEAD_HALO_NOISE_AMP_BASE_PX + kick * HEAD_HALO_NOISE_AMP_KICK_PX;
+  const segs = HEAD_HALO_SEGMENTS;
+  for (let i = 0; i < PALETTE.length; i++) {
+    ctx.strokeStyle = PALETTE[i];
+    const phase = i * 0.7;
+    const radialOffset = (i - (PALETTE.length - 1) / 2) * HEAD_HALO_RADIAL_SPREAD_PX;
+    const t = time * 1.3;
+    ctx.beginPath();
+    for (let j = 0; j <= segs; j++) {
+      const theta = (j / segs) * Math.PI * 2;
+      const noise =
+        Math.sin(theta * 3 + t + phase) * 0.7 +
+        Math.sin(theta * 7 - t * 0.7 + phase * 1.4) * 0.3;
+      const r = baseR + radialOffset + noise * writheAmp;
+      const x = cxPx + r * Math.cos(theta);
+      const y = cyPx + r * Math.sin(theta);
+      if (j === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
     }
-  } else {
+    ctx.closePath();
     ctx.stroke();
   }
 }
@@ -375,6 +398,10 @@ export function tickRibbons(
       ctx.strokeStyle = PALETTE[i];
       drawRibbon(ctx, fill, i, time, kick, bar, bar.bleedPx);
     }
+    // After all four palette passes: one shared multi-color halo at
+    // the convergence point, painted in the same pass so it inherits
+    // the same lineWidth / lineCap / globalAlpha context.
+    drawConvergenceHalo(ctx, fill, time, kick, bar, bar.bleedPx);
     ctx.restore();
   }
 }

--- a/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/ribbons.ts
@@ -17,15 +17,6 @@ const PALETTE = [
   "#f08a48", // orange
   "#e84f3d", // coral
 ];
-// rgb triplets parsed once at module load — used to build per-frame
-// linear-gradient strokeStyles that fade each ribbon's leading end to
-// alpha 0. Kept in sync with PALETTE by index.
-const PALETTE_RGB: ReadonlyArray<readonly [number, number, number]> = [
-  [0x3d, 0xb6, 0xbe],
-  [0xc7, 0xb5, 0x66],
-  [0xf0, 0x8a, 0x48],
-  [0xe8, 0x4f, 0x3d],
-];
 
 const ALONG = 1000;
 const ACROSS = 100;
@@ -47,16 +38,6 @@ const ALONG_END_INSET_PX = 16;
 const HEAD_CURL_STEPS = 8;
 const HEAD_CURL_BASE_R = 7;
 const HEAD_CURL_KICK_R = 3;
-
-// Leading-end fade — mirrors the trailing-end's CSS mask fade but
-// tracks the value position. Implemented via a createLinearGradient()
-// strokeStyle so it's a single stroke per ribbon (no sub-stroke alpha
-// juggling). Fade region: from FADE_START_T × drawLen (still full
-// color) → drawLen + FADE_END_EXTRA_PX (transparent), which makes
-// the visible ribbon look ~10% shorter than its drawLen + the curl
-// dissolves cleanly past the fade.
-const LEAD_FADE_START_T = 0.82;
-const LEAD_FADE_END_EXTRA_PX = 18;
 
 // Gray "track" ribbons drawn drawLen..ALONG behind the colored fill so
 // the slider reads as a traditional fill-up-to-value control — but the
@@ -246,10 +227,10 @@ function viewBoxToCanvas(
 }
 
 /** Colored "fill" ribbon — 0..drawLen along the bar, terminating in
- *  the original half-revolution curl. Stroked with a per-frame linear
- *  gradient strokeStyle so the leading end fades to alpha 0 — mirrors
- *  the trailing-end CSS mask fade but tracks the value position.
- *  Single beginPath / stroke per ribbon. */
+ *  the original half-revolution curl. Uses the strokeStyle set by the
+ *  caller (one of the PALETTE colors). The leading edge is SOLID; the
+ *  far end of the bar fades via the .install-ribbons CSS mask in
+ *  globals.css. Single beginPath / stroke per ribbon. */
 function drawFillRibbon(
   ctx: CanvasRenderingContext2D,
   progress: number,
@@ -273,30 +254,6 @@ function drawFillRibbon(
   const center =
     bar.innerSign > 0 ? ACROSS - INWARD_DISTANCE : INWARD_DISTANCE;
   const tform = barTransform(bar, bleedPx);
-
-  // ── Leading-end fade gradient ─────────────────────────────────────
-  // Build a linear gradient along the bar's along axis. Points where
-  // the path falls BEFORE the gradient's start get the first stop
-  // (full color); points AFTER the end get the last stop (transparent).
-  // So the writhe is full color from along=0 to ~82% of drawLen, then
-  // fades to 0 over the next ~18% + the curl extent.
-  const [cr, cg, cb] = PALETTE_RGB[ribbonIdx];
-  let g0x = 0, g0y = 0, g1x = 0, g1y = 0;
-  if (bar.horizontal) {
-    g0x = tform.alongOffset + drawLen * LEAD_FADE_START_T * tform.sx;
-    g1x = tform.alongOffset + drawLen * tform.sx + LEAD_FADE_END_EXTRA_PX;
-  } else if (bar.flipAlong) {
-    // Vertical bar, value end at TOP of canvas (small y).
-    g0y = tform.alongOffset + (ALONG - drawLen * LEAD_FADE_START_T) * tform.sy;
-    g1y = tform.alongOffset + (ALONG - drawLen) * tform.sy - LEAD_FADE_END_EXTRA_PX;
-  } else {
-    g0y = tform.alongOffset + drawLen * LEAD_FADE_START_T * tform.sy;
-    g1y = tform.alongOffset + drawLen * tform.sy + LEAD_FADE_END_EXTRA_PX;
-  }
-  const grad = ctx.createLinearGradient(g0x, g0y, g1x, g1y);
-  grad.addColorStop(0, `rgba(${cr},${cg},${cb},1)`);
-  grad.addColorStop(1, `rgba(${cr},${cg},${cb},0)`);
-  ctx.strokeStyle = grad;
 
   // ── Writhe (full lateral spread, no convergence — pre-2026-05 look) ──
   ctx.beginPath();
@@ -456,11 +413,12 @@ export function tickRibbons(
     }
 
     // PASS 2 — Colored fill ribbons (0..value), each terminating in
-    // the original half-revolution curl. Per-ribbon gradient
-    // strokeStyle (set inside drawFillRibbon) fades the leading end
-    // so the curl dissolves rather than ending abruptly.
+    // the original half-revolution curl at the head. Solid stroke;
+    // the .install-ribbons CSS mask handles the far-end fade where
+    // the gray track terminates at the bar's outer edge.
     ctx.globalAlpha = alpha;
     for (let i = 0; i < PALETTE.length; i++) {
+      ctx.strokeStyle = PALETTE[i];
       drawFillRibbon(ctx, fill, i, time, kick, bar, bar.bleedPx);
     }
     ctx.restore();

--- a/demos/realtime_motion_graph_web/web/hooks/useOneShotTooltip.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useOneShotTooltip.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+// One-shot variant of the [data-dd-tooltip] custom tooltip — shows the
+// tooltip the first time a user hovers the element, then suppresses it
+// forever after (persisted in localStorage). For top-level affordances
+// (LibraryButton cassette, RecordButton turntable) where the tooltip
+// teaches the button's identity once; repeatedly displaying the same
+// tooltip every hover becomes noise once the user knows the button.
+//
+// Usage:
+//   const tipProps = useOneShotTooltip("library", "Library");
+//   return (
+//     <button
+//       {...tipProps}
+//       data-dd-tooltip-pos="below"
+//       aria-label="Open library"  // persistent for screen readers
+//     >…</button>
+//   );
+//
+// `aria-label` should stay on the element separately and unchanged —
+// the one-shot behavior only governs the visual tooltip pseudo. Screen
+// reader users still get the same affordance information every time.
+
+const STORAGE_PREFIX = "dd:tooltip-shown:";
+
+export interface OneShotTooltipProps {
+  /** Spread alongside `data-dd-tooltip-pos`. Becomes undefined after the
+   *  first hover (or on subsequent page loads if already dismissed). */
+  "data-dd-tooltip"?: string;
+  onMouseEnter: () => void;
+}
+
+export function useOneShotTooltip(key: string, label: string): OneShotTooltipProps {
+  const storageKey = `${STORAGE_PREFIX}${key}`;
+  // Pessimistic initial: render without the tooltip attribute until
+  // the effect confirms first-run (avoids a brief tooltip flash for
+  // returning users whose localStorage already has the flag). The
+  // effect runs synchronously after mount, well before any plausible
+  // user hover.
+  const [shown, setShown] = useState<boolean>(true);
+
+  useEffect(() => {
+    try {
+      setShown(localStorage.getItem(storageKey) === "1");
+    } catch {
+      // private browsing / quota — treat as first-run. Worst case
+      // is the user sees the tooltip once per session.
+      setShown(false);
+    }
+  }, [storageKey]);
+
+  const onMouseEnter = useCallback(() => {
+    if (shown) return;
+    setShown(true);
+    try {
+      localStorage.setItem(storageKey, "1");
+    } catch {
+      // private browsing — suppress for this session only.
+    }
+  }, [shown, storageKey]);
+
+  return shown ? { onMouseEnter } : { "data-dd-tooltip": label, onMouseEnter };
+}


### PR DESCRIPTION
Four field-feedback items, bundled on one branch so they can be tested together locally.

## 1. Network "unstable connection" pill: relax thresholds + clear curve overlay

Fired too often on otherwise-fine sessions and overlapped the curve scheduler's bottom tab strip.

| Constant | Old | New | Why |
| --- | --- | --- | --- |
| `ESCALATE_TICKS` | 6 (3s) | 12 (6s) | Above Zoom/Meet debounce range — false alarms erode trust faster than missed ones here |
| `TICK_BUDGET_RATIO` | 0.85 | 0.92 | ≤15% headroom is normal scheduler noise |
| `STALL_MS` | 1500 | 2200 | Upper end of VoIP/WebRTC convention — absorbs GC/JIT pauses |
| `RECOVERY_TICKS` | 16 | 16 | Unchanged |

Also subscribed to `useCurveStore.overlayOpen` and gated a `data-curves-open` attribute on `<NetworkIndicator>`. CSS bumps `bottom` by `var(--curves-tab-strip-h, 64px)` when set, 240ms eased — pill clears the curve tabs/preset menus without disappearing entirely.

Files: `engine/networkMonitor.ts`, `components/Performance/NetworkIndicator.tsx`, `app/globals.css`.

## 2. "Upload your own" surfaced on the audio dock

Was pinned at the bottom of the AudioSourceCrate fan (had to open the fan to discover). Now an always-visible 38px icon button right next to the placard, visually attached so the pair reads as one widget. Reuses the existing `UploadIcon`, `onFilePicked` → `AlmostReadyDialog` → `commitPending` chain — same behavior, one click closer.

Files: `components/Performance/AudioSourceCrate.tsx`, `app/globals.css`.

## 3. Ribbon end → coiled tail terminator

The old "curling arrowhead" was a half-revolution polyline that read as a comma. Replaced with a near-complete logarithmic spiral (sweep π → 1.75π, 8 → 24 steps, mild 18% inward radius taper) so the end of each perimeter ribbon coils almost back on itself — implies a graspable thumb without being a hard knob. Same audio-reactive `r = 7 + kick*3`, same `altSign` alternation so adjacent ribbons coil opposite directions.

Plus a kick-gated shimmer dot at each coil's geometric center (drawn only when `kick > 0.55`) — implies mass on strong hits while the resting state stays pure ribbon. One extra `fill()` per ribbon per high-kick frame.

Per PERFORMANCE.md: 256 extra `lineTo` per frame total, trivial vs. the writhe loop. No new allocations.

File: `engine/render/ribbons.ts`.

## 4. First-run coachmark above the advanced-controls handle

Users were missing the controls behind `.install-drawer-handle` entirely — no eye-catching treatment, no surfaced keyboard shortcut. Added a one-time tutorial callout above the handle the first time the session reaches "ready" on desktop:

  > Drag up for more controls — Press `O` to toggle  ▾

Dismissed by any pointerdown, Esc, drawer-open, or 8s auto-hide. All four paths set `localStorage["dd:advanced-coachmark-dismissed"]` so it never reappears. `pointer-events: none` so a click on the coachmark falls through to the handle — one motion dismisses + opens.

Desktop-only gate (mobile has LiteControls + "All controls" already).

Files: new `components/Performance/AdvancedCoachmark.tsx`, `components/Performance/AdvancedDrawer.tsx`, `app/globals.css`.

## Test plan

- [x] HMR compiles clean (no TS / CSS errors)
- [ ] Visual: open the audio crate fan — upload sleeve still works alongside the new icon button
- [ ] Visual: drag a perimeter ribbon — coil terminator reads as a thumb, breathes with kick
- [ ] Visual: hit `O` or click the handle on a fresh user (clear `dd:advanced-coachmark-dismissed`) — coachmark appears, dismisses on first interaction
- [ ] Visual: open the curve scheduler with `quality: "unstable"` forced in dev tools — pill clears the tab strip
- [ ] Live: monitor unstable-fire rate after merge — should drop noticeably