### PR TITLE
fix(rtmg): never persist curve scheduleEnabled — fresh sessions start clean

### DIFF
--- a/demos/realtime_motion_graph_web/web/store/useCurveStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useCurveStore.ts
@@ -12,9 +12,14 @@ import {
 // Curve-scheduling state. Per-param curves the user draws in the
 // ScheduleCurvesOverlay; applied by useScheduledCurves at rAF cadence.
 //
-// Persistence: the entire state (curves + scheduleEnabled + activeCurve)
-// is JSON-stringified to a single localStorage key so user state
-// survives reloads. Hydration runs in a client-only useEffect.
+// Persistence: the drawn `curves` are JSON-stringified to a localStorage
+// key so a user's drawings survive a reload. The master `scheduleEnabled`
+// switch is deliberately NOT persisted — it always starts OFF on a fresh
+// load. A persisted-on schedule silently re-applied stored curves to
+// denoise/shift/etc. on every new session, overriding the operator's
+// sliders with no indication (the curve drawings were dragged across
+// sessions and the UI misrepresented the live param). Curves are kept;
+// the operator must explicitly re-enable scheduling to apply them.
 //
 // Dynamic params: keys can be any string the engine accepts (the fixed
 // set in SCHEDULEABLE_PARAMS is just the always-shown tabs; LoRA
@@ -22,7 +27,6 @@ import {
 // LoRA catalog arrives).
 
 const CURVES_STORAGE_KEY = "demon:curves";
-const SCHEDULE_ENABLED_KEY = "demon:scheduleEnabled";
 
 type CurveMap = Record<string, CurveState>;
 
@@ -67,24 +71,6 @@ function saveCurves(curves: CurveMap): void {
   } catch {}
 }
 
-function loadScheduleEnabled(): boolean {
-  if (typeof localStorage === "undefined") return true;
-  try {
-    const v = localStorage.getItem(SCHEDULE_ENABLED_KEY);
-    if (v === null) return true;
-    return v === "1";
-  } catch {
-    return true;
-  }
-}
-
-function saveScheduleEnabled(b: boolean): void {
-  if (typeof localStorage === "undefined") return;
-  try {
-    localStorage.setItem(SCHEDULE_ENABLED_KEY, b ? "1" : "0");
-  } catch {}
-}
-
 interface CurveStore {
   curves: CurveMap;
   /** Which curve is shown / edited in the tab strip. Stored as a
@@ -95,7 +81,9 @@ interface CurveStore {
   overlayOpen: boolean;
   /** Master enable. When false, NO curve drives any param, regardless
    *  of per-curve enabled flags. Lets the user "pause" all
-   *  automation without losing their drawings. Persisted. */
+   *  automation without losing their drawings. NOT persisted — always
+   *  starts false on a fresh load so stored curves can't silently
+   *  drive params across sessions. */
   scheduleEnabled: boolean;
 
   setCurvePoints: (param: string, points: CurvePoint[]) => void;
@@ -120,7 +108,9 @@ export const useCurveStore = create<CurveStore>((set, get) => ({
   curves: freshCurveMap(),
   activeCurve: "denoise",
   overlayOpen: false,
-  scheduleEnabled: true,
+  // Always starts OFF — see SCHEDULE_ENABLED note above. The operator
+  // explicitly turns scheduling on per session.
+  scheduleEnabled: false,
 
   setCurvePoints: (param, points) => {
     const sorted = [...points].sort((a, b) => a.x - b.x);
@@ -165,15 +155,8 @@ export const useCurveStore = create<CurveStore>((set, get) => ({
   },
 
   toggleScheduleEnabled: () =>
-    set((s) => {
-      const v = !s.scheduleEnabled;
-      saveScheduleEnabled(v);
-      return { scheduleEnabled: v };
-    }),
-  setScheduleEnabled: (b) => {
-    saveScheduleEnabled(b);
-    set({ scheduleEnabled: b });
-  },
+    set((s) => ({ scheduleEnabled: !s.scheduleEnabled })),
+  setScheduleEnabled: (b) => set({ scheduleEnabled: b }),
 
   ensureCurve: (param) => {
     if (get().curves[param]) return;
@@ -185,8 +168,10 @@ export const useCurveStore = create<CurveStore>((set, get) => ({
   },
 
   hydratePersistedCurves: () => {
+    // Restore drawings only. scheduleEnabled is intentionally left at
+    // its store default (false) — never hydrated from storage — so a
+    // fresh session never silently re-applies stored curves.
     const loaded = loadCurves();
     if (loaded) set({ curves: loaded });
-    set({ scheduleEnabled: loadScheduleEnabled() });
   },
 }));


### PR DESCRIPTION
## Bug

Drawn automation curves are saved to `localStorage` so a user's drawings survive a reload — good. But the master automation switch `scheduleEnabled` was **also** persisted, defaulting on. So on every new session `hydratePersistedCurves()` restored the stored curves *and* turned scheduling on, and `useScheduledCurves` then silently drove `denoise`/`shift`/etc. from those curves every frame — overriding the operator's sliders with no indication.

A curve drawn days ago kept hijacking the param across every later session. Only an incognito window (empty `localStorage`) behaved correctly — which is exactly how this was diagnosed in the field (operator set denoise, heard no effect until ~0.75; incognito fixed it).

## Fix

Keep persisting the `curves` drawings, but **never persist `scheduleEnabled`** — it always starts `false` on a fresh load. The operator explicitly re-enables scheduling per session to apply their curves. Drawings are not lost; they just can't silently drive params across sessions anymore.

- Removed the `demon:scheduleEnabled` localStorage key + its load/save helpers.
- `scheduleEnabled` store default flipped to `false`.
- `hydratePersistedCurves()` restores only `curves`, never `scheduleEnabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)