### PR TITLE
realtime_motion_graph_web: server-side LoRA trigger injection

### DIFF
--- a/acestep/paths.py
+++ b/acestep/paths.py
@@ -59,6 +59,39 @@ def discover_loras(directory: Path | None = None) -> list[Path]:
     return sorted(p for p in d.glob("*.safetensors") if p.is_file())
 
 
+def lora_trigger(lora_path: Path | str) -> str:
+    """Read the optional trigger-word sidecar for a LoRA.
+
+    The sidecar is a plain-text ``<stem>.trigger.txt`` file living next to
+    the ``.safetensors``. It holds a single activation word (the token
+    the LoRA was trained against) — when present, the engine prepends it
+    to the user's caption before passing to the text encoder so the LoRA
+    style actually fires at inference. The sidecar is OPTIONAL; LoRAs
+    trained without a documented trigger (or pulled in via a manifest
+    line without the ``|<TRIGGER>`` field) just have no file and the
+    engine treats them as no-trigger styles.
+
+    Returns the trigger string with whitespace stripped, or ``""`` when:
+    - the sidecar doesn't exist
+    - the sidecar is empty after stripping
+    - the file can't be read (permissions, IO error)
+
+    Empty-string return is a deliberate signal — callers can do
+    ``if trigger: ...`` to decide whether to inject. No exceptions
+    escape; this is read every catalog broadcast and shouldn't crash
+    the WS loop on a malformed sidecar.
+    """
+    p = Path(lora_path)
+    # Strip the .safetensors suffix to land on the stem, then add .trigger.txt
+    # so we resolve siblings like:
+    #   /…/loras/bptkno.safetensors        → /…/loras/bptkno.trigger.txt
+    sidecar = p.with_suffix("").with_suffix(".trigger.txt")
+    try:
+        return sidecar.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
 def trt_engine_path(engine_name: str) -> Path:
     """Full path to a specific TRT engine file.
 

--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -42,6 +42,7 @@ from acestep.paths import (
     available_trt_engines,
     checkpoints_dir,
     dreamvae_decode_engine_name,
+    lora_trigger,
     loras_dir,
     max_profile_duration_s,
     smallest_fitting_profile_duration_s,
@@ -578,15 +579,31 @@ def handle_client(
     # prompt crossfades. Recomputed on prompt change, on swap_source,
     # and on set_timbre_source / clear_timbre_source.
     def _encode_cond_pair(tags, refer_latent, bpm, duration, key, time_signature):
+        # Server-side LoRA trigger injection: every currently-ENABLED
+        # LoRA whose `<stem>.trigger.txt` sidecar is present contributes
+        # its activation word to a hidden prefix prepended to the user's
+        # caption. The user-visible promptA / promptB strings stay
+        # untouched in the UI — this prepend only happens here, just
+        # before the text encoder forward, so all five encode sites
+        # (session start, prompt change, timbre refresh, swap_source,
+        # LoRA enable/disable re-encode) inherit the same prefix from
+        # one place. Idempotent against re-encodes with the same LoRA
+        # state (the prefix is deterministic) so a noop re-encode is a
+        # noop. See `_active_trigger_prefix` for the lookup logic.
+        prefix = _active_trigger_prefix()
+        if prefix:
+            full_tags = f"{prefix}, {tags}" if tags else prefix
+        else:
+            full_tags = tags
         cs = session.encode_text(
-            tags=tags,
+            tags=full_tags,
             instruction=TASK_INSTRUCTIONS["cover"],
             refer_latent=None,
             bpm=bpm, duration=duration, key=key,
             time_signature=time_signature,
         )
         cf = session.encode_text(
-            tags=tags,
+            tags=full_tags,
             instruction=TASK_INSTRUCTIONS["cover"],
             refer_latent=refer_latent,
             bpm=bpm, duration=duration, key=key,
@@ -650,11 +667,56 @@ def handle_client(
         return [
             {
                 "id": d.id, "name": d.name, "path": d.path,
+                # `trigger` is the LoRA's activation word, read from a
+                # sibling `<stem>.trigger.txt` sidecar at the same path
+                # as the .safetensors. Empty string when the sidecar
+                # doesn't exist (LoRAs trained without a documented
+                # trigger). The engine reads the same sidecar at encode
+                # time and prepends to the user caption when this LoRA
+                # is in ENABLED state, so the UI doesn't need to act on
+                # this field — it's surfaced for transparency / tooltips.
+                "trigger": lora_trigger(d.path),
                 "state": d.state, "strength": d.strength,
                 "materialized_bytes": d.materialized_bytes,
             }
             for d in engine_obj.list_loras()
         ]
+
+    def _active_trigger_prefix() -> str:
+        """Comma-separated activation tokens for every currently-ENABLED
+        LoRA that ships with a `<stem>.trigger.txt` sidecar.
+
+        Called from `_encode_cond_pair` so every text-encode site (session
+        start, prompt change, timbre refresh, LoRA enable/disable
+        re-encode) sees the fresh set without any duplicated lookup
+        logic. Trigger lookup costs one file-read per LoRA per encode,
+        bounded by `len(engine_obj.list_loras())` — single-digit count
+        in practice; cost is negligible vs the text encoder forward.
+
+        Order: matches `engine_obj.list_loras()` (insertion order on the
+        engine side). The prefix is then prepended verbatim to the
+        user's caption with a trailing ``", "`` separator, so the final
+        tokenizer input looks like
+            ``afxdump, bptkno, <user caption>``
+        which is the exact shape every LoRA was trained against
+        (trigger as the first comma-separated token in the captioning
+        prompt, per the v5 pruned-captions rule).
+        """
+        if not lora_available:
+            return ""
+        parts: list[str] = []
+        for d in engine_obj.list_loras():
+            # Only ENABLED descriptors fire. State strings are
+            # lower-case (`"enabled"` etc.) per LoRAState's value
+            # mapping. Materializing / Registered states have no audio
+            # impact, so injecting their trigger would just confuse the
+            # text encoder.
+            if d.state != "enabled":
+                continue
+            trig = lora_trigger(d.path)
+            if trig:
+                parts.append(trig)
+        return ", ".join(parts)
 
     # Send ready + initial buffer
     ws.send(json.dumps({
@@ -980,6 +1042,33 @@ def handle_client(
             except Exception as e:
                 print(f"[Server] enable_lora({lid}) failed: {e}")
         _send_catalog_update()
+        # If the set of active triggers changed (enable adds, disable
+        # removes), re-encode the current prompt so the new prefix is
+        # baked into the conditioning. Without this the trigger only
+        # takes effect on the NEXT prompt change — toggling a LoRA in
+        # the library would visibly change the LoRA matrices but the
+        # audio wouldn't reflect the trigger's encoder-side bias until
+        # the user touched a prompt field. Cheap: one text-encode
+        # forward + a cond-blend. `_encode_cond_pair` queries the now-
+        # fresh state via `_active_trigger_prefix`.
+        try:
+            new_pair = _encode_cond_pair(
+                prompt_text[0],
+                _active_refer_latent(),
+                bpm_ref[0],
+                duration_ref[0],
+                key_ref[0],
+                time_sig_ref[0],
+            )
+            cond_pair_ref[0] = new_pair
+            stream.conditioning = _blend_for_strength(
+                new_pair[0], new_pair[1], timbre_strength_ref[0],
+            )
+        except Exception as e:
+            # Re-encode is best-effort — if it fails, the LoRA matrices
+            # still applied (engine_obj.enable/disable above succeeded);
+            # next prompt change will catch up. Log and move on.
+            print(f"[Server] re-encode after LoRA change failed: {e}")
 
     # --- on_audio_ready: delta-encode and send to client ---
     def on_audio_ready(wav_np, win_start=None, win_end=None):

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -127,12 +127,22 @@ def _process_request(connection, request):
     # resolution the WebSocket pipeline uses, so everyone agrees on
     # what's in the catalog.
     if path_only == "/api/loras":
-        from acestep.paths import discover_loras, loras_dir
+        from acestep.paths import discover_loras, lora_trigger, loras_dir
         try:
             d = loras_dir()
+            # Per-entry ``trigger`` is read from a sidecar
+            # ``<stem>.trigger.txt`` next to each .safetensors (managed
+            # by demon-public-demo's download_loras.sh + the lora-train
+            # convert step). Field is always present in the response —
+            # empty string when no sidecar — so the client can do
+            # ``entry.trigger || null`` without an existence check. The
+            # engine consults the same sidecar at encode time and
+            # prepends the trigger to the user's caption when the LoRA
+            # is enabled.
             entries = [
                 {
                     "id": p.stem, "name": p.stem, "path": str(p),
+                    "trigger": lora_trigger(p),
                     "state": "registered", "strength": 0.0,
                     "materialized_bytes": 0,
                 }

--- a/demos/realtime_motion_graph_web/web/types/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/types/protocol.ts
@@ -5,6 +5,14 @@ export interface LoraCatalogEntry {
   id: string;
   name?: string;
   path?: string;
+  /** Activation word the LoRA was trained against, sourced from a
+   *  `<stem>.trigger.txt` sidecar next to the .safetensors. Always
+   *  present in the catalog payload — empty string when no sidecar
+   *  exists (no documented trigger for that LoRA, e.g. synthpop).
+   *  The engine handles the actual prompt prepending server-side at
+   *  encode time; this field is surfaced to the UI for transparency /
+   *  tooltips only — do NOT inject it into promptA/promptB. */
+  trigger?: string;
   state?: string;
   strength?: number;
   materialized_bytes?: number;


### PR DESCRIPTION
## Summary
Companion to [daydreamlive/demon-public-demo PR #132](https://github.com/daydreamlive/demon-public-demo/pull/132). Each LoRA can ship a `<stem>.trigger.txt` sidecar carrying the activation word it was trained against (per the v5 pruned-captions rule — the trigger is the only token shared across every training caption). This patch teaches the engine to read those sidecars and prepend the active triggers to the user's caption — hidden from the UI's promptA / promptB fields, scoped to **enabled** LoRAs only, automatic across every encode site.

A prior attempt (#77) put the prepend on the UI side. Reverted (#78) because it mutated the visible prompt fields, stacked 5+ triggers when many LoRAs were on, and dragged through prompt blending. This iteration moves the work to where it belongs — the encode boundary — and the UI never touches the user prompt.

## Mechanics
- **`acestep/paths.py:lora_trigger(path)`** — reads sibling `<stem>.trigger.txt`, returns the stripped contents or `""` on miss / IO error.
- **`/api/loras`** — `trigger` field per entry. Always present, empty string on no sidecar.
- **`backend.py:_active_trigger_prefix()`** — iterates `engine_obj.list_loras()`, picks every ENABLED descriptor with a non-empty trigger, joins with `", "`.
- **`backend.py:_encode_cond_pair()`** — prepends the prefix before passing `tags` to `session.encode_text`. Covers ALL five encode sites (session start, prompt change, timbre refresh, swap_source, LoRA-state re-encode) with one change.
- **`backend.py:apply_lora_pending()`** — re-encodes the current prompt after enable/disable transactions, so toggling a LoRA updates audio immediately, not on next prompt change.
- **`web/types/protocol.ts:LoraCatalogEntry.trigger`** — new optional field, documented as **transparency-only** (tooltips), do NOT mirror to promptA/promptB.

## Backwards compat
- LoRAs without sidecars → `trigger: ""` → `_active_trigger_prefix` skips them → no prefix prepended → behaves exactly as today.
- The first time `download_loras.sh` (from demon-public-demo) runs with the new manifest format, sidecars start landing in `/workspace/demon_models/loras/`.

## Test plan
- [x] Python syntax clean (`ast.parse` on backend / server / paths).
- [x] TS typecheck clean.
- [ ] On a pod with the new sidecars, `curl /api/loras | jq` shows `trigger` per entry.
- [ ] Start a session with `enabled_loras=["deathstep"]` (sidecar = `afxdump`), user prompt \`\"slow ambient\"\`. Logs in `serve_demon.log` should show the prefix being applied; audio should reflect deathstep style.
- [ ] Toggle the LoRA off via WS \`disable_lora\` — `apply_lora_pending` re-encodes, audio reverts.
- [ ] Multiple enabled LoRAs with different triggers — all appear in the prefix, comma-separated.