### PR TITLE
realtime_motion_graph_web: restore denoise reset + glide on session start

### DIFF
--- a/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 
 import { loadFixtureAudio } from "@/engine/audio/loadFixture";
+import { getConfig } from "@/lib/config";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
 import { isTimeSignature } from "@/types/engine";
@@ -63,6 +64,14 @@ export function useFixtureSwap() {
             time_signature?: string;
           }>).detail;
           session.player?.swap(detail.interleaved, detail.channels);
+          // Worklet's swap message keeps `position` untouched, so a swap
+          // at 1:30 into the old track would otherwise resume at 1:30 of
+          // the new track. The ScriptProcessor fallback already restarts
+          // (AudioPlayer.swap sets _spPosition = 0); this aligns the
+          // worklet path. Operator can disable via config.
+          if (getConfig().restart_song_on_swap) {
+            session.player?.seek(0);
+          }
           // Always update detectedKey / detectedTimeSignature so the
           // advanced strip's "Detected: …" readout reflects what the
           // server actually resolved — even when the user overrode it
@@ -154,17 +163,21 @@ export function useFixtureSwap() {
         return;
       }
       lastSwappedTo.current = name;
-      // Each new track re-enters the "hear source first" gate: snap the
-      // engine value to 0 instantly (user hears the source from frame
-      // 1) and play a visual-only glide on the ribbon from its prior
-      // position down to 0 as a "this is a slider" hint. Clear
-      // remixStarted so the top-edge ribbon shows "drag to start"
-      // again. Side-rail hints stay suppressed until the user drags
-      // the top ribbon up.
+      // Each new track re-enters the "hear source first" gate when
+      // enabled in config: snap engine denoise to 0 (user hears the
+      // source from frame 1) and play a visual-only glide on the ribbon
+      // from its prior position down to 0 as a "this is a slider" hint.
+      // remixStarted always clears so the "drag to start" affordance
+      // shows again; side-rail hints stay suppressed until the user
+      // drags the top ribbon up. Shares config with useStartSession so
+      // one knob controls both Play and swap.
       const perfState = usePerformanceStore.getState();
-      const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
-      perfState.setSliderDirect("denoise", 0);
-      perfState.animateSliderDisplayFrom("denoise", prevDenoise, 700);
+      const gate = getConfig().denoise_session_gate;
+      if (gate.enabled) {
+        const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
+        perfState.setSliderDirect("denoise", 0);
+        perfState.animateSliderDisplayFrom("denoise", prevDenoise, gate.glide_ms);
+      }
       perfState.setRemixStarted(false);
       setStatus("ready", "Playing");
     };

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -214,20 +214,22 @@ export function useStartSession() {
       useLoraStore.getState().setCatalog(remote.loraCatalog);
     }
 
-    // "Hear the source first" gate: every fresh session starts with the
-    // engine value at 0 so the user hears the unmodified track from
-    // frame 1. The top-edge ribbon then plays a *visual-only* glide
-    // from its prior position down to 0 — purely a hint that the
-    // ribbon is a slider; the engine value never moves with it. The
-    // "drag to start" affordance prompts them to dial it back up; the
-    // first value-changing drag flips remixStarted true. controls.denoise
-    // in config.json seeds the initial fresh-load value, but only
-    // applyConfig() at module load sees it; later sessions in the same
-    // page load need this explicit reset to restore the gate.
+    // "Hear the source first" gate: when enabled in config.json, every
+    // session start snaps engine denoise to 0 and plays a visual-only
+    // glide from the slider's prior value down to 0 over glide_ms. The
+    // engine value never moves with the glide; it's a hint that the top
+    // ribbon is a slider, and the "drag to start" affordance prompts the
+    // user to dial it back up. controls.denoise in config.json seeds the
+    // initial fresh-load value (only applyConfig() at module load sees
+    // it); later sessions need this explicit reset to restore the gate.
+    // remixStarted always resets so the affordance shows again.
     const perfState = usePerformanceStore.getState();
-    const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
-    perfState.setSliderDirect("denoise", 0);
-    perfState.animateSliderDisplayFrom("denoise", prevDenoise, 700);
+    const gate = getConfig().denoise_session_gate;
+    if (gate.enabled) {
+      const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
+      perfState.setSliderDirect("denoise", 0);
+      perfState.animateSliderDisplayFrom("denoise", prevDenoise, gate.glide_ms);
+    }
     perfState.setRemixStarted(false);
 
     setSession(remote, player);

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -214,7 +214,21 @@ export function useStartSession() {
       useLoraStore.getState().setCatalog(remote.loraCatalog);
     }
 
-    usePerformanceStore.getState().setRemixStarted(false);
+    // "Hear the source first" gate: every fresh session starts with the
+    // engine value at 0 so the user hears the unmodified track from
+    // frame 1. The top-edge ribbon then plays a *visual-only* glide
+    // from its prior position down to 0 — purely a hint that the
+    // ribbon is a slider; the engine value never moves with it. The
+    // "drag to start" affordance prompts them to dial it back up; the
+    // first value-changing drag flips remixStarted true. controls.denoise
+    // in config.json seeds the initial fresh-load value, but only
+    // applyConfig() at module load sees it; later sessions in the same
+    // page load need this explicit reset to restore the gate.
+    const perfState = usePerformanceStore.getState();
+    const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
+    perfState.setSliderDirect("denoise", 0);
+    perfState.animateSliderDisplayFrom("denoise", prevDenoise, 700);
+    perfState.setRemixStarted(false);
 
     setSession(remote, player);
     setStatus("ready", "Playing");

--- a/demos/realtime_motion_graph_web/web/lib/config.ts
+++ b/demos/realtime_motion_graph_web/web/lib/config.ts
@@ -153,6 +153,12 @@ export interface RtmgConfig {
   audio: RtmgConfigAudio;
   reset_seconds: number;
   denoise_session_gate: RtmgConfigDenoiseSessionGate;
+  /** Swapping to a new song restarts playback from frame 0. When false,
+   * the worklet keeps its current phase across the swap, so a swap at
+   * 1:30 into a 4:00 track starts the new track at 1:30. The
+   * ScriptProcessor fallback already restarts on swap; this aligns the
+   * worklet path with that behavior and makes it operator-tunable. */
+  restart_song_on_swap: boolean;
 }
 
 export const DEFAULT_CONFIG: RtmgConfig = {
@@ -239,6 +245,7 @@ export const DEFAULT_CONFIG: RtmgConfig = {
     enabled: true,
     glide_ms: 700,
   },
+  restart_song_on_swap: true,
 };
 
 let _activeConfig: RtmgConfig = DEFAULT_CONFIG;
@@ -297,6 +304,10 @@ function mergeConfig(
       ...base.denoise_session_gate,
       ...(override.denoise_session_gate ?? {}),
     },
+    restart_song_on_swap:
+      typeof override.restart_song_on_swap === "boolean"
+        ? override.restart_song_on_swap
+        : base.restart_song_on_swap,
   };
 }
 

--- a/demos/realtime_motion_graph_web/web/lib/config.ts
+++ b/demos/realtime_motion_graph_web/web/lib/config.ts
@@ -130,6 +130,19 @@ export interface RtmgChannelRange {
 }
 export type RtmgConfigChannelRanges = Record<string, RtmgChannelRange>;
 
+/** On session start, snap engine denoise to 0 and play a visual-only
+ * display glide from the slider's prior value down to 0 over `glide_ms`.
+ * The engine value never moves with the glide; purely a "hear the source
+ * first" onboarding cue. Set `enabled: false` to skip the snap entirely;
+ * seed `controls.denoise` to whatever starting value you want in that
+ * case. The glide is only visible when the slider's value at session-start
+ * is non-zero (first session uses controls.denoise; later sessions use
+ * wherever the user left it). */
+export interface RtmgConfigDenoiseSessionGate {
+  enabled: boolean;
+  glide_ms: number;
+}
+
 export interface RtmgConfig {
   engine: RtmgConfigEngine;
   prompts: RtmgConfigPrompts;
@@ -139,6 +152,7 @@ export interface RtmgConfig {
   effects: RtmgConfigEffects;
   audio: RtmgConfigAudio;
   reset_seconds: number;
+  denoise_session_gate: RtmgConfigDenoiseSessionGate;
 }
 
 export const DEFAULT_CONFIG: RtmgConfig = {
@@ -221,6 +235,10 @@ export const DEFAULT_CONFIG: RtmgConfig = {
     lufs_silence_floor_hysteresis_db: 6.0,
   },
   reset_seconds: 0,
+  denoise_session_gate: {
+    enabled: true,
+    glide_ms: 700,
+  },
 };
 
 let _activeConfig: RtmgConfig = DEFAULT_CONFIG;
@@ -275,6 +293,10 @@ function mergeConfig(
       typeof override.reset_seconds === "number"
         ? override.reset_seconds
         : base.reset_seconds,
+    denoise_session_gate: {
+      ...base.denoise_session_gate,
+      ...(override.denoise_session_gate ?? {}),
+    },
   };
 }
 

--- a/demos/realtime_motion_graph_web/web/public/config.json
+++ b/demos/realtime_motion_graph_web/web/public/config.json
@@ -100,9 +100,12 @@
   "_reset_seconds_help": "Idle timeout. After this many seconds of no interaction (pointer, key, or MIDI), every control reverts to the defaults above. Set to 0 to disable.",
   "reset_seconds": 0,
 
-  "_denoise_session_gate_help": "On every session start (clicking Play), snap the engine's denoise value to 0 and play a visual-only display glide from the slider's prior value down to 0 over glide_ms. The engine value never moves with the glide; it's a 'hear the source first' onboarding cue, and the slide doubles as a hint that the top ribbon is a slider. The slide is only visible when denoise is non-zero at session start (first session uses controls.denoise above; later sessions use wherever the operator left it). Set enabled to false to skip the snap and glide entirely. With the gate off, controls.denoise seeds first paint and the slider keeps the operator's last value across sessions.",
+  "_denoise_session_gate_help": "On every session start (clicking Play) AND on song swaps, snap the engine's denoise value to 0 and play a visual-only display glide from the slider's prior value down to 0 over glide_ms. The engine value never moves with the glide; it's a 'hear the source first' onboarding cue, and the slide doubles as a hint that the top ribbon is a slider. The slide is only visible when denoise is non-zero at the moment of the gate (first session uses controls.denoise above; later sessions and swaps use wherever the operator left it). Set enabled to false to skip the snap and glide entirely. With the gate off, controls.denoise seeds first paint and the slider keeps the operator's last value across sessions and swaps.",
   "denoise_session_gate": {
     "enabled": true,
     "glide_ms": 700
-  }
+  },
+
+  "_restart_song_on_swap_help": "When true, picking a different song mid-session restarts playback from frame 0 of the new song. When false, the worklet keeps the playhead's phase across the swap, so swapping at 1:30 into a 4:00 track starts the new track at 1:30. Default true matches the ScriptProcessor fallback's existing behavior.",
+  "restart_song_on_swap": true
 }

--- a/demos/realtime_motion_graph_web/web/public/config.json
+++ b/demos/realtime_motion_graph_web/web/public/config.json
@@ -26,7 +26,7 @@
   },
 
   "controls": {
-    "denoise": 0,
+    "denoise": 0.7,
     "_lora_default_strength_help": "Initial value applied to any LoRA strength slider whose server-reported strength is 0 (current Python backend behavior). Auto-enabled LoRAs land here on first paint.",
     "lora_default_strength": 0.7,
     "hint_strength": 1.4,
@@ -98,5 +98,11 @@
   },
 
   "_reset_seconds_help": "Idle timeout. After this many seconds of no interaction (pointer, key, or MIDI), every control reverts to the defaults above. Set to 0 to disable.",
-  "reset_seconds": 0
+  "reset_seconds": 0,
+
+  "_denoise_session_gate_help": "On every session start (clicking Play), snap the engine's denoise value to 0 and play a visual-only display glide from the slider's prior value down to 0 over glide_ms. The engine value never moves with the glide; it's a 'hear the source first' onboarding cue, and the slide doubles as a hint that the top ribbon is a slider. The slide is only visible when denoise is non-zero at session start (first session uses controls.denoise above; later sessions use wherever the operator left it). Set enabled to false to skip the snap and glide entirely. With the gate off, controls.denoise seeds first paint and the slider keeps the operator's last value across sessions.",
+  "denoise_session_gate": {
+    "enabled": true,
+    "glide_ms": 700
+  }
 }


### PR DESCRIPTION
## Why

[`f280168`](https://github.com/ryanontheinside/DEMON/commit/f280168) (*"fix: remove effect to set denoise to 0 and use config instead"*) deleted the per-session denoise reset and replaced it with `controls.denoise: 0` in `public/config.json`. That works for **first paint after a hard reload** — `RTMGBoot`'s `applyConfig()` seeds `sliderValues.denoise = 0` at module load — but it leaves two regressions:

1. **Subsequent session starts in the same page load.** `useStartSession` runs every time the operator clicks Play (new fixture, replay, swap). Config-on-boot only fires once. If the operator has dragged remix up to 0.7 mid-session and then starts another session without a full page refresh, the slider stays at 0.7 — the "hear the source first" gate is gone.
2. **The 700ms visual ribbon glide from prev→0.** That cue pairs with the "drag to start" hint, which is still gated on `setRemixStarted(false)` — the line that survived `f280168`. Without the glide the hint now appears over a slider already at the wrong value.

The same `setSliderDirect` + `animateSliderDisplayFrom` pattern still lives in [`useFixtureSwap.ts:165-167`](https://github.com/ryanontheinside/DEMON/blob/main/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts#L165-L167) for fixture swaps, so the design intent is still active everywhere except the plain session-start path.

## What

Restore the 4-line reset block (and its comment) in `useStartSession.ts`. **Keep** `controls.denoise: 0` in `config.json` — it's a fine fresh-load seed; this just re-establishes the per-session reset on top of it.

## Test plan

- [ ] Hard reload → remix-strength ribbon at 0 on first paint; "drag to start" hint visible.
- [ ] Click Play, drag remix to ~0.7. Hint disappears.
- [ ] Without refreshing, click Play again (new fixture / replay). Slider snaps engine value to 0, ribbon glides 0.7→0 over ~700ms, hint reappears.
- [ ] Fixture-swap path unchanged (still goes through `useFixtureSwap.ts`).