### PR TITLE
fix(rtmg): guarantee LoRA triggers — disabled never prepended, enabled prepended exactly once

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/engine/protocol.ts
@@ -11,7 +11,10 @@
 
 import * as fzstd from "fzstd";
 
-import { enabledLoraTriggerPrefix } from "@/lib/loraTriggers";
+import {
+  enabledLoraTriggerPrefix,
+  stripLeadingTriggers,
+} from "@/lib/loraTriggers";
 import { useSessionStore } from "@/store/useSessionStore";
 import {
   SAMPLE_RATE,
@@ -556,12 +559,18 @@ export class RemoteBackend extends EventTarget {
     if (this.ws?.readyState !== WebSocket.OPEN) return;
     try {
       // Inject the enabled-LoRA trigger words on the WIRE only.
-      // Callers pass the operator's CLEAN prompt text (promptA/promptB
-      // exactly as typed in the Tags A/B boxes); the trigger prefix is
-      // computed fresh here so every send path — Send Tags button,
-      // key change, LoRA toggle — carries the current trigger set
-      // without the textareas ever showing it. Recomputing per call
-      // means there is no double-prepend.
+      // Callers pass the operator's prompt text (promptA/promptB from
+      // the Tags A/B boxes); the trigger prefix is computed fresh here
+      // so every send path — Send Tags button, key change, LoRA toggle
+      // — carries the current trigger set without the textareas ever
+      // showing it.
+      //
+      // Hard guarantee, independent of upstream state: stripLeadingTriggers
+      // removes ANY trigger prefix already on the text (stale, stacked,
+      // or belonging to a since-disabled LoRA), then we prepend exactly
+      // the de-duped enabled-set prefix. So the wire prompt always
+      // carries a disabled LoRA's trigger zero times and an enabled
+      // LoRA's trigger exactly once — per tag (A and B alike).
       const prefix = enabledLoraTriggerPrefix();
       const msg: {
         type: string;
@@ -571,9 +580,9 @@ export class RemoteBackend extends EventTarget {
         time_signature?: string;
       } = {
         type: "prompt",
-        tags: prefix + tags,
+        tags: prefix + stripLeadingTriggers(tags),
       };
-      if (tagsB) msg.tags_b = prefix + tagsB;
+      if (tagsB) msg.tags_b = prefix + stripLeadingTriggers(tagsB);
       if (key) msg.key = key;
       if (timeSignature) msg.time_signature = timeSignature;
       this.ws.send(JSON.stringify(msg));

--- a/demos/realtime_motion_graph_web/web/hooks/useMcpMirror.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useMcpMirror.ts
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 
+import { enabledLoraTriggerPrefix } from "@/lib/loraTriggers";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
@@ -33,9 +34,13 @@ import type { LoraCatalogEntry } from "@/types/protocol";
 // With Smooth off, setSlider snaps both sliderTargets and sliderValues
 // in one shot, equivalent to the prior setSliderDirect behavior.
 //
-// `prompt_applied` echoes are also consumed here: when the engine's
-// active prompt diverges from the typed promptA, we adopt the engine's
-// value so the prompt input matches what's actually being encoded.
+// `prompt_applied` echoes are also consumed here: the engine echoes the
+// WIRE prompt — the operator's clean text with the enabled-LoRA trigger
+// prefix that sendPrompt injects. We strip that prefix back off, then,
+// when the engine's clean prompt diverges from the typed promptA, adopt
+// it so the input matches what's actually being encoded. Adopting the
+// raw (prefixed) echo would bake the trigger prefix into promptA and
+// every later sendPrompt would re-prepend it — unbounded accumulation.
 
 export function useMcpMirror() {
   useEffect(() => {
@@ -90,12 +95,20 @@ export function useMcpMirror() {
       };
 
       const onPromptApplied = (e: Event) => {
-        const tags = (e as CustomEvent<string>).detail;
-        if (typeof tags !== "string") return;
+        const raw = (e as CustomEvent<string>).detail;
+        if (typeof raw !== "string") return;
         const perf = usePerformanceStore.getState();
-        // Only adopt when the engine's active prompt diverges from what's
+        // The echo is the wire prompt: clean text + the LoRA trigger
+        // prefix sendPrompt prepended. Strip the prefix so we only ever
+        // adopt the clean prompt — otherwise the prefix is baked into
+        // promptA and every later sendPrompt re-prepends it (and a
+        // disabled LoRA's trigger lingers as literal prompt text).
+        const prefix = enabledLoraTriggerPrefix();
+        const tags =
+          prefix && raw.startsWith(prefix) ? raw.slice(prefix.length) : raw;
+        // Only adopt when the engine's clean prompt diverges from what's
         // in the input box — protects the user's mid-typing state when
-        // the ack is just confirming their own send.
+        // the echo is just confirming their own send.
         if (perf.promptA !== tags) {
           perf.setPromptA(tags);
         }

--- a/demos/realtime_motion_graph_web/web/hooks/useMcpMirror.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useMcpMirror.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 
-import { enabledLoraTriggerPrefix } from "@/lib/loraTriggers";
+import { stripLeadingTriggers } from "@/lib/loraTriggers";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
@@ -99,13 +99,12 @@ export function useMcpMirror() {
         if (typeof raw !== "string") return;
         const perf = usePerformanceStore.getState();
         // The echo is the wire prompt: clean text + the LoRA trigger
-        // prefix sendPrompt prepended. Strip the prefix so we only ever
-        // adopt the clean prompt — otherwise the prefix is baked into
-        // promptA and every later sendPrompt re-prepends it (and a
-        // disabled LoRA's trigger lingers as literal prompt text).
-        const prefix = enabledLoraTriggerPrefix();
-        const tags =
-          prefix && raw.startsWith(prefix) ? raw.slice(prefix.length) : raw;
+        // prefix sendPrompt prepended. stripLeadingTriggers removes any
+        // trigger prefix (current, stale, or stacked) so we only ever
+        // adopt the clean prompt into promptA — otherwise the prefix is
+        // baked into promptA and every later sendPrompt re-prepends it
+        // (and a disabled LoRA's trigger lingers as literal text).
+        const tags = stripLeadingTriggers(raw);
         // Only adopt when the engine's clean prompt diverges from what's
         // in the input box — protects the user's mid-typing state when
         // the echo is just confirming their own send.

--- a/demos/realtime_motion_graph_web/web/lib/loraTriggers.ts
+++ b/demos/realtime_motion_graph_web/web/lib/loraTriggers.ts
@@ -54,3 +54,45 @@ export function enabledLoraTriggerPrefix(): string {
   if (triggers.length === 0) return "";
   return `${triggers.join(", ")}, `;
 }
+
+/** Every known LoRA trigger word in the catalog (lowercased), enabled
+ *  or not. The basis for stripping a trigger prefix off a prompt. */
+function catalogTriggerWords(): Set<string> {
+  const out = new Set<string>();
+  for (const entry of useLoraStore.getState().catalog) {
+    const trimmed = entry.metadata?.primary_trigger_word?.trim().toLowerCase();
+    if (trimmed) out.add(trimmed);
+  }
+  return out;
+}
+
+/** Strip a leading LoRA-trigger prefix off a prompt, returning the
+ *  operator's clean text.
+ *
+ *  Drops leading comma-separated tokens that match a known catalog
+ *  trigger word — ANY trigger, enabled or not, however many times it
+ *  repeats. It's the inverse of the prefix `enabledLoraTriggerPrefix`
+ *  builds, but resilient: it recovers the clean prompt from a stale
+ *  prefix, a prefix for a since-disabled LoRA, or a prefix accidentally
+ *  stacked N times. Matching is case-insensitive; the first non-trigger
+ *  token ends the strip.
+ *
+ *  This is the guarantee behind "a disabled LoRA's trigger is never on
+ *  the wire, an enabled LoRA's trigger is on it exactly once": sendPrompt
+ *  runs the incoming text through here before prepending the current
+ *  prefix, so whatever prefix drift happened upstream is erased and
+ *  rebuilt cleanly. Trigger words are deliberately distinctive
+ *  activation tokens, so a clean prompt legitimately leading with one
+ *  (then a comma) is vanishingly unlikely. */
+export function stripLeadingTriggers(text: string): string {
+  if (!text) return text;
+  const triggers = catalogTriggerWords();
+  if (triggers.size === 0) return text;
+  const parts = text.split(",");
+  let i = 0;
+  while (i < parts.length && triggers.has(parts[i].trim().toLowerCase())) {
+    i += 1;
+  }
+  if (i === 0) return text;
+  return parts.slice(i).join(",").replace(/^\s+/, "");
+}


### PR DESCRIPTION
## Bug

LoRA trigger words piled up on the wire prompt — `roti-d33ph0us, roti-d33ph0us, roti-d33ph0us, roti-d33ph0us, afxdump, baroque, classical, …` — and a *disabled* LoRA's trigger kept getting sent.

## Root cause

`sendPrompt` injects the enabled-LoRA trigger prefix **on the wire only** (#126) — the Tags boxes stay clean. The engine then echoes `prompt_applied` carrying the **wire** prompt (clean text **+** that prefix). `useMcpMirror.onPromptApplied` adopted that raw echo into `promptA`, baking the prefix into the "clean" store. Every later `sendPrompt` then prepended the prefix *again* — each send→echo round-trip stacked another copy. Once a trigger is literal `promptA` text it's no longer gated by the enabled set, so disabling its LoRA doesn't drop it. Only Tags A was hit — `onPromptApplied` never writes `promptB`.

## Fix — the guarantee, enforced at the chokepoint

`sendPrompt` is the single place the wire prompt is built. New **`stripLeadingTriggers()`** drops any leading comma-separated tokens that match a known catalog trigger word — *any* trigger, enabled or not, however many times stacked. `sendPrompt` runs both `tags` and `tags_b` through it, then prepends the freshly-computed, de-duped enabled-set prefix.

So regardless of any upstream drift (stale prefix, stacked prefix, a since-disabled LoRA's trigger baked into the text):

- **a disabled LoRA's trigger is on the wire zero times;**
- **an enabled LoRA's trigger is on the wire exactly once — per tag (A and B alike).**

`useMcpMirror.onPromptApplied` also adopts via `stripLeadingTriggers` now, so the `prompt_applied` echo can never bake a trigger prefix (current *or* stale) into the visible `promptA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)