### PR TITLE
feat(realtime): startup self-warmup + server-side known-fixture load (~40s→~6s begin)

### DIFF
--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -114,7 +114,7 @@ def _decode_audio_msg(audio_msg: bytes) -> torch.Tensor:
     return torch.from_numpy(arr.T.copy())[:2]
 
 
-def _load_fixture_waveform(name: str) -> torch.Tensor:
+def _load_known_fixture_waveform(name: str) -> torch.Tensor:
     """Load a known fixture's audio from the pod's own fixture cache and
     return it in the exact shape ``_decode_audio_msg`` produces
     (``[≤2, N]`` float32 at ``SAMPLE_RATE``).
@@ -417,7 +417,7 @@ def handle_client(
     _fix_name = config.get("fixture_name")
     if config.get("use_server_fixture") and _fix_name in KNOWN_FIXTURES:
         try:
-            waveform = _load_fixture_waveform(_fix_name)
+            waveform = _load_known_fixture_waveform(_fix_name)
             _ms("audio_serverside_loaded")
         except Exception as exc:
             print(

--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -114,6 +114,36 @@ def _decode_audio_msg(audio_msg: bytes) -> torch.Tensor:
     return torch.from_numpy(arr.T.copy())[:2]
 
 
+def _load_fixture_waveform(name: str) -> torch.Tensor:
+    """Load a known fixture's audio from the pod's own fixture cache and
+    return it in the exact shape ``_decode_audio_msg`` produces
+    (``[≤2, N]`` float32 at ``SAMPLE_RATE``).
+
+    The pod already serves this file at ``/fixtures/<name>``; for known
+    fixtures the browser shouldn't have to download → decode → re-upload
+    ~20 MB of PCM over the WebSocket (~11 s on the measured cold path).
+    Same uniform-path output as the upload route, so every downstream
+    consumer (sidecar resolve, echoed initial buffer, prepare_source
+    fallback) is unchanged.
+    """
+    path = str(audio_fixture(name))  # resolves to the on-disk cache
+    try:
+        import soundfile as sf
+        data, sr = sf.read(path, dtype="float32", always_2d=True)  # (n, ch)
+    except Exception:
+        import librosa
+        mono, sr = librosa.load(path, sr=None, mono=True)
+        data = np.stack([mono, mono], axis=1).astype(np.float32)
+    if sr != SAMPLE_RATE:
+        import librosa
+        data = librosa.resample(
+            data.T, orig_sr=sr, target_sr=SAMPLE_RATE
+        ).T.astype(np.float32)
+    if data.ndim == 1:
+        data = data[:, None]
+    return torch.from_numpy(np.ascontiguousarray(data.T, dtype=np.float32))[:2]
+
+
 _VALID_TIME_SIG_STRS = frozenset(str(s) for s in VALID_TIME_SIGNATURES)
 
 
@@ -367,8 +397,41 @@ def handle_client(
     config = json.loads(ws.recv())
     print(f"[Server] Config: {config}")
 
-    audio_bytes = ws.recv()
-    waveform = _decode_audio_msg(audio_bytes)
+    # Session-init timing instrumentation. t0 == config received; every
+    # milestone prints wall-seconds since t0 so the per-connect latency
+    # can be split into prepare / TRT-load / stream-build / first-gen
+    # without guessing from interleaved loguru lines.
+    _t0 = time.monotonic()
+    _first_slice = [False]
+
+    def _ms(stage: str) -> None:
+        print(f"[timing] {stage} +{time.monotonic() - _t0:.3f}s", flush=True)
+
+    # Server-side known-fixture load. When the client opts in via
+    # ``use_server_fixture`` AND names a known fixture, skip the
+    # download→decode→re-upload round-trip (~11 s of the measured cold
+    # path) and read the waveform straight from the pod's fixture cache.
+    # Old clients that don't send the flag take the unchanged upload
+    # path below, so this is safe across the Vercel(UI)/bake(backend)
+    # deploy skew.
+    _fix_name = config.get("fixture_name")
+    if config.get("use_server_fixture") and _fix_name in KNOWN_FIXTURES:
+        try:
+            waveform = _load_fixture_waveform(_fix_name)
+            _ms("audio_serverside_loaded")
+        except Exception as exc:
+            print(
+                f"[Server] server-side fixture load failed for "
+                f"{_fix_name!r} ({exc}); falling back to client upload",
+                flush=True,
+            )
+            audio_bytes = ws.recv()
+            waveform = _decode_audio_msg(audio_bytes)
+            _ms("audio_recv_decoded")
+    else:
+        audio_bytes = ws.recv()
+        waveform = _decode_audio_msg(audio_bytes)
+        _ms("audio_recv_decoded")
     use_trt = decoder_backend == "tensorrt" or vae_backend == "tensorrt"
     trt_profile_checkpoint = checkpoint if decoder_backend == "tensorrt" else "acestep-v15-turbo"
 
@@ -624,6 +687,7 @@ def handle_client(
 
     audio_in = Audio(waveform=waveform, sample_rate=SAMPLE_RATE)
 
+    _ms("resolve_source_start")
     source, detected_bpm, detected_key, detected_time_signature = (
         _resolve_bpm_key_source(
             session,
@@ -632,6 +696,7 @@ def handle_client(
             samples=int(waveform.shape[1]),
         )
     )
+    _ms("resolve_source_done")
 
     # Two-conditioning cache for the live timbre-strength slider.
     # cond_silence uses the model's silence latent (refer_latent=None);
@@ -707,6 +772,7 @@ def handle_client(
         pipeline_depth=depth,
     )
     print("[Server] Stream handle ready (pipeline built on first tick)")
+    _ms("stream_handle_ready")
 
     # Initial buffer
     src_np = waveform.numpy().T
@@ -786,6 +852,7 @@ def handle_client(
     }))
     ws.send(src_np.astype(np.float16).tobytes())
     print(f"[Server] Sent initial buffer ({len(src_np) / SAMPLE_RATE:.1f}s)")
+    _ms("initial_buffer_sent")
 
     # ---- Phase 2: Streaming ----
 
@@ -1159,6 +1226,10 @@ def handle_client(
         se = min(se, len(client_mirror), len(wav_np))
         if se <= ss:
             return
+
+        if not _first_slice[0]:
+            _first_slice[0] = True
+            _ms("first_generated_slice")
 
         # Delta = what server has now minus what client has
         region = wav_np[ss:se]
@@ -1854,3 +1925,140 @@ def handle_client(
             session.close()
         except Exception as exc:
             print(f"[Server] session.close() raised: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Startup self-warmup
+#
+# Measured 2026-05-18: a cold first session on a fresh engine takes ~40s to
+# `ready` (TRT decoder-engine load ~3s + LoRA-refit manager ~7s + Session /
+# ModelContext / conditioning ~10s + first-tick pipeline build), while the
+# *second* session on the same warm engine is ~5-6s. ~30s of the cold path is
+# one-time-after-engine-start state that persists in the process. Driving one
+# synthetic default-fixture session through `handle_client` at boot — before
+# the pod accepts real traffic — pays that once so every real "begin" gets the
+# warm path. Behaviour-neutral for real clients; the warmup session is fully
+# torn down (stream.close()+session.close()) by handle_client's own finally.
+# ---------------------------------------------------------------------------
+
+WARMUP_STATE: dict = {"done": False, "error": None, "seconds": None}
+
+_WARMUP_FIXTURE = "low_fi_Gm_loop_60s_gnm.wav"  # PREFERRED_DEFAULT_FIXTURE
+_WARMUP_PROMPT = "ambient electronic, warm pads"
+
+
+class _WarmupWS:
+    """In-process synthetic WebSocket that drives one default-fixture
+    session through handle_client to warm one-time engine state.
+
+    Scripts the Phase-1 handshake (config JSON, then the audio frame),
+    lets Phase-2 spin long enough to build the pipeline + run the first
+    generation tick, then raises ConnectionClosed so handle_client's
+    teardown path frees all per-session GPU state.
+    """
+
+    def __init__(self, config_json: str, audio_frame: bytes, budget_s: float = 35.0):
+        self._queue = [config_json, audio_frame]
+        self._t0 = time.monotonic()
+        self._budget_s = budget_s
+        self._initial_seen_at = None
+        self.closed = False
+
+    def recv(self, timeout=None):
+        if self._queue:
+            return self._queue.pop(0)
+        # Phase-2: spin until warm budget elapsed, then end the session.
+        # Mimic "no client message" via TimeoutError when the caller
+        # passed a timeout (the streaming loop polls that way); raise
+        # ConnectionClosed once warmed so every recv site unwinds into
+        # handle_client's finally (which closes the session).
+        now = time.monotonic()
+        warm_enough = (
+            now - self._t0 > self._budget_s
+            or (self._initial_seen_at is not None
+                and now - self._initial_seen_at > 10.0)
+        )
+        if warm_enough:
+            raise ConnectionClosed(None, None)
+        if timeout is not None:
+            time.sleep(min(timeout, 0.05))
+            raise TimeoutError
+        time.sleep(0.1)
+        raise TimeoutError
+
+    def send(self, msg):
+        # The initial buffer is a large binary frame (the echoed source);
+        # spotting it tells us Phase-1 finished so we can bound Phase-2.
+        if isinstance(msg, (bytes, bytearray)) and len(msg) > 1_000_000:
+            if self._initial_seen_at is None:
+                self._initial_seen_at = time.monotonic()
+
+    def close(self, *args, **kwargs):
+        self.closed = True
+
+
+def _load_warmup_audio_frame() -> bytes:
+    """Build the wire frame (<II channels,samples> + interleaved f32)
+    for the default fixture, matching the browser's upload format."""
+    from acestep.fixtures import audio_fixture
+
+    path = str(audio_fixture(_WARMUP_FIXTURE))
+    try:
+        import soundfile as sf
+        data, _sr = sf.read(path, dtype="float32", always_2d=True)  # (n, ch)
+    except Exception:
+        import librosa
+        mono, _sr = librosa.load(path, sr=None, mono=True)
+        data = np.stack([mono, mono], axis=1).astype(np.float32)
+    if data.ndim == 1:
+        data = np.stack([data, data], axis=1)
+    if data.shape[1] == 1:
+        data = np.repeat(data, 2, axis=1)
+    ch = int(data.shape[1])
+    samples = int(data.shape[0])
+    interleaved = np.ascontiguousarray(data, dtype=np.float32).reshape(-1)
+    return struct.pack("<II", ch, samples) + interleaved.tobytes()
+
+
+def run_startup_warmup(
+    *,
+    decoder_backend: str,
+    vae_backend: str,
+    checkpoint: str,
+    offload_text_encoder: bool,
+) -> None:
+    """Drive one synthetic default-fixture session at boot. Never raises
+    — a failed warmup must not stop the server from serving."""
+    t0 = time.monotonic()
+    print("[warmup] starting default-fixture session warmup...", flush=True)
+    try:
+        cfg = {
+            "fixture_name": _WARMUP_FIXTURE,
+            "prompt": _WARMUP_PROMPT,
+            "steps": 8,
+            "depth": 4,
+            "lora": False,
+            "enabled_loras": [],
+        }
+        frame = _load_warmup_audio_frame()
+        ws = _WarmupWS(json.dumps(cfg), frame)
+        handle_client(
+            ws,
+            decoder_backend=decoder_backend,
+            vae_backend=vae_backend,
+            checkpoint=checkpoint,
+            offload_text_encoder=offload_text_encoder,
+        )
+        WARMUP_STATE["done"] = True
+        WARMUP_STATE["seconds"] = round(time.monotonic() - t0, 1)
+        print(
+            f"[warmup] done in {WARMUP_STATE['seconds']}s — "
+            f"first real session will take the warm path",
+            flush=True,
+        )
+    except Exception as exc:
+        import traceback
+        WARMUP_STATE["error"] = repr(exc)
+        WARMUP_STATE["seconds"] = round(time.monotonic() - t0, 1)
+        print(f"[warmup] FAILED after {WARMUP_STATE['seconds']}s: {exc}", flush=True)
+        traceback.print_exc()

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -117,10 +117,24 @@ def _process_request(connection, request):
 
     # API: server-info — lets the client know whether the backend is up.
     if path_only == "/api/server-info":
+        # Surface startup-warmup state so the pool can gate "free" on a
+        # warmed engine. Read only if backend is already imported — don't
+        # force the heavy import in --no-backend mode.
+        _warm = None
+        _be = sys.modules.get("demos.realtime_motion_graph_web.backend")
+        if _be is not None:
+            _warm = getattr(_be, "WARMUP_STATE", None)
         body = json.dumps({
             "no_backend": _NO_BACKEND,
             "kiosk": _KIOSK,
             "default_mode": _DEFAULT_MODE,
+            "warmup": _warm,
+            # Fixtures the pod can load server-side: the client may send
+            # {use_server_fixture:true, fixture_name:<one of these>} and
+            # skip the ~20 MB PCM upload entirely. Advertised here so the
+            # UI only opts in against a backend that supports it (the UI
+            # ships via Vercel instantly; the backend via bake, lagged).
+            "server_side_fixtures": sorted(KNOWN_FIXTURES),
         }).encode()
         _log_http(remote, 200, "GET", url)
         return Response(
@@ -433,6 +447,24 @@ def main():
         def ws_handler(ws):
             handle_client(
                 ws,
+                decoder_backend=decoder_accel,
+                vae_backend=vae_accel,
+                checkpoint=checkpoint,
+                offload_text_encoder=offload_text_encoder,
+            )
+
+        # Pay the one-time cold-start cost (TRT decoder-engine load,
+        # LoRA-refit manager, ModelContext / conditioning, first-tick
+        # pipeline build) once at boot, BEFORE accepting real traffic,
+        # so every real "begin" gets the ~5s warm path instead of ~40s.
+        # Synchronous on purpose: the heartbeat sidecar only advertises
+        # this pod to the pool after main() proceeds, so the pod isn't
+        # routed real users until it's warm. Disable with
+        # DEMON_STARTUP_WARMUP=0.
+        if os.environ.get("DEMON_STARTUP_WARMUP", "1") != "0":
+            from .backend import run_startup_warmup
+
+            run_startup_warmup(
                 decoder_backend=decoder_accel,
                 vae_backend=vae_accel,
                 checkpoint=checkpoint,

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -142,6 +142,14 @@ def _process_request(connection, request):
             Headers([
                 ("Content-Type", "application/json; charset=utf-8"),
                 ("Content-Length", str(len(body))),
+                # Public, read-only capability probe. The webapp UI
+                # (served from a different origin than the pod tunnel)
+                # fetches this before the WS handshake to decide whether
+                # the pod supports server-side fixture load. Simple GET,
+                # no credentials/custom headers → no preflight; a single
+                # ACAO:* on the response is sufficient and safe (nothing
+                # sensitive here).
+                ("Access-Control-Allow-Origin", "*"),
                 *_NO_CACHE_HEADERS,
             ]),
             body,

--- a/demos/realtime_motion_graph_web/web/engine/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/engine/protocol.ts
@@ -190,19 +190,29 @@ export class RemoteBackend extends EventTarget {
 
       ws.onopen = () => {
         if (!this._pending) return;
-        // Phase 1: JSON config + binary audio upload.
+        // Phase 1: JSON config, then (unless server-side fixture) the
+        // binary audio upload. For known fixtures the pod loads the
+        // waveform from its own cache, so re-uploading ~20 MB of PCM
+        // here is pure waste (~11 s on the measured cold path). When
+        // `use_server_fixture` is set the server skips its audio recv,
+        // so we must skip the send to match.
         ws.send(JSON.stringify(this._pending.config));
-        const { interleaved, channels } = this._pending;
-        const samples = interleaved.length / channels;
-        const hdr = new ArrayBuffer(8);
-        const dv = new DataView(hdr);
-        dv.setUint32(0, channels, true);
-        dv.setUint32(4, samples, true);
-        const pcm = new Uint8Array(interleaved.buffer);
-        const combined = new Uint8Array(hdr.byteLength + pcm.byteLength);
-        combined.set(new Uint8Array(hdr), 0);
-        combined.set(pcm, hdr.byteLength);
-        ws.send(combined);
+        const useServerFixture =
+          (this._pending.config as { use_server_fixture?: boolean })
+            .use_server_fixture === true;
+        if (!useServerFixture) {
+          const { interleaved, channels } = this._pending;
+          const samples = interleaved.length / channels;
+          const hdr = new ArrayBuffer(8);
+          const dv = new DataView(hdr);
+          dv.setUint32(0, channels, true);
+          dv.setUint32(4, samples, true);
+          const pcm = new Uint8Array(interleaved.buffer);
+          const combined = new Uint8Array(hdr.byteLength + pcm.byteLength);
+          combined.set(new Uint8Array(hdr), 0);
+          combined.set(pcm, hdr.byteLength);
+          ws.send(combined);
+        }
         phase = "ready";
       };
 

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -3,7 +3,7 @@
 import { useCallback } from "react";
 
 import { AudioPlayer } from "@/engine/audio/AudioPlayer";
-import { listFixtures, pickDefaultFixture } from "@/engine/audio/loadFixture";
+import { listFixtures, loadFixtureAudio, pickDefaultFixture } from "@/engine/audio/loadFixture";
 import { resetKnobDelta } from "@/engine/midi/absoluteDelta";
 import { createNetworkMonitor } from "@/engine/networkMonitor";
 import { defaultWsUrl } from "@/engine/podUrl";
@@ -36,6 +36,41 @@ function resolveWsUrl(serverWsUrl: string | null): string {
   return url;
 }
 
+/**
+ * Capability probe: ask the target pod (via its HTTP origin, derived
+ * from the ws URL) whether it can load known fixtures server-side.
+ * Returns the advertised `server_side_fixtures` list, or `[]` on any
+ * failure / old backend. Never throws.
+ *
+ * This is what makes the server-side-fixture path safe across a mixed
+ * fleet and ANY deploy/merge order: an old backend doesn't advertise
+ * the capability, so the UI falls back to the (unchanged) upload path
+ * instead of omitting the audio frame and hanging the old pod's recv.
+ */
+async function probeServerSideFixtures(wsUrl: string): Promise<string[]> {
+  try {
+    const u = new URL(wsUrl);
+    u.protocol = u.protocol === "wss:" ? "https:" : "http:";
+    u.pathname = "/api/server-info";
+    u.search = "";
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 4000);
+    let res: Response;
+    try {
+      res = await fetch(u.toString(), { signal: ctrl.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!res.ok) return [];
+    const info = (await res.json()) as { server_side_fixtures?: unknown };
+    return Array.isArray(info.server_side_fixtures)
+      ? (info.server_side_fixtures as string[])
+      : [];
+  } catch {
+    return [];
+  }
+}
+
 // Drives the whole "click Play" flow:
 //   1. resolve fixture (use store, fall back to first listed)
 //   2. load + decode audio
@@ -44,7 +79,10 @@ function resolveWsUrl(serverWsUrl: string | null): string {
 //   5. wire slice → patch/addDelta, lora_catalog → useLoraStore, etc.
 //   6. resume audio context
 
-function buildConfig(fixtureName: string): SessionConfig {
+function buildConfig(
+  fixtureName: string,
+  useServerFixture: boolean,
+): SessionConfig {
   const perf = usePerformanceStore.getState();
   const lora = useLoraStore.getState();
   const cfg = getConfig().engine;
@@ -81,16 +119,14 @@ function buildConfig(fixtureName: string): SessionConfig {
     // dropdown's stale value here would only re-introduce the
     // override-wins-over-sidecar regression.
     fixture_name: fixtureName,
-    // This hook only ever starts a session on a built-in fixture (custom
-    // user uploads take the swap_source path, not session init), and the
-    // pod already serves that exact file at /fixtures/<name>. Tell the
-    // server to load the waveform from its own cache so the browser skips
-    // the download→decode→re-upload of ~20 MB of PCM (~11 s on the
-    // measured cold path). DEPLOY ORDERING: the backend honouring this
-    // must reach the whole fleet (bake) BEFORE this UI ships — a stale
-    // backend would block on its audio recv. Backward-compatible +
-    // baked fleet-wide first, so safe.
-    use_server_fixture: true,
+    // Only set when the target pod advertised it can load this fixture
+    // server-side (capability-gated by the caller via
+    // probeServerSideFixtures). When true the pod reads the waveform
+    // from its own /fixtures cache and the client sends no audio frame
+    // (saves the ~20 MB / ~11 s round-trip). When false we fall back to
+    // the unchanged upload path, so this is safe on a mixed fleet in
+    // any deploy/merge order.
+    use_server_fixture: useServerFixture,
   };
 }
 
@@ -134,18 +170,39 @@ export function useStartSession() {
       return;
     }
 
-    // Server-side fixture load (buildConfig sets use_server_fixture for
-    // these built-in fixtures): the pod reads the waveform from its own
-    // /fixtures cache, so we skip the client download+decode entirely
-    // and send no PCM. Playback comes from the server's echoed initial
-    // buffer (player.init uses remote.initialBuffer), so the local
-    // decode was only ever feeding the now-eliminated upload.
-    const interleaved = new Float32Array(0);
-    const channels = 2;
+    // Resolve the target pod first, then ask it (server-info) whether
+    // it can load this fixture server-side. Capability-gated so the UI
+    // is safe across a mixed fleet / any deploy order: an old backend
+    // doesn't advertise the fixture, so we keep the upload path.
+    const wsUrl = resolveWsUrl(useSessionStore.getState().wsUrl);
+    const serverSideFixtures = await probeServerSideFixtures(wsUrl);
+    const useServerFixture = serverSideFixtures.includes(fixtureName);
+
+    let interleaved: Float32Array;
+    let channels: number;
+    if (useServerFixture) {
+      // Pod loads the waveform from its own /fixtures cache; skip the
+      // client download/decode/upload entirely. Playback comes from the
+      // server's echoed initial buffer (player.init uses
+      // remote.initialBuffer), so the local decode was only ever
+      // feeding the now-eliminated upload.
+      interleaved = new Float32Array(0);
+      channels = 2;
+    } else {
+      // Old backend or unknown fixture: upload as before.
+      try {
+        const decoded = await loadFixtureAudio(fixtureName);
+        interleaved = decoded.interleaved;
+        channels = decoded.channels;
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setStatus("error", `Track failed to load: ${msg}`);
+        return;
+      }
+    }
 
     setStatus("connecting", "Connecting…");
-    const config = buildConfig(fixtureName);
-    const wsUrl = resolveWsUrl(useSessionStore.getState().wsUrl);
+    const config = buildConfig(fixtureName, useServerFixture);
     const remote = new RemoteBackend(
       wsUrl,
       interleaved,

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -3,7 +3,7 @@
 import { useCallback } from "react";
 
 import { AudioPlayer } from "@/engine/audio/AudioPlayer";
-import { listFixtures, loadFixtureAudio, pickDefaultFixture } from "@/engine/audio/loadFixture";
+import { listFixtures, pickDefaultFixture } from "@/engine/audio/loadFixture";
 import { resetKnobDelta } from "@/engine/midi/absoluteDelta";
 import { createNetworkMonitor } from "@/engine/networkMonitor";
 import { defaultWsUrl } from "@/engine/podUrl";
@@ -81,6 +81,16 @@ function buildConfig(fixtureName: string): SessionConfig {
     // dropdown's stale value here would only re-introduce the
     // override-wins-over-sidecar regression.
     fixture_name: fixtureName,
+    // This hook only ever starts a session on a built-in fixture (custom
+    // user uploads take the swap_source path, not session init), and the
+    // pod already serves that exact file at /fixtures/<name>. Tell the
+    // server to load the waveform from its own cache so the browser skips
+    // the download→decode→re-upload of ~20 MB of PCM (~11 s on the
+    // measured cold path). DEPLOY ORDERING: the backend honouring this
+    // must reach the whole fleet (bake) BEFORE this UI ships — a stale
+    // backend would block on its audio recv. Backward-compatible +
+    // baked fleet-wide first, so safe.
+    use_server_fixture: true,
   };
 }
 
@@ -124,17 +134,14 @@ export function useStartSession() {
       return;
     }
 
-    let interleaved: Float32Array;
-    let channels: number;
-    try {
-      const decoded = await loadFixtureAudio(fixtureName);
-      interleaved = decoded.interleaved;
-      channels = decoded.channels;
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      setStatus("error", `Track failed to load: ${msg}`);
-      return;
-    }
+    // Server-side fixture load (buildConfig sets use_server_fixture for
+    // these built-in fixtures): the pod reads the waveform from its own
+    // /fixtures cache, so we skip the client download+decode entirely
+    // and send no PCM. Playback comes from the server's echoed initial
+    // buffer (player.init uses remote.initialBuffer), so the local
+    // decode was only ever feeding the now-eliminated upload.
+    const interleaved = new Float32Array(0);
+    const channels = 2;
 
     setStatus("connecting", "Connecting…");
     const config = buildConfig(fixtureName);


### PR DESCRIPTION
## Summary
Cuts default-fixture **"begin" latency from ~40s to ~6s** by removing the two biggest measured per-session costs (instrumented + profiled on a live pod).

- **Startup self-warmup** (`server.py` + `backend.run_startup_warmup`): at boot, before accepting traffic, drive one synthetic default-fixture session through `handle_client` so the one-time engine state (TRT decoder-engine load, LoRA-refit manager, ModelContext/conditioning, first-tick pipeline build) is hot. Cold first session measured ~40s; warm ~5–6s. Synchronous so the heartbeat only advertises the pod once warm. Env-gated `DEMON_STARTUP_WARMUP=0`. Warmup session fully torn down (no VRAM held).
- **Server-side known-fixture load** (backend handshake): client may send `{use_server_fixture:true, fixture_name:<known>}` → pod loads the waveform from its own `/fixtures` cache instead of the browser downloading→decoding→re-uploading ~20 MB of PCM over the WS (~11s on the measured cold path). **Backward-compatible** — clients without the flag take the unchanged upload path. `/api/server-info` advertises `server_side_fixtures`.
- **UI** (`web/`): `protocol.ts` skips the binary frame when `use_server_fixture`; `useStartSession` opts in for built-in fixtures and skips the client download/decode (playback already comes from the server's echoed initial buffer).
- Adds `[timing]` session-init markers (audio/resolve/stream-build/first-gen) for measuring the split.

Measured split that motivated this (fresh engine, cold session): ~19.6s one-time engine/Session setup + ~19.5s `_resolve_bpm_key_source`/upload; warm 2nd session ~5–6s.

## Deploy order (important)
The backend honouring `use_server_fixture` must reach the whole fleet (bake) **before** this UI ships to prod — a stale backend would block on its audio `recv`. Backward-compatible + baked-first makes this safe. Isolated preview via the `?ws=` pod override is safe regardless.

## Test plan
- [ ] Bake a `:dev` pod from this branch; cold first `begin` (default fixture) ≤ ~7s, `[warmup] done` in boot log, `server-info.warmup.done=true`
- [ ] `server-info.server_side_fixtures` lists known fixtures; default `begin` shows no client PCM upload (`audio_serverside_loaded` marker, no `audio_recv_decoded`)
- [ ] Old client (no flag) still works (unchanged upload path)
- [ ] Custom user upload (swap_source) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)