### PR TITLE
realtime_motion_graph_web/web: fix dblclick handler typing (no pointerId on MouseEvent)

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
@@ -533,14 +533,14 @@ export function ScheduleCurvesOverlay() {
       const points = pointsRef.current;
       // Pinned endpoints — same rule as Alt+click + Backspace path.
       if (hit === 0 || hit === points.length - 1) return;
-      // Cancel any in-flight drag so the surviving pointer capture
+      // Cancel any in-flight drag so a surviving pointer capture
       // doesn't keep moving a now-deleted index on the next move.
-      if (dragIndex !== null) {
-        try {
-          canvas.releasePointerCapture(e.pointerId ?? 0);
-        } catch {}
-        dragIndex = null;
-      }
+      // `e` here is a MouseEvent (dblclick fires that, not a
+      // PointerEvent) — no pointerId is available, but clearing
+      // dragIndex is enough: pointermove's drag branch only runs
+      // when dragIndex !== null, and the pointer capture will be
+      // released naturally on the next pointerup.
+      dragIndex = null;
       const next = points.filter((_, i) => i !== hit);
       pointsRef.current = next;
       hoverIndex = null;


### PR DESCRIPTION
Follow-up to #89.

The curve-dot-delete-via-dblclick handler tried to release the canvas's pointer capture on the dblclick event:

\`\`\`ts
canvas.releasePointerCapture(e.pointerId ?? 0);
\`\`\`

\`dblclick\` fires a \`MouseEvent\`, not a \`PointerEvent\` — no \`pointerId\` exists on it. TypeScript flagged this on PR #89's downstream vendor sync (Vercel build failed). The release call was paranoia anyway:

- The drag handler only moves a point when \`dragIndex !== null\`, so clearing \`dragIndex\` is sufficient to stop the drag from operating on a now-deleted index.
- The pointer capture is released naturally on the next \`pointerup\`.

Dropping the line and the unreachable \`try / catch\` around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)