### PR TITLE
realtime_motion_graph_web: auto-prepend LoRA trigger words

### DIFF
--- a/demos/realtime_motion_graph_web/web/lib/loraLabels.ts
+++ b/demos/realtime_motion_graph_web/web/lib/loraLabels.ts
@@ -4,10 +4,22 @@
 // only the user-visible label is rewritten. Looked up at every render
 // site that shows a LoRA name (LibraryTile, edge bars, mobile stepper,
 // curve scheduler tabs).
+
+import { getLoraTrigger } from "./loraTriggers";
+
 const LORA_DISPLAY_OVERRIDES: Record<string, string> = {
   deathstep: "DUBSTEP",
 };
 
 export function displayLoraName(id: string, fallback?: string): string {
-  return LORA_DISPLAY_OVERRIDES[id] ?? fallback ?? id;
+  // Exact-match override wins (e.g. `deathstep` → `DUBSTEP`). Then the
+  // prefix-matched trigger map's `label` (e.g. any `bptkno-*` →
+  // `TECHNO`) — same source-of-truth as the auto-prepend logic, so a
+  // new trained LoRA only needs an entry in `loraTriggers.ts` and the
+  // library tile picks up the right name automatically.
+  const exact = LORA_DISPLAY_OVERRIDES[id];
+  if (exact) return exact;
+  const triggered = getLoraTrigger(id);
+  if (triggered?.label) return triggered.label;
+  return fallback ?? id;
 }

--- a/demos/realtime_motion_graph_web/web/lib/loraTriggers.ts
+++ b/demos/realtime_motion_graph_web/web/lib/loraTriggers.ts
@@ -1,0 +1,124 @@
+// Per-LoRA trigger word + optional display label.
+//
+// A LoRA's trigger is the text token its training captions all shared
+// (the v5 "pruned captions" rule — the trigger is the only token that
+// appears in every clip, so the entire learned style concentrates on
+// its embedding). At inference, including the trigger in the prompt
+// activates the style; omitting it leaves the LoRA dormant.
+//
+// This module is the UI-side source of truth for trigger words. When
+// the user toggles a LoRA on, the trigger is auto-prepended to the
+// active prompts so the style actually fires; when they toggle off,
+// the auto-injected trigger is stripped. Without this glue, toggling
+// a LoRA in the UI only registers it with the engine — it does NOT
+// activate the style unless the user happens to type the trigger
+// themselves, which is the failure mode of every non-deathstep LoRA
+// today (deathstep accidentally activates because its trigger
+// `afxdump` is hard-coded into the default prompt).
+//
+// Prefix-matched: checkpoint variants of the same training run
+// (`bptkno-100`, `bptkno-200`, `bptkno-300`, ...) all map to the same
+// trigger + label. Order matters — the first matching prefix wins.
+//
+// Long-term, this lookup should be replaced by trigger metadata
+// embedded in each LoRA's `.safetensors.json` sidecar (written by the
+// training pipeline at convert time, surfaced through the pod's
+// /api/loras response). The map below stays as the fallback for any
+// LoRA whose sidecar doesn't declare a trigger.
+
+interface LoraTriggerEntry {
+  /** Word to prepend to the active prompt when the LoRA toggles on.
+   *  Lower-case, single token, no surrounding whitespace — the
+   *  prepend logic adds the leading comma+space and dedupes. */
+  trigger: string;
+  /** Display label shown in the LoRA library tile / edge bars / mobile
+   *  stepper. Optional — falls back to the bare LoRA id. Capitalised
+   *  by convention to match the existing "DUBSTEP" override style. */
+  label?: string;
+}
+
+/** Prefix-keyed map. The first entry whose `prefix` is a (lowercase)
+ *  start-substring of the LoRA id wins. Bare ids (no checkpoint
+ *  suffix) match too because `"bptkno".startsWith("bptkno") === true`. */
+const PREFIX_TRIGGERS: ReadonlyArray<{
+  prefix: string;
+  entry: LoraTriggerEntry;
+}> = [
+  // v6 — Beatport Sept 2014 techno LoRA. Variants `bptkno-100`,
+  // `bptkno-200`, ..., `bptkno-500` all share the trigger; the
+  // display label is "TECHNO" because the user-facing genre is the
+  // useful name, not the internal training-run shortcode.
+  { prefix: "bptkno", entry: { trigger: "bptkno", label: "TECHNO" } },
+  // v5 — RAM-era Daft Punk pruned-captions LoRA. Trigger collides
+  // with the genre word "discofunk" by design (the v5 retrospective
+  // noted this softens activation vs a nonsense trigger; we keep it
+  // for back-compat with the trained adapter).
+  { prefix: "discofunk", entry: { trigger: "discofunk", label: "DISCOFUNK" } },
+  // hardrock — AC/DC pruned-captions LoRA. Same real-vocab caveat.
+  { prefix: "hardrock", entry: { trigger: "hardrock", label: "HARDROCK" } },
+  // deathstep — Ryan's canonical dubstep LoRA. Trigger is `afxdump`
+  // (per the deathstep-good README in his training-state archive).
+  // The default promptA happens to already include both `deathstep`
+  // and `afxdump` for legacy back-compat — `withTrigger` is
+  // idempotent so the initial-seed prepend is a no-op there; toggling
+  // off cleanly strips `afxdump` only (the literal `deathstep` word
+  // in the default prompt stays — it's a stylistic descriptor, not
+  // the LoRA's training trigger). Label override "DUBSTEP" lives in
+  // loraLabels.ts's exact-match map and takes precedence over the
+  // optional label here.
+  { prefix: "deathstep", entry: { trigger: "afxdump", label: "DUBSTEP" } },
+  // synthpop — intentionally NOT in this list. The pre-existing LoRA
+  // didn't ship with a documented training trigger; treating it as a
+  // no-trigger LoRA means toggling it does nothing to the prompt,
+  // which matches the engine-side behaviour of registering it without
+  // an associated text-side activation.
+];
+
+export function getLoraTrigger(loraId: string): LoraTriggerEntry | null {
+  if (!loraId) return null;
+  const lower = loraId.toLowerCase();
+  for (const { prefix, entry } of PREFIX_TRIGGERS) {
+    if (lower.startsWith(prefix)) return entry;
+  }
+  return null;
+}
+
+/** Check whether `prompt` already contains `trigger` as a standalone,
+ *  comma-separated token (case-insensitive). Used to make the prepend
+ *  idempotent and to detect user-typed triggers we shouldn't strip. */
+export function containsTrigger(prompt: string, trigger: string): boolean {
+  if (!trigger) return false;
+  const lowerTrig = trigger.toLowerCase();
+  return prompt
+    .split(",")
+    .map((t) => t.trim().toLowerCase())
+    .includes(lowerTrig);
+}
+
+/** Prepend `trigger` to `prompt` as the first comma-separated token.
+ *  Idempotent: a no-op when the trigger is already present. The
+ *  original prompt is preserved verbatim (whitespace untrimmed apart
+ *  from the inserted "<trigger>, " prefix) so the user's formatting
+ *  stays intact. */
+export function withTrigger(prompt: string, trigger: string): string {
+  if (!trigger) return prompt;
+  if (containsTrigger(prompt, trigger)) return prompt;
+  const trimmed = prompt.trim();
+  return trimmed ? `${trigger}, ${trimmed}` : trigger;
+}
+
+/** Remove a single trigger token from a prompt. Strips by matching
+ *  whole comma-separated tokens (case-insensitive), regardless of
+ *  position. The remaining tokens are re-joined with ", "; if the
+ *  caller cares about preserving the user's exact whitespace they
+ *  should call `containsTrigger` first and skip the strip when the
+ *  trigger isn't auto-owned. */
+export function withoutTrigger(prompt: string, trigger: string): string {
+  if (!trigger) return prompt;
+  const lowerTrig = trigger.toLowerCase();
+  const tokens = prompt
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0 && t.toLowerCase() !== lowerTrig);
+  return tokens.join(", ");
+}

--- a/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
@@ -4,10 +4,18 @@ import { create } from "zustand";
 
 import { getConfig } from "@/lib/config";
 import {
+  containsTrigger,
+  getLoraTrigger,
+  withTrigger,
+  withoutTrigger,
+} from "@/lib/loraTriggers";
+import {
   LORA_DEFAULT_STRENGTH_FRACTION,
   LORA_SLIDER_MAX,
 } from "@/types/engine";
 import type { LoraCatalogEntry } from "@/types/protocol";
+
+import { usePerformanceStore } from "./usePerformanceStore";
 
 // Server-driven LoRA catalog + per-id strength + enabled set. The catalog
 // arrives via /api/loras (cheap filesystem scan, available before WS) and
@@ -77,6 +85,12 @@ interface LoraState {
   enabled: Set<string>;
   /** Whether default-on LoRAs have already been seeded for this session. */
   _seeded: boolean;
+  /** Trigger words this store has auto-prepended to promptA/B as a side
+   *  effect of LoRA toggles. Used to decide whether to strip a trigger
+   *  on toggle-off — if the user typed the trigger manually, it's NOT
+   *  in this set, so disabling the LoRA leaves the user's text alone.
+   *  Lower-case for case-insensitive set semantics. */
+  _autoTriggers: Set<string>;
 
   setCatalog: (catalog: LoraCatalogEntry[]) => void;
   setStrength: (id: string, value: number) => void;
@@ -86,11 +100,61 @@ interface LoraState {
   reset: () => void;
 }
 
+/** Side-effect helper — auto-prepend a LoRA's trigger to both prompts
+ *  if it's registered in lib/loraTriggers and not already present. Idem-
+ *  potent: re-calling for the same LoRA is a no-op. Updates the local
+ *  `_autoTriggers` set so we know which triggers we own and can later
+ *  strip cleanly. Returns the next set to fold into the LoRA store
+ *  state (the perf store mutation is fire-and-forget). */
+function applyTriggerOnEnable(
+  id: string,
+  prevAuto: Set<string>,
+): Set<string> {
+  const t = getLoraTrigger(id);
+  if (!t) return prevAuto;
+  const trigger = t.trigger.toLowerCase();
+  const perf = usePerformanceStore.getState();
+  let touched = false;
+  if (!containsTrigger(perf.promptA, t.trigger)) {
+    perf.setPromptA(withTrigger(perf.promptA, t.trigger));
+    touched = true;
+  }
+  if (!containsTrigger(perf.promptB, t.trigger)) {
+    perf.setPromptB(withTrigger(perf.promptB, t.trigger));
+    touched = true;
+  }
+  if (!touched && prevAuto.has(trigger)) return prevAuto;
+  const next = new Set(prevAuto);
+  next.add(trigger);
+  return next;
+}
+
+/** Side-effect helper — strip a LoRA's auto-injected trigger from both
+ *  prompts when we own the injection. If the trigger isn't in
+ *  `_autoTriggers` (e.g. the user typed it manually) we leave both
+ *  prompts untouched. */
+function stripTriggerOnDisable(
+  id: string,
+  prevAuto: Set<string>,
+): Set<string> {
+  const t = getLoraTrigger(id);
+  if (!t) return prevAuto;
+  const trigger = t.trigger.toLowerCase();
+  if (!prevAuto.has(trigger)) return prevAuto;
+  const perf = usePerformanceStore.getState();
+  perf.setPromptA(withoutTrigger(perf.promptA, t.trigger));
+  perf.setPromptB(withoutTrigger(perf.promptB, t.trigger));
+  const next = new Set(prevAuto);
+  next.delete(trigger);
+  return next;
+}
+
 export const useLoraStore = create<LoraState>((set) => ({
   catalog: [],
   strengths: {},
   enabled: new Set(),
   _seeded: false,
+  _autoTriggers: new Set<string>(),
 
   setCatalog: (catalog) =>
     set((s) => {
@@ -151,7 +215,26 @@ export const useLoraStore = create<LoraState>((set) => ({
         enabled = nextEnabled;
         seeded = true;
       }
-      return { catalog, strengths: next, enabled, _seeded: seeded };
+      // For every LoRA enabled by the initial seed, auto-prepend its
+      // trigger to both prompts so the default-on demo actually
+      // activates the style. Idempotent against the user's default
+      // promptA/B (e.g. `afxdump` is already hard-coded in the
+      // default promptA → withTrigger no-ops; the deathstep slot is
+      // covered without doubling). Skipped for LoRAs absent from
+      // loraTriggers.ts (e.g. synthpop).
+      let autoTriggers = s._autoTriggers;
+      if (seeded && !s._seeded) {
+        for (const id of enabled) {
+          autoTriggers = applyTriggerOnEnable(id, autoTriggers);
+        }
+      }
+      return {
+        catalog,
+        strengths: next,
+        enabled,
+        _seeded: seeded,
+        _autoTriggers: autoTriggers,
+      };
     }),
   setStrength: (id, value) =>
     set((s) => ({ strengths: { ...s.strengths, [id]: value } })),
@@ -160,21 +243,29 @@ export const useLoraStore = create<LoraState>((set) => ({
       if (s.enabled.has(id)) return {} as Partial<LoraState>;
       const next = new Set(s.enabled);
       next.add(id);
-      return { enabled: next };
+      const autoTriggers = applyTriggerOnEnable(id, s._autoTriggers);
+      return { enabled: next, _autoTriggers: autoTriggers };
     }),
   disable: (id) =>
     set((s) => {
       if (!s.enabled.has(id)) return {} as Partial<LoraState>;
       const next = new Set(s.enabled);
       next.delete(id);
-      return { enabled: next };
+      const autoTriggers = stripTriggerOnDisable(id, s._autoTriggers);
+      return { enabled: next, _autoTriggers: autoTriggers };
     }),
   toggle: (id) =>
     set((s) => {
       const next = new Set(s.enabled);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return { enabled: next };
+      let autoTriggers: Set<string>;
+      if (next.has(id)) {
+        next.delete(id);
+        autoTriggers = stripTriggerOnDisable(id, s._autoTriggers);
+      } else {
+        next.add(id);
+        autoTriggers = applyTriggerOnEnable(id, s._autoTriggers);
+      }
+      return { enabled: next, _autoTriggers: autoTriggers };
     }),
   reset: () =>
     set((s) => {
@@ -184,7 +275,19 @@ export const useLoraStore = create<LoraState>((set) => ({
       // enabled set against the existing catalog, matching the initial
       // setCatalog seeding behaviour so "reset" actually means "back to
       // defaults", not "lose the catalog".
+      //
+      // Strip every auto-injected trigger from the prompts before
+      // re-seeding so a fresh "reset" doesn't carry stale trigger
+      // residue from the previous enabled-set; the seed pass below
+      // re-applies whichever triggers belong to the default-on LoRAs.
+      let autoTriggers = s._autoTriggers;
+      for (const id of s.enabled) {
+        autoTriggers = stripTriggerOnDisable(id, autoTriggers);
+      }
       const { strengths, enabled } = seedFromCatalog(s.catalog);
-      return { strengths, enabled };
+      for (const id of enabled) {
+        autoTriggers = applyTriggerOnEnable(id, autoTriggers);
+      }
+      return { strengths, enabled, _autoTriggers: autoTriggers };
     }),
 }));


### PR DESCRIPTION
## Summary
Every LoRA we ship has a training-time trigger word that activates its style at inference. Today the UI only registers the LoRA with the engine when toggled — the user has to type the trigger themselves to actually fire the style. That's the silent failure mode of every LoRA except \`deathstep\`, whose trigger \`afxdump\` is accidentally hard-coded into the default promptA, giving it a free activation every session and the appearance of being our "best" LoRA.

This patch lets the UI know each LoRA's trigger and **auto-prepends it to both promptA and promptB on toggle-on, stripping it on toggle-off**.

## Changes
- **\`lib/loraTriggers.ts\` (new)** — prefix-keyed \`{trigger, label}\` map. Prefix matching covers checkpoint variants (\`bptkno-100\`, \`bptkno-200\`, … all share \`bptkno\`). Covered today: **bptkno** (label "TECHNO"), **discofunk**, **hardrock**, **deathstep**. \`synthpop\` is intentionally omitted — it pre-dates the trigger-aware recipes.
- **\`lib/loraLabels.ts\`** — \`displayLoraName\` falls back to the trigger map's \`label\` field when no exact-match override exists.
- **\`store/useLoraStore.ts\`** — \`enable\` / \`disable\` / \`toggle\` / initial-seed / \`reset\` now call into \`usePerformanceStore\` to update prompts. Tracks auto-injected triggers in a private \`_autoTriggers\` Set so we only strip what we own — a user-typed \`bptkno\` survives a toggle-off cycle.

Idempotent: \`withTrigger\` no-ops if the token is already present, so the default promptA's pre-existing \`afxdump\` isn't doubled on initial-seed enable of deathstep. Tokens matched case-insensitively as whole comma-separated tokens, never as substrings.

## Test plan
- [ ] Open the app fresh — deathstep + synthpop default-enabled — prompt unchanged (afxdump already in the default promptA, so the idempotent prepend is a no-op).
- [ ] Toggle on \`bptkno\` (techno LoRA in library) → \`bptkno\` is prepended to both promptA and promptB.
- [ ] Toggle off \`bptkno\` → the auto-injected token is stripped from both prompts.
- [ ] Type \`bptkno\` manually into promptA, toggle the LoRA on then off → the user-typed token is NOT stripped on toggle-off (auto-tracking distinguishes user-owned vs auto-owned).
- [ ] Library tile / edge bars / mobile stepper show "TECHNO" for any \`bptkno-*\` LoRA, "DISCOFUNK" for discofunk, "HARDROCK" for hardrock, "DUBSTEP" still wins for deathstep (exact-match override has priority).