### PR TITLE
fix: clamp near-zero denoise to avoid 512-PiB linspace OOM

### DIFF
--- a/acestep/engine/diffusion.py
+++ b/acestep/engine/diffusion.py
@@ -641,14 +641,34 @@ class DiffusionEngine:
     # Timestep schedule
     # ------------------------------------------------------------------
 
+    # Treat any positive denoise below this as "no denoise". The last
+    # ``steps + 1`` entries of the truncated schedule for ``denoise <
+    # _DENOISE_MIN`` are indistinguishable from zero at the engine's
+    # working precision (bf16 / fp16 / fp32) — the schedule starts at
+    # ``denoise`` and descends to 0, so anything in this range is
+    # numerical noise. The cap also guards against a UI tween briefly
+    # writing a near-zero positive ``denoise`` mid-glide (e.g. the
+    # "hear source first" gate animating the ribbon down to 0): without
+    # it, ``int(steps / denoise)`` blows up into a 512-PiB ``linspace``
+    # request and OOMs on the first ``_init_slot`` after the swap.
+    _DENOISE_MIN: float = 1e-6
+
     def _build_timestep_schedule(
         self, config: DiffusionConfig, device: torch.device, dtype: torch.dtype
     ) -> torch.Tensor:
         """Build the timestep schedule, respecting denoise truncation.
 
-        When denoise < 1.0, computes int(steps/denoise) full steps with
-        shift applied, then takes the last (steps+1) entries. This matches
-        ComfyUI's BasicScheduler.set_steps() behavior.
+        When ``denoise < 1.0`` the schedule is the last ``steps + 1``
+        entries of ``linspace(1.0, 0.0, int(steps/denoise) + 1)``. We
+        compute those entries directly as
+        ``linspace(steps/full_steps, 0.0, steps + 1)`` instead of
+        materializing the full descending range and slicing — the
+        intermediate is unbounded in ``denoise`` and a near-zero positive
+        ``denoise`` (subnormal-ish floats from a UI tween) used to
+        request a ~512-PiB GPU allocation here. The direct form matches
+        ComfyUI's ``BasicScheduler.set_steps()`` for all valid inputs
+        (``shift`` is elementwise, so applying it after the slice is
+        equivalent to applying it before).
         """
         if config.timesteps is not None:
             return torch.tensor(config.timesteps, device=device, dtype=dtype)
@@ -656,26 +676,24 @@ class DiffusionEngine:
         steps = config.infer_steps
         denoise = config.denoise
 
-        if denoise <= 0.0:
-            # No denoising: single-entry schedule (t=0 -> t=0)
+        if denoise <= self._DENOISE_MIN:
+            # No (meaningful) denoising: single-entry schedule (t=0 -> t=0)
             return torch.zeros(2, device=device, dtype=dtype)
-        elif denoise >= 1.0:
-            full_steps = steps
+
+        if denoise >= 1.0:
+            t_start = 1.0
         else:
-            # Compute extended schedule, then truncate
             full_steps = int(steps / denoise)
+            # full_steps is at most steps / _DENOISE_MIN; well-bounded.
+            t_start = steps / full_steps  # ≈ denoise, exact slice endpoint
 
         t_schedule = torch.linspace(
-            1.0, 0.0, full_steps + 1, device=device, dtype=dtype
+            t_start, 0.0, steps + 1, device=device, dtype=dtype
         )
         if config.shift != 1.0:
             t_schedule = (
                 config.shift * t_schedule
                 / (1 + (config.shift - 1) * t_schedule)
             )
-
-        if denoise < 1.0 and denoise > 0.0:
-            # Take the last (steps+1) entries
-            t_schedule = t_schedule[-(steps + 1):]
 
         return t_schedule

--- a/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
@@ -85,6 +85,15 @@ const tweens = new Map<string, Tween>();
 // keeps the master rAF callback from doing dead work while idle.
 let tweenUnregister: (() => void) | null = null;
 
+// Tween outputs below this snap to 0 (when the target is 0). The
+// cubic ease-out's tail can pass through arbitrarily small positive
+// values in the last few percent of the glide, and the engine's
+// schedule builder used to do `int(steps / denoise)` on whatever it
+// received — a denoise of ~1e-17 lifted from a tween mid-flight made
+// it request a 512-PiB linspace and OOM. Below this floor the slider
+// is effectively zero anyway, so snap it.
+const TWEEN_ZERO_FLOOR = 1e-6;
+
 function tickTweens(now: number): void {
   if (tweens.size === 0) {
     // Defensive: scheduler keeps calling until we unregister, but we
@@ -105,7 +114,11 @@ function tickTweens(now: number): void {
     const k = elapsed / durationMs;
     // Cubic ease-out: snappy start, settles into target.
     const eased = 1 - Math.pow(1 - k, 3);
-    updates[param] = t.start + (target - t.start) * eased;
+    let v = t.start + (target - t.start) * eased;
+    // Snap subnormal-ish positives to 0 when we're tweening down to 0
+    // so the engine never sees a near-zero denoise (see floor comment).
+    if (target === 0 && v > 0 && v < TWEEN_ZERO_FLOOR) v = 0;
+    updates[param] = v;
   }
   if (Object.keys(updates).length > 0) {
     usePerformanceStore.setState((s) => ({


### PR DESCRIPTION
`_build_timestep_schedule` did `int(steps / denoise)` and then a `torch.linspace(1.0, 0.0, full_steps + 1, ...)` before slicing the last `steps + 1` entries. The intermediate is unbounded in `denoise`, so a tiny positive value (~1e-17 — the tail of a UI tween's cubic ease-out glide down to 0) requested a ~512-PiB GPU allocation and the pipeline crashed with "Tried to allocate 536870912.00 GiB" on the first `_init_slot` after a source swap.

Engine: compute the kept slice directly as
`linspace(steps/full_steps, 0.0, steps + 1)` — `shift` is elementwise so the result is identical for all valid `denoise`. Treat any `denoise <= _DENOISE_MIN` (1e-6) as "no denoise" and return the zeros sentinel; below that floor the kept entries are numerical noise at bf16/fp16 anyway.

UI: snap `tickTweens` outputs to 0 when they drop below `1e-6` while tweening down to 0. The cubic ease-out's tail otherwise emits subnormal-ish positives in the last few percent of the glide, which the param-sync tick can ship to the engine. Belt to the engine's suspenders; either fix alone is enough.

Verified numerical equivalence with the old schedule across denoise in {1.0, 0.7, 0.5, 0.1, 0.05, 0.001} and shift in {1.0, 3.0}. Tiny-denoise inputs (1e-10, 1e-15, 1e-17) now return the zero sentinel instead of OOMing.