### PR TITLE
fix(rtmg): trigger-prepend on auto-enable + denoise survives session resume

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 
 import { loraStrengthDispatcher } from "@/engine/lora/dispatcher";
 import { listLoras } from "@/engine/lora/listLoras";
-import { getConfig, useConfig } from "@/lib/config";
+import { useConfig } from "@/lib/config";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { isLoraCompatibleWithScale, useLoraStore } from "@/store/useLoraStore";
 import { useMidiStore } from "@/store/useMidiStore";
@@ -45,71 +45,19 @@ import type { LoraCatalogEntry, LoraMetadata } from "@/types/protocol";
 //  8px above the drawer top edge, viewport-centered. Do NOT add
 //  `position: relative` to `.lora-row` or any intermediate ancestor;
 //  it kicks the tooltip out of that shared surface.
-//  - Toggling a LoRA on, when `engine.auto_prepend_lora_triggers` is
-//    true (default), prepends the trigger word to promptA and promptB
-//    so the encoder sees what the operator sees. Toggling off removes
-//    the trigger wherever it appears as a standalone comma-delimited
-//    token — covers the case where multiple LoRAs were stacked and
-//    the trigger is no longer at the head of the prompt. Substrings
-//    inside larger user-typed phrases are left alone.
+//  - Enabling/disabling a LoRA, when `engine.auto_prepend_lora_triggers`
+//    is true (default), prepends/strips the trigger word to/from
+//    promptA and promptB so the encoder sees what the operator sees.
+//    The prepend/strip lives in useLoraStore's enable/disable actions
+//    (and the boot-time auto-enable seed inside setCatalog), so every
+//    code path that flips a LoRA — manual click here, boot seed, MIDI,
+//    future programmatic callers — picks it up without each call site
+//    having to fire it explicitly. Substrings inside larger user-typed
+//    phrases are left alone.
 //  - LoRAs whose `base_model_scale` doesn't match the active
 //    checkpoint scale (2B vs 5B) are hidden by default; an inline
 //    footer reports the count and offers a one-click override.
 //    `engine.show_incompatible_loras = true` flips the default.
-
-// ── Visible trigger-prepend helpers ─────────────────────────────────────
-
-function _containsTrigger(prompt: string, trigger: string): boolean {
-  return prompt.toLowerCase().includes(trigger.toLowerCase());
-}
-
-function _prependTrigger(prompt: string, trigger: string): string {
-  const trimmed = prompt.trim();
-  if (trimmed.length === 0) return trigger;
-  return `${trigger}, ${prompt}`;
-}
-
-/** Remove every occurrence of ``trigger`` from ``prompt`` where it
- *  appears as a standalone comma-delimited token (head, middle, tail,
- *  or sole token). Substrings of larger phrases are left alone — if
- *  the user typed "punk rock" and the trigger is "rock", we don't
- *  mangle their prompt. Returns the rewritten prompt, or null when
- *  the trigger isn't present as a token (so callers can skip the
- *  write). Case-insensitive on the trigger comparison; preserves the
- *  case of surrounding tokens. */
-function _stripTrigger(prompt: string, trigger: string): string | null {
-  const needle = trigger.trim().toLowerCase();
-  if (!needle) return null;
-  const tokens = prompt.split(", ");
-  const kept = tokens.filter((tok) => tok.trim().toLowerCase() !== needle);
-  if (kept.length === tokens.length) return null;
-  return kept.join(", ");
-}
-
-// Both prompts get the same treatment when a LoRA is toggled. Iterate
-// over [current, setter] pairs so the per-side logic lives once.
-function _promptSides(): ReadonlyArray<readonly [string, (v: string) => void]> {
-  const perf = usePerformanceStore.getState();
-  return [
-    [perf.promptA, perf.setPromptA],
-    [perf.promptB, perf.setPromptB],
-  ] as const;
-}
-
-function prependTriggerToPrompts(trigger: string): void {
-  for (const [cur, setter] of _promptSides()) {
-    if (!_containsTrigger(cur, trigger)) {
-      setter(_prependTrigger(cur, trigger));
-    }
-  }
-}
-
-function removeTriggerFromPrompts(trigger: string): void {
-  for (const [cur, setter] of _promptSides()) {
-    const next = _stripTrigger(cur, trigger);
-    if (next !== null) setter(next);
-  }
-}
 
 // ── Search ──────────────────────────────────────────────────────────────
 
@@ -316,17 +264,17 @@ function LoraRow({ entry }: RowProps) {
 
   function toggle() {
     const remote = useSessionStore.getState().remote;
-    const cfg = getConfig();
-    const autoPrepend = cfg.engine.auto_prepend_lora_triggers ?? true;
     if (enabled) {
+      // disable() in the lora store also strips the trigger from
+      // promptA/promptB when engine.auto_prepend_lora_triggers is on,
+      // so the encoder follows the operator's visible prompt without
+      // this call site needing to handle it.
       disable(id);
       remote?.sendDisableLora(id);
-      if (autoPrepend && trigger) removeTriggerFromPrompts(trigger);
     } else {
       enable(id);
       const s = useLoraStore.getState().strengths[id] ?? 0;
       remote?.sendEnableLora(id, s);
-      if (autoPrepend && trigger) prependTriggerToPrompts(trigger);
     }
   }
 

--- a/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
@@ -174,9 +174,17 @@ export function useFixtureSwap() {
       // shows again; side-rail hints stay suppressed until the user
       // drags the top ribbon up. Shares config with useStartSession so
       // one knob controls both Play and swap.
+      //
+      // skipNextDenoiseGate is a one-shot opt-out for saved-session
+      // resumes: the demo-side applySessionState sets it before
+      // writing perf.fixture so the gate doesn't trample the restored
+      // denoise value with a snap-to-zero. Consume-and-clear here so
+      // the next legitimate swap reverts to the normal behaviour.
       const perfState = usePerformanceStore.getState();
       const gate = getConfig().denoise_session_gate;
-      if (gate.enabled) {
+      if (perfState.skipNextDenoiseGate) {
+        perfState.setSkipNextDenoiseGate(false);
+      } else if (gate.enabled) {
         const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
         perfState.setSliderDirect("denoise", 0);
         perfState.animateSliderDisplayFrom("denoise", prevDenoise, gate.glide_ms);

--- a/demos/realtime_motion_graph_web/web/lib/loraTriggers.ts
+++ b/demos/realtime_motion_graph_web/web/lib/loraTriggers.ts
@@ -1,0 +1,71 @@
+"use client";
+
+// Shared helpers for the "visible LoRA trigger prepend" feature.
+//
+// The contract (mirroring the LibraryTile header comment): when a LoRA
+// with a primary_trigger_word is enabled and engine.auto_prepend_lora_triggers
+// is on, its trigger is prepended to promptA + promptB as a leading
+// comma-delimited token so the encoder sees what the operator sees. On
+// disable, the trigger is stripped wherever it appears as a standalone
+// token (substrings inside larger user-typed phrases are left alone).
+//
+// These helpers used to live inline in components/Performance/LibraryTile.tsx
+// where the click-toggle was the only caller. Lifting them here lets the
+// LoRA store's enable()/disable() actions also run them, so EVERY enable
+// path (manual click, boot auto-enable seed, MIDI, future programmatic
+// callers) gets the prepend without the call site needing to remember to
+// fire it.
+
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+
+function containsTrigger(prompt: string, trigger: string): boolean {
+  return prompt.toLowerCase().includes(trigger.toLowerCase());
+}
+
+function prependTrigger(prompt: string, trigger: string): string {
+  const trimmed = prompt.trim();
+  if (trimmed.length === 0) return trigger;
+  return `${trigger}, ${prompt}`;
+}
+
+/** Remove every occurrence of ``trigger`` from ``prompt`` where it
+ *  appears as a standalone comma-delimited token (head, middle, tail,
+ *  or sole token). Substrings of larger phrases are left alone — if
+ *  the user typed "punk rock" and the trigger is "rock", we don't
+ *  mangle their prompt. Returns the rewritten prompt, or null when
+ *  the trigger isn't present as a token (so callers can skip the
+ *  write). Case-insensitive on the trigger comparison; preserves the
+ *  case of surrounding tokens. */
+function stripTrigger(prompt: string, trigger: string): string | null {
+  const needle = trigger.trim().toLowerCase();
+  if (!needle) return null;
+  const tokens = prompt.split(", ");
+  const kept = tokens.filter((tok) => tok.trim().toLowerCase() !== needle);
+  if (kept.length === tokens.length) return null;
+  return kept.join(", ");
+}
+
+// Both prompts get the same treatment when a LoRA is toggled. Iterate
+// over [current, setter] pairs so the per-side logic lives once.
+function promptSides(): ReadonlyArray<readonly [string, (v: string) => void]> {
+  const perf = usePerformanceStore.getState();
+  return [
+    [perf.promptA, perf.setPromptA],
+    [perf.promptB, perf.setPromptB],
+  ] as const;
+}
+
+export function prependTriggerToPrompts(trigger: string): void {
+  for (const [cur, setter] of promptSides()) {
+    if (!containsTrigger(cur, trigger)) {
+      setter(prependTrigger(cur, trigger));
+    }
+  }
+}
+
+export function removeTriggerFromPrompts(trigger: string): void {
+  for (const [cur, setter] of promptSides()) {
+    const next = stripTrigger(cur, trigger);
+    if (next !== null) setter(next);
+  }
+}

--- a/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
@@ -3,12 +3,29 @@
 import { create } from "zustand";
 
 import { getConfig, isConfigApplied } from "@/lib/config";
+import {
+  prependTriggerToPrompts,
+  removeTriggerFromPrompts,
+} from "@/lib/loraTriggers";
 import { useSessionStore } from "@/store/useSessionStore";
 import {
   LORA_DEFAULT_STRENGTH_FRACTION,
   LORA_SLIDER_MAX,
 } from "@/types/engine";
 import type { LoraCatalogEntry } from "@/types/protocol";
+
+/** Whether visible trigger-prepend is on for the active config. Used
+ *  to gate every trigger write below — same source of truth as the
+ *  manual-toggle path in LibraryTile. */
+function autoPrependEnabled(): boolean {
+  return getConfig().engine.auto_prepend_lora_triggers ?? true;
+}
+
+/** Read the trigger word for a given LoRA id from the live catalog. */
+function triggerFor(catalog: LoraCatalogEntry[], id: string): string | null {
+  const entry = catalog.find((e) => e.id === id);
+  return entry?.metadata?.primary_trigger_word ?? null;
+}
 
 /** True iff a LoRA's trained ``base_model_scale`` is compatible with
  *  the active session's checkpoint scale. Unknown values on EITHER
@@ -252,6 +269,20 @@ export const useLoraStore = create<LoraState>((set) => ({
       const enabled = shouldSeed
         ? new Set<string>([...s.enabled, ...fresh.enabled])
         : s.enabled;
+      // Prepend triggers for any newly-seeded LoRAs so the encoder
+      // sees the same prompt the operator does (same contract as the
+      // manual-toggle path in LibraryTile). Iterate `fresh.enabled` so
+      // we only act on LoRAs that became enabled THIS call — not
+      // anything the user had already turned on before re-broadcast.
+      // Sidecar entries without a primary_trigger_word are skipped by
+      // the helper's null check; the autoPrepend gate is config-driven
+      // and matches the LibraryTile guard.
+      if (shouldSeed && autoPrependEnabled()) {
+        for (const id of fresh.enabled) {
+          const trigger = triggerFor(catalog, id);
+          if (trigger) prependTriggerToPrompts(trigger);
+        }
+      }
       return {
         catalog,
         strengths,
@@ -266,6 +297,19 @@ export const useLoraStore = create<LoraState>((set) => ({
       if (s.enabled.has(id)) return {} as Partial<LoraState>;
       const next = new Set(s.enabled);
       next.add(id);
+      // Visible trigger-prepend lives in the store action so EVERY
+      // caller — manual click in LibraryTile, MIDI, future
+      // programmatic enablers — gets the prepend without each call
+      // site having to remember to fire it. The setCatalog seed path
+      // has its own prepend loop above (it bypasses enable() because
+      // it builds the Set atomically with merge semantics this action
+      // doesn't have). The helper itself is idempotent: if the
+      // trigger is already in the prompt as a substring of any token,
+      // it won't double-prepend.
+      const trigger = autoPrependEnabled()
+        ? triggerFor(s.catalog, id)
+        : null;
+      if (trigger) prependTriggerToPrompts(trigger);
       return { enabled: next };
     }),
   disable: (id) =>
@@ -273,6 +317,14 @@ export const useLoraStore = create<LoraState>((set) => ({
       if (!s.enabled.has(id)) return {} as Partial<LoraState>;
       const next = new Set(s.enabled);
       next.delete(id);
+      // Symmetric strip on disable. removeTriggerFromPrompts no-ops
+      // when the trigger isn't present as a standalone token, so
+      // user-typed phrases that happen to contain the trigger as a
+      // substring (e.g. "punk rock" when trigger is "rock") survive.
+      const trigger = autoPrependEnabled()
+        ? triggerFor(s.catalog, id)
+        : null;
+      if (trigger) removeTriggerFromPrompts(trigger);
       return { enabled: next };
     }),
   toggle: (id) =>

--- a/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
@@ -366,6 +366,16 @@ interface PerformanceState {
    *  by useFixtureSwap. */
   skipNextFixtureSwap: boolean;
 
+  /** One-shot opt-out for the "hear source first" denoise gate inside
+   *  useFixtureSwap. Set true before writing perf.fixture during a
+   *  saved-session resume — the gate would otherwise snap the
+   *  restored denoise to 0 and play a glide-to-zero animation,
+   *  trampling the saved value. Consumed-and-cleared by
+   *  useFixtureSwap inside its swap completion handler. Fresh
+   *  starts and song-swaps don't set it, so their existing
+   *  snap-and-glide behaviour is unchanged. */
+  skipNextDenoiseGate: boolean;
+
   /** DCW (wavelet-domain post-step correction) non-numeric state. The
    * numeric knobs (dcw_scaler, dcw_high_scaler, dcw_mult_blend,
    * dcw_mag_phase, dcw_soft_thresh) all live in sliderValues. */
@@ -442,6 +452,7 @@ interface PerformanceState {
   togglePause: () => void;
   setRemixStarted: (b: boolean) => void;
   setSkipNextFixtureSwap: (b: boolean) => void;
+  setSkipNextDenoiseGate: (b: boolean) => void;
   /** Run a visual-only "slide to zero" demo on `param`. Seeds
    *  `sliderDisplayOverride[param] = fromValue` and tweens it down to 0
    *  over `durationMs` using a cubic ease-out, then deletes the key so
@@ -541,6 +552,7 @@ export const usePerformanceStore = create<PerformanceState>((set) => ({
   paused: false,
   remixStarted: false,
   skipNextFixtureSwap: false,
+  skipNextDenoiseGate: false,
 
   dcwEnabled: true,
   dcwMode: "double",
@@ -658,6 +670,7 @@ export const usePerformanceStore = create<PerformanceState>((set) => ({
   togglePause: () => set((s) => ({ paused: !s.paused })),
   setRemixStarted: (b) => set({ remixStarted: b }),
   setSkipNextFixtureSwap: (b) => set({ skipNextFixtureSwap: b }),
+  setSkipNextDenoiseGate: (b) => set({ skipNextDenoiseGate: b }),
   animateSliderDisplayFrom: (param, fromValue, durationMs) => {
     // Cancel any in-flight smoothing or prior demo tween for this param.
     cancelTween(param);


### PR DESCRIPTION
## Summary

Two related fixes for the realtime motion graph web UI, both diagnosed today on `music.daydream.live`.

### 1. Trigger-prepend now runs on auto-enable + every code path
LoRA trigger words were only prepended to `promptA`/`promptB` on a manual toggle click in `LibraryTile`. The boot-time auto-enable path (`computeSeed` inside `setCatalog`) bypassed it, so any LoRA listed in `engine.enabled_loras` was active in the model but the encoder never saw its activation token — exactly the discrepancy a user hit with the Bach LoRA today (works in TouchDesigner where they manually type `bach`, weak on web where the auto-enabled Bach LoRA shipped to the encoder with no `bach` token).

- Move the prepend/strip into `useLoraStore`'s `enable`/`disable` actions so every code path (manual click, MIDI, future programmatic enablers) gets the prepend without each call site having to fire it.
- Add a matching prepend loop inside `setCatalog`'s once-per-session seed (it doesn't route through `enable()` because it builds the Set atomically).
- Lift the helpers from `components/Performance/LibraryTile.tsx` into a new `lib/loraTriggers.ts` so the store and the tile share one idempotent implementation. The `_containsTrigger` guard makes re-enabling already-prepended LoRAs a no-op; `_stripTrigger`'s comma-token semantics keep user-typed phrases (e.g. "punk rock" with trigger "rock") intact.
- `LibraryTile.tsx`'s `toggle()` drops its redundant prepend/strip calls and its now-orphan `getConfig` import. The header-comment contract block is rewritten to point at the store as the authority.

### 2. Denoise level survives session resume
`applySessionState` in demon-public-demo restores all sliders (including `denoise`) and ends with `setFixture(state.perf.fixture)`. That terminal `setFixture` triggered the "hear source first" gate in `useFixtureSwap`, which **unconditionally** snapped `denoise` back to 0 and played a glide animation — trampling the just-restored value. To the operator denoise looked unsaved.

- Add a one-shot `skipNextDenoiseGate: boolean` flag on `usePerformanceStore`, mirroring the existing `skipNextFixtureSwap` pattern.
- `useFixtureSwap` consumes-and-clears it inside the swap completion handler. If set, the snap+glide is skipped; if not, the existing behaviour runs unchanged.
- The demo-side `applySessionState` (separate demon-public-demo PR) sets the flag before writing `perf.fixture`. Fresh starts and song-swaps don't set the flag, so their snap-and-glide behaviour is unchanged.

## Test plan

- [ ] LibraryTile manual toggle: enable a LoRA with a `primary_trigger_word`, confirm the trigger appears at the head of both `Tags A` and `Tags B`. Toggle off, confirm it's stripped as a comma-delimited token. Toggle back on — idempotent (no duplicate).
- [ ] Boot-time auto-enable: with `engine.enabled_loras = ["deathstep", "bach"]` in `config.json`, confirm both triggers (`afxdump`, `bach`) appear at the head of both prompts on first paint. Order: triggers prepend in `preferredList` order, so the last-listed lands at the head — final shape `bach, afxdump, <theme>`.
- [ ] Bare-stem LoRA (no `metadata.primary_trigger_word`): toggling is a no-op on the prompts.
- [ ] User-typed substring survives: type "punk rock" in Tags A, enable a LoRA with trigger "rock", toggle off — the typed phrase isn't mangled.
- [ ] Manual `denoise` change + page reload via the demo's saved-session resume flow: denoise reads the saved value, no glide-to-zero animation. (Requires the demon-public-demo follow-up PR for the demo-side flag setter.)
- [ ] Regression: fresh Play, denoise still snaps to 0 with the existing glide. Song-swap mid-session, denoise still snaps to 0 with glide. Both behaviours unchanged.
- [ ] `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)