### PR TITLE
realtime_motion_graph_web: "Record audio" mic capture in the audio-source crate

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -5582,3 +5582,105 @@ body.drawer-open .waveform-scrub-box[data-curves-open="true"] {
 .ref-control-option--current {
   color: var(--accent);
 }
+
+/* ── Mic recorder (AudioSourceCrate "Record audio") ──────────────────
+   Reuses the .almost-ready-* modal shell + .config-modal-accent ribbon.
+   Only the recorder-specific innards get their own classes. */
+.mic-rec-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  padding: 22px 20px 26px;
+}
+.mic-rec-hint {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-dim);
+  text-align: center;
+  max-width: 340px;
+}
+.mic-rec-error {
+  margin: 0;
+  font-size: 13px;
+  color: var(--critical);
+  text-align: center;
+}
+.mic-rec-timer {
+  font-family: var(--font-mono);
+  font-size: 34px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.mic-rec-timer-max {
+  font-size: 14px;
+  color: var(--text-dim);
+  letter-spacing: 0.06em;
+}
+.mic-rec-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+  background: var(--text-dim);
+}
+.mic-rec-timer--live .mic-rec-dot {
+  background: var(--critical);
+  animation: mic-rec-pulse 1s cubic-bezier(.2, .8, .2, 1) infinite;
+}
+@keyframes mic-rec-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.35; transform: scale(0.82); }
+}
+.mic-rec-progress {
+  width: 100%;
+  max-width: 320px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--input-bg);
+  overflow: hidden;
+}
+.mic-rec-progress-fill {
+  height: 100%;
+  background: var(--dd-gradient);
+  transition: width 120ms linear;
+}
+.mic-rec-btn {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  padding: 11px 22px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--frame-line);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  transition:
+    background-color 160ms cubic-bezier(.2, .8, .2, 1),
+    border-color 160ms cubic-bezier(.2, .8, .2, 1),
+    color 160ms cubic-bezier(.2, .8, .2, 1);
+}
+.mic-rec-btn:hover {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+}
+.mic-rec-btn--rec {
+  border-color: var(--accent-line);
+  color: var(--accent);
+}
+.mic-rec-btn--rec:hover {
+  background: var(--accent-medium);
+  color: var(--accent-hover);
+}
+.mic-rec-btn--stop {
+  border-color: var(--critical);
+  color: var(--critical);
+}
+.mic-rec-btn--stop:hover {
+  background: rgba(255, 80, 80, 0.12);
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -15,6 +15,7 @@ import { useSessionStore } from "@/store/useSessionStore";
 import type { TimeSignature } from "@/types/engine";
 
 import { AlmostReadyDialog } from "./AlmostReadyDialog";
+import { MicRecorder } from "./MicRecorder";
 
 // Bottom-left counterpart to the bottom-right turntable. Replaces the plain
 // fixture <select> as the primary track-picker — that dropdown hid the fact
@@ -30,6 +31,27 @@ import { AlmostReadyDialog } from "./AlmostReadyDialog";
 interface TrackOption {
   name: string;
   kind: "fixture" | "custom";
+}
+
+function MicIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.4}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="6" y="1.5" width="4" height="8" rx="2" />
+      <path d="M3.5 7.5a4.5 4.5 0 0 0 9 0" />
+      <path d="M8 12v2.5" />
+      <path d="M5.5 14.5h5" />
+    </svg>
+  );
 }
 
 function UploadIcon({ size = 14 }: { size?: number }) {
@@ -63,6 +85,7 @@ export function AudioSourceCrate() {
   const addCustomTrack = useCustomTracksStore((s) => s.add);
 
   const [open, setOpen] = useState(false);
+  const [recording, setRecording] = useState(false);
   const [uploading, setUploading] = useState(false);
   // After decode, the dialog gates the actual fixture swap so the user
   // can confirm the trim (if any) and pick a key before playback
@@ -219,6 +242,16 @@ export function AudioSourceCrate() {
         >
           <UploadIcon size={16} />
         </button>
+        <button
+          type="button"
+          className="audio-source-upload-btn"
+          disabled={uploading || recording}
+          onClick={() => setRecording(true)}
+          aria-label="Record audio from your microphone"
+          data-dd-tooltip="Record from microphone"
+        >
+          <MicIcon size={16} />
+        </button>
       </div>
 
       {open && (
@@ -274,6 +307,25 @@ export function AudioSourceCrate() {
               {uploading ? "Decoding…" : "Upload your own"}
             </span>
           </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="audio-source-sleeve audio-source-sleeve--upload"
+            disabled={uploading || recording}
+            onClick={() => {
+              setRecording(true);
+              setOpen(false);
+            }}
+            data-dd-tooltip="Record audio from your microphone"
+          >
+            <span
+              className="audio-source-sleeve-art audio-source-sleeve-art--upload"
+              aria-hidden="true"
+            >
+              <MicIcon />
+            </span>
+            <span className="audio-source-sleeve-label">Record audio</span>
+          </button>
         </div>
       )}
 
@@ -289,6 +341,17 @@ export function AudioSourceCrate() {
           if (file) void onFilePicked(file);
         }}
       />
+
+      {recording && (
+        <MicRecorder
+          onComplete={(file) => {
+            setRecording(false);
+            setOpen(false);
+            void onFilePicked(file);
+          }}
+          onClose={() => setRecording(false)}
+        />
+      )}
 
       {pending && (
         <AlmostReadyDialog

--- a/demos/realtime_motion_graph_web/web/components/Performance/MicRecorder.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/MicRecorder.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { togglePauseAndAudio } from "@/engine/audio/togglePauseAndAudio";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+
+// "Record audio" path for the AudioSourceCrate. Opens a modal, asks for
+// the mic, PAUSES playback so the daydream output isn't bleeding into
+// the recording, captures up to 60 s, and hands back a File that flows
+// through the exact same decode→AlmostReadyDialog→swap path as an
+// upload (the caller passes our File to onFilePicked).
+//
+// Same MIME ladder as useRecording (Opus-in-WebM, AAC-in-MP4 fallback)
+// so the produced File decodes everywhere decodeAudioFile runs.
+
+const MAX_MS = 60_000;
+
+const MIME_LADDER: { mime: string; ext: string; bitrate: number }[] = [
+  { mime: "audio/webm;codecs=opus", ext: "webm", bitrate: 192_000 },
+  { mime: "audio/webm", ext: "webm", bitrate: 192_000 },
+  { mime: "audio/mp4;codecs=mp4a.40.2", ext: "m4a", bitrate: 256_000 },
+  { mime: "audio/mp4", ext: "m4a", bitrate: 256_000 },
+];
+
+function pickMime(): { mime: string; ext: string; bitrate: number } | null {
+  if (typeof MediaRecorder === "undefined") return null;
+  for (const c of MIME_LADDER) {
+    try {
+      if (MediaRecorder.isTypeSupported(c.mime)) return c;
+    } catch {
+      /* isTypeSupported can throw on old impls — keep laddering */
+    }
+  }
+  return null;
+}
+
+type Phase = "init" | "ready" | "recording" | "error";
+
+// Synchronous capability check so the initial state is correct without
+// a setState-in-effect (the effect only does the async getUserMedia).
+function initialSupport(): { phase: Phase; error: string } {
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.mediaDevices?.getUserMedia
+  ) {
+    return {
+      phase: "error",
+      error: "Microphone capture isn't supported in this browser.",
+    };
+  }
+  if (!pickMime()) {
+    return {
+      phase: "error",
+      error: "Audio recording isn't supported in this browser.",
+    };
+  }
+  return { phase: "init", error: "" };
+}
+
+export function MicRecorder({
+  onComplete,
+  onClose,
+}: {
+  onComplete: (file: File) => void;
+  onClose: () => void;
+}) {
+  const [init] = useState(initialSupport);
+  const [phase, setPhase] = useState<Phase>(init.phase);
+  const [error, setError] = useState<string>(init.error);
+  const [elapsedMs, setElapsedMs] = useState(0);
+
+  const streamRef = useRef<MediaStream | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<BlobPart[]>([]);
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startedAtRef = useRef(0);
+  // Whether WE paused playback (so we only resume what we paused).
+  const weePausedRef = useRef(false);
+  const doneRef = useRef(false);
+
+  const stopTracks = useCallback(() => {
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+  }, []);
+
+  const clearTick = useCallback(() => {
+    if (tickRef.current) {
+      clearInterval(tickRef.current);
+      tickRef.current = null;
+    }
+  }, []);
+
+  // Restore playback only if we were the ones who paused it.
+  const restorePlayback = useCallback(() => {
+    if (weePausedRef.current && usePerformanceStore.getState().paused) {
+      togglePauseAndAudio();
+    }
+    weePausedRef.current = false;
+  }, []);
+
+  // Acquire mic + pause playback on mount. Capability is already
+  // resolved into initial state — skip if unsupported.
+  useEffect(() => {
+    if (init.phase !== "init") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        // Raw-ish audio for music fidelity; fall back to plain audio
+        // if the constraint object is rejected.
+        let stream: MediaStream;
+        try {
+          stream = await navigator.mediaDevices.getUserMedia({
+            audio: {
+              echoCancellation: false,
+              noiseSuppression: false,
+              autoGainControl: false,
+            },
+          });
+        } catch {
+          stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        }
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        streamRef.current = stream;
+        // Pause the daydream output so it doesn't bleed into the mic.
+        if (!usePerformanceStore.getState().paused) {
+          togglePauseAndAudio();
+          weePausedRef.current = true;
+        }
+        setPhase("ready");
+      } catch (e) {
+        if (cancelled) return;
+        const name = e instanceof DOMException ? e.name : "";
+        setError(
+          name === "NotAllowedError" || name === "SecurityError"
+            ? "Microphone access was denied."
+            : name === "NotFoundError"
+              ? "No microphone found."
+              : `Couldn't open the microphone${name ? ` (${name})` : ""}.`,
+        );
+        setPhase("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [init.phase]);
+
+  // Hard cleanup on unmount (covers any exit path).
+  useEffect(() => {
+    return () => {
+      clearTick();
+      try {
+        if (recorderRef.current && recorderRef.current.state !== "inactive") {
+          recorderRef.current.stop();
+        }
+      } catch {
+        /* already stopped */
+      }
+      stopTracks();
+      // Don't leave the user paused if we paused them and they bailed.
+      if (!doneRef.current) restorePlayback();
+    };
+  }, [clearTick, stopTracks, restorePlayback]);
+
+  const finish = useCallback(
+    (file: File | null) => {
+      if (doneRef.current) return;
+      doneRef.current = true;
+      clearTick();
+      stopTracks();
+      restorePlayback();
+      if (file) onComplete(file);
+      onClose();
+    },
+    [clearTick, stopTracks, restorePlayback, onComplete, onClose],
+  );
+
+  const startRecording = useCallback(() => {
+    const stream = streamRef.current;
+    const choice = pickMime();
+    if (!stream || !choice) return;
+    chunksRef.current = [];
+    let rec: MediaRecorder;
+    try {
+      rec = new MediaRecorder(stream, {
+        mimeType: choice.mime,
+        audioBitsPerSecond: choice.bitrate,
+      });
+    } catch {
+      setPhase("error");
+      setError("Couldn't start the recorder.");
+      return;
+    }
+    recorderRef.current = rec;
+    rec.ondataavailable = (ev) => {
+      if (ev.data && ev.data.size > 0) chunksRef.current.push(ev.data);
+    };
+    rec.onstop = () => {
+      const blob = new Blob(chunksRef.current, { type: choice.mime });
+      if (blob.size === 0) {
+        finish(null);
+        return;
+      }
+      const ts = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-");
+      finish(
+        new File([blob], `mic-recording-${ts}.${choice.ext}`, {
+          type: choice.mime,
+        }),
+      );
+    };
+    rec.start(1000); // 1 s chunks — a crash loses at most ~1 s
+    startedAtRef.current = performance.now();
+    setElapsedMs(0);
+    setPhase("recording");
+    tickRef.current = setInterval(() => {
+      const ms = performance.now() - startedAtRef.current;
+      setElapsedMs(ms);
+      if (ms >= MAX_MS) {
+        // auto-stop at the 60 s cap
+        try {
+          if (recorderRef.current?.state === "recording") {
+            recorderRef.current.stop();
+          }
+        } catch {
+          /* noop */
+        }
+        clearTick();
+      }
+    }, 100);
+  }, [finish, clearTick]);
+
+  const stopRecording = useCallback(() => {
+    clearTick();
+    const rec = recorderRef.current;
+    if (rec && rec.state !== "inactive") {
+      try {
+        rec.stop(); // onstop → finish(file)
+      } catch {
+        finish(null);
+      }
+    } else {
+      finish(null);
+    }
+  }, [clearTick, finish]);
+
+  // Escape cancels (cleanup runs in finish/unmount).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") finish(null);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [finish]);
+
+  const secs = Math.min(60, Math.floor(elapsedMs / 1000));
+  const pct = Math.min(100, (elapsedMs / MAX_MS) * 100);
+
+  return createPortal(
+    <div
+      className="almost-ready-backdrop"
+      onClick={() => finish(null)}
+      role="presentation"
+    >
+      <div
+        className="almost-ready-modal mic-rec-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mic-rec-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="config-modal-accent" aria-hidden="true" />
+        <div className="almost-ready-header">
+          <h2 id="mic-rec-title" className="almost-ready-title">
+            Record audio
+          </h2>
+          <button
+            type="button"
+            className="config-modal-close"
+            onClick={() => finish(null)}
+            aria-label="Cancel recording"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="almost-ready-body mic-rec-body">
+          {phase === "init" && (
+            <p className="mic-rec-hint">Requesting microphone…</p>
+          )}
+
+          {phase === "error" && (
+            <>
+              <p className="mic-rec-error">{error}</p>
+              <button
+                type="button"
+                className="mic-rec-btn"
+                onClick={() => finish(null)}
+              >
+                Close
+              </button>
+            </>
+          )}
+
+          {(phase === "ready" || phase === "recording") && (
+            <>
+              <p className="mic-rec-hint">
+                {phase === "recording"
+                  ? "Recording… playback is paused so it won't bleed in."
+                  : "Playback is paused. Record up to 60 seconds — this becomes your track."}
+              </p>
+
+              <div
+                className={`mic-rec-timer${
+                  phase === "recording" ? " mic-rec-timer--live" : ""
+                }`}
+              >
+                <span className="mic-rec-dot" aria-hidden="true" />
+                {String(secs).padStart(2, "0")}
+                <span className="mic-rec-timer-max"> / 60s</span>
+              </div>
+
+              <div className="mic-rec-progress" aria-hidden="true">
+                <div
+                  className="mic-rec-progress-fill"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+
+              {phase === "ready" ? (
+                <button
+                  type="button"
+                  className="mic-rec-btn mic-rec-btn--rec"
+                  onClick={startRecording}
+                >
+                  ● Start recording
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="mic-rec-btn mic-rec-btn--stop"
+                  onClick={stopRecording}
+                >
+                  ■ Stop &amp; use
+                </button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a **"Record audio"** option next to the existing upload affordance in `AudioSourceCrate` — record up to 60 s from the device mic and use it as the track.
- New `MicRecorder` modal: requests the mic (raw audio, processing off, `{audio:true}` fallback), **pauses playback** via `togglePauseAndAudio()` so the daydream output doesn't bleed into the recording, 60 s cap (live timer + gradient progress + auto-stop) with a manual "Stop & use", restores playback only if it paused it, full `MediaStream` cleanup on every exit (Escape/backdrop/deny/unsupported).
- Same Opus-WebM → AAC-MP4 MIME ladder as `useRecording`; the produced `File` is handed to the **existing `onFilePicked`**, so a recording flows through the identical decode → `AlmostReadyDialog` → `setFixture` swap as an upload — no new track-handling code, fully pod-agnostic.
- `globals.css` `.mic-rec-*` uses existing tokens (mono+caps labels, `--dd-gradient` progress, the single `cubic-bezier(.2,.8,.2,1)` easing, `--critical` for live/stop) and reuses the `almost-ready` modal shell + ribbon.

## Test plan
- [x] tsc + eslint clean
- [x] Local (`next dev` against a live pod): record → Almost Ready → swap → plays back through the engine
- [x] Cancel paths (✕ / backdrop / Escape) and denied-mic restore playback + release the mic
- [ ] Reviewer: Safari/iOS (AAC-MP4 fallback path) + 60 s auto-stop