### PR TITLE
fix(lora): auto-send the prompt when a LoRA is toggled (commit the trigger word)

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
@@ -11,6 +11,7 @@ import { useIdleReset } from "@/hooks/useIdleReset";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useMcpMirror } from "@/hooks/useMcpMirror";
+import { useLoraTriggerSync } from "@/hooks/useLoraTriggerSync";
 import { useMidi } from "@/hooks/useMidi";
 import { useParamSync } from "@/hooks/useParamSync";
 import { usePromptBlendSync } from "@/hooks/usePromptBlendSync";
@@ -76,6 +77,7 @@ export function PerformanceShell() {
   useEdgeLoraBinding();
   useTimbreSync();
   usePromptBlendSync();
+  useLoraTriggerSync();
   useStemOverlaySync();
   useRefSourceAcks("timbre");
   useRefSourceAcks("structure");

--- a/demos/realtime_motion_graph_web/web/hooks/useLoraTriggerSync.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useLoraTriggerSync.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { getConfig } from "@/lib/config";
+import { useLoraStore } from "@/store/useLoraStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { useSessionStore } from "@/store/useSessionStore";
+
+// Re-send the prompt whenever the enabled-LoRA set changes.
+//
+// Enabling/disabling a LoRA prepends/strips its trigger word to/from
+// Tags A + B (useLoraStore.enable/disable → loraTriggers), but that
+// edit only reaches the engine on a `prompt` WS message — and toggling
+// a LoRA does NOT itself send one (Send Tags / Enter / key change are
+// the only senders). Without this hook the operator enables a LoRA,
+// sees its trigger appear in the Tags box, but the engine keeps
+// generating against the OLD prompt with no trigger: the LoRA's
+// matrices apply via refit, yet its activation word never lands — the
+// style barely fires. This is exactly the "LoRAs apply weird" report.
+//
+// This hook closes the gap: on any change to `useLoraStore.enabled` it
+// debounce-sends the current promptA/promptB so the just-prepended (or
+// just-stripped on disable) trigger commits to the encoder. Debounce —
+// not throttle — because auditioning LoRAs produces rapid enable/
+// disable bursts; we want a single send once the burst settles, not
+// one per toggle.
+//
+// Gated on `engine.auto_prepend_lora_triggers`: when an operator turns
+// auto-prepend off (a fully manual trigger workflow) they also own
+// prompt sends, so the auto-send stays out of their way.
+//
+// `enabled` is replaced with a fresh Set on every real membership
+// change (enable/disable build a new Set; the no-op guards return the
+// old one), so a reference check is a reliable change signal.
+
+const DEBOUNCE_MS = 250;
+
+export function useLoraTriggerSync() {
+  useEffect(() => {
+    let timerId = 0;
+
+    const flush = () => {
+      timerId = 0;
+      const session = useSessionStore.getState();
+      if (session.status !== "ready" || !session.remote) return;
+      const perf = usePerformanceStore.getState();
+      session.remote.sendPrompt(
+        perf.promptA,
+        perf.activeKey,
+        perf.activeTimeSignature,
+        perf.promptB,
+      );
+    };
+
+    const unsub = useLoraStore.subscribe((s, prev) => {
+      if (s.enabled === prev.enabled) return;
+      if ((getConfig().engine.auto_prepend_lora_triggers ?? true) === false) {
+        return;
+      }
+      if (timerId !== 0) window.clearTimeout(timerId);
+      timerId = window.setTimeout(flush, DEBOUNCE_MS);
+    });
+
+    return () => {
+      if (timerId !== 0) window.clearTimeout(timerId);
+      unsub();
+    };
+  }, []);
+}


### PR DESCRIPTION
## The bug

Enabling a LoRA prepends its trigger word into Tags A + B (`useLoraStore.enable` → `loraTriggers.prependTriggerToPrompts`). But the prompt text only reaches the engine via a `prompt` WS message — and **toggling a LoRA never sends one**. `Send Tags` / Enter / key change are the only senders; the 8 ms param stream carries `lora_str_<id>` (strength) but not `tags`.

So: operator enables a LoRA → its `roti-…` trigger appears in the Tags box → the LoRA's matrices get applied via refit → **but the engine keeps generating against the old prompt with no trigger**. The activation word never lands, the style barely fires. This is the "the 40 LoRAs apply weird" report.

Confirmed empirically on a `:dev` pod: a temporary server-side log showed 20+ `enable_lora`/`disable_lora` events and **zero `prompt` messages** during a full audition session.

## The fix

New hook **`useLoraTriggerSync`** — on any change to `useLoraStore.enabled`, debounce-send the current `promptA`/`promptB` so the just-prepended (or just-stripped, on disable) trigger commits to the encoder.

- **Debounce, not throttle** — auditioning LoRAs is a rapid enable/disable burst; one send once it settles, not one per toggle (250 ms).
- **Gated on `engine.auto_prepend_lora_triggers`** — a fully-manual trigger workflow is left untouched.
- **Safe before `ready`** — `flush` no-ops until the session is connected.
- Mounted in `PerformanceShell` alongside `usePromptBlendSync` / `useTimbreSync`, following the same vanilla-`subscribe` sync-hook pattern.

Affects old and new LoRAs alike — the old daydreamlive set only seemed fine because `deathstep`'s trigger is hardcoded into the *default* prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)