### PR TITLE
feat(lora): hide denied LoRAs from the Library tile

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { createPortal } from "react-dom";
 
 import { loraStrengthDispatcher } from "@/engine/lora/dispatcher";
-import { listLoras } from "@/engine/lora/listLoras";
+import { listHiddenLoras, listLoras } from "@/engine/lora/listLoras";
 import { useConfig } from "@/lib/config";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { isLoraCompatibleWithScale, useLoraStore } from "@/store/useLoraStore";
@@ -458,23 +458,53 @@ export function LibraryTile() {
   const [showAllOverride, setShowAllOverride] = useState(false);
   const showAll = cfgShowAll || showAllOverride;
 
+  // Admin-hidden LoRA ids (global denylist, served by the app origin —
+  // see listHiddenLoras). Empty set = nothing hidden / service down.
+  const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
+  const enabledIds = useLoraStore((s) => s.enabled);
+
   useEffect(() => {
     if (!sessionWsUrl && !LOCAL_MODE) return;
     void listLoras().then(setCatalog).catch(() => {});
+    void listHiddenLoras().then(setHiddenIds).catch(() => {});
   }, [setCatalog, sessionWsUrl]);
 
-  // Compatibility filter runs first so the "N hidden" count tracks
+  // An admin hiding a LoRA must not leave it applied: force-disable any
+  // hidden LoRA the session currently has enabled. useLoraStore.disable
+  // also strips the trigger from the prompt, so this is the same path a
+  // manual toggle-off takes. Keyed on `enabledIds` too — not just
+  // `hiddenIds` — so a hidden LoRA that the setCatalog seed auto-enables
+  // (e.g. a hidden hardcoded-preferred LoRA) is caught on the next tick.
+  // Idempotent: disabling drops the id from `enabled`, so a re-run after
+  // the resulting state change is a no-op.
+  useEffect(() => {
+    if (hiddenIds.size === 0) return;
+    const disable = useLoraStore.getState().disable;
+    for (const id of enabledIds) {
+      if (hiddenIds.has(id)) disable(id);
+    }
+  }, [hiddenIds, enabledIds]);
+
+  // Admin-hidden LoRAs drop out of the catalog entirely — no row, no
+  // count, invisible to the regular user. Runs before the scale filter
+  // so the "N hidden" footer keeps tracking scale incompatibility only.
+  const visible = useMemo(
+    () => catalog.filter((entry) => !hiddenIds.has(entry.id)),
+    [catalog, hiddenIds],
+  );
+
+  // Compatibility filter runs next so the "N hidden" count tracks
   // scale incompatibility specifically, not query misses.
   const compatible = useMemo(
     () =>
       showAll
-        ? catalog
-        : catalog.filter((entry) =>
+        ? visible
+        : visible.filter((entry) =>
             isLoraCompatibleWithScale(entry, sessionScale),
           ),
-    [catalog, sessionScale, showAll],
+    [visible, sessionScale, showAll],
   );
-  const hiddenCount = catalog.length - compatible.length;
+  const hiddenCount = visible.length - compatible.length;
 
   const filtered = useMemo(
     () => compatible.filter((entry) => matchesQuery(entry, query)),

--- a/demos/realtime_motion_graph_web/web/engine/lora/listLoras.ts
+++ b/demos/realtime_motion_graph_web/web/engine/lora/listLoras.ts
@@ -28,3 +28,29 @@ export async function listLoras(): Promise<LoraCatalogEntry[]> {
     .setCheckpointScale(json.checkpoint_scale ?? null);
   return json.loras ?? [];
 }
+
+/** Fetch the set of LoRA ids an admin has hidden from the Library.
+ *
+ *  Unlike listLoras() this hits the **app origin** (`/api/loras/hidden`,
+ *  a Vercel route backed by the orchestrator) — NOT the pod — because
+ *  the hidden list is global, not per-pod. The Library tile uses it to
+ *  drop hidden LoRAs from the catalog it renders.
+ *
+ *  Fail-open: any error (route missing, orchestrator down, malformed
+ *  body) yields an empty set, i.e. "nothing hidden" → the Library shows
+ *  everything. A broken visibility service must never blank the tile.
+ */
+export async function listHiddenLoras(): Promise<Set<string>> {
+  try {
+    const res = await fetch("/api/loras/hidden", { cache: "no-store" });
+    if (!res.ok) return new Set();
+    const json = (await res.json()) as { hidden?: unknown };
+    return new Set(
+      Array.isArray(json.hidden)
+        ? json.hidden.filter((x): x is string => typeof x === "string")
+        : [],
+    );
+  } catch {
+    return new Set();
+  }
+}


### PR DESCRIPTION
The pod image holds every LoRA and `/api/loras` lists them all, so the Library tile shows everything. This adds a client-side filter that honors an admin-maintained global denylist.

## Changes
- **`listLoras.ts`** — new `listHiddenLoras()`: fetches the app-origin `/api/loras/hidden` (a Vercel route backed by the orchestrator — the denylist is global, not per-pod). Fail-open: any error yields an empty set, so a broken visibility service never blanks the Library.
- **`LibraryTile.tsx`** — fetches the hidden set alongside the catalog; drops hidden LoRAs from the rendered catalog before the scale-compat filter (so the "N hidden" footer keeps counting scale mismatches only). Also **force-disables** any hidden LoRA the session currently has enabled — hiding is both a Library removal and a kill for in-flight use. The force-disable effect is keyed on the enabled set too, so a hidden LoRA the seed auto-enables is caught on the next tick.

## Companion
The orchestrator endpoints, Vercel routes (`/api/loras/hidden` etc.) and the admin "LoRA visibility" panel ship in `demon-public-demo` (PR: `gio/feat/admin-lora-visibility`). This DEMON PR must merge + sync-ui before the filter is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)