### PR TITLE
rtmg/web: recording pill above scrubber + opaque tooltips

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3617,7 +3617,11 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   left: 50%;
   bottom: 96px;
   transform: translateX(-50%);
-  z-index: 12;
+  /* Above .waveform-scrub-box (z:60) so the Save / Share / Discard
+     buttons aren't covered or click-intercepted by the scrub strip,
+     which sits at the same bottom edge. Still below full-screen modal
+     backdrops (z:100+). */
+  z-index: 70;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -4494,14 +4498,14 @@ body.drawer-open .waveform-scrub-box[data-curves-open="true"] {
   left: 50%;
   transform: translateX(-50%) translateY(4px);
   padding: 5px 10px 4px;
+  /* Solid sheet body + frame-line border. The earlier layered-gradient
+     trick painted a brand hairline along a transparent top border via
+     background-clip: padding-box, border-box; visually it read as a
+     soft halo that made the tooltip feel translucent against the dark
+     canvas. A plain border + deeper drop shadow keeps the chrome
+     vocabulary (matches .halo-menu body) and reads as fully opaque. */
   background: var(--sheet-bg);
   border: 1px solid var(--frame-line);
-  border-top: 2px solid transparent;
-  background-image:
-    linear-gradient(var(--sheet-bg), var(--sheet-bg)),
-    var(--dd-gradient);
-  background-origin: padding-box, border-box;
-  background-clip: padding-box, border-box;
   border-radius: var(--radius-sm);
   font-family: var(--font-mono);
   font-size: 9px;
@@ -4514,7 +4518,7 @@ body.drawer-open .waveform-scrub-box[data-curves-open="true"] {
   opacity: 0;
   visibility: hidden;
   box-shadow:
-    0 6px 18px rgba(0, 0, 0, 0.45),
+    0 6px 18px rgba(0, 0, 0, 0.55),
     0 0 14px rgba(240, 138, 72, 0.15);
   transition:
     opacity 140ms cubic-bezier(.2, .8, .2, 1),


### PR DESCRIPTION
## Summary

Two small CSS fixes in `demos/realtime_motion_graph_web/web/app/globals.css`:

- **`.recording-preview` z-index 12 → 70.** The new `.waveform-scrub-box` strip (z:60) painted over the Save / Share / Discard pill and intercepted clicks on its `pointer-events: auto` area. Reported as "I can't click the buttons; the dialogue looks semi-transparent." z-70 puts the pill above the strip and still below full-screen modal backdrops (z:100+).
- **`[data-dd-tooltip]::after` simplified.** Dropped the layered `background-image` + transparent `border-top` brand-hairline trick that was reading as translucent against the dark canvas. Flat sheet-bg body, uniform 1px frame-line border, drop-shadow alpha 0.45 → 0.55. Matches the `.halo-menu` body vocabulary; tooltips read as fully opaque.

No JS, no protocol changes, isolated to `globals.css`. Verified locally that hover/focus tooltip appearance is opaque and the recording pill renders above the scrubber strip with clickable buttons.

## Test plan
- [ ] Start a session, wait for the waveform scrub strip to fade in, hit Record → wait a few seconds → Stop. Confirm the Save / Share / Discard pill renders fully opaque above the strip and all three buttons accept clicks.
- [ ] Hover the HaloBadge and a slider tile caption. Confirm tooltips render fully solid against the dark canvas — no brand-color hairline at the top edge, body matches the `.halo-menu` panel body.
- [ ] Tab through with the keyboard — `:focus-visible` shows the same opaque tooltip (no regression on the focus path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)