### PR TITLE
realtime_motion_graph_web/web: caps-lock display labels for v6 LoRAs

### DIFF
--- a/demos/realtime_motion_graph_web/web/lib/loraLabels.ts
+++ b/demos/realtime_motion_graph_web/web/lib/loraLabels.ts
@@ -6,6 +6,10 @@
 // curve scheduler tabs).
 const LORA_DISPLAY_OVERRIDES: Record<string, string> = {
   deathstep: "DUBSTEP",
+  bptkno: "TECHNO",
+  hardrock: "HARDROCK",
+  bach: "BAROQUE",
+  discofunk: "DISCOFUNK",
 };
 
 export function displayLoraName(id: string, fallback?: string): string {


### PR DESCRIPTION
## Summary

Adds display-label overrides for the v6 in-house LoRAs (`bptkno`, `hardrock`, `bach`, `discofunk`) matching the existing \`deathstep → DUBSTEP\` treatment.

  - bptkno    → TECHNO
  - hardrock  → HARDROCK
  - bach      → BAROQUE
  - discofunk → DISCOFUNK

Underlying lora ids stay untouched everywhere they cross an engine boundary (prompts, MIDI keys, curve storage, catalog wire format) — \`displayLoraName()\` is the only override site, hit by LibraryTile, edge bars, mobile stepper, and the curve scheduler tabs.

\`synthpop\` is intentionally left as-is; no rename was requested.

## Test plan

- [ ] LibraryTile + edge bars + curve scheduler show the new caps-lock labels.
- [ ] MIDI mappings keyed by \`bptkno\`/\`hardrock\`/etc. still resolve (id is untouched).
- [ ] Toggling each LoRA still surfaces the right \`trigger\` in /api/loras (already verified server-side; this PR is render-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)