### PR TITLE
rtmg/web: four UX fixes — handle, ref upload, midi reconnect, network pill

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1472,7 +1472,7 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
    above the bottom edge. Clicking the handle (or Esc / `o`) toggles open.
    ============================================================================ */
 :root {
-  --drawer-handle-h: 28px;
+  --drawer-handle-h: 40px;
   --drawer-h: clamp(380px, 50vh, 540px);
 }
 
@@ -1491,11 +1491,11 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
 }
 .install-sheet.open { transform: translateY(0); }
 
-/* Drawer handle — full-width bar at the top of the drawer. The only
-   on-screen close affordance, so it's deliberately bigger and more
-   discoverable than the old corner button. Two rounded "grip"
-   indicators flank a small label so the bar reads as a draggable
-   surface even on first sight. */
+/* Drawer handle — full-width bar at the top of the drawer. Painted
+   with an accent-tinted top edge + bright label so it reads as a
+   *button* (not a chrome divider) even on a busy canvas. The handle
+   used to be 28px of frame-dark text-dim that disappeared into the
+   HUD; bumped to 40px with persistent legibility. */
 .install-drawer-handle {
   flex-shrink: 0;
   height: var(--drawer-handle-h);
@@ -1504,31 +1504,44 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   justify-content: center;
   gap: 14px;
   padding: 0 18px;
-  background: var(--frame);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--accent) 14%, var(--frame)) 0%,
+    var(--frame) 100%
+  );
   border: none;
+  border-top: 1px solid var(--accent-line);
   border-bottom: 1px solid var(--frame-line);
-  color: var(--text-dim);
+  color: var(--text-strong);
   font: inherit;
   font-family: var(--font-mono);
-  font-size: 0.7em;
-  letter-spacing: var(--tracking-bar);
+  font-size: 0.78em;
+  font-weight: 600;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: color 120ms, background 120ms;
+  transition: color 120ms, background 120ms, border-color 120ms;
 }
 .install-drawer-handle:hover {
-  color: var(--accent);
-  background: var(--accent-soft);
+  color: var(--accent-hover);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--accent) 22%, var(--frame)) 0%,
+    var(--frame) 100%
+  );
+  border-top-color: var(--accent);
 }
 .install-drawer-handle-grip {
   width: 56px;
   height: 4px;
-  background: var(--frame-line);
+  background: var(--accent);
   border-radius: 2px;
   transition: background 120ms;
+  opacity: 0.85;
 }
 .install-drawer-handle:hover .install-drawer-handle-grip {
-  background: var(--accent);
+  background: var(--accent-hover);
+  opacity: 1;
 }
 .install-drawer-handle-label {
   white-space: nowrap;
@@ -1539,10 +1552,12 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   pointer-events: none;
   background: var(--frame);
   color: var(--text-dim);
+  border-top-color: var(--frame-line);
   cursor: not-allowed;
 }
 .install-drawer-handle--disabled .install-drawer-handle-grip {
   background: var(--frame-line);
+  opacity: 1;
 }
 
 /* First-run coachmark — floats above the drawer handle to teach new
@@ -5252,6 +5267,40 @@ body.drawer-open .waveform-scrub-box[data-curves-open="true"] {
   flex: 1 1 0;
   min-width: 0;
   display: flex;
+  gap: 4px;
+}
+/* Sibling upload button. Lives outside the dropdown so opening the
+   file picker (and the AlmostReadyDialog modal that follows) no
+   longer closes / occludes the ref list the user was browsing.
+   Square footprint matches the dropdown button height; --accent hover
+   matches the rest of the mixer-tile palette. */
+.ref-control-upload {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: color 80ms linear, border-color 80ms linear, background 80ms linear;
+}
+.ref-control-upload:hover:not(:disabled) {
+  color: var(--accent-hover);
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+}
+.ref-control-upload:focus-visible {
+  outline: none;
+  border-color: var(--accent-line);
+  color: var(--accent-hover);
+}
+.ref-control-upload:disabled {
+  opacity: 0.5;
+  cursor: progress;
 }
 .ref-control-button {
   flex: 1 1 0;

--- a/demos/realtime_motion_graph_web/web/components/Performance/RefControl.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RefControl.tsx
@@ -17,22 +17,24 @@ import { RefSelect } from "./RefSelect";
 
 // Unified picker for the timbre and structure references. Both
 // reference axes share the exact same UI shape (caption + dropdown
-// with "Input Track" / "Upload…" pinned, then library + your-tracks
-// optgroups) and the exact same upload flow (decode locally → push to
-// useCustomTracksStore → ship to the server). The only differences
-// are the store field for the displayed name, the remote send method,
-// and the status-bar prefix — everything else is shared.
+// with "Input Track" pinned + library + your-tracks optgroups, plus a
+// sibling upload icon button) and the exact same upload flow (decode
+// locally → push to useCustomTracksStore → ship to the server). The
+// only differences are the store field for the displayed name, the
+// remote send method, and the status-bar prefix — everything else is
+// shared.
 //
-// Default options at the top:
+// Default option at the top:
 //   "Input Track"  — clear any active override; server falls back to
 //                    encoding against the playback source's own latent.
-//   "Upload…"      — open a file picker. The new clip is added to
-//                    useCustomTracksStore (the same pool the audio-
-//                    source crate uses) so it shows up everywhere.
-// Then any tracks already in useCustomTracksStore appear underneath.
+//
+// Upload sits NEXT TO the dropdown, not inside it: opening a file
+// picker through the dropdown closes the menu and then the
+// AlmostReadyDialog modal hides whatever the user was just comparing
+// against. The sibling button lets the user upload without ever
+// opening (or hiding) the list.
 
 const VAL_INPUT = "__input__";
-const VAL_UPLOAD = "__upload__";
 
 export type RefKind = "timbre" | "structure";
 
@@ -214,12 +216,6 @@ export function RefControl({ kind }: { kind: RefKind }) {
       clearActive();
       return;
     }
-    if (v === VAL_UPLOAD) {
-      // The displayed value snaps back via the controlled `value` prop
-      // on the next render — no need to update store state here.
-      fileInputRef.current?.click();
-      return;
-    }
     if (v !== currentName) void pickExisting(v);
   }
 
@@ -228,10 +224,7 @@ export function RefControl({ kind }: { kind: RefKind }) {
       <RefSelect
         label={bind.label}
         value={value}
-        pinned={[
-          { value: VAL_INPUT, label: "Input Track" },
-          { value: VAL_UPLOAD, label: "Upload…" },
-        ]}
+        pinned={[{ value: VAL_INPUT, label: "Input Track" }]}
         groups={[
           {
             label: "Library",
@@ -245,6 +238,8 @@ export function RefControl({ kind }: { kind: RefKind }) {
         onSelect={onSelect}
         disabled={busy}
         ariaLabel={bind.ariaLabel}
+        onUpload={() => fileInputRef.current?.click()}
+        uploadLabel={`Upload ${bind.label}`}
       />
       <input
         ref={fileInputRef}

--- a/demos/realtime_motion_graph_web/web/components/Performance/RefSelect.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RefSelect.tsx
@@ -27,6 +27,33 @@ interface Props {
   onSelect: (value: string) => void;
   disabled?: boolean;
   ariaLabel: string;
+  /** Optional sibling action button rendered next to the dropdown. Used
+   *  for the inline upload affordance so the modal that follows doesn't
+   *  occlude the dropdown list the user was just browsing. */
+  onUpload?: () => void;
+  /** Tooltip / aria-label for the upload button, kind-specific so screen
+   *  readers and the one-shot tooltip both get useful copy. */
+  uploadLabel?: string;
+}
+
+function UploadIcon({ size = 12 }: { size?: number }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.4}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M8 10V2" />
+      <path d="M4.5 5.5L8 2l3.5 3.5" />
+      <path d="M2.5 10v3a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3" />
+    </svg>
+  );
 }
 
 export function RefSelect({
@@ -37,6 +64,8 @@ export function RefSelect({
   onSelect,
   disabled,
   ariaLabel,
+  onUpload,
+  uploadLabel,
 }: Props) {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
@@ -93,6 +122,18 @@ export function RefSelect({
           <span className="ref-control-button-text">{displayed}</span>
           <span className="ref-control-button-caret" aria-hidden="true" />
         </button>
+        {onUpload && (
+          <button
+            type="button"
+            className="ref-control-upload"
+            onClick={onUpload}
+            disabled={disabled}
+            aria-label={uploadLabel ?? "Upload"}
+            title={uploadLabel ?? "Upload"}
+          >
+            <UploadIcon />
+          </button>
+        )}
         {open && (
           <div ref={menuRef} className="ref-control-menu" role="listbox">
             {pinned.map((o) => (

--- a/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
+++ b/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
@@ -1,18 +1,27 @@
 import { useNetworkStore } from "@/store/useNetworkStore";
-import { useSessionStore } from "@/store/useSessionStore";
 import type { RemoteBackend } from "@/engine/protocol";
 import type { AudioSlice } from "@/types/protocol";
 
 // Detect "connection is actually broken" from existing WebSocket signals.
-// Two inputs, one verdict:
+// One input, one verdict:
 //
-//   1. Stall watchdog — no AudioSlice received in STALL_MS. This is the
-//      one signal that always corresponds to a real user-audible problem:
-//      slices stopped arriving, so the AudioPlayer's buffer drains and
-//      playback hitches.
+//   Stall watchdog — no AudioSlice received in STALL_MS. The one signal
+//   that always corresponds to a real user-audible problem: slices
+//   stopped arriving, so the AudioPlayer's buffer drains and playback
+//   hitches. If the WebSocket dies for any reason (transient blip the
+//   server side recovered from, hard close, network drop), slices
+//   stop flowing and this catches it.
 //
-//   2. Session status — useSessionStore reports "error" / "closed" when
-//      the WebSocket has actually torn down. Beats every other gate.
+// What this monitor used to do but no longer does (2026-05-13):
+//
+//   - **sessionStatus === "error" | "closed" override.** Fired instantly
+//     (no debounce) on every WebSocket close — including transient
+//     close codes the connection recovered from at the protocol layer.
+//     There is no path that flips the store back to "ready" once
+//     frames resume, so once stuck the pill stayed on until the next
+//     full session-start `reset()`. Redundant with the stall watchdog
+//     for the cases that actually matter (real disconnects stop the
+//     slice flow on their own).
 //
 // What this monitor used to do but no longer does (2026-05-12):
 //
@@ -81,7 +90,6 @@ export function createNetworkMonitor(remote: RemoteBackend): NetworkMonitor {
 
   const evaluate = () => {
     const now = performance.now();
-    const sessionStatus = useSessionStore.getState().status;
     const staleMs = lastSliceAt > 0 ? now - lastSliceAt : 0;
 
     // Only meaningful once we've seen at least one slice — pre-first-
@@ -89,10 +97,6 @@ export function createNetworkMonitor(remote: RemoteBackend): NetworkMonitor {
     const haveBaseline = lastSliceAt > 0;
     let candidate: "healthy" | "unstable" = "healthy";
     if (haveBaseline && staleMs >= THRESHOLDS.STALL_MS) {
-      candidate = "unstable";
-    }
-    // WS error/close beats every other signal — connection's gone.
-    if (sessionStatus === "error" || sessionStatus === "closed") {
       candidate = "unstable";
     }
 
@@ -124,7 +128,20 @@ export function createNetworkMonitor(remote: RemoteBackend): NetworkMonitor {
       // removed (see header).
       jitterRatio: 1,
     });
-    if (shouldFlip) pendingTicks = 0;
+    if (shouldFlip) {
+      // Diagnostic trip-wire. This surface has been patched twice
+      // already (2026-05-12 trigger pruning, 2026-05-13 sessionStatus
+      // override removal). If the pill ever flips on a healthy session
+      // again, the next regression should be observable, not guessed
+      // at — a single line in the console gives us staleMs +
+      // lastSliceAt + the direction of the flip.
+      console.debug("[networkMonitor]", {
+        quality: pendingQuality,
+        staleMs: Math.round(staleMs),
+        lastSliceAt: Math.round(lastSliceAt),
+      });
+      pendingTicks = 0;
+    }
   };
 
   const intervalId = window.setInterval(

--- a/demos/realtime_motion_graph_web/web/hooks/useMidi.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useMidi.ts
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 
 import { loraStrengthDispatcher } from "@/engine/lora/dispatcher";
-import { readKnob } from "@/engine/midi/absoluteDelta";
+import { readKnob, resetKnobDelta } from "@/engine/midi/absoluteDelta";
 import { decodeKnob } from "@/engine/midi/knob";
 import { LORA_SLOT_MARKER, type NoteAction } from "@/engine/midi/types";
 import { getChannelRange } from "@/lib/config";
@@ -216,6 +216,14 @@ export function useMidi() {
         a.inputs.forEach(bindInput);
         a.onstatechange = () => {
           a.inputs.forEach(bindInput);
+          // Plug/unplug invalidates the per-CC `lastValue` cache used
+          // by readKnob() — the next message from a reconnected
+          // controller would otherwise compute its delta against a
+          // pre-disconnect value, yanking every bound slider on the
+          // first wiggle. Clearing here means the first message after
+          // any state change is treated as a fresh baseline (no
+          // motion), matching first-time-mapping behaviour.
+          resetKnobDelta();
           useMidiStore
             .getState()
             .setStatus(`MIDI ${a.inputs.size} dev`, "ok");

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 
 import { AudioPlayer } from "@/engine/audio/AudioPlayer";
 import { listFixtures, loadFixtureAudio, pickDefaultFixture } from "@/engine/audio/loadFixture";
+import { resetKnobDelta } from "@/engine/midi/absoluteDelta";
 import { createNetworkMonitor } from "@/engine/networkMonitor";
 import { defaultWsUrl } from "@/engine/podUrl";
 import { RemoteBackend, SLICE_FLAG_DELTA } from "@/engine/protocol";
@@ -96,6 +97,11 @@ export function useStartSession() {
       prev.remote?.close();
     } catch {}
     reset();
+    // Clear the per-CC MIDI delta cache. Stale `lastValue` entries
+    // from the previous session would otherwise produce phantom
+    // deltas on the first knob wiggle of the new one — a long-
+    // reported "knobs go crazy on session start" complaint.
+    resetKnobDelta();
 
     setStatus("loading-fixture", "Loading track…");
 

--- a/demos/realtime_motion_graph_web/web/store/useMidiStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useMidiStore.ts
@@ -171,6 +171,10 @@ export const useMidiStore = create<MidiState>((set, get) => ({
       notes: { ...DEFAULT_MIDI_MAP.notes },
     };
     saveMap(def);
+    // Drop every per-CC delta-tracking baseline. After a full map
+    // reset, the next message on any CC should re-establish a
+    // baseline, not compute a delta against the previous binding.
+    resetKnobDelta();
     set({ map: def, status: { message: "MIDI reset", tone: "ok" } });
   },
 }));


### PR DESCRIPTION
Batch of UX fixes after another round of dogfooding.

## Summary

1. **Advanced Controls drawer handle** — bumped to 40 px (from 28 px), accent-tinted top edge + accent grip bars + bright label so it reads as a *button* instead of a chrome divider. Tooltip + coachmark from `6542092` still apply; they're additive now, not the primary signal.
2. **Timbre / Structure ref `Upload…`** — moved out of the dropdown and into a sibling icon button next to `RefSelect`. Selecting `Upload…` inside the menu used to fire the file picker, dismiss the menu, and then have `AlmostReadyDialog` cover the list the user was browsing. Sibling button keeps the upload action nearby without ever opening or hiding the list.
3. **MIDI knob reconnect / session-start jumps** — the per-CC `lastValue` cache in `engine/midi/absoluteDelta.ts` now resets on (a) device state-change, (b) session start, (c) full MIDI map reset. `resetKnobDelta()` already existed; it was only being called on rebind, never on lifecycle events. Stale deltas were producing phantom yank-to-previous-value behaviour the first time a user wiggled a knob after plugging the controller back in or starting a fresh session.
4. **`UNSTABLE CONNECTION` pill stuck on** — removed the `sessionStatus === "error" | "closed"` override in `networkMonitor.evaluate()`. It fired instantly on any WS close (including transient blips the connection recovered from) and had no path back to healthy until the next full session reset. Redundant with the stall watchdog. Also added a one-line `[networkMonitor]` `console.debug` on every quality flip — this surface has been patched twice in three days; the next regression should be observable, not guessed at.

## Files

```
demos/realtime_motion_graph_web/web/app/globals.css                              (parts 1, 2)
demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx    (part 1 — untouched in this PR; existing tooltip/coachmark still apply)
demos/realtime_motion_graph_web/web/components/Performance/RefControl.tsx        (part 2)
demos/realtime_motion_graph_web/web/components/Performance/RefSelect.tsx         (part 2)
demos/realtime_motion_graph_web/web/engine/midi/absoluteDelta.ts                 (part 3 — untouched; existing `resetKnobDelta()` is sufficient)
demos/realtime_motion_graph_web/web/hooks/useMidi.ts                             (part 3)
demos/realtime_motion_graph_web/web/hooks/useStartSession.ts                     (part 3)
demos/realtime_motion_graph_web/web/store/useMidiStore.ts                        (part 3)
demos/realtime_motion_graph_web/web/engine/networkMonitor.ts                     (part 4)
```

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes on touched files (pre-existing warnings on unrelated lines unchanged)
- [x] `next build` succeeds
- [x] Dev server boots; Advanced Controls handle renders 40 px with accent treatment; `.ref-control-upload` button renders with the upload icon and correct `aria-label`
- [ ] Plug + unplug a MIDI controller mid-session, wiggle a bound knob — should nudge, not jump (verify on hardware)
- [ ] Force WS close (devtools); pill should still appear via stall watchdog within ~6 s
- [ ] Run a healthy session for 2–3 min; pill stays hidden (today it shows even on healthy sessions — this is the regression being fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)