### PR TITLE
realtime_motion_graph_web: env-driven cap on the TRT profile ceiling

### DIFF
--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -12,6 +12,7 @@ through :class:`.pipeline.PipelineRunner`, with:
 """
 
 import json
+import os
 import socket
 import struct
 import sys
@@ -338,6 +339,31 @@ def handle_client(
     # all the way up to that ceiling — picking the smallest-fitting
     # engine happens below in available_trt_engines().
     max_seconds = max_profile_duration_s()
+    # Operator-side cap on the largest profile this pod will load.
+    # On a 32 GB card, the 240 s decoder + vae_encode pair plus the
+    # resident allocators (text encoder, dreamvae, LUFS buffers, rcfg
+    # state) leave single-digit MiB of headroom and the next 20 MiB
+    # scratch trips the allocator. Setting RTMG_TRT_PROFILE_CAP_S=120
+    # caps both the initial profile pick and every later
+    # ensure_profile() swap (since the new waveform reuses this same
+    # ceiling on swap_source — see the ``new_wf[:, :int(max_seconds *
+    # SAMPLE_RATE)]`` clip in apply_swap_if_pending). Trades support for
+    # longer uploads against VRAM headroom.
+    cap_env = os.environ.get("RTMG_TRT_PROFILE_CAP_S")
+    if cap_env:
+        try:
+            cap_s = float(cap_env)
+            if cap_s > 0 and cap_s < max_seconds:
+                print(
+                    f"[Server] RTMG_TRT_PROFILE_CAP_S={cap_s:.0f}s active "
+                    f"(profile ceiling was {max_seconds:.0f}s)"
+                )
+                max_seconds = cap_s
+        except ValueError:
+            print(
+                f"[Server] WARNING: ignoring non-numeric "
+                f"RTMG_TRT_PROFILE_CAP_S={cap_env!r}"
+            )
     waveform = waveform[:, :int(max_seconds * SAMPLE_RATE)]
     pool = 1920 * 5
     rem = waveform.shape[-1] % pool


### PR DESCRIPTION
## Summary

- Adds `RTMG_TRT_PROFILE_CAP_S` so a pod can refuse to load the 240 s decoder + vae_encode profile when its VRAM headroom doesn't support it.
- Audio longer than the cap gets clipped to the cap (same code path as the existing largest-registered-profile ceiling — `waveform = waveform[:, :int(max_seconds * SAMPLE_RATE)]`).
- The clamp lives at `max_seconds` so the swap-source path picks it up automatically (the existing `new_wf[:, :int(max_seconds * SAMPLE_RATE)]` clip in `apply_swap_if_pending` + the `ensure_profile()` call that follows both honor it).

## Motivation

32 GB 5090 pods are OOM-ing on tiny (~20 MiB) allocations at session start. The steady-state VRAM baseline keeps growing (text encoder resident by default, LUFS buffers, dreamvae, rcfg/rescale state, server-side LoRA injection), and the 240 s decoder + 240 s vae_encode together push the 5090 to single-digit MiB of headroom. The next session's scratch tensor trips the allocator → Python crashes → supervisor respawns → next client sees WS 1011 ("Server restarted to clear memory").

Capping the profile to 120 s on 5090s drops VRAM use enough to give the allocator real headroom, at the cost of long uploads being trimmed to the cap. Better to lose 120 s of audio than to lose the session entirely.

## How to roll out

Set `RTMG_TRT_PROFILE_CAP_S=120` in `/workspace/demon.env` on 5090 pods (and any other card class that needs the same trade). Unset → current behavior, ceiling = largest registered profile.

## Test plan

- [ ] Backend boots with no env var set → log shows no cap message, behavior identical to current.
- [ ] Backend boots with `RTMG_TRT_PROFILE_CAP_S=120` → log shows `RTMG_TRT_PROFILE_CAP_S=120s active (profile ceiling was 240s)`.
- [ ] Upload a 30 s track with the cap on → 60 s profile picked (existing smallest-fit logic).
- [ ] Upload a 200 s track with the cap on → trimmed to 120 s, 120 s profile picked.
- [ ] Swap to a 180 s track mid-session with the cap on → swap succeeds, trimmed to 120 s, no profile swap if 120 s was already loaded.
- [ ] Backend boots with `RTMG_TRT_PROFILE_CAP_S=garbage` → log shows the ignoring-non-numeric warning, behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)