### PR TITLE
fix: restore default shift to 3.5 (regressed remix-strength response)

### DIFF
--- a/demos/realtime_motion_graph_web/knobs.py
+++ b/demos/realtime_motion_graph_web/knobs.py
@@ -70,7 +70,7 @@ def build_banks(sde: bool, loras=None) -> list:
     ); cc += 1
     # Shift value flows verbatim into the diffusion solver. Useful operator
     # range is roughly [1, 6]; max_val caps the MIDI sweep at 6.
-    core["shift"] = KnobDef(cc=cc, default=3.0, sensitivity=1.0, max_val=6.0); cc += 1
+    core["shift"] = KnobDef(cc=cc, default=3.5, sensitivity=1.0, max_val=6.0); cc += 1
     if sde:
         core["periodicity"] = KnobDef(cc=cc, sensitivity=2.0, max_val=12.5); cc += 1
     for lid in lora_ids:

--- a/demos/realtime_motion_graph_web/mcp_server.py
+++ b/demos/realtime_motion_graph_web/mcp_server.py
@@ -205,7 +205,7 @@ def _build_knob_catalog(sde: bool, enabled_lora_ids: list[str]) -> dict[str, dic
                    "description": "Stream seed (uint32 integer; passed to torch.manual_seed)"}
     out["feedback"] = {"default": 0.0, "max": 1.0, "group": "core",
                        "description": "Feedback amount"}
-    out["shift"] = {"default": 3.0, "min": 1.0, "max": 6.0, "group": "core",
+    out["shift"] = {"default": 3.5, "min": 1.0, "max": 6.0, "group": "core",
                     "description": "Flow shift (timing/curve shape). Passed verbatim to the diffusion solver."}
     out["steps_override"] = {"default": 8, "min": 1, "max": 16, "group": "core",
                              "description": "Diffusion step count. Lower = lower quality, higher = more latency. Changing rebuilds the StreamPipeline."}

--- a/demos/realtime_motion_graph_web/pipeline.py
+++ b/demos/realtime_motion_graph_web/pipeline.py
@@ -469,7 +469,7 @@ class PipelineRunner:
                     "seed": 0.0,
                     "feedback": 0.0,
                     "feedback_depth": 1.0,
-                    "shift": 3.0,
+                    "shift": 3.5,
                 }
                 if self.use_sde:
                     raw["periodicity"] = 0.0

--- a/demos/realtime_motion_graph_web/web/lib/config.ts
+++ b/demos/realtime_motion_graph_web/web/lib/config.ts
@@ -261,7 +261,7 @@ export const DEFAULT_CONFIG: RtmgConfig = {
     hint_strength: 1.4,
     feedback: 0.0,
     feedback_depth: 1,
-    shift: 0.5,
+    shift: 3.5,
     ch_g0: 1.0,
     ch_g1: 1.0,
     ch_g2: 1.0,

--- a/demos/realtime_motion_graph_web/web/public/config.json
+++ b/demos/realtime_motion_graph_web/web/public/config.json
@@ -47,7 +47,7 @@
 
     "feedback": 0.0,
     "feedback_depth": 1,
-    "shift": 3.0,
+    "shift": 3.5,
 
     "_rcfg_help": "Residual CFG. 'off' = no guidance (turbo default, free). 'self' = virtual uncond from initial noise, ~1.06x cost. 'initialize' = uncond run once per slot then cached, ~1.07x. 'full' = standard two-pass CFG, ~2x.",
     "rcfg_mode": "initialize",


### PR DESCRIPTION
Restores the default `shift` to **3.5** across the realtime-motion-graph engine + config. 3.5 is the value the fleet has been hotpatched to and is, per Ryan, the actual fix — upstream recommends 3.0, but that predates the denoise-parameter concept added on top here, and 3.0 regressed the remix-strength response.

Single commit, 5 one-line changes:
- `knobs.py` — `KnobDef` core `shift` default
- `mcp_server.py` — `_build_knob_catalog` shift default
- `pipeline.py` — stream raw-knobs fallback
- `web/lib/config.ts` — `DEFAULT_CONFIG.shift` (also fixes a stale `0.5`)
- `web/public/config.json` — shift default

Note: this PR was re-scoped — it previously also carried two experimental remix-strength latent-drift commits; those were dropped as not-the-fix. The branch is now just the shift stopgap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)