### PR TITLE
rtmg: now-playing dock polish + 2-step upload modal + LoRA-name labels

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -5889,12 +5889,16 @@ body.curve-open #install-video-area #graph {
    placard carries the brand gradient strip + radii). */
 .audio-source-dock {
   position: fixed;
-  /* "Now playing" placard + upload pair tucked right into the
-     lower-right corner — a small flat inset from the viewport edge
-     (not offset by the thick HUD frame band) so it reads as a true
-     corner widget. Mirrored by .save-pill in the lower-left. */
-  bottom: max(24px, env(safe-area-inset-bottom, 0px));
-  right: max(24px, env(safe-area-inset-right, 0px));
+  /* Mirrors the halo badge across the horizontal midline: the same
+     right inset as the badge, and a bottom margin equal to the badge's
+     TOP margin — so the now-playing dock and the hamburger read as a
+     symmetric pair with matching page margins. .save-pill mirrors this
+     in the lower-left. */
+  bottom: max(
+    calc(var(--hud-thickness) / 2 - 10px + var(--top-bias, 5px)),
+    env(safe-area-inset-bottom, 0px)
+  );
+  right: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-right, 0px));
   z-index: 8;
   /* Only the interactive children — the body when expanded, the bubble
      when collapsed — catch input; the dock's own footprint stays
@@ -7943,11 +7947,14 @@ body.curve-open #install-video-area #graph {
    whole pill in the dirty state) to fire useSavedSessions.save(). */
 .save-pill {
   position: fixed;
-  /* Tucked into the lower-left corner, mirroring .audio-source-dock in
-     the lower-right for visual balance. Flat inset from the viewport
-     edge, not offset by the HUD frame band. */
-  bottom: max(24px, env(safe-area-inset-bottom, 0px));
-  left: max(24px, env(safe-area-inset-left, 0px));
+  /* Lower-left mirror of .audio-source-dock — identical insets, so the
+     save pill and the now-playing dock balance the bottom corners the
+     way the wordmark and the hamburger balance the top. */
+  bottom: max(
+    calc(var(--hud-thickness) / 2 - 10px + var(--top-bias, 5px)),
+    env(safe-area-inset-bottom, 0px)
+  );
+  left: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-left, 0px));
   display: inline-flex;
   align-items: center;
   gap: 6px;

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -7309,7 +7309,7 @@ body.curve-open #install-video-area #graph {
 }
 .almost-ready-modal {
   position: relative;
-  width: min(440px, 100%);
+  width: min(540px, 100%);
   max-height: min(80vh, 640px);
   background: var(--sheet-bg);
   border: 1px solid var(--frame-line);
@@ -7365,52 +7365,128 @@ body.curve-open #install-video-area #graph {
   font-size: 0.92em;
   line-height: 1.45;
 }
-.almost-ready-key-section {
+/* Step indicator — two bars; the active step's bar is accent-filled. */
+.almost-ready-steps {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin: 4px 0 0;
-  padding: 0;
-  border: none;
+  gap: 6px;
+  margin: 10px 0 0;
 }
-.almost-ready-key-legend {
-  font-family: var(--font-mono);
-  font-size: 0.7em;
+.almost-ready-step-dot {
+  width: 24px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--frame-line);
+  transition: background 160ms ease;
+}
+.almost-ready-step-dot.is-active { background: var(--accent); }
+.almost-ready-step-head {
+  margin: 14px 0 10px;
+}
+.almost-ready-step-num {
+  display: block;
+  font-size: 0.82em;
   letter-spacing: var(--tracking-wide);
   text-transform: uppercase;
   color: var(--text-dim);
-  padding: 0 0 4px;
 }
-.almost-ready-key-mode {
+.almost-ready-step-title {
+  margin: 3px 0 0;
+  font-size: 1.18em;
+  font-weight: 500;
+  color: var(--text-strong);
+  letter-spacing: 0.02em;
+}
+
+/* Step 1 — selectable source cards (one per inference source). */
+.almost-ready-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.almost-ready-card {
   display: flex;
   align-items: flex-start;
-  gap: 10px;
-  padding: 8px 10px;
+  gap: 11px;
+  width: 100%;
+  text-align: left;
+  padding: 12px 13px;
+  background: rgba(255, 255, 255, 0.02);
   border: 1px solid var(--frame-line);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: border-color 120ms, background 120ms;
+  font-family: inherit;
+  transition: border-color 130ms ease, background 130ms ease;
 }
-.almost-ready-key-mode:hover { border-color: var(--accent); }
-.almost-ready-key-mode input[type="radio"] {
-  margin-top: 2px;
-  cursor: pointer;
+.almost-ready-card:hover { border-color: var(--accent-line); }
+.almost-ready-card.is-selected {
+  border-color: var(--accent);
+  background: var(--accent-soft);
 }
-.almost-ready-key-mode strong {
-  display: block;
+.almost-ready-card-radio {
+  flex: none;
+  width: 15px;
+  height: 15px;
+  margin-top: 1px;
+  border-radius: 50%;
+  border: 1.5px solid var(--frame-line);
+  transition: border-color 130ms ease, background 130ms ease;
+}
+.almost-ready-card:hover .almost-ready-card-radio {
+  border-color: var(--accent-line);
+}
+.almost-ready-card.is-selected .almost-ready-card-radio {
+  border-color: var(--accent);
+  background: radial-gradient(circle, var(--accent) 0 4px, transparent 5px);
+}
+.almost-ready-card-text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.almost-ready-card-title {
   color: var(--text-strong);
   font-weight: 500;
-  margin-bottom: 2px;
 }
-.almost-ready-key-mode-hint {
-  display: block;
+.almost-ready-card.is-selected .almost-ready-card-title {
+  color: var(--accent);
+}
+.almost-ready-card-hint {
   color: var(--text-dim);
   font-size: 0.92em;
-  line-height: 1.35;
+  line-height: 1.4;
 }
-.almost-ready-key-select {
-  margin-left: 28px;
-  width: calc(100% - 28px);
+
+/* Step 2 — key / time-signature fields. */
+.almost-ready-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin: 0 0 14px;
+}
+.almost-ready-field:last-child { margin-bottom: 0; }
+.almost-ready-field-label {
+  font-size: 0.82em;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.almost-ready-select {
+  width: 100%;
+}
+.almost-ready-field-hint {
+  color: var(--text-dim);
+  font-size: 0.9em;
+  line-height: 1.4;
+}
+
+/* Condensed disclaimer footnote on step 1. */
+.almost-ready-note {
+  margin: 14px 0 0;
+  color: var(--text-dim);
+  font-size: 0.86em;
+  line-height: 1.4;
+  opacity: 0.85;
 }
 .almost-ready-footer {
   display: flex;
@@ -7445,6 +7521,15 @@ body.curve-open #install-video-area #graph {
   color: var(--text);
   border-color: var(--text-dim);
 }
+/* Ghost button ("Pick another") — borderless, pushed to the far left
+   of the footer via margin-right:auto. */
+.almost-ready-btn--ghost {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-dim);
+  margin-right: auto;
+}
+.almost-ready-btn--ghost:hover { color: var(--text); }
 
 /* ─────────────────────────────────────────────────────────────────────
    ConfirmDialog — generic yes/no replacement for window.confirm().
@@ -7548,21 +7633,6 @@ body.curve-open #install-video-area #graph {
 .confirm-dialog-btn--secondary:hover {
   color: var(--text);
   border-color: var(--text-dim);
-}
-
-/* AlmostReadyDialog disclaimer paragraph: subdued, smaller, italic so it
-   reads as advisory copy rather than primary content. Sits below the
-   key fieldset. */
-.almost-ready-disclaimer {
-  margin: 12px 0 0;
-  padding: 8px 10px;
-  border: 1px dashed var(--frame-line);
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--text-dim);
-  font-size: 0.85em;
-  line-height: 1.45;
-  font-style: italic;
 }
 
 /* Reference picker (timbre / structure) — sits under the strength

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -2201,28 +2201,29 @@ body.drawer-open {
    drawer is open since the drawer's own help bar takes over there. */
 .hud-help-readout {
   position: fixed;
-  top: max(calc(var(--hud-thickness) + 18px), env(safe-area-inset-top, 0px));
+  /* Sits in the header band — aligned with the halo badge — so the
+     readout floats ABOVE the waveform scrub strip
+     (top: hud-thickness + 24px) instead of landing on top of it. */
+  top: max(
+    calc(var(--hud-thickness) / 2 - 10px + var(--top-bias, 5px)),
+    env(safe-area-inset-top, 0px)
+  );
   left: 50%;
   transform: translateX(-50%);
   z-index: 25;
   pointer-events: none;
   max-width: min(540px, 70vw);
-  padding: 7px 14px 8px;
-  background: rgba(6, 6, 12, 0.78);
+  padding: 5px 13px 6px;
+  /* Quiet chip — light translucent fill + blur, no gradient border or
+     drop-shadow (those read as "too much" against the header chrome). */
+  background: rgba(10, 10, 16, 0.6);
   border: 1px solid var(--frame-line);
-  border-top: 2px solid transparent;
-  background-image:
-    linear-gradient(rgba(6, 6, 12, 0.78), rgba(6, 6, 12, 0.78)),
-    var(--dd-gradient);
-  background-origin: padding-box, border-box;
-  background-clip: padding-box, border-box;
   border-radius: var(--radius-md);
-  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.45);
-  -webkit-backdrop-filter: blur(6px);
-  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(8px);
+          backdrop-filter: blur(8px);
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 2px;
 }
 body.drawer-open .hud-help-readout {
   display: none;
@@ -5888,12 +5889,17 @@ body.curve-open #install-video-area #graph {
    placard carries the brand gradient strip + radii). */
 .audio-source-dock {
   position: fixed;
-  /* "Now playing" placard + upload pair sits in the lower-right corner.
-     Right-anchored; the Full Controls panel is on the LEFT now so this
-     dock does NOT need to slide inward when the panel opens. */
-  bottom: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-bottom, 0px));
-  right: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-right, 0px));
+  /* "Now playing" placard + upload pair tucked right into the
+     lower-right corner — a small flat inset from the viewport edge
+     (not offset by the thick HUD frame band) so it reads as a true
+     corner widget. Mirrored by .save-pill in the lower-left. */
+  bottom: max(24px, env(safe-area-inset-bottom, 0px));
+  right: max(24px, env(safe-area-inset-right, 0px));
   z-index: 8;
+  /* Only the interactive children — the body when expanded, the bubble
+     when collapsed — catch input; the dock's own footprint stays
+     click-through (see .audio-source-dock-body / .audio-source-bubble). */
+  pointer-events: none;
   display: flex;
   flex-direction: row;
   align-items: stretch;
@@ -5921,6 +5927,90 @@ body.curve-open #install-video-area #graph {
 .audio-source-dock:has(.audio-source-upload-btn:active),
 .audio-source-dock:has(.audio-source-mic-btn:active) {
   transform: translateY(0);
+}
+
+/* ── Auto-collapse to a play bubble ──────────────────────────────────
+   AudioSourceCrate sets [data-collapsed] on the dock 2s after the
+   pointer leaves. The body (placard + upload + mic) cross-fades + folds
+   toward the corner as the bubble pops in; hovering the bubble (which
+   bubbles the dock's onMouseEnter) clears the flag and expands again. */
+.audio-source-dock-body {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 0;
+  pointer-events: auto;
+  transform-origin: bottom right;
+  transition:
+    opacity 0.2s ease,
+    transform 0.26s cubic-bezier(.2, .8, .2, 1);
+}
+.audio-source-dock[data-collapsed] .audio-source-dock-body {
+  opacity: 0;
+  transform: scale(0.86) translateX(16px);
+  pointer-events: none;
+}
+.audio-source-bubble {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 46px;
+  height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  /* Let the writhing ribbon ring bleed outside the circle. */
+  overflow: visible;
+  /* Hidden while the dock is expanded. */
+  opacity: 0;
+  transform: scale(0.5);
+  transition:
+    opacity 0.2s ease,
+    transform 0.26s cubic-bezier(.2, .8, .2, 1),
+    filter 0.18s ease;
+}
+/* Dark inner disc — the writhing ribbon canvas is the visible border,
+   exactly like .halo-badge::before + .halo-badge .halo-ribbons. */
+.audio-source-bubble::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: rgba(6, 6, 12, 0.66);
+  -webkit-backdrop-filter: blur(6px);
+          backdrop-filter: blur(6px);
+  z-index: 0;
+}
+.audio-source-bubble .halo-ribbons {
+  position: absolute;
+  inset: -3px;
+  width: calc(100% + 6px);
+  height: calc(100% + 6px);
+  pointer-events: none;
+  overflow: visible;
+  z-index: 1;
+  filter: drop-shadow(
+    0 0 calc(1px + var(--bloom-amount, 0) * 8px) rgba(255, 255, 255, 0.55)
+  );
+}
+.audio-source-bubble svg {
+  position: relative;
+  z-index: 2;
+}
+.audio-source-bubble:hover {
+  filter: brightness(1.1) saturate(1.08);
+}
+.audio-source-dock[data-collapsed] .audio-source-bubble {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
 }
 .audio-source-crate {
   position: relative; /* positioning context for the brand gradient ::before */
@@ -7853,8 +7943,11 @@ body.curve-open #install-video-area #graph {
    whole pill in the dirty state) to fire useSavedSessions.save(). */
 .save-pill {
   position: fixed;
-  bottom: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-bottom, 0px));
-  left: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-left, 0px));
+  /* Tucked into the lower-left corner, mirroring .audio-source-dock in
+     the lower-right for visual balance. Flat inset from the viewport
+     edge, not offset by the HUD frame band. */
+  bottom: max(24px, env(safe-area-inset-bottom, 0px));
+  left: max(24px, env(safe-area-inset-left, 0px));
   display: inline-flex;
   align-items: center;
   gap: 6px;

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3547,11 +3547,37 @@ body.curve-open #install-video-area #graph {
    this before sweeping the faders". Recessed background so it reads as
    advisory rather than a primary control surface. */
 .voice-tile-warning {
+  position: relative;
   margin: 0 0 6px;
-  padding: 6px 8px 7px;
+  padding: 6px 22px 7px 8px;
   border: 1px solid var(--accent-line);
   border-radius: var(--radius-sm);
   background: rgba(255, 184, 60, 0.04);
+}
+/* Dismiss the experimental-feature notice — the dismissal is persisted
+   to localStorage by VoiceTile. */
+.voice-tile-warning-close {
+  position: absolute;
+  top: 3px;
+  right: 4px;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 100ms ease, background 100ms ease;
+}
+.voice-tile-warning-close:hover {
+  color: var(--text-strong);
+  background: rgba(255, 255, 255, 0.06);
 }
 .voice-tile-warning-title {
   font-family: var(--font-mono);
@@ -6637,18 +6663,6 @@ body.curve-open #install-video-area #graph {
     start-whisper-breathe 2.6s ease-in-out infinite 200ms;
   transition: bottom 240ms cubic-bezier(.2, .8, .2, 1);
 }
-/* Curve scheduler overlay docks its tab strip + close button against
-   the bottom of the viewport (≈48–56px tall). When that overlay is
-   open, hoist the pill above the tabs so it doesn't sit on top of the
-   curve tabs or the preset menus that grow upward from them. */
-.network-indicator[data-curves-open="true"] {
-  bottom: calc(
-    var(--drawer-handle-h, 28px) +
-    env(safe-area-inset-bottom, 0px) +
-    var(--curves-tab-strip-h, 64px) +
-    12px
-  );
-}
 .network-indicator__bars rect {
   fill: currentColor;
 }
@@ -7680,6 +7694,7 @@ body.curve-open #install-video-area #graph {
   flex: 1 1 0;
   min-width: 0;
   display: flex;
+  gap: 5px;
 }
 .ref-control-button {
   flex: 1 1 0;
@@ -7733,6 +7748,35 @@ body.curve-open #install-video-area #graph {
   border-color: var(--text-dim);
 }
 .ref-control-button:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}
+/* Sibling upload button — same outlined vocabulary as the dropdown
+   button, sized to a compact icon square. (Was an unstyled default
+   <button>.) */
+.ref-control-upload {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  background: transparent;
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 0;
+  transition: color 80ms linear, border-color 80ms linear;
+}
+.ref-control-upload:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+.ref-control-upload:focus-visible {
+  outline: none;
+  border-color: var(--text-dim);
+}
+.ref-control-upload:disabled {
   opacity: 0.5;
   cursor: progress;
 }

--- a/demos/realtime_motion_graph_web/web/components/Performance/AlmostReadyDialog.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AlmostReadyDialog.tsx
@@ -3,11 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
+import { type StemSourceMode } from "@/engine/audio/loadFixture";
 import {
-  type StemSourceMode,
-} from "@/engine/audio/loadFixture";
-import {
-  DEFAULT_TIME_SIGNATURE,
   TIME_SIGNATURE_LABELS,
   VALID_KEYSCALES,
   VALID_TIME_SIGNATURES,
@@ -15,34 +12,49 @@ import {
   type TimeSignature,
 } from "@/types/engine";
 
-// Sits between file-pick and fixture-swap so users can confirm the
-// upload before playback transitions. Three jobs:
-//   1. If the source was longer than 240 s, the parent has already
-//      auto-trimmed it; we surface that fact and offer "Pick another
-//      song" as a one-click escape.
-//   2. Let the user choose a key for the model: default is "Auto-detect"
-//      (server CNN runs as part of the swap and its result populates the
-//      activeKey). "Set manually" sets a one-shot override that wins
-//      over the CNN's result for this swap (see useFixtureSwap.ts).
-//   3. Same auto/manual choice for time signature. There's no audio-
-//      domain detector for meter today — "Auto-detect" actually means
-//      "let the server pick (sidecar value on a hit, "4" otherwise)";
-//      "Set manually" tags the upload with the operator's pick which
-//      wins over the server's default.
+// Two-step confirm dialog between file-pick and fixture-swap:
+//   Step 1 — inference source: full track / instruments / vocals.
+//   Step 2 — key + time signature. Each is "Auto-detect" or an explicit
+//            override that wins over the server's resolver for this
+//            swap (see useFixtureSwap.ts).
+// If the source was longer than 240 s the parent has already
+// auto-trimmed it; step 1 surfaces that with a one-click "pick another"
+// escape.
 
-type KeyMode = "auto" | "manual";
-type TimeSigMode = "auto" | "manual";
+type Step = 1 | 2;
+
+interface SourceOption {
+  mode: StemSourceMode;
+  title: string;
+  hint: string;
+}
+
+const SOURCE_OPTIONS: SourceOption[] = [
+  {
+    mode: "full",
+    title: "Full track",
+    hint: "Feed the whole upload to inference. Stems are still ripped automatically for the realtime layers.",
+  },
+  {
+    mode: "instruments",
+    title: "Instruments",
+    hint: "Auto-rip stems, then feed only the instrumental bed to inference.",
+  },
+  {
+    mode: "vocals",
+    title: "Vocals",
+    hint: "Auto-rip stems, then feed only the vocal stem to inference.",
+  },
+];
+
+const AUTO = "auto";
 
 export interface AlmostReadyDialogProps {
   fileName: string;
   wasTrimmed: boolean;
-  /** Default value for the manual-mode dropdown. Usually the user's
-   *  current activeKey so they don't have to re-pick if they had a
-   *  preference. */
+  /** Retained for call-site compatibility; the step-2 selects default
+   *  to "Auto-detect" rather than pre-filling a prior pick. */
   defaultKey: string;
-  /** Default for the time-signature manual dropdown. Same posture as
-   *  defaultKey: the operator's current activeTimeSignature carries
-   *  forward so they don't lose their pick on every upload. */
   defaultTimeSignature: TimeSignature;
   onContinue: (opts: {
     keyOverride: string | null;
@@ -50,8 +62,7 @@ export interface AlmostReadyDialogProps {
     sourceMode: StemSourceMode;
   }) => void;
   /** Only invoked when wasTrimmed is true; parent re-opens the file
-   *  picker so the user can swap to a shorter source instead of
-   *  accepting the trim. */
+   *  picker so the user can swap to a shorter source. */
   onPickAnother: () => void;
   onClose: () => void;
 }
@@ -59,69 +70,61 @@ export interface AlmostReadyDialogProps {
 export function AlmostReadyDialog({
   fileName,
   wasTrimmed,
-  defaultKey,
-  defaultTimeSignature,
   onContinue,
   onPickAnother,
   onClose,
 }: AlmostReadyDialogProps) {
   const [mounted, setMounted] = useState(false);
-  const [mode, setMode] = useState<KeyMode>("auto");
-  const [manualKey, setManualKey] = useState(
-    VALID_KEYSCALES.includes(defaultKey) ? defaultKey : "C major",
-  );
-  const [timeSigMode, setTimeSigMode] = useState<TimeSigMode>("auto");
+  const [step, setStep] = useState<Step>(1);
   const [sourceMode, setSourceMode] = useState<StemSourceMode>("full");
-  const [manualTimeSig, setManualTimeSig] = useState<TimeSignature>(
-    isTimeSignature(defaultTimeSignature)
-      ? defaultTimeSignature
-      : DEFAULT_TIME_SIGNATURE,
-  );
-  const continueRef = useRef<HTMLButtonElement | null>(null);
+  const [keyChoice, setKeyChoice] = useState<string>(AUTO);
+  const [tsChoice, setTsChoice] = useState<string>(AUTO);
+  const primaryRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => setMounted(true), []);
 
-  // Esc closes; preventDefault so an open AdvancedDrawer underneath
-  // doesn't also toggle.
+  function finish() {
+    onContinue({
+      keyOverride: keyChoice === AUTO ? null : keyChoice,
+      timeSignatureOverride:
+        tsChoice !== AUTO && isTimeSignature(tsChoice) ? tsChoice : null,
+      sourceMode,
+    });
+  }
+
+  // Esc closes; Enter advances (step 1 → next, step 2 → start) unless
+  // focus is on a SELECT whose Enter has its own meaning.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.stopPropagation();
         e.preventDefault();
         onClose();
-      } else if (e.key === "Enter") {
-        // Enter = primary action, but only when focus isn't already
-        // on a form control whose Enter has its own meaning.
+        return;
+      }
+      if (e.key === "Enter") {
         const tag = (e.target as HTMLElement | null)?.tagName;
-        if (tag === "SELECT" || tag === "TEXTAREA") return;
+        if (tag === "SELECT") return;
         e.preventDefault();
-        onContinue({
-          keyOverride: mode === "manual" ? manualKey : null,
-          timeSignatureOverride:
-            timeSigMode === "manual" ? manualTimeSig : null,
-          sourceMode,
-        });
+        if (step === 1) setStep(2);
+        else finish();
       }
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [mode, manualKey, timeSigMode, manualTimeSig, sourceMode, onClose, onContinue]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step, sourceMode, keyChoice, tsChoice, onClose, onContinue]);
 
-  // Move keyboard focus to the primary button when the dialog mounts so
-  // Enter / Space immediately fires Continue.
+  // Focus the primary button on mount and on every step change so
+  // Enter / Space fire it.
   useEffect(() => {
-    if (!mounted) return;
-    continueRef.current?.focus();
-  }, [mounted]);
+    if (mounted) primaryRef.current?.focus();
+  }, [mounted, step]);
 
   if (!mounted) return null;
 
   return createPortal(
-    <div
-      className="almost-ready-backdrop"
-      onClick={onClose}
-      role="presentation"
-    >
+    <div className="almost-ready-backdrop" onClick={onClose} role="presentation">
       <div
         className="almost-ready-modal"
         role="dialog"
@@ -133,7 +136,7 @@ export function AlmostReadyDialog({
 
         <div className="almost-ready-header">
           <h2 id="almost-ready-title" className="almost-ready-title">
-            Almost Ready
+            Almost ready
           </h2>
           <button
             type="button"
@@ -146,209 +149,167 @@ export function AlmostReadyDialog({
         </div>
 
         <div className="almost-ready-body">
-          <p className="almost-ready-disclaimer">
-            This is new tech and has some limitations. For the best
-            results, choose songs without key or tempo changes.
-          </p>
-
-          <p className="almost-ready-filename" title={fileName}>
+          <div className="almost-ready-filename" title={fileName}>
             {fileName}
-          </p>
+          </div>
 
-          {wasTrimmed && (
-            <p className="almost-ready-trim-msg">
-              Uploads are limited to 240 seconds. We&apos;ve trimmed your
-              upload to fit within this limit.
-            </p>
+          <div className="almost-ready-steps" aria-hidden="true">
+            <span
+              className={`almost-ready-step-dot${step === 1 ? " is-active" : ""}`}
+            />
+            <span
+              className={`almost-ready-step-dot${step === 2 ? " is-active" : ""}`}
+            />
+          </div>
+
+          {step === 1 ? (
+            <>
+              <div className="almost-ready-step-head">
+                <span className="almost-ready-step-num">Step 1 of 2</span>
+                <h3 className="almost-ready-step-title">Inference source</h3>
+              </div>
+
+              {wasTrimmed && (
+                <p className="almost-ready-trim-msg">
+                  Trimmed to the 240-second upload limit.
+                </p>
+              )}
+
+              <div
+                className="almost-ready-cards"
+                role="radiogroup"
+                aria-label="Inference source"
+              >
+                {SOURCE_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.mode}
+                    type="button"
+                    role="radio"
+                    aria-checked={sourceMode === opt.mode}
+                    className={`almost-ready-card${sourceMode === opt.mode ? " is-selected" : ""}`}
+                    onClick={() => setSourceMode(opt.mode)}
+                  >
+                    <span className="almost-ready-card-radio" aria-hidden="true" />
+                    <span className="almost-ready-card-text">
+                      <span className="almost-ready-card-title">
+                        {opt.title}
+                      </span>
+                      <span className="almost-ready-card-hint">{opt.hint}</span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              <p className="almost-ready-note">
+                New tech with limits — songs without key or tempo changes
+                work best.
+              </p>
+            </>
+          ) : (
+            <>
+              <div className="almost-ready-step-head">
+                <span className="almost-ready-step-num">Step 2 of 2</span>
+                <h3 className="almost-ready-step-title">
+                  Key &amp; time signature
+                </h3>
+              </div>
+
+              <div className="almost-ready-field">
+                <label className="almost-ready-field-label" htmlFor="ar-key">
+                  Key
+                </label>
+                <select
+                  id="ar-key"
+                  className="almost-ready-select fixture-select"
+                  value={keyChoice}
+                  onChange={(e) => setKeyChoice(e.target.value)}
+                >
+                  <option value={AUTO}>Auto-detect</option>
+                  {VALID_KEYSCALES.map((k) => (
+                    <option key={k} value={k}>
+                      {k}
+                    </option>
+                  ))}
+                </select>
+                <span className="almost-ready-field-hint">
+                  Tells the model the song&apos;s key — it doesn&apos;t
+                  repitch the audio.
+                </span>
+              </div>
+
+              <div className="almost-ready-field">
+                <label className="almost-ready-field-label" htmlFor="ar-ts">
+                  Time signature
+                </label>
+                <select
+                  id="ar-ts"
+                  className="almost-ready-select fixture-select"
+                  value={tsChoice}
+                  onChange={(e) => setTsChoice(e.target.value)}
+                >
+                  <option value={AUTO}>Auto-detect</option>
+                  {VALID_TIME_SIGNATURES.map((ts) => (
+                    <option key={ts} value={ts}>
+                      {TIME_SIGNATURE_LABELS[ts]}
+                    </option>
+                  ))}
+                </select>
+                <span className="almost-ready-field-hint">
+                  Tells the model the song&apos;s meter — it doesn&apos;t
+                  change the tempo or beat grid.
+                </span>
+              </div>
+            </>
           )}
-
-          <fieldset className="almost-ready-key-section">
-            <legend className="almost-ready-key-legend">Inference source</legend>
-
-            <label className="almost-ready-key-mode">
-              <input
-                type="radio"
-                name="source-mode"
-                value="full"
-                checked={sourceMode === "full"}
-                onChange={() => setSourceMode("full")}
-              />
-              <span>
-                <strong>Use full track</strong>
-                <span className="almost-ready-key-mode-hint">
-                  Feed the full upload to inference. Stems are still ripped
-                  automatically for realtime layers.
-                </span>
-              </span>
-            </label>
-
-            <label className="almost-ready-key-mode">
-              <input
-                type="radio"
-                name="source-mode"
-                value="vocals"
-                checked={sourceMode === "vocals"}
-                onChange={() => setSourceMode("vocals")}
-              />
-              <span>
-                <strong>Use vocals</strong>
-                <span className="almost-ready-key-mode-hint">
-                  Auto-rip stems, then feed only the vocal stem to inference.
-                </span>
-              </span>
-            </label>
-
-            <label className="almost-ready-key-mode">
-              <input
-                type="radio"
-                name="source-mode"
-                value="instruments"
-                checked={sourceMode === "instruments"}
-                onChange={() => setSourceMode("instruments")}
-              />
-              <span>
-                <strong>Use instruments</strong>
-                <span className="almost-ready-key-mode-hint">
-                  Auto-rip stems, then feed the instrumental bed to inference.
-                </span>
-              </span>
-            </label>
-          </fieldset>
-
-          <fieldset className="almost-ready-key-section">
-            <legend className="almost-ready-key-legend">Key</legend>
-
-            <label className="almost-ready-key-mode">
-              <input
-                type="radio"
-                name="key-mode"
-                value="auto"
-                checked={mode === "auto"}
-                onChange={() => setMode("auto")}
-              />
-              <span>
-                <strong>Auto-detect</strong>
-                <span className="almost-ready-key-mode-hint">
-                  We&apos;ll detect the song&apos;s key automatically.
-                </span>
-              </span>
-            </label>
-
-            <label className="almost-ready-key-mode">
-              <input
-                type="radio"
-                name="key-mode"
-                value="manual"
-                checked={mode === "manual"}
-                onChange={() => setMode("manual")}
-              />
-              <span>
-                <strong>Set manually</strong>
-                <span className="almost-ready-key-mode-hint">
-                  Tells the model the song&apos;s key. Does not change
-                  the song&apos;s pitch.
-                </span>
-              </span>
-            </label>
-
-            {mode === "manual" && (
-              <select
-                className="almost-ready-key-select fixture-select"
-                value={manualKey}
-                onChange={(e) => setManualKey(e.target.value)}
-                aria-label="Pick a key"
-              >
-                {VALID_KEYSCALES.map((k) => (
-                  <option key={k} value={k}>
-                    {k}
-                  </option>
-                ))}
-              </select>
-            )}
-          </fieldset>
-
-          <fieldset className="almost-ready-key-section">
-            <legend className="almost-ready-key-legend">Time signature</legend>
-
-            <label className="almost-ready-key-mode">
-              <input
-                type="radio"
-                name="time-sig-mode"
-                value="auto"
-                checked={timeSigMode === "auto"}
-                onChange={() => setTimeSigMode("auto")}
-              />
-              <span>
-                <strong>Auto-detect</strong>
-                <span className="almost-ready-key-mode-hint">
-                  We&apos;ll use the server&apos;s default (4/4 unless a
-                  matching fixture sidecar says otherwise).
-                </span>
-              </span>
-            </label>
-
-            <label className="almost-ready-key-mode">
-              <input
-                type="radio"
-                name="time-sig-mode"
-                value="manual"
-                checked={timeSigMode === "manual"}
-                onChange={() => setTimeSigMode("manual")}
-              />
-              <span>
-                <strong>Set manually</strong>
-                <span className="almost-ready-key-mode-hint">
-                  Tells the model the song&apos;s meter. Does not change
-                  the song&apos;s tempo or beat grid.
-                </span>
-              </span>
-            </label>
-
-            {timeSigMode === "manual" && (
-              <select
-                className="almost-ready-key-select fixture-select"
-                value={manualTimeSig}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  if (isTimeSignature(v)) setManualTimeSig(v);
-                }}
-                aria-label="Pick a time signature"
-              >
-                {VALID_TIME_SIGNATURES.map((ts) => (
-                  <option key={ts} value={ts}>
-                    {TIME_SIGNATURE_LABELS[ts]}
-                  </option>
-                ))}
-              </select>
-            )}
-          </fieldset>
         </div>
 
         <div className="almost-ready-footer">
-          {wasTrimmed && (
-            <button
-              type="button"
-              className="almost-ready-btn almost-ready-btn--secondary"
-              onClick={onPickAnother}
-            >
-              Pick another song
-            </button>
+          {step === 1 ? (
+            <>
+              {wasTrimmed && (
+                <button
+                  type="button"
+                  className="almost-ready-btn almost-ready-btn--ghost"
+                  onClick={onPickAnother}
+                >
+                  Pick another
+                </button>
+              )}
+              <button
+                type="button"
+                className="almost-ready-btn almost-ready-btn--secondary"
+                onClick={onClose}
+              >
+                Cancel
+              </button>
+              <button
+                ref={primaryRef}
+                type="button"
+                className="almost-ready-btn almost-ready-btn--primary"
+                onClick={() => setStep(2)}
+              >
+                Next →
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                className="almost-ready-btn almost-ready-btn--secondary"
+                onClick={() => setStep(1)}
+              >
+                ← Back
+              </button>
+              <button
+                ref={primaryRef}
+                type="button"
+                className="almost-ready-btn almost-ready-btn--primary"
+                onClick={finish}
+              >
+                Start
+              </button>
+            </>
           )}
-          <button
-            ref={continueRef}
-            type="button"
-            className="almost-ready-btn almost-ready-btn--primary"
-            onClick={() =>
-              onContinue({
-                keyOverride: mode === "manual" ? manualKey : null,
-                timeSignatureOverride:
-                  timeSigMode === "manual" ? manualTimeSig : null,
-                sourceMode,
-              })
-            }
-          >
-            Continue
-          </button>
         </div>
       </div>
     </div>,

--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -75,6 +75,20 @@ function MicIcon({ size = 14 }: { size?: number }) {
   );
 }
 
+function NoteIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
+    </svg>
+  );
+}
+
 export function AudioSourceCrate() {
   const fixture = usePerformanceStore((s) => s.fixture);
   const setFixture = usePerformanceStore((s) => s.setFixture);
@@ -97,6 +111,12 @@ export function AudioSourceCrate() {
     wasTrimmed: boolean;
     originalFile: File;
   } | null>(null);
+
+  // Auto-collapse: the dock folds to a small play bubble 2s after it's
+  // left alone, and expands back on hover / focus. `collapsed` drives
+  // the CSS cross-fade; `hovered` is the pointer-over signal.
+  const [collapsed, setCollapsed] = useState(false);
+  const [hovered, setHovered] = useState(false);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const placardRef = useRef<HTMLButtonElement | null>(null);
@@ -139,6 +159,21 @@ export function AudioSourceCrate() {
       document.removeEventListener("keydown", onKey);
     };
   }, [open]);
+
+  // Expand whenever the dock is being used (hovered, or a picker /
+  // dialog / upload is in flight); otherwise collapse to the bubble
+  // 2s after the last interaction. The timeout is cleared on any
+  // re-activation so it only fires once the dock is truly idle.
+  const dockActive =
+    hovered || open || micOpen || uploading || pending !== null;
+  useEffect(() => {
+    if (dockActive) {
+      setCollapsed(false);
+      return;
+    }
+    const t = window.setTimeout(() => setCollapsed(true), 2000);
+    return () => window.clearTimeout(t);
+  }, [dockActive]);
 
   async function onFilePicked(file: File) {
     const { setStatus } = useSessionStore.getState();
@@ -205,7 +240,28 @@ export function AudioSourceCrate() {
 
   return (
     <>
-      <div className="audio-source-dock">
+      <div
+        className="audio-source-dock"
+        data-collapsed={collapsed ? "" : undefined}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        {/* Collapsed face — a music-note bubble wreathed by the same
+            writhing ribbon ring as the HaloBadge (useRenderLoop finds
+            this `.halo-ribbons` canvas by selector and ticks it).
+            Hovering it fires the dock's onMouseEnter and expands;
+            onClick/onFocus cover touch + keyboard. */}
+        <button
+          type="button"
+          className="audio-source-bubble"
+          aria-label="Show now-playing controls"
+          onClick={() => setHovered(true)}
+          onFocus={() => setHovered(true)}
+        >
+          <canvas className="halo-ribbons" aria-hidden="true" />
+          <NoteIcon size={18} />
+        </button>
+        <div className="audio-source-dock-body">
         <button
           ref={placardRef}
           type="button"
@@ -258,6 +314,7 @@ export function AudioSourceCrate() {
           <MicIcon size={16} />
           <span className="audio-source-upload-label">Mic</span>
         </button>
+        </div>
       </div>
 
       {open && (

--- a/demos/realtime_motion_graph_web/web/components/Performance/HeroMacros.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/HeroMacros.tsx
@@ -6,6 +6,7 @@ import type { StemOverlayKind } from "@/engine/audio/loadFixture";
 import { LORA_SLOT_MARKER } from "@/engine/midi/types";
 import { useLoraFaderDrag } from "@/hooks/useLoraFaderDrag";
 import { useStemPannerDrag } from "@/hooks/useStemPannerDrag";
+import { loraDisplayName } from "@/lib/loraLabels";
 import { useCurveStore } from "@/store/useCurveStore";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { useLoraStore } from "@/store/useLoraStore";
@@ -116,7 +117,7 @@ function HeroStyleFader({ slotIndex }: HeroStyleFaderProps) {
   useLoraFaderDrag(trackRef, slotIndex, !isEmpty);
 
   const displayLabel = loraId
-    ? (catalog.find((c) => c.id === loraId)?.name ?? loraId)
+    ? loraDisplayName(catalog.find((c) => c.id === loraId) ?? { id: loraId })
     : `Style ${slotIndex + 1}`;
   const kbdHint = loraId
     ? `${slotIndex === 0 ? "Z" : "X"} + ▲▼`

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -6,6 +6,7 @@ import { createPortal } from "react-dom";
 import { loraStrengthDispatcher } from "@/engine/lora/dispatcher";
 import { listHiddenLoras, listLoras } from "@/engine/lora/listLoras";
 import { useConfig } from "@/lib/config";
+import { LORA_LABELS, loraDisplayName } from "@/lib/loraLabels";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { isLoraCompatibleWithScale, useLoraStore } from "@/store/useLoraStore";
 import { useMidiStore } from "@/store/useMidiStore";
@@ -119,7 +120,7 @@ function categoryOf(entry: LoraCatalogEntry): string {
 }
 
 function displayNameOf(entry: LoraCatalogEntry): string {
-  return entry.name || entry.id;
+  return loraDisplayName(entry);
 }
 
 function byDisplayName(a: LoraCatalogEntry, b: LoraCatalogEntry): number {
@@ -136,6 +137,7 @@ function matchesQuery(entry: LoraCatalogEntry, q: string): boolean {
   const parts: (string | null | undefined)[] = [
     entry.id,
     entry.name,
+    LORA_LABELS[entry.id],
     md?.name,
     md?.description,
     md?.primary_trigger_word,

--- a/demos/realtime_motion_graph_web/web/components/Performance/NetworkIndicator.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/NetworkIndicator.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useCurveStore } from "@/store/useCurveStore";
 import { useNetworkStore } from "@/store/useNetworkStore";
 
 // Subtle bottom-center pill that fades in when the user is likely
@@ -10,19 +9,17 @@ import { useNetworkStore } from "@/store/useNetworkStore";
 // the canvas or the AdvancedDrawer handle behind it. aria-live polite
 // so screen readers announce the engagement once, not per eval tick.
 //
-// When the schedule-curves overlay is open, the pill shifts up so it
-// clears the curve tab strip at the overlay's bottom — handled via the
-// `data-curves-open` attribute and a CSS bottom-offset bump.
+// Fixed bottom-center, just above the drawer handle — the position
+// does NOT shift when the schedule-curves overlay opens; it stays put
+// rather than hopping up over the curve tab strip / editor controls.
 export function NetworkIndicator() {
   const quality = useNetworkStore((s) => s.quality);
-  const curvesOpen = useCurveStore((s) => s.overlayOpen);
   if (quality === "healthy") return null;
 
   return (
     <div
       className="network-indicator"
       data-quality={quality}
-      data-curves-open={curvesOpen ? "true" : undefined}
       role="status"
       aria-live="polite"
     >

--- a/demos/realtime_motion_graph_web/web/components/Performance/VoiceTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/VoiceTile.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { useEffect, useState } from "react";
+
 import { useConfig } from "@/lib/config";
 
 import { SliderGroup } from "./SliderGroup";
 import { defaultLabelFor, kbdHintFor } from "./SliderTile";
+
+// localStorage key for the dismissable experimental-feature notice.
+const VOICE_WARNING_DISMISSED_KEY = "demon:voiceWarningDismissed";
 
 // The CHANNELS tab body — the model's internal latent channels. These
 // 14 latent-space sliders are the closest thing this app has to a
@@ -26,17 +31,44 @@ const MORPH = ["ch13", "ch14", "ch19", "ch23", "ch29", "ch56"];
 
 export function VoiceTile() {
   const ranges = useConfig().channel_ranges;
+  // Experimental-feature notice — dismissable, and the dismissal sticks
+  // across reloads. Read after mount (not in the useState initializer)
+  // so a localStorage read can't break SSR hydration.
+  const [warningDismissed, setWarningDismissed] = useState(false);
+  useEffect(() => {
+    try {
+      setWarningDismissed(
+        localStorage.getItem(VOICE_WARNING_DISMISSED_KEY) === "1",
+      );
+    } catch {}
+  }, []);
+  const dismissWarning = () => {
+    try {
+      localStorage.setItem(VOICE_WARNING_DISMISSED_KEY, "1");
+    } catch {}
+    setWarningDismissed(true);
+  };
   return (
     <div className="mixer-tile mixer-tile--voice" data-tile="voice">
-      <div className="voice-tile-warning" role="note">
-        <div className="voice-tile-warning-title">Experimental feature</div>
-        <p className="voice-tile-warning-body">
-          These are not traditional audio channels and gains. They
-          manipulate different dimensions of the model&apos;s latent
-          space, and produce results ranging from nuanced and beautiful
-          to abrupt and discordant. Use at your own risk.
-        </p>
-      </div>
+      {!warningDismissed && (
+        <div className="voice-tile-warning" role="note">
+          <button
+            type="button"
+            className="voice-tile-warning-close"
+            onClick={dismissWarning}
+            aria-label="Dismiss experimental-feature notice"
+          >
+            ×
+          </button>
+          <div className="voice-tile-warning-title">Experimental feature</div>
+          <p className="voice-tile-warning-body">
+            These are not traditional audio channels and gains. They
+            manipulate different dimensions of the model&apos;s latent
+            space, and produce results ranging from nuanced and beautiful
+            to abrupt and discordant. Use at your own risk.
+          </p>
+        </div>
+      )}
       <div className="voice-sections-row">
         <div className="voice-section">
           <div className="voice-section-label">Highlights</div>

--- a/demos/realtime_motion_graph_web/web/hooks/useEdgeLoraBinding.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useEdgeLoraBinding.ts
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { loraDisplayName } from "@/lib/loraLabels";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import {
@@ -65,7 +66,7 @@ function applyDesktopBindings(): void {
 
     if (labelEl) {
       const entry = catalog.find((e) => e.id === id);
-      labelEl.textContent = entry?.name ?? id;
+      labelEl.textContent = loraDisplayName(entry ?? { id });
     }
 
     const strength = strengths[id] ?? 0;
@@ -116,7 +117,7 @@ function applyMobileRightEdge(
   const labelEl = edge.querySelector<HTMLElement>(".install-edge-label");
   const { catalog } = useLoraStore.getState();
   const nameOf = (id: string | null) =>
-    id ? (catalog.find((e) => e.id === id)?.name ?? id) : "—";
+    id ? loraDisplayName(catalog.find((e) => e.id === id) ?? { id }) : "—";
 
   edge.dataset.bar = "lora_blend";
   if (idA && idB) {

--- a/demos/realtime_motion_graph_web/web/hooks/useRenderLoop.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useRenderLoop.ts
@@ -65,6 +65,13 @@ export function useRenderLoop(refs: Refs) {
     const haloHost = document.querySelector(".halo-badge") as HTMLElement | null;
     const halo: HaloRibbon | null = haloHost ? initHaloRibbon(haloHost) : null;
 
+    // Now-playing dock collapse bubble — wears the same writhing ribbon
+    // ring as the halo badge. AudioSourceCrate mounts/unmounts with
+    // session state, so (like the turntable below) re-query each frame
+    // and cache once it appears.
+    let bubbleHalo: HaloRibbon | null = null;
+    let lastBubbleHost: Element | null = null;
+
     // Turntable grooves — concentric polar paths driven by the live audio
     // mirror buffer (the music is literally etched into the disc surface).
     // The button mounts/unmounts with session state so re-query each frame
@@ -230,6 +237,15 @@ export function useRenderLoop(refs: Refs) {
       const ribbonTime = (now - startedAt) / 1000;
       tickRibbons(ribbons, ribbonTime, kick, bloom);
       if (halo) tickHaloRibbon(halo, ribbonTime, kick, bloom);
+      const bubbleHost = document.querySelector(".audio-source-bubble");
+      if (bubbleHost !== lastBubbleHost) {
+        if (bubbleHalo) destroyHaloRibbon(bubbleHalo);
+        bubbleHalo = bubbleHost
+          ? initHaloRibbon(bubbleHost as HTMLElement)
+          : null;
+        lastBubbleHost = bubbleHost;
+      }
+      if (bubbleHalo) tickHaloRibbon(bubbleHalo, ribbonTime, kick, bloom);
       if (startMark) tickStartMarkRibbon(startMark, ribbonTime);
 
       // Turntable: the grooves trace the actual audio waveform from the
@@ -296,6 +312,7 @@ export function useRenderLoop(refs: Refs) {
       if (turntable) destroyTurntable(turntable);
       destroyRibbons(ribbons);
       if (halo) destroyHaloRibbon(halo);
+      if (bubbleHalo) destroyHaloRibbon(bubbleHalo);
     };
   }, [refs.hudCanvas, refs.graphCanvas, refs.effectsCanvas, refs.videoA, refs.videoB]);
 }

--- a/demos/realtime_motion_graph_web/web/lib/loraLabels.ts
+++ b/demos/realtime_motion_graph_web/web/lib/loraLabels.ts
@@ -1,0 +1,24 @@
+// Hardcoded display labels for the bare "v6" LoRAs.
+//
+// These LoRAs ship without a metadata sidecar, so their catalog entry
+// has no `name` and the UI would otherwise fall back to the raw
+// filename stem (`bach`, `deathstep`, …). The team picked these
+// caps-styled names (originally PR #84 / #113). LoRAs that DO carry a
+// real metadata `name` — e.g. the genre LoRAs — are not in this map
+// and keep their own name.
+
+export const LORA_LABELS: Record<string, string> = {
+  deathstep: "DUBSTEP",
+  bach: "BAROQUE",
+  bptkno: "TECHNO",
+  hardrock: "HARDROCK",
+  discofunk: "DISCOFUNK",
+};
+
+/** Display name for a LoRA: hardcoded label → metadata name → id. */
+export function loraDisplayName(entry: {
+  id: string;
+  name?: string | null;
+}): string {
+  return LORA_LABELS[entry.id] ?? (entry.name || entry.id);
+}


### PR DESCRIPTION
A UI pass on the Performance surface. Reviewed via the paired demon-public-demo preview ([#249](https://github.com/daydreamlive/demon-public-demo/pull/249)).

### Now-playing dock
- Dock + save pill aligned to the halo badge — same right/left inset, and a bottom margin equal to the badge's top margin, so the corners read as a symmetric pair.
- The dock **auto-collapses to a music-note bubble** 2s after the pointer leaves and expands back on hover (cross-fade + fold). The bubble wears the **same writhing ribbon ring as the HaloBadge** — `useRenderLoop` re-queries the late-mounting `.audio-source-bubble` (turntable pattern) and ticks its halo ribbon.

### Upload modal — 2-step wizard
- `AlmostReadyDialog` was one cramped 440px modal with three radio fieldsets. Now a **2-step wizard**: step 1 picks the inference source (Full track / Instruments / Vocals as selectable cards), step 2 picks key + time signature (single "Auto-detect"-first selects, no radios). Wider (540px), step indicator, Next/Back/Start nav.

### Smaller fixes
- Hover-help readout (`HudHelpReadout`) moved into the header band — off the waveform scrub strip — and de-loudened (no gradient border / drop-shadow).
- The timbre / structure / input-track **upload buttons** (`.ref-control-upload`) had zero CSS — styled to match the outlined dropdown beside them.
- The CHANNELS-tab "Experimental feature" notice gets a **×** to dismiss it; the dismissal persists in `localStorage`.
- The "unstable connection" pill no longer hops up onto the curve-editor controls when the curve editor opens — it stays put.
- Restored the hardcoded caps display labels for the bare v6 LoRAs (`lib/loraLabels.ts` — BAROQUE / DUBSTEP / TECHNO / …), routed through a shared `loraDisplayName()` helper.

Rebased on `main`, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)