### PR TITLE
realtime_motion_graph_web/web: MIDI clamp + v6 LoRA UI polish

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1654,13 +1654,17 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
 .mixer-rack-row {
   display: flex;
   /* Tiles keep their content-driven widths and stay on a single line
-     until the viewport drops below the compact floor (~1500px), at
-     which point they wrap onto a second line — wrapping is preferred
-     over horizontal scroll, always. The fluid clamp on
-     `--slider-strip-w` already keeps the row fitting between 1500px
-     and 2400px without wrapping. */
+     across the laptop range. At MacBook Pro 14" (1512px viewport) the
+     7 tiles + per-strip widths used to overflow because the compact
+     floor (--slider-strip-w 36px, 6/7/7 padding, fixed 8px row gap)
+     still summed to ~1500-1520px of intrinsic content, so the seed
+     tile dropped to a second line and pushed prompts down. The floor
+     below now compresses harder (32px strips, 4/5/5 padding, 4px row
+     gap) so the rack stays on one line at 14" MBP and tablet widths.
+     Wrapping remains the fallback if a future tile ever exceeds the
+     true min — preferred over horizontal scroll, always. */
   flex-wrap: wrap;
-  gap: 8px;
+  gap: clamp(4px, calc(4px + (100vw - 1300px) * 4 / 1100), 8px);
   align-items: stretch;
   flex: 0 0 auto;
 }
@@ -1668,26 +1672,27 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
    abrupt mode flip. The row's total content at standard density
    (50px slider strips, 8/10/10 padding) measures ~1800px; on
    anything narrower, the strips and padding interpolate down to
-   compact (36px / 6/7/7) so the rack always fits without horizontal
+   compact (32px / 4/5/5) so the rack always fits without horizontal
    scroll. Above ~2400px viewport, full standard density takes over;
-   below ~1500px, full compact. In between (every laptop screen
-   anywhere), the controls smoothly thicken as room appears. */
+   below ~1300px, full compact. In between (every laptop screen
+   anywhere — including 14" MBP at 1512px), the controls smoothly
+   thicken as room appears. */
 .mixer-rack {
   --slider-strip-w: clamp(
-    36px,
-    calc(36px + (100vw - 1500px) * 14 / 900),
+    32px,
+    calc(32px + (100vw - 1300px) * 18 / 1100),
     50px
   );
 }
 .mixer-rack .mixer-tile {
   padding:
-    clamp(6px, calc(6px + (100vw - 1500px) * 2 / 900), 8px)
-    clamp(7px, calc(7px + (100vw - 1500px) * 3 / 900), 10px)
-    clamp(7px, calc(7px + (100vw - 1500px) * 3 / 900), 10px);
-  gap: clamp(4px, calc(4px + (100vw - 1500px) * 2 / 900), 6px);
+    clamp(4px, calc(4px + (100vw - 1300px) * 4 / 1100), 8px)
+    clamp(5px, calc(5px + (100vw - 1300px) * 5 / 1100), 10px)
+    clamp(5px, calc(5px + (100vw - 1300px) * 5 / 1100), 10px);
+  gap: clamp(3px, calc(3px + (100vw - 1300px) * 3 / 1100), 6px);
 }
 .mixer-rack .mixer-channels {
-  gap: clamp(3px, calc(3px + (100vw - 1500px) * 1 / 900), 4px);
+  gap: clamp(2px, calc(2px + (100vw - 1300px) * 2 / 1100), 4px);
 }
 .mixer-rack .dcw-panel.dcw-panel--bottom {
   /* Bottom-strip variant lays out horizontally below the fader row, so

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -152,7 +152,7 @@ export function LibraryTile() {
   if (catalog.length === 0) {
     return (
       <div className="mixer-tile" data-tile="library">
-        <div className="mixer-tile-label">Library</div>
+        <div className="mixer-tile-label">LoRA Library</div>
         <div className="lora-empty">no LoRAs found</div>
       </div>
     );

--- a/demos/realtime_motion_graph_web/web/components/Performance/PromptsTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/PromptsTile.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useEffect, useRef } from "react";
+
+import { computePromptTags, usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
 
 export function PromptsTile() {
@@ -15,23 +17,51 @@ export function PromptsTile() {
 
   function sendPrompt() {
     const remote = useSessionStore.getState().remote;
-    // Server expects `tags` as the prompt string. Blend is handled via
-    // params; for the prompt-text wire we just pick A (matches app.js).
-    if (remote) remote.sendPrompt(promptA, activeKey, activeTimeSignature);
+    // Server expects `tags` as the prompt string. Use computePromptTags so
+    // we pick the right side as the operator drags the A↔B blend slider.
+    if (remote) {
+      remote.sendPrompt(
+        computePromptTags({ promptA, promptB, blend }),
+        activeKey,
+        activeTimeSignature,
+      );
+    }
   }
+
+  // Auto-submit on blend change. Debounced so dragging the slider doesn't
+  // spam the server (one prompt message per ~180ms of stillness is plenty
+  // for the operator's gesture to land). Initial mount skips so we don't
+  // re-emit the server's own initial prompt back at it.
+  const firstBlendEffect = useRef(true);
+  useEffect(() => {
+    if (firstBlendEffect.current) {
+      firstBlendEffect.current = false;
+      return;
+    }
+    const handle = window.setTimeout(() => {
+      const remote = useSessionStore.getState().remote;
+      if (!remote) return;
+      remote.sendPrompt(
+        computePromptTags({ promptA, promptB, blend }),
+        activeKey,
+        activeTimeSignature,
+      );
+    }, 180);
+    return () => window.clearTimeout(handle);
+  }, [blend, promptA, promptB, activeKey, activeTimeSignature]);
 
   return (
     <div className="mixer-tile mixer-tile-prompts" data-tile="prompts">
-      <div className="mixer-tile-label">Prompts</div>
+      <div className="mixer-tile-label">Tags</div>
       <div id="prompt-section">
         <div className="prompt-slot">
           <label
             className="prompt-label"
             htmlFor="prompt-a"
-            data-dd-tooltip="Primary prompt — text the model conditions on. With the blend at 0, this is the only prompt driving the output."
+            data-dd-tooltip="Primary tags — text the model conditions on. With the blend at 0, these are the only tags driving the output."
             data-dd-tooltip-wide=""
           >
-            Prompt A
+            Tags A
           </label>
           <textarea
             id="prompt-a"
@@ -41,9 +71,16 @@ export function PromptsTile() {
             onChange={(e) => setPromptA(e.target.value)}
           />
         </div>
+        {/* data-param wrapper makes the right-click → MIDI learn
+            handler in useMidi.ts pick this up (kind="cc",
+            target="prompt_blend") without adopting slider-group
+            styling. useMidi has a #blend-control branch in the
+            contextmenu handler and special-cases this param to route
+            writes through setBlend instead of setSlider. */}
         <div
           id="blend-control"
-          data-dd-tooltip="Crossfade between Prompt A and Prompt B. 0 = pure A, 1 = pure B. Hold B and use ▲▼ on desktop to nudge."
+          data-param="prompt_blend"
+          data-dd-tooltip="Crossfade between Tags A and Tags B. 0 = pure A, 1 = pure B. Hold B and use ▲▼ on desktop to nudge. Right-click to MIDI-learn."
           data-dd-tooltip-wide=""
         >
           <span className="blend-label">A</span>
@@ -66,10 +103,10 @@ export function PromptsTile() {
           <label
             className="prompt-label"
             htmlFor="prompt-b"
-            data-dd-tooltip="Secondary prompt — interpolates with A based on the blend slider. With the blend at 1, only B drives the output."
+            data-dd-tooltip="Secondary tags — interpolates with A based on the blend slider. With the blend at 1, only B drives the output."
             data-dd-tooltip-wide=""
           >
-            Prompt B
+            Tags B
           </label>
           <textarea
             id="prompt-b"
@@ -83,11 +120,11 @@ export function PromptsTile() {
           id="send-prompt"
           className="send-prompt-btn"
           data-midi-learn="send_prompt"
-          data-dd-tooltip="Send prompt — Enter (out of textarea) or ⌘/Ctrl + Enter (in textarea); right-click to MIDI-learn"
+          data-dd-tooltip="Send tags — Enter (out of textarea) or ⌘/Ctrl + Enter (in textarea); right-click to MIDI-learn"
           type="button"
           onClick={sendPrompt}
         >
-          Send Prompt
+          Send Tags
           <kbd className="desktop-only send-kbd">⏎</kbd>
         </button>
       </div>

--- a/demos/realtime_motion_graph_web/web/hooks/useMidi.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useMidi.ts
@@ -88,10 +88,14 @@ function handleCC(cc: number, value: number): void {
   // an absolute MIDI knob's full sweep would map 0..127 → 0..2.0 and
   // the perf-store clamp would silently truncate the top ~10% — the
   // operator-visible slider stops at 1.8 but the MIDI input still
-  // crosses it.
+  // crosses it. `prompt_blend` lives in usePerformanceStore.blend
+  // directly (not in sliderValues) and its rail is [0, 1] — both
+  // ends are meaningful, so we cap there explicitly.
   const max = range?.max
     ?? meta?.max
-    ?? (param.startsWith("lora_str_") ? LORA_SLIDER_MAX : 2.0);
+    ?? (param.startsWith("lora_str_") ? LORA_SLIDER_MAX
+        : param === "prompt_blend" ? 1.0
+        : 2.0);
   const span = Math.max(0, max - min);
   const reverse = range?.reverse ?? false;
   const step = meta?.step ?? 0.05;
@@ -130,6 +134,15 @@ function handleCC(cc: number, value: number): void {
  *  knob sweeps debounce into one engine-side refit per gesture,
  *  matching the touch/edge-drag paths. */
 function applyMidiSet(param: string, value: number): void {
+  // `prompt_blend` is the Tags-A↔Tags-B slider in PromptsTile. It lives
+  // in usePerformanceStore.blend (a 0..1 scalar with its own setter),
+  // NOT in sliderValues, so the generic setSlider path won't move the
+  // visible slider or trigger the PromptsTile auto-submit useEffect.
+  // Route it to setBlend instead.
+  if (param === "prompt_blend") {
+    usePerformanceStore.getState().setBlend(value);
+    return;
+  }
   if (param.startsWith("lora_str_")) {
     const id = param.slice("lora_str_".length);
     loraStrengthDispatcher.set(id, value);
@@ -139,6 +152,11 @@ function applyMidiSet(param: string, value: number): void {
 }
 
 function applyMidiBump(param: string, delta: number): void {
+  if (param === "prompt_blend") {
+    const cur = usePerformanceStore.getState().blend;
+    usePerformanceStore.getState().setBlend(cur + delta);
+    return;
+  }
   if (param.startsWith("lora_str_")) {
     const id = param.slice("lora_str_".length);
     // Compute the new absolute target from sliderTargets (kept current
@@ -163,12 +181,33 @@ function bindInput(input: MIDIInput): void {
     const data = e.data;
     if (!data || data.length < 2) return;
     const status = data[0] & 0xf0;
+    // Diagnostic for MIDI-learn debugging: when learn is active, dump
+    // every raw message so we can see whether the pad fires a status
+    // byte the dispatcher doesn't route (e.g. 0xa0 aftertouch, 0xc0
+    // program change, or note-on with velocity 0 used as the "press"
+    // signal). Drop this log once the pad-bind issue is fully diagnosed.
+    if (useMidiStore.getState().learn) {
+      const statusHex = (data[0] | 0).toString(16).padStart(2, "0");
+      console.log(
+        `[midi-learn] raw: status=0x${statusHex} data1=${data[1]} data2=${data[2] ?? "n/a"} len=${data.length}`,
+      );
+    }
     if (status === 0xb0) {
       // Control change.
       handleCC(data[1], data[2]);
     } else if (status === 0x90 && data[2] > 0) {
       // Note on (velocity > 0).
       handleNote(data[1]);
+    } else if (status === 0x80 || (status === 0x90 && data[2] === 0)) {
+      // Note off (or note-on vel=0, which some controllers send instead
+      // of a proper 0x80 note-off). When LEARN is active, treat this as
+      // a binding hint too — some "press" pads only emit on release, so
+      // refusing to bind on note-off leaves those pads unbindable. The
+      // normal dispatch (non-learn) still ignores note-off, matching the
+      // long-standing fire-on-rising-edge behavior for action buttons.
+      if (useMidiStore.getState().learn) {
+        handleNote(data[1]);
+      }
     }
   };
 }
@@ -207,6 +246,10 @@ export function useMidi() {
     // Right-click → MIDI learn. Targets:
     //   .slider-group[data-param=...] → CC
     //   .lora-row[data-param=...]     → CC (Phase 11 will populate)
+    //   #blend-control[data-param=...] → CC (Tags A↔B blend slider,
+    //                                       intentionally NOT a
+    //                                       slider-group — keeps the
+    //                                       horizontal rail styling)
     //   [data-midi-learn=...]         → note (transport buttons, send-prompt, etc.)
     const onContextMenu = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null;
@@ -221,6 +264,12 @@ export function useMidi() {
       if (loraRow?.dataset.param) {
         e.preventDefault();
         useMidiStore.getState().startLearn("cc", loraRow.dataset.param, loraRow);
+        return;
+      }
+      const blendEl = target.closest<HTMLElement>("#blend-control");
+      if (blendEl?.dataset.param) {
+        e.preventDefault();
+        useMidiStore.getState().startLearn("cc", blendEl.dataset.param, blendEl);
         return;
       }
       const learnEl = target.closest<HTMLElement>("[data-midi-learn]");

--- a/demos/realtime_motion_graph_web/web/hooks/useMidi.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useMidi.ts
@@ -12,7 +12,7 @@ import { useLoraStore } from "@/store/useLoraStore";
 import { useMidiStore } from "@/store/useMidiStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
-import { SLIDER_META } from "@/types/engine";
+import { LORA_SLIDER_MAX, SLIDER_META } from "@/types/engine";
 
 // Web MIDI bootstrap. Asks for navigator.requestMIDIAccess on mount, wires
 // onmidimessage to either the learn handler (if learn is active) or the
@@ -82,7 +82,16 @@ function handleCC(cc: number, value: number): void {
   // tick UP → engine value DOWN), mirroring SliderGroup's behavior.
   const range = getChannelRange(param);
   const min = range?.min ?? 0;
-  const max = range?.max ?? meta?.max ?? 2.0;
+  // LoRA strength sliders (`lora_str_<id>`) aren't in SLIDER_META;
+  // their range is fixed by LORA_SLIDER_MAX (matches the LibraryTile
+  // widget, edge bars, and useScheduledCurves). Without this branch
+  // an absolute MIDI knob's full sweep would map 0..127 → 0..2.0 and
+  // the perf-store clamp would silently truncate the top ~10% — the
+  // operator-visible slider stops at 1.8 but the MIDI input still
+  // crosses it.
+  const max = range?.max
+    ?? meta?.max
+    ?? (param.startsWith("lora_str_") ? LORA_SLIDER_MAX : 2.0);
   const span = Math.max(0, max - min);
   const reverse = range?.reverse ?? false;
   const step = meta?.step ?? 0.05;

--- a/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
@@ -7,6 +7,7 @@ import { getChannelRange } from "@/lib/config";
 
 import {
   DEFAULT_TIME_SIGNATURE,
+  LORA_SLIDER_MAX,
   SLIDER_META,
   type DcwMode,
   type DcwWavelet,
@@ -444,8 +445,14 @@ function clampToMeta(param: string, value: number): number {
     return Math.max(range.min, Math.min(range.max, value));
   }
   const meta = SLIDER_META[param];
-  // LoRA sliders (lora_str_<id>) aren't in SLIDER_META — clamp to [0, 2].
-  const max = meta?.max ?? 2.0;
+  // LoRA sliders (lora_str_<id>) aren't in SLIDER_META — their cap is
+  // LORA_SLIDER_MAX (currently 1.8). Same convention as the LibraryTile
+  // slider widget, the edge bars, and useScheduledCurves. Without this,
+  // MIDI knobs / hardware controllers (which go through bumpSlider /
+  // setSlider) would write past the operator-facing 1.8 ceiling up to
+  // the generic 2.0 fallback.
+  const max = meta?.max
+    ?? (param.startsWith("lora_str_") ? LORA_SLIDER_MAX : 2.0);
   return Math.max(0, Math.min(max, value));
 }
 


### PR DESCRIPTION
## Summary

Two slider-write callsites silently allowed MIDI hardware to push LoRA strength past the 1.8 ceiling that the LibraryTile widget / edge bars / curve scheduler all enforce:

1. **\`clampToMeta\` in \`usePerformanceStore.ts\`** — the final clamp every slider write goes through. The comment even said *\"clamp to [0, 2]\"* for \`lora_str_*\` — that was the bug, not the intent.
2. **\`handleCC\` in \`useMidi.ts\`** — span calc for absolute knobs and bump deltas. Without the cap here, a 127-tick MIDI knob sweep still physically advances toward 2.0; the clamp in (1) silently truncates the top ~10%, so the operator sees a dead zone at the top of the knob even after fixing (1) alone.

Both now branch on \`param.startsWith(\"lora_str_\")\` and use \`LORA_SLIDER_MAX\` — same convention already used by \`LibraryTile\` and \`useScheduledCurves\`. Non-LoRA sliders keep the 2.0 fallback.

## Test plan

- [ ] MIDI knob full-sweep on a LoRA strength CC → value display stops cleanly at 1.80, no dead zone.
- [ ] LibraryTile drag still maxes at 1.80 (unchanged).
- [ ] Channel-gain sliders (`ch_g*` / `ch*`) still use their per-channel max from `public/config.json` (unaffected — `range?.max` still wins).
- [ ] Non-LoRA sliders without explicit meta still fall back to 2.0 (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)