### PR TITLE
chore: github ownership transfer ryanontheinside -> daydreamlive

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,7 @@ uv run pytest tests/ -v
 DEMON is built on top of [ACE-Step](https://github.com/ace-step/ACE-Step). The base diffusion model, VAE, text encoder, and 5Hz LM are all ACE-Step's work — without them, none of this exists. Huge thanks to the ACE-Step team for releasing the v1.5 weights and code under MIT.
 
 If you use DEMON in your work, please also cite ACE-Step.
+
+## Authors
+
+DEMON originally created by Ryan Fosdick ([@RyanOnTheInside](https://ryanontheinside.com)). Maintained by [Daydream Live](https://daydream.live) and contributors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,12 @@ description = "DEMON: Diffusion Engine for Musical Orchestrated Noise"
 readme = "README.md"
 requires-python = "==3.11.*"
 license = {text = "MIT"}
+authors = [
+    {name = "Ryan Fosdick"}
+]
+maintainers = [
+    {name = "Daydream Live"}
+]
 dependencies = [
     # PyTorch with CUDA 12.8 - pinned to match ComfyUI
     "torch==2.9.1+cu128",

--- a/scripts/deploy/bootstrap_h100.sh
+++ b/scripts/deploy/bootstrap_h100.sh
@@ -37,7 +37,7 @@ ssh-keyscan github.com >> /root/.ssh/known_hosts 2>/dev/null || true
 
 # ---------- clone repo ----------
 if [ ! -d "$REPO_DIR/.git" ]; then
-    git clone git@github.com:ryanontheinside/DEMON.git "$REPO_DIR"
+    git clone git@github.com:daydreamlive/DEMON.git "$REPO_DIR"
 else
     echo "Repo already present at $REPO_DIR"
     (cd "$REPO_DIR" && git fetch && git reset --hard origin/main)


### PR DESCRIPTION
## Summary

  Finalize the GitHub ownership transfer from ryanontheinside/DEMON to daydreamlive/DEMON.

  - pyproject.toml: add authors (Ryan Fosdick) and maintainers (Daydream Live)
  - README: add Authors section crediting Ryan Fosdick / Daydream Live
  - scripts/deploy/bootstrap_h100.sh: update clone URL to new owner"