### PR TITLE
rtmg: redesign LoRA library + collapsible Styles tiles + hidden-LoRA filter

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -124,6 +124,24 @@ html, body {
   -webkit-tap-highlight-color: transparent;
 }
 
+/* Custom scrollbars everywhere — thin + dark, matching the panel
+   chrome, instead of the OS default white bar. Applies to every scroll
+   container on the page (Firefox via scrollbar-*, WebKit via the
+   ::-webkit-scrollbar pseudos). Component-level rules can still
+   override per-surface. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+}
+*::-webkit-scrollbar { width: 8px; height: 8px; }
+*::-webkit-scrollbar-track { background: transparent; }
+*::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 4px;
+}
+*::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.32); }
+*::-webkit-scrollbar-corner { background: transparent; }
+
 .hidden { display: none !important; }
 
 /* Hide the OS cursor only inside the Performance surface — useCursor
@@ -1479,36 +1497,47 @@ body[data-mode="graph"]::before {
    the same visual role. No `.install-edge-bottom` rule needed. */
 
 /* ============================================================================
-   LoRA Library tile.  One row per catalog entry:
-       [switch]  name              [horizontal slider]  0.30
-   The body scrolls internally — adding LoRAs to the catalog grows the
-   list, not the Advanced drawer's height.  Width is bounded so the
-   tile sits comfortably alongside the other mixer tiles.
+   LoRA Library tile.  Two stacked sections:
+     ── Active rack ──  enabled LoRAs only, each with a strength slider.
+     ── Browse ──       every LoRA in a collapsible genre accordion;
+                        compact click-to-enable rows, inline description.
+   Each section scrolls internally so the Advanced drawer keeps its
+   natural height.  Width is bounded to sit alongside the other tiles.
    ============================================================================ */
 .mixer-tile[data-tile="library"] {
   min-width: 280px;
   max-width: 360px;
 }
-.mixer-tile[data-tile="library"] .lora-list {
-  display: flex; flex-direction: column;
-  gap: 6px;
-  padding: 4px 8px;
-  /* Internal scroll: the Library tile holds its own height and
-     scrolls when there are too many rows to fit.  The Advanced drawer
-     stays at its natural size. */
-  max-height: 240px;
-  overflow-y: auto;
-  overflow-x: hidden;
-  /* Subtle scrollbar styling (Firefox + WebKit) so it doesn't shout. */
-  scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
+
+.lora-search {
+  padding: 6px 8px 2px;
 }
-.mixer-tile[data-tile="library"] .lora-list::-webkit-scrollbar { width: 6px; }
-.mixer-tile[data-tile="library"] .lora-list::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.2); border-radius: 3px;
+.lora-search-input {
+  width: 100%;
+  box-sizing: border-box;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--frame-line);
+  border-radius: 5px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  padding: 5px 8px;
 }
-.mixer-tile[data-tile="library"] .lora-list::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.35);
+.lora-search-input:focus {
+  outline: none;
+  border-color: var(--accent-line);
+}
+.lora-search-input::placeholder {
+  color: var(--text-dim);
+}
+
+.lora-section-head {
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  padding: 8px 10px 3px;
 }
 
 .mixer-tile[data-tile="library"] .lora-empty {
@@ -1516,86 +1545,239 @@ body[data-mode="graph"]::before {
   text-align: center; font-style: italic;
 }
 
-.lora-row {
-  display: grid;
-  grid-template-columns: 26px 1fr auto;
-  grid-template-rows: auto auto;
-  align-items: center;
-  column-gap: 10px;
-  row-gap: 4px;
-  padding: 4px 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+/* Internal scroll surfaces (active rack + browse). Subtle scrollbar so
+   it doesn't shout. */
+.lora-active-list,
+.lora-browse {
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
 }
-.lora-row:last-child { border-bottom: none; }
+.lora-active-list::-webkit-scrollbar,
+.lora-browse::-webkit-scrollbar { width: 6px; }
+.lora-active-list::-webkit-scrollbar-thumb,
+.lora-browse::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2); border-radius: 3px;
+}
+.lora-active-list::-webkit-scrollbar-thumb:hover,
+.lora-browse::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
 
-.lora-row-name {
+/* ── Active rack ── */
+.lora-active-list {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 2px 8px 4px;
+  max-height: 168px;
+}
+.lora-active-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  column-gap: 8px;
+  row-gap: 2px;
+  padding: 5px 8px 7px;
+  color: var(--accent);
+  background: rgba(240, 138, 72, 0.07);
+  border: 1px solid var(--accent-line);
+  border-radius: 6px;
+}
+.lora-active-name {
   font-size: 11px;
   letter-spacing: 0.04em;
-  opacity: 0.9;
-  cursor: pointer;
-  user-select: none;
+  color: var(--text-strong);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.lora-row[data-state="disabled"] .lora-row-name { opacity: 0.55; }
-
-/* Toggle: compact sliding pill. The state difference is carried by
-   thumb-position (visual scan), thumb-color (dim → bright), and
-   track-fill (transparent → accent). Earlier the colors all inherited
-   from currentColor which made the difference washed-out — switching
-   to explicit tokens (--text-dim / --accent / --accent-glow) gives the
-   ON state real visual weight without growing the control. */
-.lora-switch {
-  width: 22px; height: 12px;
+.lora-active-remove {
+  width: 16px; height: 16px;
   padding: 0;
+  display: flex; align-items: center; justify-content: center;
   background: transparent;
-  border: 1px solid var(--frame-line);
-  border-radius: 7px;
-  position: relative;
+  border: none;
+  border-radius: 50%;
+  color: var(--text-dim);
+  font-size: 10px;
   cursor: pointer;
-  transition:
-    background 0.18s ease,
-    border-color 0.14s ease,
-    box-shadow 0.18s ease;
+  transition: color 0.12s ease, background 0.12s ease;
 }
-.lora-switch:hover {
+.lora-active-remove:hover {
+  color: var(--text-strong);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* ── Browse accordion ── */
+.lora-browse {
+  display: flex;
+  flex-direction: column;
+  padding: 0 8px 6px;
+  max-height: 256px;
+}
+.lora-genre-head {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 4px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--frame-line);
+  cursor: pointer;
+  color: var(--text);
+  transition: color 0.12s ease;
+}
+.lora-genre-head:hover { color: var(--text-strong); }
+.lora-genre-caret {
+  width: 9px;
+  flex: none;
+  color: var(--text-dim);
+  font-size: 9px;
+}
+.lora-genre-name {
+  flex: 1;
+  text-align: left;
+  font-size: 10px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+.lora-genre-count {
+  color: var(--text-dim);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  min-width: 2ch;
+  text-align: right;
+}
+.lora-genre-on {
+  color: var(--accent);
+  font-size: 9px;
+  letter-spacing: 0.03em;
+  border: 1px solid var(--accent-line);
+  border-radius: 8px;
+  padding: 1px 6px;
+}
+.lora-genre-body {
+  display: flex;
+  flex-direction: column;
+  padding: 3px 0 7px;
+}
+
+.lora-browse-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  padding: 5px 7px;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.lora-browse-row:hover { background: rgba(255, 255, 255, 0.04); }
+.lora-browse-row.enabled { background: rgba(240, 138, 72, 0.09); }
+.lora-browse-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.lora-browse-name {
+  flex: 1;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.lora-browse-row.enabled .lora-browse-name { color: var(--text-strong); }
+.lora-browse-add {
+  width: 16px; height: 16px;
+  flex: none;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 50%;
+  border: 1px solid var(--frame-line);
+  color: var(--text-dim);
+  font-size: 11px;
+  line-height: 1;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+.lora-browse-row:hover .lora-browse-add {
   border-color: var(--accent-line);
+  color: var(--text);
 }
-.lora-switch[aria-checked="true"] {
+.lora-browse-row.enabled .lora-browse-add {
   background: var(--accent);
   border-color: var(--accent);
-  box-shadow: 0 0 6px var(--accent-glow);
+  color: #ffffff;
 }
-.lora-switch[aria-checked="true"]:hover {
-  background: var(--accent-hover);
-  border-color: var(--accent-hover);
-}
-.lora-switch-thumb {
-  position: absolute;
-  top: 1px; left: 1px;
-  width: 8px; height: 8px;
-  border-radius: 50%;
-  background: var(--text-dim);
-  transition:
-    transform 0.16s cubic-bezier(.3,1.3,.5,1),
-    background 0.14s ease;
-  pointer-events: none;
-}
-.lora-switch:hover .lora-switch-thumb {
-  background: var(--text);
-}
-.lora-switch[aria-checked="true"] .lora-switch-thumb {
-  transform: translateX(10px);
-  background: #ffffff;
-}
-.lora-switch.midi-learning {
-  outline: 1px dashed currentColor;
-  outline-offset: 2px;
+.lora-browse-desc {
+  font-size: 10px;
+  line-height: 1.35;
+  color: var(--text-dim);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
-/* Horizontal strength slider.  Spans the full row width below the
-   switch+name line, giving the operator a wide drag surface without
+/* ── Context menu (right-click a row) ── */
+.lora-context-menu {
+  position: fixed;
+  z-index: 200;
+  min-width: 150px;
+  padding: 4px;
+  background: var(--panel, #16161f);
+  border: 1px solid var(--frame-line);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+.lora-context-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 11px;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+.lora-context-menu-item:hover {
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--text-strong);
+}
+
+/* ── Hidden-LoRA footer ── */
+.lora-hidden-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 10px;
+  border-top: 1px solid var(--frame-line);
+  font-size: 10px;
+  color: var(--text-dim);
+}
+.lora-hidden-toggle {
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  font-family: inherit;
+  font-size: 10px;
+  cursor: pointer;
+  padding: 0;
+}
+.lora-hidden-toggle:hover { color: var(--accent-hover, var(--accent)); }
+
+/* Horizontal strength slider.  Spans the full active-row width below
+   the name line, giving the operator a wide drag surface without
    making each row tall. */
 .lora-strength {
   grid-column: 1 / -1;
@@ -1653,16 +1835,6 @@ body[data-mode="graph"]::before {
   text-align: right;
   opacity: 0.7;
 }
-
-/* Disabled state: lock the slider, dim the name, dim the fill — but
-   leave the switch alone so the operator can re-enable. */
-.lora-row[data-state="disabled"] .lora-strength-track {
-  cursor: not-allowed;
-  background: rgba(255, 255, 255, 0.04);
-}
-.lora-row[data-state="disabled"] .lora-strength-fill { opacity: 0.25; }
-.lora-row[data-state="disabled"] .lora-strength-thumb { opacity: 0.35; }
-.lora-row[data-state="disabled"] .lora-strength-value { opacity: 0.35; }
 
 /* ============================================================================
    Buttons — single shared "outline + accent on hover" language. The Seed /
@@ -2352,6 +2524,56 @@ body.drawer-open .hud-help-readout {
   border-top: 1px solid var(--frame-line);
   padding-top: 12px;
 }
+
+/* Styles-tab accordions — Tags + LoRA Library each collapse under a
+   clickable header (CollapsibleTile). Closed by default. */
+.styles-accordion {
+  width: 100%;
+  min-height: 0;
+}
+.styles-accordion-head {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--text);
+  transition: color 0.12s ease;
+}
+.styles-accordion-head:hover { color: var(--text-strong); }
+.styles-accordion-caret {
+  width: 10px;
+  flex: none;
+  color: var(--text-dim);
+  font-size: 10px;
+}
+.styles-accordion-title {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  transition: color 0.12s ease;
+}
+.styles-accordion.open .styles-accordion-title,
+.styles-accordion-head:hover .styles-accordion-title {
+  color: var(--text-strong);
+}
+.styles-accordion-body {
+  padding-top: 2px;
+}
+/* Inside the accordion the header is the section label, so drop the
+   wrapped tile's own label + card frame. */
+.styles-accordion-body .mixer-tile {
+  border: none;
+  background: transparent;
+  padding: 0;
+  width: 100%;
+  max-width: 100%;
+}
+.styles-accordion-body .mixer-tile-label { display: none; }
 /* Drop the inner tile frame for tabbed content — the active tab is
    already the section delimiter; an extra card border just adds noise.
    Sound Particles' UIs do the same: panels live on the open canvas. */

--- a/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
@@ -7,6 +7,7 @@ import { useCurveStore } from "@/store/useCurveStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
 
+import { CollapsibleTile } from "./CollapsibleTile";
 import { CoreTile } from "./CoreTile";
 import { DrawerHelpBar } from "./DrawerHelpBar";
 import { DrawerTabs, useDrawerTab, type DrawerTab } from "./DrawerTabs";
@@ -208,7 +209,7 @@ function renderAllSections(savedTab?: ReactNode) {
   return SPREAD_SECTIONS.map((s) => (
     <section key={s.id} className="spread-section" data-section={s.id}>
       <h3 className="spread-section-label">{s.label}</h3>
-      {renderTabBody(s.id, savedTab)}
+      {renderTabBody(s.id, savedTab, true)}
     </section>
   ));
 }
@@ -217,7 +218,7 @@ function renderAllSections(savedTab?: ReactNode) {
 // every tile already runs its own hooks/subscriptions, and a wrapping
 // React component would just add another re-render layer with no
 // upside.
-function renderTabBody(tab: DrawerTab, savedTab?: ReactNode) {
+function renderTabBody(tab: DrawerTab, savedTab?: ReactNode, spread = false) {
   switch (tab) {
     case "core":
       return <CoreTile />;
@@ -226,10 +227,26 @@ function renderTabBody(tab: DrawerTab, savedTab?: ReactNode) {
     case "voice":
       return <VoiceTile />;
     case "styles":
+      // Tabbed view: each panel sits under its own collapsed accordion
+      // so the operator expands only what they're working on. Spread
+      // view is a show-everything surface, so the tiles render bare.
       return (
         <div className="styles-tab">
-          <PromptsTile />
-          <LibraryTile />
+          {spread ? (
+            <>
+              <PromptsTile />
+              <LibraryTile />
+            </>
+          ) : (
+            <>
+              <CollapsibleTile title="Tags">
+                <PromptsTile />
+              </CollapsibleTile>
+              <CollapsibleTile title="LoRA Library">
+                <LibraryTile />
+              </CollapsibleTile>
+            </>
+          )}
         </div>
       );
     case "saved":

--- a/demos/realtime_motion_graph_web/web/components/Performance/CollapsibleTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/CollapsibleTile.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+// Collapsible wrapper for a drawer tile. Used in the Styles tab so the
+// Tags and LoRA Library panels each sit under their own accordion —
+// closed by default, expand to manage what's inside. The header
+// replaces the wrapped tile's own `.mixer-tile-label` (hidden via CSS
+// while inside `.styles-accordion-body`).
+
+export function CollapsibleTile({
+  title,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className={`styles-accordion${open ? " open" : ""}`}>
+      <button
+        type="button"
+        className="styles-accordion-head"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <span className="styles-accordion-caret" aria-hidden="true">
+          {open ? "▾" : "▸"}
+        </span>
+        <span className="styles-accordion-title">{title}</span>
+      </button>
+      {open && <div className="styles-accordion-body">{children}</div>}
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { createPortal } from "react-dom";
 
 import { loraStrengthDispatcher } from "@/engine/lora/dispatcher";
-import { listLoras } from "@/engine/lora/listLoras";
+import { listHiddenLoras, listLoras } from "@/engine/lora/listLoras";
 import { useConfig } from "@/lib/config";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { isLoraCompatibleWithScale, useLoraStore } from "@/store/useLoraStore";
@@ -14,48 +14,117 @@ import { useSessionStore } from "@/store/useSessionStore";
 import { LORA_SLIDER_MAX } from "@/types/engine";
 import type { LoraCatalogEntry, LoraMetadata } from "@/types/protocol";
 
-// LoRA library tile. Each row: pill-style enable switch, name, full-width
-// strength slider with a colored fill. The whole tile also exposes:
+// LoRA library tile — redesigned for a large catalog (40+ genre LoRAs).
 //
-//  - A search bar at the top filtering on name + description + tags +
-//    primary_genre. Empty query shows everything.
-//  - A right-click anywhere on the row opens a portaled context menu
-//    (LoraContextMenu) with two items:
-//       MIDI learn       → arms `useMidiStore.startLearn("cc", "lora_str_<id>", row)`
-//       Copy trigger     → clipboard write + transient tooltip flash
-//    The row stops the contextmenu's native propagation so the
-//    document-level fallback in `useMidi.ts` doesn't *also* arm learn
-//    (that fallback's `.lora-row` branch has been removed in tandem;
-//    this menu is now the sole entry point for both actions on a row).
-//    The copy confirmation rides the same `data-dd-tooltip` chrome as
-//    every other tooltip in the drawer: after a successful copy, the
-//    row's tooltip text is swapped to "Copied 'word'" and
-//    `data-dd-tooltip-show` is forced true for 1.5s.
-//  - Hover on a row surfaces the same `data-dd-tooltip-wide` chrome
-//    with the description, classification chips, and recommended
-//    inference params. Bare LoRAs fall back to id-as-name display.
+// The old layout was one long scroll of full-width rows, each carrying an
+// always-visible strength slider, with the description trapped in a hover
+// tooltip. With 40+ LoRAs that meant scrolling a wall of sliders and
+// fighting tooltips. This layout splits the tile in two:
 //
-//  Tooltip placement note: the `[data-dd-tooltip]::after` pseudo is
-//  `position: absolute`, and `.lora-row` (and every drawer-body
-//  ancestor between the row and `.install-sheet`) is unpositioned, so
-//  the tooltip walks up to the drawer (which is `position: fixed`).
-//  Combined with the default `bottom: calc(100% + 8px); left: 50%`,
-//  every tooltip in the drawer — slider labels, OperatorStrip
-//  buttons, prompts, library rows — lands in the same screen spot
-//  8px above the drawer top edge, viewport-centered. Do NOT add
-//  `position: relative` to `.lora-row` or any intermediate ancestor;
-//  it kicks the tooltip out of that shared surface.
-//  - Enabling/disabling a LoRA does NOT mutate the Tags A/B textareas.
-//    The trigger word is injected onto the WS `prompt` message at
-//    send-time by RemoteBackend.sendPrompt (via enabledLoraTriggerPrefix),
-//    gated on `engine.auto_prepend_lora_triggers` (default true).
-//    The click-toggle here calls sendPrompt right after enable/disable
-//    so the engine immediately re-encodes with the new trigger set;
-//    useLoraTriggerSync is the backstop for non-click enable paths.
-//  - LoRAs whose `base_model_scale` doesn't match the active
-//    checkpoint scale (2B vs 5B) are hidden by default; an inline
-//    footer reports the count and offers a one-click override.
-//    `engine.show_incompatible_loras = true` flips the default.
+//  ── ACTIVE rack ──  Only the *enabled* LoRAs, each with its strength
+//     slider. Usually 1–4 entries, so there is no slider wall — you only
+//     ever see sliders for things you are actually using.
+//
+//  ── BROWSE accordion ──  Every LoRA, grouped into collapsible genre
+//     categories (Electronic / Rock / Pop / …), all collapsed by default.
+//     Each browse row is a compact click-to-enable button showing the
+//     name + a short inline description (no hover tooltip). Enabling a
+//     LoRA pops it up into the ACTIVE rack with a slider.
+//
+// A search box at the top filters across name + description + tags +
+// genre; while a query is active the accordion flattens to a plain
+// results list. Right-click any row → portaled context menu (MIDI learn,
+// Copy trigger). Enabling/disabling a LoRA does not mutate the Tags A/B
+// textareas — the trigger word rides the WS `prompt` message, injected by
+// RemoteBackend.sendPrompt (enabledLoraTriggerPrefix), and the toggle
+// re-sends the prompt so the engine re-encodes with the new trigger set.
+
+// ── Genre → category map ────────────────────────────────────────────────
+//
+// Ryan's 40 acestep1.5 LoRAs each carry their own `primary_genre`, so
+// grouping by genre directly would yield 40 groups of one. This static
+// map folds the genres into a handful of browsable categories. Genres
+// not listed (and the older daydreamlive LoRAs) fall through to "Other".
+
+const GENRE_CATEGORY: Record<string, string> = {
+  // Electronic
+  edm: "Electronic",
+  electronic: "Electronic",
+  electropop: "Electronic",
+  house: "Electronic",
+  deep_house: "Electronic",
+  techno: "Electronic",
+  dubstep: "Electronic",
+  future_bass: "Electronic",
+  synthwave: "Electronic",
+  synth_pop: "Electronic",
+  trap: "Electronic",
+  phonk: "Electronic",
+  industrial: "Electronic",
+  // Rock
+  rock: "Rock",
+  hardrock: "Rock",
+  alternative: "Rock",
+  alternative_rock: "Rock",
+  indie_rock: "Rock",
+  progressive_rock: "Rock",
+  psychedelic_rock: "Rock",
+  post_punk: "Rock",
+  punk: "Rock",
+  grunge: "Rock",
+  metal: "Rock",
+  metalcore: "Rock",
+  emo: "Rock",
+  shoegaze: "Rock",
+  // Pop
+  pop: "Pop",
+  j_pop: "Pop",
+  dream_pop: "Pop",
+  indie: "Pop",
+  // Hip-Hop
+  hip_hop: "Hip-Hop",
+  rap: "Hip-Hop",
+  // Acoustic & Folk
+  acoustic: "Acoustic & Folk",
+  folk: "Acoustic & Folk",
+  jazz: "Acoustic & Folk",
+  // Chill & Other
+  ambient: "Chill & Other",
+  lo_fi: "Chill & Other",
+  funk: "Chill & Other",
+  experimental: "Chill & Other",
+  r_b: "Chill & Other",
+};
+
+const CATEGORY_ORDER = [
+  "Electronic",
+  "Rock",
+  "Pop",
+  "Hip-Hop",
+  "Acoustic & Folk",
+  "Chill & Other",
+  "Other",
+];
+
+function normGenre(g: string | null | undefined): string {
+  return (g ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function categoryOf(entry: LoraCatalogEntry): string {
+  return GENRE_CATEGORY[normGenre(entry.metadata?.primary_genre)] ?? "Other";
+}
+
+function displayNameOf(entry: LoraCatalogEntry): string {
+  return entry.name || entry.id;
+}
+
+function byDisplayName(a: LoraCatalogEntry, b: LoraCatalogEntry): number {
+  return displayNameOf(a).localeCompare(displayNameOf(b));
+}
 
 // ── Search ──────────────────────────────────────────────────────────────
 
@@ -81,35 +150,23 @@ function matchesQuery(entry: LoraCatalogEntry, q: string): boolean {
     .some((s) => s.toLowerCase().includes(needle));
 }
 
-// ── Tooltip text ────────────────────────────────────────────────────────
+// ── Inline description ──────────────────────────────────────────────────
+//
+// Replaces the old hover tooltip. Returns a short line shown directly
+// under the LoRA name in browse rows — the real description when present,
+// otherwise a moods/recommended-strength fallback.
 
-function buildTooltipText(md: LoraMetadata | undefined): string | undefined {
+function shortDescription(md: LoraMetadata | undefined): string | undefined {
   if (!md || !md.has_metadata) return undefined;
-  const parts: string[] = [];
-  if (md.description) {
-    parts.push(md.description);
+  if (md.description) return md.description;
+  const bits: string[] = [];
+  if (md.moods && md.moods.length > 0) {
+    bits.push(md.moods.slice(0, 3).join(", "));
   }
-  const classBits: string[] = [];
-  if (md.primary_genre) classBits.push(md.primary_genre);
-  if (md.tags.length > 0) classBits.push(md.tags.join(", "));
-  if (classBits.length > 0) parts.push(classBits.join(" • "));
-  const recBits: string[] = [];
   if (md.recommended_strength != null) {
-    recBits.push(`strength ${md.recommended_strength.toFixed(2)}`);
+    bits.push(`rec. strength ${md.recommended_strength.toFixed(2)}`);
   }
-  if (md.recommended_steps != null) recBits.push(`${md.recommended_steps} steps`);
-  if (md.recommended_shift != null) {
-    recBits.push(`shift ${md.recommended_shift.toFixed(2)}`);
-  }
-  if (md.recommended_guidance != null) {
-    recBits.push(`guidance ${md.recommended_guidance.toFixed(2)}`);
-  }
-  if (recBits.length > 0) parts.push(`Recommended: ${recBits.join(", ")}`);
-  if (md.primary_trigger_word) {
-    parts.push(`Trigger: "${md.primary_trigger_word}" (right-click for menu)`);
-  }
-  if (parts.length === 0) return undefined;
-  return parts.join(" — ");
+  return bits.length > 0 ? bits.join(" · ") : undefined;
 }
 
 // ── Context menu ────────────────────────────────────────────────────────
@@ -203,214 +260,7 @@ function LoraContextMenu({ x, y, items, onClose }: ContextMenuProps) {
   );
 }
 
-// ── Row ─────────────────────────────────────────────────────────────────
-
-interface RowProps {
-  entry: LoraCatalogEntry;
-}
-
-function LoraRow({ entry }: RowProps) {
-  const { id } = entry;
-  const enabled = useLoraStore((s) => s.enabled.has(id));
-  const strength = usePerformanceStore(
-    (s) => s.sliderTargets[`lora_str_${id}`],
-  );
-  const fallbackStrength = useLoraStore((s) => s.strengths[id] ?? 0);
-  const value = typeof strength === "number" ? strength : fallbackStrength;
-  const enable = useLoraStore((s) => s.enable);
-  const disable = useLoraStore((s) => s.disable);
-
-  const rowRef = useRef<HTMLDivElement | null>(null);
-  const trackRef = useRef<HTMLDivElement | null>(null);
-  // Transient tooltip override for click confirmations (e.g. "Copied
-  // 'roti-1ndstrl'"). When set, the row's data-dd-tooltip text is
-  // swapped to this value and data-dd-tooltip-show is forced on for
-  // CONFIRM_MS, surfacing the same shared display surface above the
-  // drawer that hover uses. No parallel toast chrome needed.
-  const [confirmMsg, setConfirmMsg] = useState<string | null>(null);
-  const confirmTimerRef = useRef<number | null>(null);
-  // Right-click context menu state — set on row contextmenu, cleared
-  // by item click / outside pointerdown / Escape / scroll.
-  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
-  const closeMenu = useCallback(() => setMenuPos(null), []);
-
-  const md = entry.metadata;
-  const displayName = entry.name || id;
-  const baseTooltipText = useMemo(() => buildTooltipText(md), [md]);
-  const tooltipText = confirmMsg ?? baseTooltipText;
-  const trigger = md?.primary_trigger_word ?? null;
-
-  const flashConfirm = useCallback((text: string) => {
-    setConfirmMsg(text);
-    if (confirmTimerRef.current !== null) {
-      window.clearTimeout(confirmTimerRef.current);
-    }
-    confirmTimerRef.current = window.setTimeout(() => {
-      setConfirmMsg(null);
-      confirmTimerRef.current = null;
-    }, 1500);
-  }, []);
-
-  useEffect(
-    () => () => {
-      if (confirmTimerRef.current !== null) {
-        window.clearTimeout(confirmTimerRef.current);
-      }
-    },
-    [],
-  );
-
-  function toggle() {
-    const remote = useSessionStore.getState().remote;
-    if (enabled) {
-      disable(id);
-      remote?.sendDisableLora(id);
-    } else {
-      enable(id);
-      const s = useLoraStore.getState().strengths[id] ?? 0;
-      remote?.sendEnableLora(id, s);
-    }
-    // Re-send the prompt so the engine's encoded conditioning picks up
-    // the new enabled-LoRA trigger set. The promptA/promptB read here
-    // are the operator's CLEAN textarea text; sendPrompt injects the
-    // trigger prefix on the wire (see enabledLoraTriggerPrefix). The
-    // enable()/disable() above already mutated useLoraStore.enabled,
-    // so the prefix sendPrompt computes reflects this toggle.
-    const perf = usePerformanceStore.getState();
-    remote?.sendPrompt(
-      perf.promptA,
-      perf.activeKey,
-      perf.activeTimeSignature,
-      perf.promptB,
-    );
-  }
-
-  // Right-click anywhere on the row → open the context menu at click
-  // coords. stopPropagation keeps the document-level fallback in
-  // useMidi.ts (if anything were to read .lora-row again) from also
-  // firing on the same gesture.
-  function onRowContextMenu(e: React.MouseEvent<HTMLDivElement>) {
-    e.preventDefault();
-    e.stopPropagation();
-    setMenuPos({ x: e.clientX, y: e.clientY });
-  }
-
-  const menuItems = useMemo<ContextMenuItem[]>(() => {
-    const items: ContextMenuItem[] = [
-      {
-        label: "MIDI learn",
-        onClick: () => {
-          useMidiStore
-            .getState()
-            .startLearn("cc", `lora_str_${id}`, rowRef.current);
-        },
-      },
-    ];
-    if (trigger) {
-      items.push({
-        label: `Copy trigger "${trigger}"`,
-        onClick: () => {
-          void copyTriggerToClipboard(trigger, flashConfirm);
-        },
-      });
-    }
-    return items;
-  }, [id, trigger, flashConfirm]);
-
-  const setFromClientX = useCallback(
-    (clientX: number) => {
-      const el = trackRef.current;
-      if (!el) return;
-      const rect = el.getBoundingClientRect();
-      const t = (clientX - rect.left) / rect.width;
-      const v = Math.max(0, Math.min(1, t)) * LORA_SLIDER_MAX;
-      loraStrengthDispatcher.set(id, v);
-    },
-    [id],
-  );
-
-  useEffect(() => {
-    const el = trackRef.current;
-    if (!el || !enabled) return;
-    let dragging = false;
-    const onPointerDown = (e: PointerEvent) => {
-      if (e.button !== 0) return; // right-click → MIDI learn (document handler)
-      dragging = true;
-      el.setPointerCapture(e.pointerId);
-      setFromClientX(e.clientX);
-    };
-    const onPointerMove = (e: PointerEvent) => {
-      if (!dragging) return;
-      setFromClientX(e.clientX);
-    };
-    const onPointerUp = (e: PointerEvent) => {
-      if (!dragging) return;
-      dragging = false;
-      el.releasePointerCapture(e.pointerId);
-    };
-    el.addEventListener("pointerdown", onPointerDown);
-    el.addEventListener("pointermove", onPointerMove);
-    el.addEventListener("pointerup", onPointerUp);
-    el.addEventListener("pointercancel", onPointerUp);
-    return () => {
-      el.removeEventListener("pointerdown", onPointerDown);
-      el.removeEventListener("pointermove", onPointerMove);
-      el.removeEventListener("pointerup", onPointerUp);
-      el.removeEventListener("pointercancel", onPointerUp);
-    };
-  }, [enabled, setFromClientX]);
-
-  const pct = Math.max(0, Math.min(1, value / LORA_SLIDER_MAX)) * 100;
-
-  return (
-    <>
-      <div
-        ref={rowRef}
-        className={`lora-row${enabled ? " enabled" : ""}`}
-        data-param={`lora_str_${id}`}
-        data-state={enabled ? "enabled" : "disabled"}
-        data-dd-tooltip={tooltipText}
-        data-dd-tooltip-wide={tooltipText ? "" : undefined}
-        data-dd-tooltip-title={displayName}
-        data-dd-tooltip-show={confirmMsg !== null ? "true" : undefined}
-        onContextMenu={onRowContextMenu}
-      >
-        <button
-          type="button"
-          className="lora-switch"
-          role="switch"
-          aria-checked={enabled}
-          onClick={toggle}
-          aria-label={enabled ? `Disable ${displayName}` : `Enable ${displayName}`}
-        >
-          <span className="lora-switch-thumb" aria-hidden="true" />
-        </button>
-        <span className="lora-row-name" onClick={toggle}>
-          {displayName}
-        </span>
-        <div className="lora-strength">
-          <div className="lora-strength-track" ref={trackRef}>
-            <div className="lora-strength-fill" style={{ width: `${pct}%` }} />
-            <div
-              className="lora-strength-thumb"
-              style={{ left: `${pct}%` }}
-              aria-hidden="true"
-            />
-          </div>
-          <span className="lora-strength-value">{value.toFixed(2)}</span>
-        </div>
-      </div>
-      {menuPos && (
-        <LoraContextMenu
-          x={menuPos.x}
-          y={menuPos.y}
-          items={menuItems}
-          onClose={closeMenu}
-        />
-      )}
-    </>
-  );
-}
+// ── Clipboard ───────────────────────────────────────────────────────────
 
 async function copyTriggerToClipboard(
   trigger: string,
@@ -447,11 +297,311 @@ function _legacyCopy(text: string): void {
   }
 }
 
+// ── Shared row hooks ────────────────────────────────────────────────────
+
+// Enable/disable a LoRA and immediately re-send the prompt so the engine
+// re-encodes with the new enabled-LoRA trigger set. The promptA/promptB
+// read here are the operator's CLEAN textarea text; sendPrompt injects
+// the trigger prefix on the wire (see enabledLoraTriggerPrefix).
+function useLoraToggle() {
+  const enable = useLoraStore((s) => s.enable);
+  const disable = useLoraStore((s) => s.disable);
+  return useCallback(
+    (id: string, currentlyEnabled: boolean) => {
+      const remote = useSessionStore.getState().remote;
+      if (currentlyEnabled) {
+        disable(id);
+        remote?.sendDisableLora(id);
+      } else {
+        enable(id);
+        const s = useLoraStore.getState().strengths[id] ?? 0;
+        remote?.sendEnableLora(id, s);
+      }
+      const perf = usePerformanceStore.getState();
+      remote?.sendPrompt(
+        perf.promptA,
+        perf.activeKey,
+        perf.activeTimeSignature,
+        perf.promptB,
+      );
+    },
+    [enable, disable],
+  );
+}
+
+// Transient confirmation text (e.g. "Copied 'word'") that briefly
+// replaces a row's name. Replaces the old data-dd-tooltip-show flash.
+function useConfirmFlash(): [string | null, (text: string) => void] {
+  const [msg, setMsg] = useState<string | null>(null);
+  const timerRef = useRef<number | null>(null);
+  const flash = useCallback((text: string) => {
+    setMsg(text);
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(() => {
+      setMsg(null);
+      timerRef.current = null;
+    }, 1500);
+  }, []);
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    },
+    [],
+  );
+  return [msg, flash];
+}
+
+// Right-click context menu state for a row.
+function useRowMenu() {
+  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
+  const onContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setMenuPos({ x: e.clientX, y: e.clientY });
+  }, []);
+  const close = useCallback(() => setMenuPos(null), []);
+  return { menuPos, onContextMenu, close };
+}
+
+function buildMenuItems(
+  id: string,
+  trigger: string | null,
+  rowEl: HTMLElement | null,
+  flashConfirm: (text: string) => void,
+): ContextMenuItem[] {
+  const items: ContextMenuItem[] = [
+    {
+      label: "MIDI learn",
+      onClick: () => {
+        useMidiStore.getState().startLearn("cc", `lora_str_${id}`, rowEl);
+      },
+    },
+  ];
+  if (trigger) {
+    items.push({
+      label: `Copy trigger "${trigger}"`,
+      onClick: () => {
+        void copyTriggerToClipboard(trigger, flashConfirm);
+      },
+    });
+  }
+  return items;
+}
+
+// ── Active rack row ─────────────────────────────────────────────────────
+
+function ActiveLoraRow({ entry }: { entry: LoraCatalogEntry }) {
+  const { id } = entry;
+  const strength = usePerformanceStore(
+    (s) => s.sliderTargets[`lora_str_${id}`],
+  );
+  const fallbackStrength = useLoraStore((s) => s.strengths[id] ?? 0);
+  const value = typeof strength === "number" ? strength : fallbackStrength;
+  const toggle = useLoraToggle();
+
+  const md = entry.metadata;
+  const displayName = displayNameOf(entry);
+  const trigger = md?.primary_trigger_word ?? null;
+
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const [confirmMsg, flashConfirm] = useConfirmFlash();
+  const { menuPos, onContextMenu, close } = useRowMenu();
+
+  const setFromClientX = useCallback(
+    (clientX: number) => {
+      const el = trackRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const t = (clientX - rect.left) / rect.width;
+      loraStrengthDispatcher.set(id, Math.max(0, Math.min(1, t)) * LORA_SLIDER_MAX);
+    },
+    [id],
+  );
+
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el) return;
+    let dragging = false;
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.button !== 0) return; // right-click → MIDI learn (context menu)
+      dragging = true;
+      el.setPointerCapture(e.pointerId);
+      setFromClientX(e.clientX);
+    };
+    const onPointerMove = (e: PointerEvent) => {
+      if (dragging) setFromClientX(e.clientX);
+    };
+    const onPointerUp = (e: PointerEvent) => {
+      if (!dragging) return;
+      dragging = false;
+      el.releasePointerCapture(e.pointerId);
+    };
+    el.addEventListener("pointerdown", onPointerDown);
+    el.addEventListener("pointermove", onPointerMove);
+    el.addEventListener("pointerup", onPointerUp);
+    el.addEventListener("pointercancel", onPointerUp);
+    return () => {
+      el.removeEventListener("pointerdown", onPointerDown);
+      el.removeEventListener("pointermove", onPointerMove);
+      el.removeEventListener("pointerup", onPointerUp);
+      el.removeEventListener("pointercancel", onPointerUp);
+    };
+  }, [setFromClientX]);
+
+  const pct = Math.max(0, Math.min(1, value / LORA_SLIDER_MAX)) * 100;
+  const menuItems = useMemo(
+    () => buildMenuItems(id, trigger, rowRef.current, flashConfirm),
+    [id, trigger, flashConfirm],
+  );
+
+  return (
+    <>
+      <div
+        ref={rowRef}
+        className="lora-active-row"
+        data-param={`lora_str_${id}`}
+        onContextMenu={onContextMenu}
+      >
+        <span className="lora-active-name" title={displayName}>
+          {confirmMsg ?? displayName}
+        </span>
+        <button
+          type="button"
+          className="lora-active-remove"
+          onClick={() => toggle(id, true)}
+          aria-label={`Disable ${displayName}`}
+        >
+          ✕
+        </button>
+        <div className="lora-strength">
+          <div className="lora-strength-track" ref={trackRef}>
+            <div className="lora-strength-fill" style={{ width: `${pct}%` }} />
+            <div
+              className="lora-strength-thumb"
+              style={{ left: `${pct}%` }}
+              aria-hidden="true"
+            />
+          </div>
+          <span className="lora-strength-value">{value.toFixed(2)}</span>
+        </div>
+      </div>
+      {menuPos && (
+        <LoraContextMenu
+          x={menuPos.x}
+          y={menuPos.y}
+          items={menuItems}
+          onClose={close}
+        />
+      )}
+    </>
+  );
+}
+
+// ── Browse row ──────────────────────────────────────────────────────────
+
+function BrowseLoraRow({ entry }: { entry: LoraCatalogEntry }) {
+  const { id } = entry;
+  const enabled = useLoraStore((s) => s.enabled.has(id));
+  const toggle = useLoraToggle();
+
+  const md = entry.metadata;
+  const displayName = displayNameOf(entry);
+  const trigger = md?.primary_trigger_word ?? null;
+  const desc = useMemo(() => shortDescription(md), [md]);
+
+  const rowRef = useRef<HTMLButtonElement | null>(null);
+  const [confirmMsg, flashConfirm] = useConfirmFlash();
+  const { menuPos, onContextMenu, close } = useRowMenu();
+
+  const menuItems = useMemo(
+    () => buildMenuItems(id, trigger, rowRef.current, flashConfirm),
+    [id, trigger, flashConfirm],
+  );
+
+  return (
+    <>
+      <button
+        ref={rowRef}
+        type="button"
+        className={`lora-browse-row${enabled ? " enabled" : ""}`}
+        onClick={() => toggle(id, enabled)}
+        onContextMenu={onContextMenu}
+        aria-pressed={enabled}
+      >
+        <span className="lora-browse-main">
+          <span className="lora-browse-name" title={displayName}>
+            {confirmMsg ?? displayName}
+          </span>
+          <span className="lora-browse-add" aria-hidden="true">
+            {enabled ? "✓" : "+"}
+          </span>
+        </span>
+        {desc && <span className="lora-browse-desc">{desc}</span>}
+      </button>
+      {menuPos && (
+        <LoraContextMenu
+          x={menuPos.x}
+          y={menuPos.y}
+          items={menuItems}
+          onClose={close}
+        />
+      )}
+    </>
+  );
+}
+
+// ── Genre accordion section ─────────────────────────────────────────────
+
+interface GenreSectionProps {
+  label: string;
+  entries: LoraCatalogEntry[];
+  enabledCount: number;
+  open: boolean;
+  onToggle: () => void;
+}
+
+function GenreSection({
+  label,
+  entries,
+  enabledCount,
+  open,
+  onToggle,
+}: GenreSectionProps) {
+  return (
+    <div className="lora-genre">
+      <button
+        type="button"
+        className="lora-genre-head"
+        onClick={onToggle}
+        aria-expanded={open}
+      >
+        <span className="lora-genre-caret" aria-hidden="true">
+          {open ? "▾" : "▸"}
+        </span>
+        <span className="lora-genre-name">{label}</span>
+        {enabledCount > 0 && (
+          <span className="lora-genre-on">{enabledCount} on</span>
+        )}
+        <span className="lora-genre-count">{entries.length}</span>
+      </button>
+      {open && (
+        <div className="lora-genre-body">
+          {entries.map((e) => (
+            <BrowseLoraRow key={e.id} entry={e} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── Tile ────────────────────────────────────────────────────────────────
 
 export function LibraryTile() {
   const catalog = useLoraStore((s) => s.catalog);
   const setCatalog = useLoraStore((s) => s.setCatalog);
+  const enabledSet = useLoraStore((s) => s.enabled);
   const sessionWsUrl = useSessionStore((s) => s.wsUrl);
   const sessionScale = useSessionStore((s) => s.checkpointScale);
   const cfg = useConfig();
@@ -464,29 +614,103 @@ export function LibraryTile() {
   // configured default.
   const [showAllOverride, setShowAllOverride] = useState(false);
   const showAll = cfgShowAll || showAllOverride;
+  // Which genre sections are expanded. All collapsed by default — the
+  // tile opens compact, the operator expands only what they want.
+  const [openCats, setOpenCats] = useState<Set<string>>(() => new Set());
+  // Admin-hidden LoRA ids (orchestrator state, fetched app-origin).
+  const [adminHidden, setAdminHidden] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   useEffect(() => {
     if (!sessionWsUrl && !LOCAL_MODE) return;
     void listLoras().then(setCatalog).catch(() => {});
+    void listHiddenLoras().then(setAdminHidden).catch(() => {});
   }, [setCatalog, sessionWsUrl]);
 
-  // Compatibility filter runs first so the "N hidden" count tracks
-  // scale incompatibility specifically, not query misses.
+  // Force-disable any admin-hidden LoRA that's currently enabled — an
+  // operator must not keep applying a LoRA an admin has retired. Runs
+  // when the hidden set or the catalog changes (the latter covers the
+  // setCatalog auto-seed possibly enabling a hidden id). disable()
+  // mutates useLoraStore.enabled, which useLoraTriggerSync observes to
+  // re-send the prompt without the now-dropped trigger.
+  useEffect(() => {
+    if (adminHidden.size === 0) return;
+    const { enabled, disable } = useLoraStore.getState();
+    const remote = useSessionStore.getState().remote;
+    for (const id of enabled) {
+      if (adminHidden.has(id)) {
+        disable(id);
+        remote?.sendDisableLora(id);
+      }
+    }
+  }, [adminHidden, catalog]);
+
+  // Admin-hidden LoRAs drop out entirely — no row, no count. The
+  // scale-compat filter then runs on what's left so the "N hidden"
+  // footer count tracks scale incompatibility specifically.
+  const visible = useMemo(
+    () => catalog.filter((entry) => !adminHidden.has(entry.id)),
+    [catalog, adminHidden],
+  );
   const compatible = useMemo(
     () =>
       showAll
-        ? catalog
-        : catalog.filter((entry) =>
+        ? visible
+        : visible.filter((entry) =>
             isLoraCompatibleWithScale(entry, sessionScale),
           ),
-    [catalog, sessionScale, showAll],
+    [visible, sessionScale, showAll],
   );
-  const hiddenCount = catalog.length - compatible.length;
+  const hiddenCount = visible.length - compatible.length;
 
   const filtered = useMemo(
     () => compatible.filter((entry) => matchesQuery(entry, query)),
     [compatible, query],
   );
+  const searching = query.trim().length > 0;
+
+  const activeEntries = useMemo(
+    () => filtered.filter((entry) => enabledSet.has(entry.id)),
+    [filtered, enabledSet],
+  );
+
+  // Browse list grouped into genre categories, in CATEGORY_ORDER, each
+  // category alphabetised by display name.
+  const groups = useMemo(() => {
+    const byCat = new Map<string, LoraCatalogEntry[]>();
+    for (const entry of filtered) {
+      const cat = categoryOf(entry);
+      const arr = byCat.get(cat);
+      if (arr) arr.push(entry);
+      else byCat.set(cat, [entry]);
+    }
+    const ordered: { label: string; entries: LoraCatalogEntry[] }[] = [];
+    for (const cat of CATEGORY_ORDER) {
+      const arr = byCat.get(cat);
+      if (arr) {
+        arr.sort(byDisplayName);
+        ordered.push({ label: cat, entries: arr });
+        byCat.delete(cat);
+      }
+    }
+    // Any category not in CATEGORY_ORDER (defensive — shouldn't happen).
+    for (const cat of [...byCat.keys()].sort()) {
+      const arr = byCat.get(cat)!;
+      arr.sort(byDisplayName);
+      ordered.push({ label: cat, entries: arr });
+    }
+    return ordered;
+  }, [filtered]);
+
+  const toggleCat = useCallback((label: string) => {
+    setOpenCats((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) next.delete(label);
+      else next.add(label);
+      return next;
+    });
+  }, []);
 
   if (catalog.length === 0) {
     return (
@@ -504,29 +728,57 @@ export function LibraryTile() {
         <input
           type="text"
           className="lora-search-input"
-          placeholder="search"
+          placeholder="search LoRAs"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           aria-label="Search LoRA library"
         />
       </div>
-      <div className="lora-list">
-        {filtered.length === 0 ? (
-          <div className="lora-empty">no matches</div>
-        ) : (
-          filtered.map((entry) => <LoraRow key={entry.id} entry={entry} />)
-        )}
+
+      {activeEntries.length > 0 && (
+        <div className="lora-section lora-active">
+          <div className="lora-section-head">Active · {activeEntries.length}</div>
+          <div className="lora-active-list">
+            {activeEntries.map((entry) => (
+              <ActiveLoraRow key={entry.id} entry={entry} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="lora-section">
+        <div className="lora-section-head">
+          {searching
+            ? `Results · ${filtered.length}`
+            : `All LoRAs · ${compatible.length}`}
+        </div>
+        <div className="lora-browse">
+          {filtered.length === 0 ? (
+            <div className="lora-empty">no matches</div>
+          ) : searching ? (
+            filtered.map((entry) => (
+              <BrowseLoraRow key={entry.id} entry={entry} />
+            ))
+          ) : (
+            groups.map((g) => (
+              <GenreSection
+                key={g.label}
+                label={g.label}
+                entries={g.entries}
+                enabledCount={
+                  g.entries.filter((e) => enabledSet.has(e.id)).length
+                }
+                open={openCats.has(g.label)}
+                onToggle={() => toggleCat(g.label)}
+              />
+            ))
+          )}
+        </div>
       </div>
+
       {hiddenCount > 0 && (
         <div className="lora-hidden-footer">
-          <span
-            data-dd-tooltip={
-              sessionScale
-                ? `LoRAs trained for the other scale are hidden because the active checkpoint is ${sessionScale}. Click "show all" to inspect them.`
-                : undefined
-            }
-            data-dd-tooltip-wide={sessionScale ? "" : undefined}
-          >
+          <span>
             {hiddenCount} hidden
             {sessionScale ? ` (not ${sessionScale})` : ""}
           </span>

--- a/demos/realtime_motion_graph_web/web/engine/lora/listLoras.ts
+++ b/demos/realtime_motion_graph_web/web/engine/lora/listLoras.ts
@@ -28,3 +28,28 @@ export async function listLoras(): Promise<LoraCatalogEntry[]> {
     .setCheckpointScale(json.checkpoint_scale ?? null);
   return json.loras ?? [];
 }
+
+/** Fetch the set of admin-hidden LoRA ids.
+ *
+ *  Unlike listLoras() this hits the APP ORIGIN (`/api/loras/hidden`),
+ *  not the pod — admin visibility is webapp/orchestrator state, not
+ *  engine state. The route proxies the orchestrator and is fail-open.
+ *
+ *  Fail-open here too: any error (route missing in a standalone DEMON
+ *  dev server, orchestrator down, bad JSON) returns an empty set so a
+ *  broken visibility backend never blanks the Library — worst case is
+ *  "nothing hidden", never "nothing shown".
+ */
+export async function listHiddenLoras(): Promise<Set<string>> {
+  try {
+    const res = await fetch("/api/loras/hidden", { cache: "no-store" });
+    if (!res.ok) return new Set();
+    const json = (await res.json()) as { hidden?: unknown };
+    if (!Array.isArray(json.hidden)) return new Set();
+    return new Set(
+      json.hidden.filter((x): x is string => typeof x === "string"),
+    );
+  } catch {
+    return new Set();
+  }
+}


### PR DESCRIPTION
## What

The LoRA library tile didn't scale to a 40+ LoRA catalog — one long scroll of full-width slider rows, descriptions trapped in hover tooltips.

### LoRA library (`LibraryTile`)
- **Active rack** — enabled LoRAs only, each with its strength slider. No more scrolling 40+ sliders.
- **Browse accordion** — every LoRA grouped into collapsible genre categories (Electronic / Rock / Pop / Hip-Hop / Acoustic & Folk / Chill & Other), all collapsed by default.
- Browse rows are compact click-to-enable buttons with a short **inline** description — no hover tooltips. Search flattens the accordion to a results list.

### Styles tab (`AdvancedDrawer` + new `CollapsibleTile`)
- **Tags** and **LoRA Library** each sit under their own collapsible header, closed by default. Spread view still renders the tiles bare.

### Hidden-LoRA filter (`listLoras` + `LibraryTile`)
- New `listHiddenLoras()` fetches the admin-hidden id set from the app-origin `/api/loras/hidden` route. `LibraryTile` filters hidden LoRAs out entirely and force-disables any hidden id still enabled.
- Closes the gap where the admin/orchestrator hide feature shipped but the **frontend never consumed it** — hiding a LoRA in the admin dashboard was a no-op for users.

### Global
- Thin dark custom scrollbars page-wide, replacing the OS default white bar.

## Test
Verified on localhost against a live 47-LoRA pod: active rack / genre accordion / search, Styles-tab accordions, and admin-hidden LoRAs (`bptkno`, `discofunk`, `hardrock`, `nocturne`) correctly removed from the library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)