### PR TITLE
fix: inject LoRA triggers on the wire, keep Tags boxes clean

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -45,15 +45,13 @@ import type { LoraCatalogEntry, LoraMetadata } from "@/types/protocol";
 //  8px above the drawer top edge, viewport-centered. Do NOT add
 //  `position: relative` to `.lora-row` or any intermediate ancestor;
 //  it kicks the tooltip out of that shared surface.
-//  - Enabling/disabling a LoRA, when `engine.auto_prepend_lora_triggers`
-//    is true (default), prepends/strips the trigger word to/from
-//    promptA and promptB so the encoder sees what the operator sees.
-//    The prepend/strip lives in useLoraStore's enable/disable actions
-//    (and the boot-time auto-enable seed inside setCatalog), so every
-//    code path that flips a LoRA — manual click here, boot seed, MIDI,
-//    future programmatic callers — picks it up without each call site
-//    having to fire it explicitly. Substrings inside larger user-typed
-//    phrases are left alone.
+//  - Enabling/disabling a LoRA does NOT mutate the Tags A/B textareas.
+//    The trigger word is injected onto the WS `prompt` message at
+//    send-time by RemoteBackend.sendPrompt (via enabledLoraTriggerPrefix),
+//    gated on `engine.auto_prepend_lora_triggers` (default true).
+//    The click-toggle here calls sendPrompt right after enable/disable
+//    so the engine immediately re-encodes with the new trigger set;
+//    useLoraTriggerSync is the backstop for non-click enable paths.
 //  - LoRAs whose `base_model_scale` doesn't match the active
 //    checkpoint scale (2B vs 5B) are hidden by default; an inline
 //    footer reports the count and offers a one-click override.
@@ -265,10 +263,6 @@ function LoraRow({ entry }: RowProps) {
   function toggle() {
     const remote = useSessionStore.getState().remote;
     if (enabled) {
-      // disable() in the lora store also strips the trigger from
-      // promptA/promptB when engine.auto_prepend_lora_triggers is on,
-      // so the encoder follows the operator's visible prompt without
-      // this call site needing to handle it.
       disable(id);
       remote?.sendDisableLora(id);
     } else {
@@ -276,6 +270,19 @@ function LoraRow({ entry }: RowProps) {
       const s = useLoraStore.getState().strengths[id] ?? 0;
       remote?.sendEnableLora(id, s);
     }
+    // Re-send the prompt so the engine's encoded conditioning picks up
+    // the new enabled-LoRA trigger set. The promptA/promptB read here
+    // are the operator's CLEAN textarea text; sendPrompt injects the
+    // trigger prefix on the wire (see enabledLoraTriggerPrefix). The
+    // enable()/disable() above already mutated useLoraStore.enabled,
+    // so the prefix sendPrompt computes reflects this toggle.
+    const perf = usePerformanceStore.getState();
+    remote?.sendPrompt(
+      perf.promptA,
+      perf.activeKey,
+      perf.activeTimeSignature,
+      perf.promptB,
+    );
   }
 
   // Right-click anywhere on the row → open the context menu at click

--- a/demos/realtime_motion_graph_web/web/engine/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/engine/protocol.ts
@@ -11,6 +11,7 @@
 
 import * as fzstd from "fzstd";
 
+import { enabledLoraTriggerPrefix } from "@/lib/loraTriggers";
 import { useSessionStore } from "@/store/useSessionStore";
 import {
   SAMPLE_RATE,
@@ -554,6 +555,14 @@ export class RemoteBackend extends EventTarget {
   ): void {
     if (this.ws?.readyState !== WebSocket.OPEN) return;
     try {
+      // Inject the enabled-LoRA trigger words on the WIRE only.
+      // Callers pass the operator's CLEAN prompt text (promptA/promptB
+      // exactly as typed in the Tags A/B boxes); the trigger prefix is
+      // computed fresh here so every send path — Send Tags button,
+      // key change, LoRA toggle — carries the current trigger set
+      // without the textareas ever showing it. Recomputing per call
+      // means there is no double-prepend.
+      const prefix = enabledLoraTriggerPrefix();
       const msg: {
         type: string;
         tags: string;
@@ -562,9 +571,9 @@ export class RemoteBackend extends EventTarget {
         time_signature?: string;
       } = {
         type: "prompt",
-        tags,
+        tags: prefix + tags,
       };
-      if (tagsB) msg.tags_b = tagsB;
+      if (tagsB) msg.tags_b = prefix + tagsB;
       if (key) msg.key = key;
       if (timeSignature) msg.time_signature = timeSignature;
       this.ws.send(JSON.stringify(msg));

--- a/demos/realtime_motion_graph_web/web/hooks/useLoraTriggerSync.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useLoraTriggerSync.ts
@@ -9,22 +9,21 @@ import { useSessionStore } from "@/store/useSessionStore";
 
 // Re-send the prompt whenever the enabled-LoRA set changes.
 //
-// Enabling/disabling a LoRA prepends/strips its trigger word to/from
-// Tags A + B (useLoraStore.enable/disable → loraTriggers), but that
-// edit only reaches the engine on a `prompt` WS message — and toggling
-// a LoRA does NOT itself send one (Send Tags / Enter / key change are
-// the only senders). Without this hook the operator enables a LoRA,
-// sees its trigger appear in the Tags box, but the engine keeps
-// generating against the OLD prompt with no trigger: the LoRA's
-// matrices apply via refit, yet its activation word never lands — the
-// style barely fires. This is exactly the "LoRAs apply weird" report.
+// A LoRA's trigger word reaches the engine only on a `prompt` WS
+// message, and it's injected onto the wire by RemoteBackend.sendPrompt
+// (via enabledLoraTriggerPrefix) — the Tags A/B textareas stay the
+// operator's clean prompt text. But most LoRA-enable paths don't
+// themselves send a `prompt` (Send Tags / Enter / key change are the
+// usual senders). LibraryTile's click-toggle now sends one directly;
+// this hook is the BACKSTOP for the other enable paths — MIDI,
+// edge-binding, reset — so they too commit the new trigger set to the
+// encoder.
 //
-// This hook closes the gap: on any change to `useLoraStore.enabled` it
-// debounce-sends the current promptA/promptB so the just-prepended (or
-// just-stripped on disable) trigger commits to the encoder. Debounce —
-// not throttle — because auditioning LoRAs produces rapid enable/
-// disable bursts; we want a single send once the burst settles, not
-// one per toggle.
+// On any change to `useLoraStore.enabled` it debounce-sends the
+// current clean promptA/promptB; sendPrompt rebuilds the trigger
+// prefix fresh. Debounce — not throttle — because auditioning LoRAs
+// produces rapid enable/disable bursts; we want a single send once the
+// burst settles, not one per toggle.
 //
 // Gated on `engine.auto_prepend_lora_triggers`: when an operator turns
 // auto-prepend off (a fully manual trigger workflow) they also own
@@ -43,7 +42,11 @@ export function useLoraTriggerSync() {
     const flush = () => {
       timerId = 0;
       const session = useSessionStore.getState();
-      if (session.status !== "ready" || !session.remote) return;
+      // Match PromptsTile.sendPrompt — the proven send path — which
+      // only checks `remote`. The WS readyState guard inside
+      // RemoteBackend.sendPrompt is the real gate; an extra
+      // status !== "ready" check here only drops legitimate sends.
+      if (!session.remote) return;
       const perf = usePerformanceStore.getState();
       session.remote.sendPrompt(
         perf.promptA,

--- a/demos/realtime_motion_graph_web/web/lib/loraTriggers.ts
+++ b/demos/realtime_motion_graph_web/web/lib/loraTriggers.ts
@@ -1,71 +1,56 @@
 "use client";
 
-// Shared helpers for the "visible LoRA trigger prepend" feature.
+// Wire-side LoRA trigger injection.
 //
-// The contract (mirroring the LibraryTile header comment): when a LoRA
-// with a primary_trigger_word is enabled and engine.auto_prepend_lora_triggers
-// is on, its trigger is prepended to promptA + promptB as a leading
-// comma-delimited token so the encoder sees what the operator sees. On
-// disable, the trigger is stripped wherever it appears as a standalone
-// token (substrings inside larger user-typed phrases are left alone).
+// Each LoRA in the catalog can carry a `metadata.primary_trigger_word`
+// — the activation word the LoRA was trained against. For the LoRA's
+// style to actually fire, that word has to reach the engine's text
+// encoder. We do NOT store it in promptA/promptB (the Tags A/B
+// textareas stay the operator's clean prompt text); instead we inject
+// the triggers onto the WIRE at send-time.
 //
-// These helpers used to live inline in components/Performance/LibraryTile.tsx
-// where the click-toggle was the only caller. Lifting them here lets the
-// LoRA store's enable()/disable() actions also run them, so EVERY enable
-// path (manual click, boot auto-enable seed, MIDI, future programmatic
-// callers) gets the prepend without the call site needing to remember to
-// fire it.
+// `enabledLoraTriggerPrefix()` builds the comma-joined prefix for the
+// currently-enabled LoRAs. `RemoteBackend.sendPrompt` prepends it to
+// both `tags` and `tags_b` right before the WS `prompt` message goes
+// out. Callers always pass the clean prompt text; sendPrompt adds the
+// triggers. The prefix is computed fresh on every send, so there is no
+// double-prepend and toggling a LoRA immediately changes what the
+// encoder sees on the next send.
+//
+// Gated on `engine.auto_prepend_lora_triggers` (default true): with it
+// off, the operator owns the trigger workflow manually and the prefix
+// is empty.
 
-import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { getConfig } from "@/lib/config";
+import { useLoraStore } from "@/store/useLoraStore";
 
-function containsTrigger(prompt: string, trigger: string): boolean {
-  return prompt.toLowerCase().includes(trigger.toLowerCase());
-}
-
-function prependTrigger(prompt: string, trigger: string): string {
-  const trimmed = prompt.trim();
-  if (trimmed.length === 0) return trigger;
-  return `${trigger}, ${prompt}`;
-}
-
-/** Remove every occurrence of ``trigger`` from ``prompt`` where it
- *  appears as a standalone comma-delimited token (head, middle, tail,
- *  or sole token). Substrings of larger phrases are left alone — if
- *  the user typed "punk rock" and the trigger is "rock", we don't
- *  mangle their prompt. Returns the rewritten prompt, or null when
- *  the trigger isn't present as a token (so callers can skip the
- *  write). Case-insensitive on the trigger comparison; preserves the
- *  case of surrounding tokens. */
-function stripTrigger(prompt: string, trigger: string): string | null {
-  const needle = trigger.trim().toLowerCase();
-  if (!needle) return null;
-  const tokens = prompt.split(", ");
-  const kept = tokens.filter((tok) => tok.trim().toLowerCase() !== needle);
-  if (kept.length === tokens.length) return null;
-  return kept.join(", ");
-}
-
-// Both prompts get the same treatment when a LoRA is toggled. Iterate
-// over [current, setter] pairs so the per-side logic lives once.
-function promptSides(): ReadonlyArray<readonly [string, (v: string) => void]> {
-  const perf = usePerformanceStore.getState();
-  return [
-    [perf.promptA, perf.setPromptA],
-    [perf.promptB, perf.setPromptB],
-  ] as const;
-}
-
-export function prependTriggerToPrompts(trigger: string): void {
-  for (const [cur, setter] of promptSides()) {
-    if (!containsTrigger(cur, trigger)) {
-      setter(prependTrigger(cur, trigger));
-    }
+/** Comma-joined trigger prefix for the currently-enabled LoRAs, with a
+ *  trailing ", " so it can be cheaply concatenated ahead of a prompt.
+ *
+ *  Reads the live `useLoraStore` state (the `enabled` Set + `catalog`),
+ *  collects each enabled LoRA's `metadata.primary_trigger_word`,
+ *  skipping null/empty values, de-duping while preserving insertion
+ *  order. Returns "" when no enabled LoRA has a trigger, or when
+ *  `engine.auto_prepend_lora_triggers` is false (manual workflow). */
+export function enabledLoraTriggerPrefix(): string {
+  if ((getConfig().engine.auto_prepend_lora_triggers ?? true) === false) {
+    return "";
   }
-}
-
-export function removeTriggerFromPrompts(trigger: string): void {
-  for (const [cur, setter] of promptSides()) {
-    const next = stripTrigger(cur, trigger);
-    if (next !== null) setter(next);
+  const { enabled, catalog } = useLoraStore.getState();
+  if (enabled.size === 0) return "";
+  const seen = new Set<string>();
+  const triggers: string[] = [];
+  for (const entry of catalog) {
+    if (!enabled.has(entry.id)) continue;
+    const trigger = entry.metadata?.primary_trigger_word;
+    if (!trigger) continue;
+    const trimmed = trigger.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    triggers.push(trimmed);
   }
+  if (triggers.length === 0) return "";
+  return `${triggers.join(", ")}, `;
 }

--- a/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
@@ -3,29 +3,12 @@
 import { create } from "zustand";
 
 import { getConfig, isConfigApplied } from "@/lib/config";
-import {
-  prependTriggerToPrompts,
-  removeTriggerFromPrompts,
-} from "@/lib/loraTriggers";
 import { useSessionStore } from "@/store/useSessionStore";
 import {
   LORA_DEFAULT_STRENGTH_FRACTION,
   LORA_SLIDER_MAX,
 } from "@/types/engine";
 import type { LoraCatalogEntry } from "@/types/protocol";
-
-/** Whether visible trigger-prepend is on for the active config. Used
- *  to gate every trigger write below — same source of truth as the
- *  manual-toggle path in LibraryTile. */
-function autoPrependEnabled(): boolean {
-  return getConfig().engine.auto_prepend_lora_triggers ?? true;
-}
-
-/** Read the trigger word for a given LoRA id from the live catalog. */
-function triggerFor(catalog: LoraCatalogEntry[], id: string): string | null {
-  const entry = catalog.find((e) => e.id === id);
-  return entry?.metadata?.primary_trigger_word ?? null;
-}
 
 /** True iff a LoRA's trained ``base_model_scale`` is compatible with
  *  the active session's checkpoint scale. Unknown values on EITHER
@@ -269,20 +252,10 @@ export const useLoraStore = create<LoraState>((set) => ({
       const enabled = shouldSeed
         ? new Set<string>([...s.enabled, ...fresh.enabled])
         : s.enabled;
-      // Prepend triggers for any newly-seeded LoRAs so the encoder
-      // sees the same prompt the operator does (same contract as the
-      // manual-toggle path in LibraryTile). Iterate `fresh.enabled` so
-      // we only act on LoRAs that became enabled THIS call — not
-      // anything the user had already turned on before re-broadcast.
-      // Sidecar entries without a primary_trigger_word are skipped by
-      // the helper's null check; the autoPrepend gate is config-driven
-      // and matches the LibraryTile guard.
-      if (shouldSeed && autoPrependEnabled()) {
-        for (const id of fresh.enabled) {
-          const trigger = triggerFor(catalog, id);
-          if (trigger) prependTriggerToPrompts(trigger);
-        }
-      }
+      // Note: seeding a LoRA does NOT mutate promptA/promptB. Trigger
+      // words are injected onto the WS `prompt` message at send-time by
+      // RemoteBackend.sendPrompt (via enabledLoraTriggerPrefix) — the
+      // Tags A/B textareas stay the operator's clean prompt text.
       return {
         catalog,
         strengths,
@@ -297,19 +270,10 @@ export const useLoraStore = create<LoraState>((set) => ({
       if (s.enabled.has(id)) return {} as Partial<LoraState>;
       const next = new Set(s.enabled);
       next.add(id);
-      // Visible trigger-prepend lives in the store action so EVERY
-      // caller — manual click in LibraryTile, MIDI, future
-      // programmatic enablers — gets the prepend without each call
-      // site having to remember to fire it. The setCatalog seed path
-      // has its own prepend loop above (it bypasses enable() because
-      // it builds the Set atomically with merge semantics this action
-      // doesn't have). The helper itself is idempotent: if the
-      // trigger is already in the prompt as a substring of any token,
-      // it won't double-prepend.
-      const trigger = autoPrependEnabled()
-        ? triggerFor(s.catalog, id)
-        : null;
-      if (trigger) prependTriggerToPrompts(trigger);
+      // The LoRA's trigger word is NOT written into promptA/promptB.
+      // It's injected onto the WS `prompt` message at send-time by
+      // RemoteBackend.sendPrompt (via enabledLoraTriggerPrefix), so
+      // the Tags A/B textareas stay the operator's clean prompt text.
       return { enabled: next };
     }),
   disable: (id) =>
@@ -317,14 +281,9 @@ export const useLoraStore = create<LoraState>((set) => ({
       if (!s.enabled.has(id)) return {} as Partial<LoraState>;
       const next = new Set(s.enabled);
       next.delete(id);
-      // Symmetric strip on disable. removeTriggerFromPrompts no-ops
-      // when the trigger isn't present as a standalone token, so
-      // user-typed phrases that happen to contain the trigger as a
-      // substring (e.g. "punk rock" when trigger is "rock") survive.
-      const trigger = autoPrependEnabled()
-        ? triggerFor(s.catalog, id)
-        : null;
-      if (trigger) removeTriggerFromPrompts(trigger);
+      // Symmetric with enable(): no prompt mutation. Dropping the LoRA
+      // from `enabled` is enough — the next sendPrompt rebuilds the
+      // wire-side trigger prefix without it.
       return { enabled: next };
     }),
   toggle: (id) =>


### PR DESCRIPTION
## Problem

Two issues with the post-redesign LoRA-trigger flow:

1. **Regression:** enabling a LoRA prepended its trigger word into the Tags A/B textareas but never sent a `prompt` WS message. The engine kept generating against the old conditioning, so the LoRA's matrices applied via refit but its activation word never reached the encoder — the style barely fired.
2. The visible prepend dirtied the operator's clean prompt text in the Tags boxes.

## Fix

Inject trigger words on the **wire only**, at send-time. Never store them in `promptA`/`promptB`.

- **`lib/loraTriggers.ts`** — replaced the prompt-mutating `prependTriggerToPrompts`/`removeTriggerFromPrompts` helpers with `enabledLoraTriggerPrefix()`: reads `useLoraStore` state, collects each enabled LoRA's `metadata.primary_trigger_word` (skip empty, de-dupe, preserve order), returns them comma-joined with a trailing `", "` — or `""` when none or when `engine.auto_prepend_lora_triggers` is false.
- **`store/useLoraStore.ts`** — `enable()`, `disable()`, and the `setCatalog` boot-seed loop no longer mutate `usePerformanceStore.promptA/promptB`. The `enabled` Set / strengths / seed logic is unchanged.
- **`engine/protocol.ts` `sendPrompt`** — the single chokepoint: prepends `enabledLoraTriggerPrefix()` to both `tags` and `tags_b`. Callers pass clean prompt text; the prefix is recomputed fresh per call so there is no double-prepend.
- **`components/Performance/LibraryTile.tsx` `toggle()`** — after `enable`/`disable` + `sendEnableLora`/`sendDisableLora`, also calls `sendPrompt` with the clean `promptA`/`promptB`/`activeKey`/`activeTimeSignature`, so toggling a LoRA immediately re-encodes with the new trigger set.
- **`hooks/useLoraTriggerSync.ts`** — kept as the backstop for non-click enable paths (MIDI, edge-binding, reset). Relaxed its `flush` guard from `status !== "ready" || !remote` to just `!remote`, matching the proven `PromptsTile.sendPrompt` path.

## Judgment call: circular import (step 3)

`protocol.ts` now imports `enabledLoraTriggerPrefix` from `loraTriggers.ts`, which imports `useLoraStore` and `getConfig`. `useLoraStore` does **not** import `protocol.ts`; `useSessionStore` imports `RemoteBackend` only as a `type` (erased at compile time). So there is no runtime import cycle — a plain static import is safe, and `useLoraStore.getState()` is called lazily at send-time, never at module init. No lazy `import()` or wrapper needed.

## Verify

- `npm run typecheck` passes.
- Tags A/B textareas only ever hold the operator's clean text; the WS `prompt` message's `tags`/`tags_b` carry the trigger prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)