### PR TITLE
realtime_motion_graph_web/web: gate LoRA toggle during session-start race

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1311,6 +1311,30 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   outline: 1px dashed currentColor;
   outline-offset: 2px;
 }
+/* During session-start (`status` in {loading-fixture, connecting}) the
+   pill silently drops sendEnableLora/sendDisableLora because the WS
+   isn't OPEN yet. LibraryTile sets disabled+aria-disabled on the
+   button and data-locked on the name span; visually dim them so the
+   operator gets immediate "wait" feedback instead of clicking a dead
+   control. The hover-color change cascade is overridden so it doesn't
+   look interactive while locked. */
+.lora-switch:disabled,
+.lora-switch[aria-disabled="true"] {
+  cursor: wait;
+  opacity: 0.45;
+}
+.lora-switch:disabled:hover,
+.lora-switch[aria-disabled="true"]:hover {
+  border-color: var(--frame-line);
+}
+.lora-switch:disabled:hover .lora-switch-thumb,
+.lora-switch[aria-disabled="true"]:hover .lora-switch-thumb {
+  background: var(--text-dim);
+}
+.lora-row-name[data-locked] {
+  cursor: wait;
+  opacity: 0.55;
+}
 
 /* Horizontal strength slider.  Spans the full row width below the
    switch+name line, giving the operator a wide drag surface without

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -38,10 +38,24 @@ function LoraRow({ id, name }: RowProps) {
   const value = typeof strength === "number" ? strength : fallbackStrength;
   const enable = useLoraStore((s) => s.enable);
   const disable = useLoraStore((s) => s.disable);
+  // Gate the enable/disable pill during the session-start race window.
+  // Between `useStartSession`'s buildConfig snapshot of `enabled_loras`
+  // and the WS reaching readyState=OPEN, sendEnableLora/sendDisableLora
+  // silently drop (protocol.ts gates on OPEN) and `useSessionStore.remote`
+  // is still null — so a click would update the local store but never
+  // reach the engine, and the user would need to disable+re-enable after
+  // ready to recover the intended state. status='idle' is fine: toggles
+  // are picked up by buildConfig on the next click-play. status='ready'
+  // is fine: send path works normally. Lock specifically during the
+  // in-flight start.
+  const togglesLocked = useSessionStore(
+    (s) => s.status === "loading-fixture" || s.status === "connecting",
+  );
 
   const trackRef = useRef<HTMLDivElement | null>(null);
 
   function toggle() {
+    if (togglesLocked) return;
     const remote = useSessionStore.getState().remote;
     if (enabled) {
       disable(id);
@@ -114,12 +128,21 @@ function LoraRow({ id, name }: RowProps) {
         className="lora-switch"
         role="switch"
         aria-checked={enabled}
+        aria-disabled={togglesLocked}
+        disabled={togglesLocked}
         onClick={toggle}
-        data-dd-tooltip={enabled ? "Disable" : "Enable"}
+        data-dd-tooltip={
+          togglesLocked ? "Connecting…" : enabled ? "Disable" : "Enable"
+        }
       >
         <span className="lora-switch-thumb" aria-hidden="true" />
       </button>
-      <span className="lora-row-name" title={id} onClick={toggle}>
+      <span
+        className="lora-row-name"
+        title={id}
+        onClick={toggle}
+        data-locked={togglesLocked || undefined}
+      >
         {name}
       </span>
       <div className="lora-strength">


### PR DESCRIPTION
## Summary

Closes the race where toggling a LoRA between **click Play** and **WS ready** silently drops the change — the user has to disable+re-enable after the session connects to actually trigger it.

Smallest possible fix: disable the enable/disable pill while \`useSessionStore.status\` is \`loading-fixture\` or \`connecting\`. Toggles at \`idle\` (pre-click-play) and \`ready\` (post-handshake) continue to work as before.

## Root cause

Three layers of silent failure overlap in the connect window:

1. \`sendEnableLora\` / \`sendDisableLora\` (\`protocol.ts:454,466\`) silently return when \`ws.readyState !== OPEN\` — no queueing, no retry.
2. \`LibraryTile.toggle()\` calls \`remote?.sendEnableLora(...)\` — optional chaining no-ops when \`useSessionStore.remote\` is still null, which it is until \`setSession\` runs at the very end of \`useStartSession\`.
3. \`useStartSession\` snapshots \`useLoraStore.enabled\` into the session-init config at \`buildConfig\` time, then awaits \`remote.connect()\` for hundreds of ms — anything toggled between those two points is captured by neither the snapshot (already taken) nor the live send path (WS not OPEN, remote not set).

There's no \"reconcile current state to engine\" step after WS-ready, so the local store and the engine diverge until the user manually toggles again.

## Why gating is the right fix here (vs. queueing or reconcile)

- **Queueing pre-OPEN sends** is a clean fix but touches \`RemoteBackend\` and would need invariants around session teardown / reconnects.
- **Reconcile-on-ready** is also clean but adds a code path that fires every session start.
- **Gating** is one component, three lines of logic, and one CSS block. It surfaces the state to the operator (\"Connecting…\" tooltip + dimmed pill) instead of letting them click into silence.

The race window is 1-3 s in the worst case; the UX cost is a brief dead pill instead of a lying one.

## What's not gated

The strength slider's per-tick send goes through \`useParamSync\`, which reads the current store on every tick post-ready and self-heals. Only the one-shot enable/disable path has no follow-up sync, so only the pill needs gating.

## Test plan

- [ ] Click Play, immediately toggle a LoRA pill while \"Connecting…\" status is up → pill is visibly dimmed, tooltip says \"Connecting…\", click is no-op, no divergence after ready.
- [ ] Click Play (no pre-toggles) → session lands with the expected default LoRAs enabled (unchanged behavior).
- [ ] Toggle LoRA pills on the splash page (\`status=idle\`) before clicking Play → toggles register normally and the session inits with them on (\`buildConfig\` snapshot still works).
- [ ] After session is ready, toggle pills → still works (unchanged).
- [ ] Strength slider stays draggable throughout (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)