### PR TITLE
feat(rtmg): opt-in wire-prompt debug log (see exactly what's sent to the engine)

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/engine/protocol.ts
@@ -586,6 +586,24 @@ export class RemoteBackend extends EventTarget {
       if (key) msg.key = key;
       if (timeSignature) msg.time_signature = timeSignature;
       this.ws.send(JSON.stringify(msg));
+      // Opt-in wire-prompt debug. Run `window.__demonPromptLog = true`
+      // in the browser console to log exactly what each `prompt`
+      // message carries: the injected LoRA-trigger prefix and the
+      // final Tags A / B as actually sent to the engine. `false` (or
+      // unset) silences it. Pure console output, no other effect.
+      if (
+        typeof window !== "undefined" &&
+        (window as unknown as { __demonPromptLog?: boolean }).__demonPromptLog
+      ) {
+        console.log(
+          "[demon prompt → engine]\n" +
+            `  trigger prefix : ${prefix ? JSON.stringify(prefix) : "(none)"}\n` +
+            `  tags A (wire)  : ${JSON.stringify(msg.tags)}\n` +
+            `  tags B (wire)  : ${
+              msg.tags_b != null ? JSON.stringify(msg.tags_b) : "(none)"
+            }`,
+        );
+      }
     } catch {}
   }
 


### PR DESCRIPTION
## What

Adds a console log of exactly what each `prompt` WS message carries — the injected LoRA-trigger **prefix** and the final **Tags A / B as sent to the engine** — so trigger prepending can be verified against what's actually on the wire.

## Usage

In the browser console:

```js
window.__demonPromptLog = true   // enable
window.__demonPromptLog = false  // silence
```

While enabled, every `sendPrompt` logs:

```
[demon prompt → engine]
  trigger prefix : "roti-d33ph0us, "
  tags A (wire)  : "roti-d33ph0us, baroque, classical, orchestral, harpsichord, strings"
  tags B (wire)  : "roti-d33ph0us, daft punk style, beautiful, four to the floor"
```

(`JSON.stringify` so leading/trailing whitespace is visible; `(none)` when there's no prefix / no B prompt.)

## Notes

- Opt-in and zero-cost when off — gated on `window.__demonPromptLog`, no effect beyond the console output. Safe to ship.
- `sendPrompt` is the single chokepoint that builds the wire prompt, so this logs *the* value sent — strip + prefix already applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)