### PR TITLE
rtmg/web: fix mobile recursion in edge LoRA binding

### DIFF
--- a/demos/realtime_motion_graph_web/web/hooks/useEdgeLoraBinding.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useEdgeLoraBinding.ts
@@ -161,11 +161,16 @@ export function useEdgeLoraBinding(): void {
       const blendChanged = blend !== lastBlend;
       if (!pairChanged && !blendChanged) return;
 
-      applyMobileRightEdge(blend, a, b);
-      fanOutBlend(blend, a, b);
+      // Latch BEFORE the writes — fanOutBlend's setStrength calls fire
+      // useLoraStore subscribers synchronously, re-entering apply(). If
+      // the latch is still stale, the guard above won't short-circuit
+      // and we recurse until the stack blows.
       lastBlend = blend;
       lastA = a;
       lastB = b;
+
+      applyMobileRightEdge(blend, a, b);
+      fanOutBlend(blend, a, b);
     };
 
     apply();


### PR DESCRIPTION
## Summary

The mobile branch of `useEdgeLoraBinding` was hitting infinite recursion on Android (reported on Pixel 9 Pro / Android 16). Two visible symptoms, same root cause:

1. Performance page non-functional on mobile — black canvas, AdvancedDrawer knobs do nothing.
2. `/sounds/<code>` share-link imports throw `RangeError: Maximum call stack size exceeded` in the console.

## Root cause

`useLoraStore.subscribe(apply)` → `apply()` → `fanOutBlend` → `setStrength` → `useLoraStore` subscribers fire synchronously → `apply()` re-enters.

The `lastBlend` / `lastA` / `lastB` latch values were assigned **after** `fanOutBlend`, so the re-entrant call always saw stale latch values, the guard at the top of `apply` never short-circuited, and the call stack grew until it blew.

Triggered on mobile any time:
- the LoRA catalog finished loading and auto-paired the first two entries (fresh page load), or
- `applySessionState` wrote `lora_str_*` / `lora_blend` (every `/sounds/<code>` share-link landing).

Desktop is unaffected — `applyDesktopBindings` only mutates the DOM (`--fill`, `data-bar`, label text), so its subscriber cannot re-enter through the store.

## Fix

Move the three latch assignments above the writes. With the latch updated first, the re-entered `apply()` short-circuits at the `if (!pairChanged && !blendChanged) return;` check.

```diff
       if (!pairChanged && !blendChanged) return;

+      // Latch BEFORE the writes — fanOutBlend's setStrength calls fire
+      // useLoraStore subscribers synchronously, re-entering apply(). If
+      // the latch is still stale, the guard above won't short-circuit
+      // and we recurse until the stack blows.
+      lastBlend = blend;
+      lastA = a;
+      lastB = b;
+
       applyMobileRightEdge(blend, a, b);
       fanOutBlend(blend, a, b);
-      lastBlend = blend;
-      lastA = a;
-      lastB = b;
     };
```

One-line conceptual change, no new state, no flag, desktop path untouched.

## Test plan

- [ ] Local: open Performance in Chrome DevTools mobile viewport (≤ 768px) — canvas renders, ribbons animate, AdvancedDrawer knobs visibly change visuals, right-edge LoRA blend rail fans out into paired LoRAs.
- [ ] Local: visit `/sounds/<code>` of any existing share in mobile viewport — no stack overflow, page hydrates with imported state.
- [ ] Desktop sanity: viewport ≥ 1024 — left/right edges still mirror first/second enabled LoRA, DesktopEdgeDrag writes strengths normally.
- [ ] After merge: verify on a real Pixel 9 Pro via the demon-public-demo sync PR's Vercel preview.

Generated with [Claude Code](https://claude.com/claude-code).