### PR TITLE
fix(rtmg): re-apply timbre/structure refs after a WS reconnect

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/RefControl.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RefControl.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/engine/audio/loadFixture";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
-import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { usePerformanceStore, type RefSource } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
 import type { RemoteBackend } from "@/engine/protocol";
 
@@ -55,6 +55,9 @@ interface KindBinding {
    *  from its local HF cache by name, no PCM round trip. */
   sendFixture: (remote: RemoteBackend, name: string) => void;
   clear: (remote: RemoteBackend) => void;
+  /** Record what was just set (or null on clear) so a WS reconnect can
+   *  re-apply it — consumed by restoreRefs() in useStartSession. */
+  setRef: (ref: RefSource | null) => void;
 }
 
 function bindingFor(kind: RefKind): KindBinding {
@@ -67,6 +70,7 @@ function bindingFor(kind: RefKind): KindBinding {
       send: (r, i, c, n) => r.sendSetTimbreSource(i, c, n),
       sendFixture: (r, n) => r.sendSetTimbreFixture(n),
       clear: (r) => r.sendClearTimbreSource(),
+      setRef: (ref) => usePerformanceStore.getState().setTimbreRef(ref),
     };
   }
   return {
@@ -77,6 +81,7 @@ function bindingFor(kind: RefKind): KindBinding {
     send: (r, i, c, n) => r.sendSetStructureSource(i, c, n),
     sendFixture: (r, n) => r.sendSetStructureFixture(n),
     clear: (r) => r.sendClearStructureSource(),
+    setRef: (ref) => usePerformanceStore.getState().setStructRef(ref),
   };
 }
 
@@ -108,7 +113,10 @@ export function RefControl({ kind }: { kind: RefKind }) {
   function clearActive() {
     const session = useSessionStore.getState();
     if (session.status !== "ready" || !session.remote) return;
-    if (currentName) bind.clear(session.remote);
+    if (currentName) {
+      bind.clear(session.remote);
+      bind.setRef(null);
+    }
   }
 
   async function pickExisting(name: string) {
@@ -123,6 +131,7 @@ export function RefControl({ kind }: { kind: RefKind }) {
     // path because they only exist in the browser.
     if (fixtures.includes(name)) {
       bind.sendFixture(session.remote, name);
+      bind.setRef({ mode: "fixture", name });
       useSessionStore
         .getState()
         .setStatus("ready", `Loading ${bind.statusPrefix} ${name}…`);
@@ -144,7 +153,9 @@ export function RefControl({ kind }: { kind: RefKind }) {
         decoded.channels,
         name,
       );
-      if (!ok) {
+      if (ok) {
+        bind.setRef({ mode: "clip", name });
+      } else {
         useSessionStore
           .getState()
           .setStatus(
@@ -194,7 +205,9 @@ export function RefControl({ kind }: { kind: RefKind }) {
         decoded.channels,
         chosen,
       );
-      if (!ok) {
+      if (ok) {
+        bind.setRef({ mode: "clip", name: chosen });
+      } else {
         setStatus(
           "ready",
           `${bind.statusPrefix[0].toUpperCase()}${bind.statusPrefix.slice(1)} upload failed (socket)`,

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -13,7 +13,7 @@ import { WsReconnector } from "@/engine/wsReconnect";
 import { getConfig } from "@/lib/config";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { useLoraStore } from "@/store/useLoraStore";
-import { usePerformanceStore } from "@/store/usePerformanceStore";
+import { usePerformanceStore, type RefSource } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
 import { isTimeSignature } from "@/types/engine";
 import type { AudioSlice, SessionConfig } from "@/types/protocol";
@@ -292,6 +292,51 @@ async function resolveFixtureForConnect(): Promise<ResolvedFixture | null> {
   return { fixtureName, useServerFixture, interleaved, channels };
 }
 
+/**
+ * Re-apply the operator's timbre / structure references to a freshly
+ * (re)connected backend. The server session boots with no overrides
+ * and refs are NOT part of SessionConfig — so a reconnect would
+ * silently drop them without this. Fixture refs re-send by name; clip
+ * refs re-resolve their PCM from useCustomTracksStore via
+ * loadFixtureAudio. Best-effort: a ref whose source no longer resolves
+ * is skipped (the operator can re-pick it).
+ *
+ * Note: a ref-set that the server REJECTED still leaves its RefSource
+ * recorded, so a later reconnect re-attempts it — harmless (it just
+ * re-fails with the same status message). Perfect failure-rollback
+ * fidelity is a follow-up.
+ */
+async function restoreRefs(remote: RemoteBackend): Promise<void> {
+  const perf = usePerformanceStore.getState();
+  const apply = async (
+    ref: RefSource | null,
+    sendFixture: (name: string) => void,
+    sendSource: (i: Float32Array, c: number, n: string) => boolean,
+  ): Promise<void> => {
+    if (!ref) return;
+    if (ref.mode === "fixture") {
+      sendFixture(ref.name);
+      return;
+    }
+    try {
+      const decoded = await loadFixtureAudio(ref.name);
+      sendSource(decoded.interleaved, decoded.channels, ref.name);
+    } catch {
+      // Source no longer resolvable — skip.
+    }
+  };
+  await apply(
+    perf.timbreRef,
+    (n) => remote.sendSetTimbreFixture(n),
+    (i, c, n) => remote.sendSetTimbreSource(i, c, n),
+  );
+  await apply(
+    perf.structRef,
+    (n) => remote.sendSetStructureFixture(n),
+    (i, c, n) => remote.sendSetStructureSource(i, c, n),
+  );
+}
+
 export function useStartSession() {
   return useCallback(async () => {
     const { setStatus, setSession, reset } = useSessionStore.getState();
@@ -310,6 +355,13 @@ export function useStartSession() {
     // deltas on the first knob wiggle of the new one — a long-
     // reported "knobs go crazy on session start" complaint.
     resetKnobDelta();
+    // A fresh session boots with no timbre / structure override. Drop
+    // any RefSource recorded by a prior session so the reconnect path
+    // (restoreRefs) can't re-apply a ref the operator didn't set this
+    // session. Reconnects go through buildAndConnect, never this hook,
+    // so the in-session record is preserved across a recovery.
+    usePerformanceStore.getState().setTimbreRef(null);
+    usePerformanceStore.getState().setStructRef(null);
 
     setStatus("loading-fixture", "Loading track…");
 
@@ -466,6 +518,11 @@ export function useStartSession() {
           useSessionStore
             .getState()
             .setMonitor(createNetworkMonitor(remote));
+          // Re-apply the timbre / structure references the operator
+          // had active. The fresh server session boots with none and
+          // refs aren't carried in buildConfig, so without this a
+          // reconnect silently drops them.
+          await restoreRefs(remote);
         },
         {
           onAttempt: ({ attempt, maxAttempts }) => {

--- a/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
@@ -271,6 +271,16 @@ const DEFAULT_SLIDER_VALUES: Record<string, number> = {
   steps_override: 8,
 };
 
+/** A re-applyable record of an active timbre / structure reference.
+ *  `timbreName` / `structName` are the server-acked DISPLAY name
+ *  (cleared whenever the session leaves "ready"); this is the client's
+ *  own record of WHAT it set, kept so a WS reconnect can re-send it to
+ *  the fresh server session. `clip` refs re-resolve their PCM from
+ *  useCustomTracksStore via loadFixtureAudio, so no buffer is stored. */
+export type RefSource =
+  | { mode: "fixture"; name: string }
+  | { mode: "clip"; name: string };
+
 interface PerformanceState {
   /** Per-param defaults used by double-click reset, long-press snap-back,
    *  and idle reset. Seeded from DEFAULT_SLIDER_VALUES and overwritten by
@@ -327,6 +337,12 @@ interface PerformanceState {
    *  semantic hints). Set/cleared by structure_set / structure_cleared
    *  acks. Per-session — not persisted. */
   structName: string | null;
+  /** Client-side record of the active timbre / structure references —
+   *  enough to re-send them after a WS reconnect (the fresh server
+   *  session boots with no overrides, and refs aren't part of the
+   *  session config). Null when no override is active. */
+  timbreRef: RefSource | null;
+  structRef: RefSource | null;
   /** Detected musical metadata from server's "ready" frame. */
   detectedBpm: number | null;
   detectedKey: string | null;
@@ -428,6 +444,8 @@ interface PerformanceState {
   setFixture: (name: string) => void;
   setTimbreName: (name: string | null) => void;
   setStructName: (name: string | null) => void;
+  setTimbreRef: (ref: RefSource | null) => void;
+  setStructRef: (ref: RefSource | null) => void;
   /** Update server-reported metadata. ``timeSignature`` is optional for
    *  call-site convenience (older callers only carry bpm + key); when
    *  omitted, ``detectedTimeSignature`` is left untouched. As with key,
@@ -543,6 +561,8 @@ export const usePerformanceStore = create<PerformanceState>((set) => ({
   fixture: "",
   timbreName: null,
   structName: null,
+  timbreRef: null,
+  structRef: null,
   detectedBpm: null,
   detectedKey: null,
   detectedTimeSignature: null,
@@ -641,6 +661,8 @@ export const usePerformanceStore = create<PerformanceState>((set) => ({
   setFixture: (name) => set({ fixture: name }),
   setTimbreName: (name) => set({ timbreName: name }),
   setStructName: (name) => set({ structName: name }),
+  setTimbreRef: (ref) => set({ timbreRef: ref }),
+  setStructRef: (ref) => set({ structRef: ref }),
   setDetected: (bpm, key, timeSignature) =>
     set((s) => ({
       detectedBpm: bpm,


### PR DESCRIPTION
Stacked on **DEMON #132** (`fix/1006-handshake-recovery`, the 1006 auto-reconnect).

> Base branch `gio/base/pr-132` is a snapshot of #132's branch — #132 lives on a fork, and GitHub can't base an upstream PR on a fork branch, so this is the workaround. **Once #132 merges, retarget this PR to `main`.** The diff here is exactly the 3-file ref-restore change.

## Gap in the 1006 reconnect

The auto-reconnect rebuilds the session from `buildConfig()`, which carries `enabled_loras` / `prompt` / `fixture` — but **not** the timbre/structure reference overrides. Those are set through separate one-shot WS messages (`set_timbre_source`/`set_timbre_fixture`, `set_structure_source`/`set_structure_fixture`), and nothing on the reconnect path re-sends them.

So after any 1006, the recovered server session runs with **no timbre/structure ref** — the operator's selection is silently dropped on a network blip. `usePerformanceStore` only kept the server-acked display name (`timbreName`/`structName`), which is cleared whenever the session leaves `"ready"` and can't tell a Library fixture from an uploaded clip — not enough to replay.

## Fix (3 files, +97/−5)

- **`usePerformanceStore`** — add `timbreRef`/`structRef`: a re-applyable `RefSource = {mode:"fixture"|"clip", name}`. No PCM stored — clip refs already live in `useCustomTracksStore` and re-resolve via `loadFixtureAudio`.
- **`RefControl`** — record the `RefSource` on every set (fixture pick / clip upload); clear it on "Input Track".
- **`useStartSession`** — new `restoreRefs()` re-sends both refs in the reconnect factory after `setSession`; the fresh-Play path clears the records so a new session can't inherit a prior ref.

## Known limitation

A ref-set the server *rejected* still leaves its `RefSource` recorded, so a later reconnect re-attempts it — harmless (re-fails with the same status message). Perfect failure-rollback fidelity is a follow-up.

`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)