### PR TITLE
fix(rtmg): honor skipNextDenoiseGate in useStartSession too

### DIFF
--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -346,9 +346,19 @@ export function useStartSession() {
     // initial fresh-load value (only applyConfig() at module load sees
     // it); later sessions need this explicit reset to restore the gate.
     // remixStarted always resets so the affordance shows again.
+    //
+    // skipNextDenoiseGate is a one-shot opt-out for saved-session
+    // resumes: applySessionState sets it before writing perf.fixture so
+    // the just-restored denoise survives this hook's snap-to-zero. The
+    // useFixtureSwap consumer normally clears it, but on a fresh resume
+    // its run() bails on session.status !== "ready" without firing, so
+    // we consume-and-clear here too. Fresh sessions don't set the flag,
+    // so their gate behaviour is unchanged.
     const perfState = usePerformanceStore.getState();
     const gate = getConfig().denoise_session_gate;
-    if (gate.enabled) {
+    if (perfState.skipNextDenoiseGate) {
+      perfState.setSkipNextDenoiseGate(false);
+    } else if (gate.enabled) {
       const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
       perfState.setSliderDirect("denoise", 0);
       perfState.animateSliderDisplayFrom("denoise", prevDenoise, gate.glide_ms);


### PR DESCRIPTION
## Summary

Follow-up to #117. Saved-session resumes still snap denoise to 0 because the `skipNextDenoiseGate` opt-out only patched `useFixtureSwap`'s gate — `useStartSession`'s identical gate at session-start was left unconditional.

On a resume the demo-side `applySessionState` writes `perf.fixture` *before* the session is live, so `useFixtureSwap.run()` bails on `session.status !== "ready"` without consuming the flag. Then `useStartSession` runs from `PerformanceShell`'s first mount and snaps denoise back to 0 — exactly the bug #117 was meant to close, still visible to users as "my saved denoise value never sticks across reloads."

This PR mirrors the existing `useFixtureSwap` consumer in `useStartSession`: if the flag is set, consume-and-clear it and skip the gate; otherwise run the gate as before. Fresh starts (where `applySessionState` never ran) don't set the flag, so their snap-and-glide behavior is unchanged.

## Test plan

- [ ] Open music.daydream.live with this branch synced into demon-public-demo
- [ ] Pick a track → Play → drag denoise to ~0.7 → save the session
- [ ] Reload + reopen the saved session — denoise restores to ~0.7 (no glide-down to 0)
- [ ] Switch to a different track mid-session — gate still fires (denoise glides to 0) ✓ regression check on `useFixtureSwap`
- [ ] Fresh page load → Play without resuming — gate still fires ✓ regression check on `useStartSession`

🤖 Generated with [Claude Code](https://claude.com/claude-code)