### PR TITLE
realtime_motion_graph_web/web: waveform scrub strip + band loops + curve fixes

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -4360,11 +4360,14 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
    open, hoist the pill above the tabs so it doesn't sit on top of the
    curve tabs or the preset menus that grow upward from them. */
 .network-indicator[data-curves-open="true"] {
+  /* +15px above the default curves-open row so the pill clears the
+     waveform-scrub strip below it (which was pushed 15px down in
+     curves mode to clear the curve dot area). */
   bottom: calc(
     var(--drawer-handle-h, 28px) +
     env(safe-area-inset-bottom, 0px) +
     var(--curves-tab-strip-h, 64px) +
-    12px
+    12px + 15px
   );
 }
 .network-indicator__bars rect {
@@ -4379,6 +4382,91 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
     animation:
       network-indicator-fade-in 200ms cubic-bezier(.2, .8, .2, 1) forwards;
   }
+}
+
+/* ── Waveform scrub box ────────────────────────────────────────────────
+   Bottom-center strip showing the source-track waveform with a playhead.
+   Click/drag scrubs via AudioPlayer.seek(). Sits just above the network
+   indicator pill; tracks the same `data-curves-open` bottom-offset bump
+   so it clears the curve scheduler tab strip when that overlay is open.
+   Hidden until session is `ready` and (in the component) on mobile. */
+.waveform-scrub-box {
+  position: fixed;
+  left: 50%;
+  /* Drawer-closed default: sit just above the network pill / drawer
+     handle. The body.drawer-open rule below lifts this to clear the
+     drawer panel when it slides up, so the strip is never covered. */
+  bottom: calc(
+    var(--drawer-handle-h, 28px) +
+    env(safe-area-inset-bottom, 0px) +
+    /* pill (~28px) + spacer */ 12px + 40px
+  );
+  transform: translateX(-50%);
+  width: min(640px, 90vw);
+  height: 56px;
+  /* Above AdvancedDrawer (z:50) so the strip stays visible while the
+     drawer is open (paired with the bottom-lift rule below so they
+     never overlap). Below modals (z:100). */
+  z-index: 60;
+  /* No chrome — the waveform is the entire visual. Just the canvases
+     painted directly on the page. */
+  border: 0;
+  background: none;
+  cursor: ew-resize;
+  pointer-events: auto;
+  /* Strip is mounted as soon as the player exists so the peak-compute
+     effect has canvases to draw onto, but visually hidden until the
+     first peak-pass lands (component sets data-ready="true" then). */
+  opacity: 0;
+  transition: bottom 240ms cubic-bezier(.2, .8, .2, 1),
+              opacity 180ms ease-out;
+  overflow: hidden;
+}
+.waveform-scrub-box[data-ready="true"] {
+  opacity: 1;
+}
+.waveform-scrub-box:not([data-ready="true"]) {
+  pointer-events: none;
+}
+/* Lift above the drawer's top edge when the drawer is open. The drawer
+   panel sits at fixed `height: var(--drawer-h)` so the strip sits at
+   `var(--drawer-h) + small gap`. */
+body.drawer-open .waveform-scrub-box {
+  bottom: calc(
+    var(--drawer-h, 50vh) +
+    env(safe-area-inset-bottom, 0px) +
+    8px
+  );
+}
+/* Schedule-curves overlay open: match the NetworkIndicator pill's
+   vertical position exactly (drawer-handle-h + safe-area + tab-strip-h
+   + 12px) AND collapse the strip to a thin band so it fits cleanly
+   between the curve tab strip and the bottom of the curve drawing
+   area. At the default 56px height the strip overlaps curve dots
+   that sit at the bottom of the curves canvas, stealing their click
+   target. Thin band keeps it as a visual reference + minimal-area
+   scrub target without occluding any curve dots. */
+.waveform-scrub-box[data-curves-open="true"],
+body.drawer-open .waveform-scrub-box[data-curves-open="true"] {
+  /* 15px lower than the network pill's row so the strip clears the
+     curve tab strip's hover halo and the operator's pinkie when
+     dragging dots near the bottom of the curves canvas. */
+  bottom: calc(
+    var(--drawer-handle-h, 28px) +
+    env(safe-area-inset-bottom, 0px) +
+    var(--curves-tab-strip-h, 64px) +
+    12px - 15px
+  );
+  height: 24px;
+}
+.waveform-scrub-box .waveform-scrub-bg,
+.waveform-scrub-box .waveform-scrub-fg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  pointer-events: none;
 }
 
 /* ── Custom tooltip (replaces native `title=` for hover-visible UI) ──

--- a/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
@@ -42,6 +42,7 @@ import { RecordButton } from "./RecordButton";
 import { RecordingPreview } from "./RecordingPreview";
 import { StartOverlay } from "./StartOverlay";
 import { StatusBar } from "./StatusBar";
+import { WaveformScrubBox } from "./WaveformScrubBox";
 
 // Demo shell — wires the package's hooks + components into a working app.
 //
@@ -140,6 +141,8 @@ export function PerformanceShell() {
       <StatusBar />
 
       <LiveIndicator />
+
+      {!isMobile && <WaveformScrubBox />}
 
       <NetworkIndicator />
 

--- a/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
@@ -426,6 +426,19 @@ export function ScheduleCurvesOverlay() {
       const { x: px, y: py } = eventToLocal(e);
       const hit = hitTestPoint(px, py, w, h);
       if (hit !== null) {
+        // Alt + click on a point → delete it (matches Logic/Live/Pro
+        // Tools convention for removing an automation node). The two
+        // pinned endpoints (x=0, x=1) can't be deleted — the curve
+        // would lose its boundary conditions. Backspace/Delete keys
+        // still work as an alternative when the point is hovered.
+        if (e.altKey) {
+          const points = pointsRef.current;
+          if (hit === 0 || hit === points.length - 1) return;
+          const next = points.filter((_, i) => i !== hit);
+          pointsRef.current = next;
+          setCurvePoints(activeCurve, next);
+          return;
+        }
         dragIndex = hit;
         canvas.setPointerCapture(e.pointerId);
         return;
@@ -505,11 +518,41 @@ export function ScheduleCurvesOverlay() {
       setCurvePoints(activeCurve, next);
     };
 
+    // Double-click on a point → delete it. The most discoverable
+    // delete gesture, paired with the existing Alt+click and
+    // Backspace/Delete keys. Listened on the canvas so it fires for
+    // clicks on dots OR empty area; the hit-test inside discards
+    // empty-area dblclicks (they would otherwise insert two
+    // overlapping new dots from the pointerdown handler firing
+    // twice).
+    const onDblClick = (e: MouseEvent) => {
+      const { w, h } = sizeMeta();
+      const { x: px, y: py } = eventToLocal(e);
+      const hit = hitTestPoint(px, py, w, h);
+      if (hit === null) return;
+      const points = pointsRef.current;
+      // Pinned endpoints — same rule as Alt+click + Backspace path.
+      if (hit === 0 || hit === points.length - 1) return;
+      // Cancel any in-flight drag so the surviving pointer capture
+      // doesn't keep moving a now-deleted index on the next move.
+      if (dragIndex !== null) {
+        try {
+          canvas.releasePointerCapture(e.pointerId ?? 0);
+        } catch {}
+        dragIndex = null;
+      }
+      const next = points.filter((_, i) => i !== hit);
+      pointsRef.current = next;
+      hoverIndex = null;
+      setCurvePoints(activeCurve, next);
+    };
+
     canvas.addEventListener("pointerdown", onPointerDown);
     canvas.addEventListener("pointermove", onPointerMove);
     canvas.addEventListener("pointerup", onPointerUp);
     canvas.addEventListener("pointercancel", onPointerUp);
     canvas.addEventListener("contextmenu", onContextMenu);
+    canvas.addEventListener("dblclick", onDblClick);
     document.addEventListener("keydown", onKeyDown);
 
     return () => {
@@ -520,6 +563,7 @@ export function ScheduleCurvesOverlay() {
       canvas.removeEventListener("pointerup", onPointerUp);
       canvas.removeEventListener("pointercancel", onPointerUp);
       canvas.removeEventListener("contextmenu", onContextMenu);
+      canvas.removeEventListener("dblclick", onDblClick);
       document.removeEventListener("keydown", onKeyDown);
     };
   }, [open, activeCurve, setCurvePoints]);

--- a/demos/realtime_motion_graph_web/web/components/Performance/WaveformScrubBox.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/WaveformScrubBox.tsx
@@ -1,0 +1,421 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { computePeaks, drawPeaks } from "@/engine/curves/waveformPeaks";
+import { frameScheduler } from "@/engine/scheduler/FrameScheduler";
+import { useCurveStore } from "@/store/useCurveStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+// Bottom-center scrub strip. Shows the source-track waveform, overlays
+// a playhead at the current AudioPlayer.positionSec, lets the operator
+// click/drag anywhere to call player.seek(t).
+//
+// The audio buffer here IS the looped source track — the engine streams
+// generated `audio_slice` messages that `patch` into this same buffer.
+// Seek is therefore client-only and instant: jumping to t=X plays
+// whichever lives there now (generated audio if that region has been
+// touched in a prior lap; otherwise the original source). No engine
+// protocol message is involved — see audio-worklet.js:106 and
+// AudioPlayer.seek():339.
+//
+// Loop bands (v1):
+//   • Shift + drag      → draw a new band (start at down, end at up)
+//   • Drag band body    → move the whole band
+//   • Drag band edge    → resize that edge
+//   • Right-click band  → clear
+// All client-side via AudioPlayer.setLoopBand/clearLoopBand, which the
+// AudioWorklet honours by wrapping end→start on each pass.
+
+const WAVEFORM_BUCKETS = 640;
+const EDGE_PADDING_PX = 4;
+const BAND_EDGE_HIT_PX = 7; // hit-zone radius around each band edge
+const MIN_BAND_SEC = 0.05;  // 50 ms — below this the band is meaningless
+
+function ensureCanvasSize(canvas: HTMLCanvasElement): {
+  w: number;
+  h: number;
+  dpr: number;
+} {
+  const rect = canvas.getBoundingClientRect();
+  const dpr = window.devicePixelRatio || 1;
+  const w = Math.max(1, Math.floor(rect.width));
+  const h = Math.max(1, Math.floor(rect.height));
+  const targetW = Math.floor(w * dpr);
+  const targetH = Math.floor(h * dpr);
+  if (canvas.width !== targetW || canvas.height !== targetH) {
+    canvas.width = targetW;
+    canvas.height = targetH;
+  }
+  return { w, h, dpr };
+}
+
+type Band = { start: number; end: number };
+type DragMode =
+  | "seek"
+  | "draw-band"
+  | "move-band"
+  | "resize-band-start"
+  | "resize-band-end";
+
+interface DragState {
+  mode: DragMode;
+  /** Anchor time at the moment of pointerdown — interpretation depends
+   *  on mode. seek/draw-band: t at pointerdown. move-band: original
+   *  pointerdown t. resize-band-*: original t of the edge being grabbed. */
+  anchorT: number;
+  /** For move-band: original band at pointerdown so we can recompute
+   *  start/end from delta on every move without drift. */
+  startBand?: Band;
+}
+
+export function WaveformScrubBox() {
+  const player = useSessionStore((s) => s.player);
+  const curvesOpen = useCurveStore((s) => s.overlayOpen);
+  const boxRef = useRef<HTMLDivElement>(null);
+  const bgCanvasRef = useRef<HTMLCanvasElement>(null);
+  const fgCanvasRef = useRef<HTMLCanvasElement>(null);
+
+  // Active band (seconds). Mirrored to the worklet via player.setLoopBand
+  // any time it changes to a complete band. Kept in a ref so the rAF
+  // foreground tick can read it without making React state changes
+  // invalidate the tick's frameScheduler subscription.
+  const [bandState, setBandState] = useState<Band | null>(null);
+  const bandRef = useRef<Band | null>(null);
+  bandRef.current = bandState;
+
+  const [hasPeaks, setHasPeaks] = useState(false);
+  const hasPlayer = player !== null;
+
+  // ── Background canvas: waveform ───────────────────────────────────
+  useEffect(() => {
+    if (!hasPlayer) {
+      setHasPeaks(false);
+      return;
+    }
+    const canvas = bgCanvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let peaks: Float32Array | null = null;
+
+    const redraw = () => {
+      const { w, h, dpr } = ensureCanvasSize(canvas);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, w, h);
+      if (!peaks) return;
+      ctx.fillStyle = "rgba(240, 138, 72, 0.28)";
+      drawPeaks(ctx, peaks, w, h);
+      ctx.fillStyle = "rgba(255, 255, 255, 0.08)";
+      drawPeaks(ctx, peaks, w, h);
+    };
+
+    const recompute = () => {
+      const p = useSessionStore.getState().player;
+      if (!p) {
+        peaks = null;
+        setHasPeaks(false);
+      } else {
+        const mirror = p.getMirror();
+        peaks = computePeaks(mirror, p.channels, WAVEFORM_BUCKETS);
+        setHasPeaks(true);
+      }
+      redraw();
+    };
+
+    recompute();
+
+    const ro = new ResizeObserver(redraw);
+    ro.observe(canvas);
+
+    const unsubMirror = player.onMirrorChange?.(() => recompute()) ?? (() => {});
+    const unsubSession = useSessionStore.subscribe((s, prev) => {
+      if (s.player !== prev.player) recompute();
+    });
+
+    return () => {
+      ro.disconnect();
+      unsubMirror();
+      unsubSession();
+    };
+  }, [hasPlayer, player]);
+
+  // ── Foreground canvas: playhead + active band ─────────────────────
+  useEffect(() => {
+    if (!hasPlayer) return;
+    const canvas = fgCanvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const tick = () => {
+      const p = useSessionStore.getState().player;
+      if (!p) return;
+      const duration = p.duration;
+      if (duration <= 0) return;
+      const { w, h, dpr } = ensureCanvasSize(canvas);
+      const innerW = Math.max(1, w - 2 * EDGE_PADDING_PX);
+      const tToX = (t: number) =>
+        EDGE_PADDING_PX + (Math.min(1, Math.max(0, t / duration))) * innerW;
+
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, w, h);
+
+      // Active band — translucent orange rect.
+      const band = bandRef.current;
+      if (band) {
+        const x0 = tToX(band.start);
+        const x1 = tToX(band.end);
+        ctx.fillStyle = "rgba(240, 138, 72, 0.18)";
+        ctx.fillRect(Math.min(x0, x1), 0, Math.abs(x1 - x0), h);
+        // Edge markers — slightly brighter so the resize hit-zones are
+        // findable by eye.
+        ctx.fillStyle = "rgba(255, 222, 196, 0.55)";
+        ctx.fillRect(x0 - 0.5, 0, 1.5, h);
+        ctx.fillRect(x1 - 0.5, 0, 1.5, h);
+      }
+
+      // Playhead — orange line with halo.
+      const x = tToX(p.positionSec);
+      ctx.strokeStyle = "rgba(240, 138, 72, 0.28)";
+      ctx.lineWidth = 3;
+      ctx.beginPath();
+      ctx.moveTo(x, 2);
+      ctx.lineTo(x, h - 2);
+      ctx.stroke();
+      ctx.strokeStyle = "rgba(255, 222, 196, 0.95)";
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(x, 2);
+      ctx.lineTo(x, h - 2);
+      ctx.stroke();
+    };
+
+    const unregister = frameScheduler.register("waveform-scrub", tick, {
+      phase: "compute",
+      budgetMs: 0.2,
+    });
+    return () => unregister();
+  }, [hasPlayer]);
+
+  // Apply / clear band on the worklet whenever the React band state
+  // settles to a valid range (or null). Guarded with `typeof === "function"`
+  // because a session that started before this code shipped has an
+  // AudioPlayer instance whose prototype predates these methods —
+  // calling them blind would crash the render and tear the session.
+  useEffect(() => {
+    if (!hasPlayer || !player) return;
+    const setBand = (player as unknown as {
+      setLoopBand?: (s: number, e: number) => void;
+    }).setLoopBand;
+    const clearBand = (player as unknown as {
+      clearLoopBand?: () => void;
+    }).clearLoopBand;
+    if (
+      bandState &&
+      bandState.end - bandState.start >= MIN_BAND_SEC &&
+      bandState.start >= 0
+    ) {
+      if (typeof setBand === "function") {
+        setBand.call(player, bandState.start, bandState.end);
+      }
+    } else if (bandState === null) {
+      if (typeof clearBand === "function") clearBand.call(player);
+    }
+  }, [bandState, hasPlayer, player]);
+
+  // ── Pointer state machine ─────────────────────────────────────────
+  useEffect(() => {
+    if (!hasPlayer) return;
+    const box = boxRef.current;
+    if (!box) return;
+
+    let drag: DragState | null = null;
+
+    const tFromEvent = (e: PointerEvent): number => {
+      const p = useSessionStore.getState().player;
+      if (!p) return 0;
+      const duration = p.duration;
+      if (duration <= 0) return 0;
+      const rect = box.getBoundingClientRect();
+      const innerW = Math.max(1, rect.width - 2 * EDGE_PADDING_PX);
+      const x = e.clientX - rect.left - EDGE_PADDING_PX;
+      return Math.min(duration, Math.max(0, (x / innerW) * duration));
+    };
+
+    /** Pixels per second at the current canvas width. Used to convert
+     *  the band-edge hit-zone (defined in pixels) to a tolerance in
+     *  seconds at pointerdown. */
+    const secPerPx = (): number => {
+      const p = useSessionStore.getState().player;
+      if (!p || p.duration <= 0) return 0;
+      const rect = box.getBoundingClientRect();
+      const innerW = Math.max(1, rect.width - 2 * EDGE_PADDING_PX);
+      return p.duration / innerW;
+    };
+
+    const onDown = (e: PointerEvent) => {
+      // Right-click → clear band (if any). Don't preventDefault here —
+      // contextmenu handler below also fires and is the place to
+      // suppress the browser's native menu.
+      if (e.button === 2) return;
+      if (e.button !== 0) return;
+
+      const t = tFromEvent(e);
+      const band = bandRef.current;
+      const tol = secPerPx() * BAND_EDGE_HIT_PX;
+
+      let mode: DragMode = "seek";
+      let anchorT = t;
+      let startBand: Band | undefined;
+
+      if (e.shiftKey) {
+        // Draw a brand-new band from this point. Clears any existing one
+        // so the user always sees their freshest gesture.
+        mode = "draw-band";
+        setBandState({ start: t, end: t });
+      } else if (band) {
+        // Existing band — check for edge / body hits.
+        if (Math.abs(t - band.start) <= tol) {
+          mode = "resize-band-start";
+        } else if (Math.abs(t - band.end) <= tol) {
+          mode = "resize-band-end";
+        } else if (t >= band.start && t <= band.end) {
+          mode = "move-band";
+          anchorT = t;
+          startBand = { ...band };
+        } else {
+          // Plain click outside the band — regular seek. Leave the band
+          // in place; the worklet keeps looping it. (Seeks outside the
+          // band fall back into it on the next wrap.)
+          mode = "seek";
+        }
+      }
+
+      drag = { mode, anchorT, startBand };
+      box.setPointerCapture(e.pointerId);
+
+      if (mode === "seek") {
+        const p = useSessionStore.getState().player;
+        p?.seek(t);
+      }
+    };
+
+    const onMove = (e: PointerEvent) => {
+      if (!drag) return;
+      const t = tFromEvent(e);
+      const p = useSessionStore.getState().player;
+      const duration = p?.duration ?? 0;
+
+      switch (drag.mode) {
+        case "seek":
+          p?.seek(t);
+          return;
+        case "draw-band": {
+          const a = drag.anchorT;
+          const start = Math.max(0, Math.min(a, t));
+          const end = Math.min(duration, Math.max(a, t));
+          setBandState({ start, end });
+          return;
+        }
+        case "move-band": {
+          const sb = drag.startBand;
+          if (!sb) return;
+          const len = sb.end - sb.start;
+          const delta = t - drag.anchorT;
+          let start = sb.start + delta;
+          let end = sb.end + delta;
+          // Clamp to buffer ends without resizing.
+          if (start < 0) {
+            end -= start;
+            start = 0;
+          }
+          if (end > duration) {
+            start -= end - duration;
+            end = duration;
+          }
+          setBandState({ start, end: start + len });
+          return;
+        }
+        case "resize-band-start": {
+          const b = bandRef.current;
+          if (!b) return;
+          const newStart = Math.min(b.end - MIN_BAND_SEC, Math.max(0, t));
+          setBandState({ start: newStart, end: b.end });
+          return;
+        }
+        case "resize-band-end": {
+          const b = bandRef.current;
+          if (!b) return;
+          const newEnd = Math.max(
+            b.start + MIN_BAND_SEC,
+            Math.min(duration, t),
+          );
+          setBandState({ start: b.start, end: newEnd });
+          return;
+        }
+      }
+    };
+
+    const onUp = (e: PointerEvent) => {
+      if (!drag) return;
+      // Draw mode finalises on release: if the user just tap-clicked
+      // with shift (no drag), kill the band so we don't lock playback
+      // to a zero-width sliver.
+      if (drag.mode === "draw-band") {
+        const b = bandRef.current;
+        if (!b || b.end - b.start < MIN_BAND_SEC) {
+          setBandState(null);
+        }
+      }
+      drag = null;
+      try {
+        box.releasePointerCapture(e.pointerId);
+      } catch {}
+    };
+
+    const onContextMenu = (e: MouseEvent) => {
+      // Right-click clears the band entirely. Operators familiar with
+      // DAWs expect "right-click loop marker = remove" so we mirror that
+      // without spinning up a real context menu in v1.
+      if (bandRef.current) {
+        e.preventDefault();
+        setBandState(null);
+      }
+    };
+
+    box.addEventListener("pointerdown", onDown);
+    box.addEventListener("pointermove", onMove);
+    box.addEventListener("pointerup", onUp);
+    box.addEventListener("pointercancel", onUp);
+    box.addEventListener("contextmenu", onContextMenu);
+    return () => {
+      box.removeEventListener("pointerdown", onDown);
+      box.removeEventListener("pointermove", onMove);
+      box.removeEventListener("pointerup", onUp);
+      box.removeEventListener("pointercancel", onUp);
+      box.removeEventListener("contextmenu", onContextMenu);
+    };
+  }, [hasPlayer]);
+
+  // Render the DOM as soon as we have a player so the peak-compute
+  // effect can find the canvases in the DOM. The strip stays visually
+  // hidden (opacity 0) until the first peak-pass lands.
+  if (!hasPlayer) return null;
+
+  return (
+    <div
+      ref={boxRef}
+      className="waveform-scrub-box"
+      data-curves-open={curvesOpen ? "true" : undefined}
+      data-ready={hasPeaks ? "true" : undefined}
+      data-has-band={bandState ? "true" : undefined}
+      role="slider"
+      aria-label="Scrub playhead"
+    >
+      <canvas ref={bgCanvasRef} className="waveform-scrub-bg" aria-hidden="true" />
+      <canvas ref={fgCanvasRef} className="waveform-scrub-fg" aria-hidden="true" />
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/engine/audio/AudioPlayer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/AudioPlayer.ts
@@ -152,7 +152,10 @@ export class AudioPlayer {
 
     if (this._useWorklet) {
       // Stable URL — worklet ships from public/ so AudioContext can resolve it.
-      await this.ctx.audioWorklet.addModule("/audio-worklet.js");
+      // Cache-busting query bumped manually when the worklet message
+      // surface changes (e.g. v2 added setLoopBand). The browser caches
+      // worklet bytes per-URL and hard refresh doesn't always invalidate.
+      await this.ctx.audioWorklet.addModule("/audio-worklet.js?v=2");
 
       const node = new AudioWorkletNode(this.ctx, "realtime-buffer", {
         numberOfInputs: 0,
@@ -351,6 +354,45 @@ export class AudioPlayer {
       });
     } else {
       this._spPosition = target;
+    }
+  }
+
+  /** Lock playback to a sub-region of the buffer. The AudioWorklet wraps
+   *  end→start each time the playhead reaches `endSec`. Pure client-side
+   *  loop — the engine keeps generating linearly and writing slices into
+   *  the same buffer, so what plays inside the band is whatever lives
+   *  there now (regenerated audio on subsequent laps; original source
+   *  in regions generation hasn't touched yet).
+   *
+   *  Pass min 30 ms band — anything shorter spins the wrap path tight
+   *  enough to be perceived as silence. Out-of-range values are clamped.
+   */
+  setLoopBand(startSec: number, endSec: number): void {
+    if (this.frameCount === 0) return;
+    const startFrames = Math.max(
+      0,
+      Math.min(this.frameCount - 1, Math.round(startSec * SAMPLE_RATE)),
+    );
+    const endFrames = Math.max(
+      startFrames + Math.floor(SAMPLE_RATE * 0.03),
+      Math.min(this.frameCount, Math.round(endSec * SAMPLE_RATE)),
+    );
+    if (this._useWorklet && this.node) {
+      (this.node as AudioWorkletNode).port.postMessage({
+        type: "setLoopBand",
+        startFrames,
+        endFrames,
+      });
+    }
+  }
+
+  /** Remove any active band loop; playback resumes wrapping at
+   *  end-of-buffer (subject to `setLoop`). */
+  clearLoopBand(): void {
+    if (this._useWorklet && this.node) {
+      (this.node as AudioWorkletNode).port.postMessage({
+        type: "clearLoopBand",
+      });
     }
   }
 

--- a/demos/realtime_motion_graph_web/web/hooks/useScheduledCurves.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useScheduledCurves.ts
@@ -8,6 +8,7 @@ import {
   isManualOverrideActive,
   usePerformanceStore,
 } from "@/store/usePerformanceStore";
+import { useLoraStore } from "@/store/useLoraStore";
 import { useSessionStore } from "@/store/useSessionStore";
 import { useCurveStore } from "@/store/useCurveStore";
 import { LORA_SLIDER_MAX, SLIDER_META } from "@/types/engine";
@@ -53,6 +54,7 @@ export function useScheduledCurves(): void {
         );
         const curves = curveState.curves;
         const setSliderDirect = usePerformanceStore.getState().setSliderDirect;
+        const setLoraStrength = useLoraStore.getState().setStrength;
         for (const param of Object.keys(curves)) {
           const c = curves[param];
           if (!c.enabled) continue;
@@ -64,7 +66,22 @@ export function useScheduledCurves(): void {
           const max = param.startsWith("lora_str_")
             ? LORA_SLIDER_MAX
             : (SLIDER_META[param]?.max ?? 1.0);
-          setSliderDirect(param, yNorm * max);
+          const value = yNorm * max;
+          setSliderDirect(param, value);
+          // LoRA strength sliders rendered on the desktop edge rails
+          // (DesktopEdgeDrag) read from useLoraStore.strengths — the
+          // canonical "current strength" store — not from
+          // sliderTargets. Mirror the curve write there so the
+          // rails track curves the same way LibraryTile does. We
+          // deliberately do NOT route through
+          // loraStrengthDispatcher.set() because that stamps a
+          // manualTouch on the param, which would suppress the curve
+          // on the next tick (isManualOverrideActive == true for
+          // 500 ms after every stamp).
+          if (param.startsWith("lora_str_")) {
+            const id = param.slice("lora_str_".length);
+            setLoraStrength(id, value);
+          }
         }
       },
       { phase: "compute", budgetMs: 1 },

--- a/demos/realtime_motion_graph_web/web/public/audio-worklet.js
+++ b/demos/realtime_motion_graph_web/web/public/audio-worklet.js
@@ -9,6 +9,8 @@
 //   {type:'swap',     buffer:Float32Array, channels:int}
 //   {type:'setLoop',  enabled:bool}                            // loop at end-of-buffer
 //   {type:'seek',     positionFrames:int}                      // jump playhead
+//   {type:'setLoopBand', startFrames:int, endFrames:int}       // wrap at end→start
+//   {type:'clearLoopBand'}                                     // disable band loop
 //
 // Messages to main thread:
 //   {type:'position',    positionSec:float, swapCount:int, kick:float}
@@ -62,6 +64,12 @@ class RealtimeBufferProcessor extends AudioWorkletProcessor {
     this.loop = true;
     this._endSignaled = false;
 
+    // Band loop: when both >= 0 and end > start, the wrap path below
+    // sends the playhead from loopBandEnd → loopBandStart on each pass
+    // instead of letting it run to frameCount. -1 = no band.
+    this.loopBandStart = -1;
+    this.loopBandEnd = -1;
+
     this._framesSinceReport = 0;
 
     // Kick state: ring of squared frame energies, running sum.
@@ -111,6 +119,35 @@ class RealtimeBufferProcessor extends AudioWorkletProcessor {
         this.position = Math.max(0, Math.min(this.frameCount - 1, target));
       }
       this._endSignaled = false;
+      return;
+    }
+    if (type === "setLoopBand") {
+      // Band defined in frames. Refuse if degenerate (≤0 frames between
+      // the two markers) so the wrap path doesn't spin in place.
+      const s = Math.max(0, msg.startFrames | 0);
+      const e = Math.min(this.frameCount, msg.endFrames | 0);
+      if (e - s < 1) {
+        this.loopBandStart = -1;
+        this.loopBandEnd = -1;
+        return;
+      }
+      this.loopBandStart = s;
+      this.loopBandEnd = e;
+      // If the playhead is outside the new band, snap it to the band
+      // start so the next process() block plays from where the user
+      // pointed at. Without this, position can sit past loopBandEnd
+      // and the wrap below fires every block — fine, but the operator
+      // wouldn't hear the band start until naturally cycling past
+      // frameCount, which is confusing.
+      if (this.position < s || this.position >= e) {
+        this.position = s;
+      }
+      this._endSignaled = false;
+      return;
+    }
+    if (type === "clearLoopBand") {
+      this.loopBandStart = -1;
+      this.loopBandEnd = -1;
       return;
     }
     if (type === "patch" || type === "add") {
@@ -231,7 +268,18 @@ class RealtimeBufferProcessor extends AudioWorkletProcessor {
       if (this._kickFilled < KICK_WINDOW) this._kickFilled++;
 
       this.position++;
-      if (this.position >= nCur) {
+      // Band loop takes precedence — wrap end → start, no seam fade
+      // for v1 (tiny click is acceptable; can polish with a per-band
+      // crossfade later). The band is only honoured when fully defined
+      // (start ≥ 0 AND end > start) so a partially-cleared state can't
+      // freeze the playhead at the band start.
+      if (
+        this.loopBandStart >= 0 &&
+        this.loopBandEnd > this.loopBandStart &&
+        this.position >= this.loopBandEnd
+      ) {
+        this.position = this.loopBandStart;
+      } else if (this.position >= nCur) {
         // Loop: wrap to `seam` so the head frames blended by the
         // crossfade above aren't replayed. No loop: clamp at end so
         // the freeze branch on the next iteration takes over.


### PR DESCRIPTION
## Summary

A SoundCloud-style waveform strip at the bottom-center of the screen that surfaces the source-track waveform, draws the playhead, and lets the operator click / drag to scrub. **Shift+drag** draws a loop band that wraps end → start in the AudioWorklet; drag the band's body / edges to move / resize; right-click clears it.

Seek + band-loop are pure client-side: the buffer IS the source track (engine slices `patch` into it), so scrubbing into already-generated regions plays the generated audio and scrubbing into untouched regions plays the original source until generation laps around. No new protocol message — both behaviours sit at the existing AudioWorklet boundary.

### Loop UX

- **Plain click / drag** — seek the playhead.
- **Shift + drag** — draw a new band (replaces any existing one).
- **Drag the band body** — move the whole loop.
- **Drag either edge** (~7 px hit zone) — resize that side. Min loop length 50 ms.
- **Right-click** — clear the band.

The strip mounts as soon as the player exists; the canvases stay invisible (opacity 0, pointer-events: none) until the first peak-pass lands. Drawer-aware: when the AdvancedDrawer slides up, the strip lifts to clear the drawer's top edge. Curves-aware: when the schedule-curves overlay is open, the strip collapses to a thin 24 px band and shifts 15 px below the network pill row so it sits between the curves canvas and the tab strip, out of the curve dot drawing area.

### Bundled curve / LoRA fixes

- **Schedule-curves: LoRA rails track curves.** `useScheduledCurves` now mirrors `lora_str_<id>` writes into `useLoraStore.strengths` alongside `sliderValues / sliderTargets`. The `DesktopEdgeDrag` rails read from `useLoraStore`, so without this mirror they stayed frozen while curves drove the engine.
- **Curve node deletion: discoverable.** Double-click a node deletes it (alongside the pre-existing Alt+click + Backspace/Delete-when-hovered paths). Pinned endpoints (x=0, x=1) are protected.
- **Layout in curves mode.** Network pill lifts +15 px above its default curves-open row so the pill + waveform stay visually separated.

## How the band loop is implemented

1. **WaveformScrubBox** (new component) maintains the band as React state. Shift+drag tracks pointermove → updates `bandState: { start, end }`.
2. A `useEffect` on `bandState` calls `AudioPlayer.setLoopBand(startSec, endSec)` whenever the band settles to a valid range, `AudioPlayer.clearLoopBand()` when it's null. Runtime guards `typeof === "function"` so HMR can't crash older AudioPlayer instances mid-session.
3. **AudioPlayer** posts `{ type: \"setLoopBand\", startFrames, endFrames }` to the AudioWorklet. Clamping + a 30 ms min-length guard prevents degenerate bands that would spin the wrap path tight.
4. **AudioWorklet** stores `loopBandStart` / `loopBandEnd`. The wrap path checks band-end *before* end-of-buffer:
   ```js
   this.position++;
   if (bandActive && this.position >= loopBandEnd) {
     this.position = loopBandStart;
   } else if (this.position >= nCur) { /* existing wrap */ }
   ```
5. `addModule(\"/audio-worklet.js?v=2\")` cache-busts so deployments that change the worklet's message surface don't get served stale bytes by the browser's per-URL worklet cache.

## Test plan

- [x] Strip appears at the bottom-center once the session is `ready`; fades in once peaks compute.
- [x] Click / drag → playhead jumps and tracks the cursor.
- [x] Shift+drag → orange-tinted band appears; release locks it; playhead wraps end→start.
- [x] Drag band body → loop moves. Drag edges → resize.
- [x] Right-click on the band → cleared.
- [x] Open AdvancedDrawer → strip lifts above the drawer top.
- [x] Open ScheduleCurvesOverlay → strip collapses to 24 px, drops 15 px below the pill row, out of the dot area; pill lifts +15 px.
- [x] Drive a LoRA strength curve → both the LibraryTile slider AND the desktop edge rail track the curve.
- [x] Double-click a curve dot → deleted (endpoints protected). Alt+click + Backspace/Delete still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)