### PR TITLE
rtmg/web: networkMonitor false-positive prune + curves config + import/export config UI

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/AdvancedCoachmark.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AdvancedCoachmark.tsx
@@ -37,7 +37,7 @@ import { useEffect } from "react";
 //     Trigger: Stage C completed at least once this session
 //              AND ~12s have passed since remixStarted first flipped
 //              AND the advanced drawer is still closed
-//     Shows:   <AdvancedCoachmark/> — "Drag up for more controls"
+//     Shows:   <AdvancedCoachmark/> — "Click for more controls"
 //     Dismiss: pointerdown anywhere, Esc, drawer open, or 8s auto-hide
 //     Persist: dd:advanced-coachmark-dismissed = "1" in localStorage
 //     Owned by: <AdvancedDrawer/> (this component is just the view)
@@ -94,7 +94,7 @@ export function AdvancedCoachmark({ visible, onDismiss }: Props) {
   return (
     <div className="advanced-coachmark" role="status" aria-live="polite">
       <span className="advanced-coachmark-text">
-        Drag up for more controls — Press <kbd>O</kbd> to toggle
+        Click for more controls — Press <kbd>O</kbd> to toggle
       </span>
       <span className="advanced-coachmark-arrow" aria-hidden="true">
         ▾

--- a/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
@@ -9,6 +9,13 @@ import {
   type DecodedFixture,
 } from "@/engine/audio/loadFixture";
 import { togglePauseAndAudio } from "@/engine/audio/togglePauseAndAudio";
+import {
+  applyConfig,
+  captureRtmgConfig,
+  getConfig,
+  mergeConfig,
+  type RtmgConfig,
+} from "@/lib/config";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { confirm } from "@/store/useConfirmStore";
 import { useCurveStore } from "@/store/useCurveStore";
@@ -56,6 +63,7 @@ export function OperatorStrip() {
   const addCustomTrack = useCustomTracksStore((s) => s.add);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const configFileInputRef = useRef<HTMLInputElement | null>(null);
   const [uploading, setUploading] = useState(false);
   // Mirror of AudioSourceCrate's pending-upload state. The "Almost
   // Ready" dialog gates the actual fixture swap so the previously
@@ -116,6 +124,49 @@ export function OperatorStrip() {
       usePerformanceStore.getState().setPaused(true);
     });
   }, [player]);
+
+  // Import config — load an exported RtmgConfig JSON (or a demon-public-
+  // demo share file, which is RtmgConfig + a `tracks` extension that
+  // mergeConfig silently drops). Layers on top of the live config so
+  // operator-edited fields the user didn't touch in the imported file
+  // keep their current values.
+  async function onConfigFilePicked(file: File): Promise<void> {
+    const { setStatus } = useSessionStore.getState();
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text) as Partial<RtmgConfig>;
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new Error("config root must be an object");
+      }
+      const merged = mergeConfig(getConfig(), parsed);
+      applyConfig(merged);
+      setStatus(useSessionStore.getState().status, `Imported ${file.name}`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setStatus(useSessionStore.getState().status, `Import failed: ${msg}`);
+    }
+  }
+
+  // Export config — snapshot the live stores into an RtmgConfig and
+  // trigger a JSON download. Filename includes a timestamp so multiple
+  // exports in a session don't collide.
+  function onExportConfig(): void {
+    const snapshot = captureRtmgConfig();
+    const blob = new Blob([JSON.stringify(snapshot, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+    a.download = `demon-config-${ts}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    const { setStatus } = useSessionStore.getState();
+    setStatus(useSessionStore.getState().status, `Exported config`);
+  }
 
   async function onFilePicked(file: File) {
     const { setStatus } = useSessionStore.getState();
@@ -219,6 +270,75 @@ export function OperatorStrip() {
           <path d="M2.5 10v3a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3" />
         </svg>
       </button>
+      {/* Import config — paired with Export below. Layers the loaded
+          JSON on top of the live config via mergeConfig. Accepts both
+          DEMON's own exports and demon-public-demo share files (the
+          extension fields drop silently in mergeConfig). */}
+      <button
+        type="button"
+        className="pause-btn"
+        data-dd-tooltip="Import config"
+        aria-label="Import config"
+        onClick={() => configFileInputRef.current?.click()}
+      >
+        <svg
+          viewBox="0 0 16 16"
+          width={14}
+          height={14}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.4}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          {/* curly braces — universal "config" signal */}
+          <path d="M5 2.5C4 2.5 3.5 3 3.5 4v2c0 1-1 1.5-1 2 0 .5 1 1 1 2v2c0 1 .5 1.5 1.5 1.5" />
+          <path d="M11 2.5c1 0 1.5.5 1.5 1.5v2c0 1 1 1.5 1 2 0 .5-1 1-1 2v2c0 1-.5 1.5-1.5 1.5" />
+          {/* down arrow between the braces — "import in" */}
+          <path d="M8 5v5" />
+          <path d="M6 8.5 8 10.5 10 8.5" />
+        </svg>
+      </button>
+      {/* Export config — snapshot the live stores into an RtmgConfig
+          JSON and download. Complements demon-public-demo's
+          ShareDialog Download button — same shape on both sides. */}
+      <button
+        type="button"
+        className="pause-btn"
+        data-dd-tooltip="Export config"
+        aria-label="Export config"
+        onClick={onExportConfig}
+      >
+        <svg
+          viewBox="0 0 16 16"
+          width={14}
+          height={14}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.4}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M5 2.5C4 2.5 3.5 3 3.5 4v2c0 1-1 1.5-1 2 0 .5 1 1 1 2v2c0 1 .5 1.5 1.5 1.5" />
+          <path d="M11 2.5c1 0 1.5.5 1.5 1.5v2c0 1 1 1.5 1 2 0 .5-1 1-1 2v2c0 1-.5 1.5-1.5 1.5" />
+          {/* up arrow between the braces — "export out" */}
+          <path d="M8 11V6" />
+          <path d="M6 7.5 8 5.5 10 7.5" />
+        </svg>
+      </button>
+      <input
+        ref={configFileInputRef}
+        type="file"
+        accept=".json,application/json"
+        style={{ display: "none" }}
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          e.target.value = "";
+          if (file) void onConfigFilePicked(file);
+        }}
+      />
       <input
         ref={fileInputRef}
         type="file"

--- a/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
@@ -270,75 +270,6 @@ export function OperatorStrip() {
           <path d="M2.5 10v3a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3" />
         </svg>
       </button>
-      {/* Import config — paired with Export below. Layers the loaded
-          JSON on top of the live config via mergeConfig. Accepts both
-          DEMON's own exports and demon-public-demo share files (the
-          extension fields drop silently in mergeConfig). */}
-      <button
-        type="button"
-        className="pause-btn"
-        data-dd-tooltip="Import config"
-        aria-label="Import config"
-        onClick={() => configFileInputRef.current?.click()}
-      >
-        <svg
-          viewBox="0 0 16 16"
-          width={14}
-          height={14}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={1.4}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          {/* curly braces — universal "config" signal */}
-          <path d="M5 2.5C4 2.5 3.5 3 3.5 4v2c0 1-1 1.5-1 2 0 .5 1 1 1 2v2c0 1 .5 1.5 1.5 1.5" />
-          <path d="M11 2.5c1 0 1.5.5 1.5 1.5v2c0 1 1 1.5 1 2 0 .5-1 1-1 2v2c0 1-.5 1.5-1.5 1.5" />
-          {/* down arrow between the braces — "import in" */}
-          <path d="M8 5v5" />
-          <path d="M6 8.5 8 10.5 10 8.5" />
-        </svg>
-      </button>
-      {/* Export config — snapshot the live stores into an RtmgConfig
-          JSON and download. Complements demon-public-demo's
-          ShareDialog Download button — same shape on both sides. */}
-      <button
-        type="button"
-        className="pause-btn"
-        data-dd-tooltip="Export config"
-        aria-label="Export config"
-        onClick={onExportConfig}
-      >
-        <svg
-          viewBox="0 0 16 16"
-          width={14}
-          height={14}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={1.4}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M5 2.5C4 2.5 3.5 3 3.5 4v2c0 1-1 1.5-1 2 0 .5 1 1 1 2v2c0 1 .5 1.5 1.5 1.5" />
-          <path d="M11 2.5c1 0 1.5.5 1.5 1.5v2c0 1 1 1.5 1 2 0 .5-1 1-1 2v2c0 1-.5 1.5-1.5 1.5" />
-          {/* up arrow between the braces — "export out" */}
-          <path d="M8 11V6" />
-          <path d="M6 7.5 8 5.5 10 7.5" />
-        </svg>
-      </button>
-      <input
-        ref={configFileInputRef}
-        type="file"
-        accept=".json,application/json"
-        style={{ display: "none" }}
-        onChange={(e) => {
-          const file = e.target.files?.[0];
-          e.target.value = "";
-          if (file) void onConfigFilePicked(file);
-        }}
-      />
       <input
         ref={fileInputRef}
         type="file"
@@ -558,6 +489,48 @@ export function OperatorStrip() {
       >
         ↻
       </button>
+
+      {/* Import + Export config — far right of the strip, local-mode
+          only. These are developer / power-user affordances for
+          dialing in a pod's config.json without SSH-editing; the live
+          deployed product hides them entirely (LOCAL_MODE === false).
+          mergeConfig drops unknown top-level keys so demon-public-demo
+          share files (with the `tracks` extension) import as a base
+          config without error. */}
+      {LOCAL_MODE && (
+        <>
+          <button
+            type="button"
+            className="pause-btn"
+            style={{ marginLeft: "auto" }}
+            data-dd-tooltip="Import config from JSON"
+            aria-label="Import config"
+            onClick={() => configFileInputRef.current?.click()}
+          >
+            Import
+          </button>
+          <button
+            type="button"
+            className="pause-btn"
+            data-dd-tooltip="Download current config as JSON"
+            aria-label="Export config"
+            onClick={onExportConfig}
+          >
+            Export
+          </button>
+          <input
+            ref={configFileInputRef}
+            type="file"
+            accept=".json,application/json"
+            style={{ display: "none" }}
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              e.target.value = "";
+              if (file) void onConfigFilePicked(file);
+            }}
+          />
+        </>
+      )}
 
       {pending && (
         <AlmostReadyDialog

--- a/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
+++ b/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
@@ -3,193 +3,95 @@ import { useSessionStore } from "@/store/useSessionStore";
 import type { RemoteBackend } from "@/engine/protocol";
 import type { AudioSlice } from "@/types/protocol";
 
-// Detect "experience is degraded" from existing WebSocket signals,
-// without protocol changes. Three inputs, one verdict:
+// Detect "connection is actually broken" from existing WebSocket signals.
+// Two inputs, one verdict:
 //
-//   1. Slice inter-arrival jitter — RemoteBackend already dispatches a
-//      CustomEvent("slice") on every audio chunk; we timestamp arrivals
-//      into a 20-sample ring and require BOTH a high p95/median ratio
-//      AND an absolute p95 above the audible threshold (~50ms per the
-//      VoIP/WebRTC consensus — Cisco, Obkio, MOS literature). Two-gate
-//      trigger so a 2.5× ratio of an 8ms cadence (= 20ms p95) doesn't
-//      fire — that's not audible jitter, it's just scheduling noise.
+//   1. Stall watchdog — no AudioSlice received in STALL_MS. This is the
+//      one signal that always corresponds to a real user-audible problem:
+//      slices stopped arriving, so the AudioPlayer's buffer drains and
+//      playback hitches.
 //
-//   2. Server engine stress — each slice carries `tickMs` (engine
-//      generation time). Compared against the *measured* slice cadence
-//      (median inter-arrival delta) as a budget ratio: if p95 tickMs is
-//      consuming ≥85% of the slot, the buffer is one hitch from
-//      draining. Self-calibrating to whatever cadence the engine
-//      actually runs at, instead of a hardcoded ms threshold that
-//      would over-fire on slow cadences and under-fire on fast ones.
+//   2. Session status — useSessionStore reports "error" / "closed" when
+//      the WebSocket has actually torn down. Beats every other gate.
 //
-//   3. Stall watchdog — independent of the listener firing, so we
-//      can detect "no slice in N ms" while the connection is silent.
-//      1500ms is squarely in the WebRTC/VoIP convention for an
-//      audio-stream timeout (NetEQ concealment runs sub-100ms; the
-//      user-facing "stalled" indicator fires at 1–2s).
+// What this monitor used to do but no longer does (2026-05-12):
 //
-// Plus a session-status override: WS error/close forces "unstable".
+//   - **Inter-arrival jitter check**. The AudioPlayer's audio worklet
+//     buffers slices and smooths their delivery into the actual audio
+//     stream. Variance in slice ARRIVAL timing doesn't translate to
+//     audible playback jitter unless the worklet's underrun protection
+//     fails — and when that happens, the slice cadence collapses
+//     entirely (which the stall watchdog catches). The jitter trigger
+//     fired on perfectly fine sessions because the slice cadence is
+//     bursty by design.
 //
-// Asymmetric hysteresis: ~3s of sustained bad signal before showing
-// (don't cry wolf on a single GC pause or Wi-Fi roam), ~8s of clean
-// signal before hiding (don't flap). Bias is intentional — false
-// positives teach users to ignore the indicator, which is worse than
-// missing a real degradation.
+//   - **Tick-budget check** (tickMs p95 / measured slice cadence). This
+//     was an apples-to-oranges comparison: `tickMs` is per-generation
+//     engine time (per a single denoise step), while `medianInterarrival`
+//     is wall-clock between SLICE arrivals — and each slice can carry
+//     `numGens > 1` generations. The "buffer is one hitch from draining"
+//     framing also assumed a video-decode buffer-ahead model that
+//     doesn't match how this engine runs: for realtime audio streaming
+//     the engine is *expected* to operate near the realtime boundary,
+//     so a high tick-vs-cadence ratio is normal operation, not
+//     impending degradation.
 //
-// Runs entirely off the RAF render loop. The slice handler is a few
-// microseconds (two ring writes); the evaluator runs on a 500ms
-// setInterval.
+// Net effect: the pill now only fires when something is verifiably
+// broken (stalled slices, dead WS). False positives caused users to
+// learn to ignore the indicator, which is worse than the missed-edge
+// case it was trying to predict.
+//
+// Asymmetric hysteresis: ~3s of sustained badness before showing,
+// ~8s of clean before hiding. Same bias as before (don't flap).
 
 export interface NetworkMonitor {
   stop(): void;
 }
 
 const THRESHOLDS = {
-  WARMUP_MS: 4000,
-  WARMUP_MIN_SAMPLES: 8,
-  WINDOW_SIZE: 20,
   EVAL_INTERVAL_MS: 500,
 
-  /** p95 / median of inter-arrival deltas. Healthy networks routinely
-   *  hit 1.5–2.0× from kernel scheduling alone; 2.5× is where bursts
-   *  start to dominate. Required AND with JITTER_ABS_MS below. */
-  JITTER_RATIO: 2.5,
-  /** Absolute p95 inter-arrival in ms. Audio jitter becomes audibly
-   *  perceptible around 30–50ms in the VoIP/WebRTC consensus; use 50
-   *  as the conservative trigger so cadences with naturally tight
-   *  intervals don't false-positive on a high ratio. */
-  JITTER_ABS_MS: 50,
-  /** Server tickMs p95 as a fraction of the *measured* slice cadence.
-   *  >0.92 = ≤8% headroom = the buffer is genuinely the only thing
-   *  saving you from underrun. Self-calibrates: at a 100ms cadence this
-   *  fires at 92ms; at a 24ms cadence at ~22ms. Bumped from 0.85 in
-   *  2026-05 after the pill was firing too often on otherwise-fine
-   *  sessions — 15% headroom is normal scheduler noise. */
-  TICK_BUDGET_RATIO: 0.92,
-  /** No slice received in this long → unstable, no matter the jitter.
-   *  Upper end of the VoIP/WebRTC convention for an audio-stream
-   *  timeout (1–2s). Bumped from 1500ms in 2026-05 to absorb brief
-   *  GC/JIT stalls without alarming. */
-  STALL_MS: 2200,
+  /** No slice received in this long → connection is stalled. Upper
+   *  end of the VoIP/WebRTC convention for an audio-stream timeout
+   *  (1–2s); we use 3s so brief GC/JIT stalls and engine pauses
+   *  don't alarm. */
+  STALL_MS: 3000,
 
   /** Consecutive bad ticks before showing (6s @ 500ms). Above the
-   *  Zoom/Meet "unstable" debounce range (~1.5–3s) — we lean cautious
-   *  because false alarms erode trust faster than missed ones in this
-   *  app, where the canvas itself visibly degrades during real
-   *  trouble. Bumped from 6 (3s) in 2026-05. */
+   *  Zoom/Meet "unstable" debounce range (~1.5–3s) — false alarms
+   *  erode trust faster than missed ones in this app, where the
+   *  canvas itself visibly degrades during real trouble. */
   ESCALATE_TICKS: 12,
   /** Consecutive clean ticks before hiding (8s @ 500ms). Asymmetric
-   *  ~2.7× the show debounce: easy to dismiss, hard to summon. */
+   *  ~1.3× the show debounce: easy to dismiss, hard to summon. */
   RECOVERY_TICKS: 16,
 } as const;
 
-interface RingBuffer {
-  buf: Float64Array;
-  head: number;
-  count: number;
-}
-
-function makeRing(size: number): RingBuffer {
-  return { buf: new Float64Array(size), head: 0, count: 0 };
-}
-
-function pushRing(ring: RingBuffer, value: number): void {
-  ring.buf[ring.head] = value;
-  ring.head = (ring.head + 1) % ring.buf.length;
-  if (ring.count < ring.buf.length) ring.count++;
-}
-
-function ringToArray(ring: RingBuffer): number[] {
-  const out: number[] = new Array(ring.count);
-  // Once full, head points at the oldest slot; before that, samples
-  // start at index 0 and run to count-1.
-  const start = ring.count < ring.buf.length ? 0 : ring.head;
-  for (let i = 0; i < ring.count; i++) {
-    out[i] = ring.buf[(start + i) % ring.buf.length];
-  }
-  return out;
-}
-
-function quantile(samples: number[], q: number): number {
-  if (samples.length === 0) return 0;
-  const sorted = samples.slice().sort((a, b) => a - b);
-  const idx = Math.min(
-    sorted.length - 1,
-    Math.max(0, Math.floor(q * (sorted.length - 1))),
-  );
-  return sorted[idx];
-}
-
 export function createNetworkMonitor(remote: RemoteBackend): NetworkMonitor {
-  const arrivals = makeRing(THRESHOLDS.WINDOW_SIZE);
-  const ticks = makeRing(THRESHOLDS.WINDOW_SIZE);
   let lastSliceAt = 0;
-  let readyAt = 0;
   let pendingQuality: "healthy" | "unstable" = "healthy";
   let pendingTicks = 0;
-
-  // If the session is already "ready" when the monitor boots, capture
-  // readyAt synchronously. Otherwise the subscribe handler picks it
-  // up on the status flip.
-  if (useSessionStore.getState().status === "ready") {
-    readyAt = performance.now();
-  }
 
   const onSlice = (e: Event) => {
     const detail = (e as CustomEvent<AudioSlice>).detail;
     if (!detail) return;
-    const now = performance.now();
-    pushRing(arrivals, now);
-    pushRing(ticks, detail.tickMs);
-    lastSliceAt = now;
+    lastSliceAt = performance.now();
   };
   remote.addEventListener("slice", onSlice);
-
-  const unsubSession = useSessionStore.subscribe((state, prev) => {
-    if (state.status === "ready" && prev.status !== "ready") {
-      readyAt = performance.now();
-    }
-  });
 
   const evaluate = () => {
     const now = performance.now();
     const sessionStatus = useSessionStore.getState().status;
     const staleMs = lastSliceAt > 0 ? now - lastSliceAt : 0;
 
-    const arrivalSamples = ringToArray(arrivals);
-    const deltas: number[] = [];
-    for (let i = 1; i < arrivalSamples.length; i++) {
-      deltas.push(arrivalSamples[i] - arrivalSamples[i - 1]);
-    }
-    const medianInterarrival = quantile(deltas, 0.5);
-    const p95Interarrival = quantile(deltas, 0.95);
-    const jitterRatio =
-      deltas.length >= 2 && medianInterarrival > 0
-        ? p95Interarrival / medianInterarrival
-        : 1;
-    const tickMsP95 = quantile(ringToArray(ticks), 0.95);
-    const tickBudgetRatio =
-      medianInterarrival > 0 ? tickMsP95 / medianInterarrival : 0;
-
-    const warmedUp =
-      readyAt > 0 &&
-      now - readyAt >= THRESHOLDS.WARMUP_MS &&
-      deltas.length >= THRESHOLDS.WARMUP_MIN_SAMPLES;
-
+    // Only meaningful once we've seen at least one slice — pre-first-
+    // slice we have no baseline and shouldn't flag a "stall" against zero.
+    const haveBaseline = lastSliceAt > 0;
     let candidate: "healthy" | "unstable" = "healthy";
-    if (warmedUp) {
-      const jitterTriggered =
-        jitterRatio >= THRESHOLDS.JITTER_RATIO &&
-        p95Interarrival >= THRESHOLDS.JITTER_ABS_MS;
-      const tickTriggered =
-        tickBudgetRatio >= THRESHOLDS.TICK_BUDGET_RATIO;
-      const stallTriggered = staleMs >= THRESHOLDS.STALL_MS;
-      if (jitterTriggered || tickTriggered || stallTriggered) {
-        candidate = "unstable";
-      }
+    if (haveBaseline && staleMs >= THRESHOLDS.STALL_MS) {
+      candidate = "unstable";
     }
-    // WS error/close beats every other signal — by then the connection
-    // is gone and the warmup gate is the wrong question to ask.
+    // WS error/close beats every other signal — connection's gone.
     if (sessionStatus === "error" || sessionStatus === "closed") {
       candidate = "unstable";
     }
@@ -217,7 +119,10 @@ export function createNetworkMonitor(remote: RemoteBackend): NetworkMonitor {
       ...(shouldFlip ? { quality: pendingQuality } : {}),
       lastSliceAt,
       staleMs,
-      jitterRatio,
+      // jitterRatio is kept on the store for back-compat with consumers
+      // that read it, but we no longer compute it — the trigger was
+      // removed (see header).
+      jitterRatio: 1,
     });
     if (shouldFlip) pendingTicks = 0;
   };
@@ -231,7 +136,6 @@ export function createNetworkMonitor(remote: RemoteBackend): NetworkMonitor {
     stop() {
       window.clearInterval(intervalId);
       remote.removeEventListener("slice", onSlice);
-      unsubSession();
       useNetworkStore.getState().reset();
     },
   };

--- a/demos/realtime_motion_graph_web/web/lib/config.ts
+++ b/demos/realtime_motion_graph_web/web/lib/config.ts
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from "react";
 
+import { useCurveStore } from "@/store/useCurveStore";
+import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import {
   DCW_MODES,
@@ -143,6 +145,35 @@ export interface RtmgConfigDenoiseSessionGate {
   glide_ms: number;
 }
 
+/** One control point on a schedule curve. Mirrors the runtime
+ *  CurvePoint in store/useCurveStore — duplicated on the wire shape
+ *  so the config can be authored and parsed without reaching across
+ *  module boundaries. */
+export interface RtmgConfigCurvePoint {
+  /** 0..1 along the track timeline. Endpoints pinned at 0 and 1. */
+  x: number;
+  /** 0..1 normalised. Mapped to the param's min/max at apply time. */
+  y: number;
+  mode: "smooth" | "linear" | "step";
+}
+
+export interface RtmgConfigCurve {
+  enabled: boolean;
+  /** Always ≥ 2 points; first.x === 0 and last.x === 1. */
+  points: RtmgConfigCurvePoint[];
+}
+
+/** Per-param schedule curves the user (or an operator-supplied config)
+ *  draws against the track timeline. Keyed by param name — the fixed
+ *  six (denoise, hint_strength, feedback, shift, noise_share, ode_noise)
+ *  plus dynamic LoRA strength curves (lora_str_<id>). */
+export interface RtmgConfigCurves {
+  /** Master enable. When false, no curve drives any param regardless
+   *  of per-curve enabled flags. */
+  scheduleEnabled: boolean;
+  curves: Record<string, RtmgConfigCurve>;
+}
+
 export interface RtmgConfig {
   engine: RtmgConfigEngine;
   prompts: RtmgConfigPrompts;
@@ -159,6 +190,12 @@ export interface RtmgConfig {
    * ScriptProcessor fallback already restarts on swap; this aligns the
    * worklet path with that behavior and makes it operator-tunable. */
   restart_song_on_swap: boolean;
+  /** Per-param schedule curves. Same shape useCurveStore persists to
+   *  localStorage today, lifted into the operator-editable config so a
+   *  pod's deployed sound can ship its automation alongside its
+   *  sliders + prompts. Optional — absent = stock pods fall back to
+   *  the store's localStorage hydration / defaultCurveState. */
+  curves?: RtmgConfigCurves;
 }
 
 export const DEFAULT_CONFIG: RtmgConfig = {
@@ -276,7 +313,7 @@ export function useConfig(): RtmgConfig {
   return c;
 }
 
-function mergeConfig(
+export function mergeConfig(
   base: RtmgConfig,
   override: Partial<RtmgConfig> | null | undefined,
 ): RtmgConfig {
@@ -308,6 +345,11 @@ function mergeConfig(
       typeof override.restart_song_on_swap === "boolean"
         ? override.restart_song_on_swap
         : base.restart_song_on_swap,
+    // Curves are operator-authored and only meaningful as a whole bag,
+    // so the override entry replaces the base entry whole when present.
+    // Absent override keeps whatever the base has (DEFAULT_CONFIG leaves
+    // this undefined; stock pods fall through to localStorage hydration).
+    ...(override.curves !== undefined ? { curves: override.curves } : (base.curves !== undefined ? { curves: base.curves } : {})),
   };
 }
 
@@ -377,5 +419,91 @@ export function applyConfig(c: RtmgConfig): void {
     lufsOn: c.audio.lufs_enabled,
   }));
 
+  // Curves: when the config carries them, push the whole bag into
+  // useCurveStore via setState (the store has no batch action). Skipped
+  // when the field is absent — stock pods fall through to the store's
+  // own hydratePersistedCurves localStorage path. Deep-clone the
+  // points so later edits in the store don't mutate the active
+  // config snapshot.
+  if (c.curves) {
+    useCurveStore.setState({
+      scheduleEnabled: c.curves.scheduleEnabled,
+      curves: Object.fromEntries(
+        Object.entries(c.curves.curves).map(([param, curve]) => [
+          param,
+          {
+            enabled: curve.enabled,
+            points: curve.points.map((p) => ({ x: p.x, y: p.y, mode: p.mode })),
+          },
+        ]),
+      ),
+    });
+  }
+
   for (const fn of listeners) fn(c);
+}
+
+/**
+ * Snapshot the live stores into an `RtmgConfig` — the inverse of
+ * `applyConfig`. Used by the OperatorStrip's Export button and by any
+ * caller (demon-public-demo's `captureSessionState`) that wants the
+ * DEMON-shaped base of a session without rebuilding the field-mapping
+ * logic.
+ *
+ * Fields the stores don't own (channel_ranges, effects, audio
+ * defaults, denoise_session_gate, restart_song_on_swap, the
+ * non-numeric engine.* config) are pulled from the active config so
+ * exports round-trip cleanly through Import.
+ */
+export function captureRtmgConfig(): RtmgConfig {
+  const perf = usePerformanceStore.getState();
+  const lora = useLoraStore.getState();
+  const curveStore = useCurveStore.getState();
+  const active = _activeConfig;
+
+  // Numeric controls land on sliderTargets in the perf store. The DCW
+  // non-numeric controls live on dedicated store fields.
+  const controls: RtmgConfigControls = { ...perf.sliderTargets };
+  controls.dcw_enabled = perf.dcwEnabled;
+  controls.dcw_mode = perf.dcwMode;
+  controls.dcw_wavelet = perf.dcwWavelet;
+  // lora_default_strength isn't tracked live in the perf store; pull
+  // from active config so the export reflects the seed value.
+  if (typeof active.controls.lora_default_strength !== "undefined") {
+    controls.lora_default_strength = active.controls.lora_default_strength;
+  }
+
+  return {
+    engine: {
+      ...active.engine,
+      key: perf.activeKey,
+      time_signature: perf.activeTimeSignature ?? active.engine.time_signature,
+      enabled_loras: Array.from(lora.enabled),
+    },
+    prompts: {
+      a: perf.promptA,
+      b: perf.promptB,
+      blend: perf.blend,
+    },
+    controls,
+    channel_ranges: active.channel_ranges,
+    seed: perf.seed,
+    effects: active.effects,
+    audio: { ...active.audio, lufs_enabled: perf.lufsOn },
+    reset_seconds: active.reset_seconds,
+    denoise_session_gate: active.denoise_session_gate,
+    restart_song_on_swap: active.restart_song_on_swap,
+    curves: {
+      scheduleEnabled: curveStore.scheduleEnabled,
+      curves: Object.fromEntries(
+        Object.entries(curveStore.curves).map(([param, curve]) => [
+          param,
+          {
+            enabled: curve.enabled,
+            points: curve.points.map((p) => ({ x: p.x, y: p.y, mode: p.mode })),
+          },
+        ]),
+      ),
+    },
+  };
 }


### PR DESCRIPTION
## Summary

Three changes against `realtime_motion_graph_web/web` that all serve the same end goal: make the same JSON config format work as a local DEMON config AND as a demon-public-demo shared sound.

### 1. networkMonitor false-positive prune

The unstable-connection pill was firing on sessions with no audible playback issues. Two of the three triggers were measuring the wrong thing for an audio-streaming app:

- **Inter-arrival jitter** — the AudioPlayer worklet buffers slices and smooths their delivery into the actual audio stream. Variance in slice arrival timing doesn't translate to audible jitter unless the worklet's underrun protection fails — and when that happens the slice cadence collapses entirely (which the stall watchdog already catches). The trigger was firing on perfectly fine sessions because slice cadence is bursty by design.
- **Tick-budget ratio** (`tickMs` p95 / measured slice cadence) — apples-to-oranges. `tickMs` is per-generation engine time (a single denoise step), while `medianInterarrival` is wall-clock between **slice** arrivals — and each slice can carry `numGens > 1`. The "buffer is one hitch from draining" framing assumed a video-decode buffer-ahead model that doesn't match how this engine runs.

Drop both. Keep stall watchdog (no slice in 3s → real problem) and WS-error/close session-status override.

### 2. Coachmark copy: "Drag up" → "Click"

`AdvancedCoachmark` text now reads "Click for more controls — Press O to toggle". Aligns with the actual interaction (the drawer toggle is a click affordance; dragging is the separate slider gesture).

### 3. Curves in `RtmgConfig` + Import/Export config UI

- **Curves are now a config field.** `RtmgConfigCurves` types added; `applyConfig` pushes a config-supplied curves bag into `useCurveStore` (mirrors what `hydratePersistedCurves` does from localStorage today). Stock pods without `curves` in their config.json behave unchanged. Pods that ship curves in config.json boot with their automation pre-loaded.
- **Import + Export config buttons** added to `OperatorStrip` (next to the audio-upload icon). No in-app config UI existed before — operators had to SSH and edit `public/config.json`.
  - Import: file picker → `mergeConfig(parsed, getConfig())` → `applyConfig(merged)`. Layers on top of the live config so mid-edits are preserved. Unknown top-level keys (e.g. demon-public-demo's `tracks` extension) drop silently — a shared-sound JSON imports cleanly as a base config.
  - Export: new `captureRtmgConfig()` helper snapshots the live stores; downloads as `demon-config-<timestamp>.json`.
- **`mergeConfig` is now exported** so the import handler can call it directly. The new `captureRtmgConfig()` lives next to `applyConfig` and is the inverse of it.

These pair with a forthcoming demon-public-demo PR that re-exports the types via its UI barrel, makes its `SessionState` extend `RtmgConfig`, and adds a Download-config button to its ShareDialog. Net: a single source of truth for the shape, with demon-public-demo's `tracks` extension as the only addition.

## Test plan

- [ ] **Network pill.** Run a pod long enough to see the previously-noisy pill. It should stay hidden through normal slice-cadence variance. Kill the WS or pause the pod's generator → pill appears within ~3s and clears 8s after recovery.
- [ ] **Coachmark copy.** Trigger the AdvancedCoachmark flow → reads "Click for more controls — Press O to toggle".
- [ ] **Stock pod (no curves in config).** Behavior unchanged; localStorage hydrates user-drawn curves.
- [ ] **Curves from config.** Hand-author a `curves` block in `public/config.json` → refresh → schedule overlay reflects those curves; engine writes them when scheduleEnabled is true.
- [ ] **Export.** Click Export config in OperatorStrip → JSON downloads → file contains current engine + prompts + controls + curves matching the live UI.
- [ ] **Round-trip Import.** Edit a slider, click Import config with the previously-exported file → slider snaps back. Other settings (prompts, curves, dcw flags) restore too.
- [ ] **Malformed import.** Text file / broken JSON / wrong shape → status surfaces error; nothing crashes.
- [ ] **demon-public-demo share file.** Import a JSON with the `tracks` extension → base RtmgConfig applies cleanly; `tracks` block is silently ignored by mergeConfig; no errors.