### PR TITLE
rtmg/web: preserve imported denoise on session start

### DIFF
--- a/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
@@ -171,9 +171,17 @@ export function useFixtureSwap() {
       // shows again; side-rail hints stay suppressed until the user
       // drags the top ribbon up. Shares config with useStartSession so
       // one knob controls both Play and swap.
+      //
+      // skipNextDenoiseGate is the same one-shot opt-out used by
+      // useStartSession: a mid-session Remix-onto-running-engine flow
+      // (LibraryPanel handleRemix → applySessionState → setFixture)
+      // sets the flag before setFixture so the imported denoise survives
+      // the swap. Consumed-and-cleared regardless of gate.enabled.
       const perfState = usePerformanceStore.getState();
       const gate = getConfig().denoise_session_gate;
-      if (gate.enabled) {
+      const skipGate = perfState.skipNextDenoiseGate;
+      if (skipGate) perfState.setSkipNextDenoiseGate(false);
+      if (gate.enabled && !skipGate) {
         const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
         perfState.setSliderDirect("denoise", 0);
         perfState.animateSliderDisplayFrom("denoise", prevDenoise, gate.glide_ms);

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -228,10 +228,21 @@ export function useStartSession() {
     // user to dial it back up. controls.denoise in config.json seeds the
     // initial fresh-load value (only applyConfig() at module load sees
     // it); later sessions need this explicit reset to restore the gate.
+    //
+    // skipNextDenoiseGate is a one-shot opt-out: the import path
+    // (applySessionState in demon-public-demo's lib/sessions/client.ts)
+    // sets it after writing the sharer's sliderTargets, so a session
+    // started from a shared / saved / pasted state plays from frame 1 at
+    // the imported denoise instead of being snapped to 0 by the
+    // onboarding cue. Consumed-and-cleared regardless of gate.enabled so
+    // the flag never survives past one session start.
+    //
     // remixStarted always resets so the affordance shows again.
     const perfState = usePerformanceStore.getState();
     const gate = getConfig().denoise_session_gate;
-    if (gate.enabled) {
+    const skipGate = perfState.skipNextDenoiseGate;
+    if (skipGate) perfState.setSkipNextDenoiseGate(false);
+    if (gate.enabled && !skipGate) {
       const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
       perfState.setSliderDirect("denoise", 0);
       perfState.animateSliderDisplayFrom("denoise", prevDenoise, gate.glide_ms);

--- a/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
@@ -334,6 +334,13 @@ interface PerformanceState {
    *  flips it true. Drives the "drag to start" affordance and gates
    *  the side-rail tutorial hints. */
   remixStarted: boolean;
+  /** One-shot flag: when true, the next firing of the denoise_session_gate
+   *  in useStartSession / useFixtureSwap is skipped and the flag is
+   *  cleared. Set by the import path (applySessionState) so that a
+   *  shared / saved / pasted session lands with the sharer's denoise
+   *  value preserved instead of being snapped to 0 by the onboarding
+   *  cue. Fresh sessions leave this false and get the normal gate. */
+  skipNextDenoiseGate: boolean;
 
   /** DCW (wavelet-domain post-step correction) non-numeric state. The
    * numeric knobs (dcw_scaler, dcw_high_scaler, dcw_mult_blend,
@@ -410,6 +417,7 @@ interface PerformanceState {
   setPaused: (p: boolean) => void;
   togglePause: () => void;
   setRemixStarted: (b: boolean) => void;
+  setSkipNextDenoiseGate: (b: boolean) => void;
   /** Run a visual-only "slide to zero" demo on `param`. Seeds
    *  `sliderDisplayOverride[param] = fromValue` and tweens it down to 0
    *  over `durationMs` using a cubic ease-out, then deletes the key so
@@ -506,6 +514,7 @@ export const usePerformanceStore = create<PerformanceState>((set) => ({
   kiosk: false,
   paused: false,
   remixStarted: false,
+  skipNextDenoiseGate: false,
 
   dcwEnabled: true,
   dcwMode: "double",
@@ -620,6 +629,7 @@ export const usePerformanceStore = create<PerformanceState>((set) => ({
   setPaused: (p) => set({ paused: p }),
   togglePause: () => set((s) => ({ paused: !s.paused })),
   setRemixStarted: (b) => set({ remixStarted: b }),
+  setSkipNextDenoiseGate: (b) => set({ skipNextDenoiseGate: b }),
   animateSliderDisplayFrom: (param, fromValue, durationMs) => {
     // Cancel any in-flight smoothing or prior demo tween for this param.
     cancelTween(param);


### PR DESCRIPTION
## Summary

Add a one-shot `skipNextDenoiseGate` flag to `usePerformanceStore` so a session started from an imported state (share / saved / pasted) keeps the importer's denoise value instead of being snapped to 0 by the "hear source first" onboarding gate.

The gate is great for fresh sessions — it teaches the user that the top ribbon is a slider by playing the source dry for a moment with a visual glide. But for a Remix landing (or a Resume of a saved session), the user is explicitly inheriting a remix; they expect the sharer's denoise value to play from frame 1, not have to drag the ribbon up to discover their own remix.

The downstream consumer in [`demon-public-demo`](https://github.com/daydreamlive/demon-public-demo) — `lib/sessions/client.ts` `applySessionState` — will set the flag after writing the imported `sliderTargets`. Fresh sessions never set it, so the existing onboarding cue is unchanged.

## What changed

- `store/usePerformanceStore.ts` — new `skipNextDenoiseGate: boolean` (default `false`) + `setSkipNextDenoiseGate` setter. Mirrors the `remixStarted` pattern: per-session, not persisted.
- `hooks/useStartSession.ts` — read-and-clear the flag immediately before the gate. Skip the snap+glide when the flag was set.
- `hooks/useFixtureSwap.ts` — same pattern at the post-swap gate, so a mid-session Remix-onto-running-engine flow also preserves the imported value.

The flag is consumed regardless of `gate.enabled` so it never lingers past one session start.

## Test plan

- [ ] Fresh session (open `/`, click Begin): denoise still snaps to 0 with visual glide — gate fires as before.
- [ ] Remix landing (open `/sounds/<code>` for a share with non-zero denoise, click Begin): denoise stays at the sharer's value, no glide to 0.
- [ ] Mid-session Remix click (running session → click Remix on a library card with non-zero denoise): denoise lands at the imported value after swap_ready.
- [ ] Mid-session fixture swap from picker (not via apply): denoise still snaps to 0 — no regression.
- [ ] Saved-session Resume: denoise lands at the saved value.
- [ ] `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)