### PR TITLE
ui(rtmg): right-click MIDI-learn on new knobs + hero LoRA faders

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/HeroMacros.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/HeroMacros.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { LORA_SLOT_MARKER } from "@/engine/midi/types";
 import { useLoraFaderDrag } from "@/hooks/useLoraFaderDrag";
 import { useCurveStore } from "@/store/useCurveStore";
 import { useLoraStore } from "@/store/useLoraStore";
@@ -117,7 +118,17 @@ function HeroStyleFader({ slotIndex }: HeroStyleFaderProps) {
     ? `${slotIndex === 0 ? "Z" : "X"} + ▲▼`
     : null;
   return (
-    <div className={`hero-style-fader${isEmpty ? " hero-style-fader--empty" : ""}`}>
+    <div
+      className={`hero-style-fader${isEmpty ? " hero-style-fader--empty" : ""}`}
+      // Right-click → MIDI-learn. Use the slot marker (lora_slot_0 /
+      // lora_slot_1) rather than the concrete `lora_str_<id>` so a CC
+      // binding survives swapping the LoRA in this slot — matches the
+      // default keymap (CC71→lora_slot_0, CC72→lora_slot_1) and the
+      // resolveCcParam slot-marker branch in useMidi.ts. Empty slots
+      // omit the attribute so right-clicking an unloaded fader is a
+      // no-op rather than arming a binding that resolves to null.
+      data-param={isEmpty ? undefined : LORA_SLOT_MARKER[slotIndex]}
+    >
       <div className="hero-style-fader-label" title={displayLabel}>
         {displayLabel}
       </div>

--- a/demos/realtime_motion_graph_web/web/components/Performance/Knob.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/Knob.tsx
@@ -290,6 +290,9 @@ export function Knob({ param, label, max, min, reverse, unity, kbd }: Props) {
   return (
     <div
       className="knob-group"
+      // Picked up by useMidi.ts's contextmenu handler (`.knob-group
+      // [data-param]` → CC-learn), mirroring SliderGroup.
+      data-param={param}
       style={style}
       data-dd-tooltip={tooltip}
       data-dd-tooltip-wide={tooltip ? "" : undefined}

--- a/demos/realtime_motion_graph_web/web/hooks/useMidi.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useMidi.ts
@@ -234,12 +234,17 @@ export function useMidi() {
       });
 
     // Right-click → MIDI learn. Targets:
-    //   .slider-group[data-param=...] → CC
-    //   #blend-control[data-param=...] → CC (Tags A↔B blend slider,
+    //   .slider-group[data-param=...]      → CC (vertical faders)
+    //   .knob-group[data-param=...]        → CC (rotary knobs — Knob.tsx)
+    //   .hero-style-fader[data-param=...]  → CC (bottom-bay LoRA strength
+    //                                       faders in HeroMacros — set to
+    //                                       `lora_slot_<0|1>` so the
+    //                                       binding survives LoRA swaps)
+    //   #blend-control[data-param=...]     → CC (Tags A↔B blend slider,
     //                                       intentionally NOT a
     //                                       slider-group — keeps the
     //                                       horizontal rail styling)
-    //   [data-midi-learn=...]         → note (transport buttons, send-prompt, etc.)
+    //   [data-midi-learn=...]              → note (transport buttons, send-prompt, etc.)
     //
     // LoRA rows used to have a `.lora-row[data-param=...]` branch here.
     // It's gone — LibraryTile now owns its own right-click via a
@@ -253,6 +258,20 @@ export function useMidi() {
       if (slider?.dataset.param) {
         e.preventDefault();
         useMidiStore.getState().startLearn("cc", slider.dataset.param, slider);
+        return;
+      }
+      const knob = target.closest<HTMLElement>(".knob-group");
+      if (knob?.dataset.param) {
+        e.preventDefault();
+        useMidiStore.getState().startLearn("cc", knob.dataset.param, knob);
+        return;
+      }
+      const heroFader = target.closest<HTMLElement>(".hero-style-fader");
+      if (heroFader?.dataset.param) {
+        e.preventDefault();
+        useMidiStore
+          .getState()
+          .startLearn("cc", heroFader.dataset.param, heroFader);
         return;
       }
       const blendEl = target.closest<HTMLElement>("#blend-control");


### PR DESCRIPTION
## Summary

Restores right-click → MIDI-learn on the rotary `<Knob>` introduced in the 2026-05-19 sync and the new `HeroStyleFader` LoRA strength faders in the HeroMacros bottom bay. Both shipped with the contextmenu wiring half-finished: the knob's pointerdown handler defers right-click to MIDI-learn, but the root `.knob-group` div never carried the `data-param` attribute the global handler in `useMidi.ts` matches against, so the browser's native menu always won.

Affected params (13 knobs + 2 hero faders):
- **CORE tab** + **HeroMacros bay**: `denoise`, `hint_strength`, `timbre_strength`
- **MOD tab**: `shift`, `feedback`, `feedback_depth`, `dcw_scaler`, `dcw_high_scaler`, `dcw_mult_blend`, `dcw_mag_phase`, `dcw_soft_thresh`, `guidance_scale`, `cfg_rescale`
- **HeroMacros bay LoRA faders**: `lora_slot_0`, `lora_slot_1` (slot-marker so CC binding survives LoRA swaps — mirrors the existing default keymap)

## Change set

- `Knob.tsx`: emit `data-param={param}` on the `.knob-group` root.
- `HeroMacros.tsx` → `HeroStyleFader`: emit `data-param={LORA_SLOT_MARKER[slotIndex]}` on populated slots; empty slots omit the attribute so right-click is silent.
- `useMidi.ts`: extend the `onContextMenu` handler with two new branches — `.knob-group[data-param]` and `.hero-style-fader[data-param]` — both routing to `startLearn("cc", …)` exactly like the existing `.slider-group` branch. Updated the leading comment to enumerate all target selectors.

## Test plan

- [x] `npx tsc --noEmit` clean in `demos/realtime_motion_graph_web/web/`
- [ ] Local browser verification (downstream demon-public-demo): right-click each rotary in CORE/MOD/HeroMacros → learn arms (midi-learning class flickers, status bar updates), CC wiggle binds, subsequent CC moves drive the param.
- [ ] Right-click HeroStyleFader on a populated LoRA slot → learn arms for `lora_slot_<idx>`. Swap LoRA in the slot → CC continues to drive the new LoRA's strength.
- [ ] Right-click an empty HeroStyleFader → no-op.
- [ ] Regression: channel sliders (CHANNELS tab) and the A/B blend slider in PromptsTile still arm learn; SeedKnob still arms note-learn; LibraryTile per-LoRA right-click still shows its own menu (MIDI learn + Copy trigger).
- [ ] Esc cancels learn from any new target.