### PR TITLE
rtmg: loop UX (grid snap) + config import fixes + mobile/playhead polish

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -6685,11 +6685,21 @@ body.curve-open #install-video-area #graph {
 .waveform-scrub-box {
   position: fixed;
   top: max(calc(var(--hud-thickness) + 24px), env(safe-area-inset-top, 0px));
-  left:  max(
-    calc(var(--hud-thickness) + 144px + var(--drawer-l-open, 0px)),
+  /* Horizontal insets match .schedule-curves-overlay exactly so the
+     scrub strip and the curve overlay share the same left/right edges
+     (they previously used a hand-tuned 144px/80px that drifted ~50px
+     off the overlay). */
+  left: max(
+    calc(
+      var(--hud-thickness) + var(--ribbon-bleed) + var(--remix-hint-extend)
+      + 12px + var(--drawer-l-open, 0px)
+    ),
     env(safe-area-inset-left, 0px)
   );
-  right: max(calc(var(--hud-thickness) + 80px),  env(safe-area-inset-right, 0px));
+  right: max(
+    calc(var(--hud-thickness) + var(--ribbon-bleed) + var(--remix-hint-extend) + 12px),
+    env(safe-area-inset-right, 0px)
+  );
   height: 48px;
   z-index: 4;
   cursor: ew-resize;

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -6714,6 +6714,39 @@ body.curve-open #install-video-area #graph {
   display: block;
   pointer-events: none;
 }
+/* While loop mode is armed the strip drags out a loop band rather than
+   scrubbing — reflect that in the cursor. */
+.waveform-scrub-box[data-loop-mode="true"] {
+  cursor: crosshair;
+}
+/* LOOP toggle — the discoverable entry point for the loop band. Sits in
+   the top-left corner of the strip; flat per the design language. */
+.waveform-loop-toggle {
+  position: absolute;
+  top: 4px;
+  left: 6px;
+  z-index: 2;
+  padding: 2px 8px;
+  font: 600 9px/1.4 var(--font-ui, ui-sans-serif), sans-serif;
+  letter-spacing: 0.08em;
+  border-radius: 4px;
+  background: rgba(10, 8, 6, 0.55);
+  color: rgba(255, 222, 196, 0.62);
+  border: 1px solid rgba(255, 222, 196, 0.22);
+  cursor: pointer;
+  pointer-events: auto;
+  transition: background 120ms ease-out, color 120ms ease-out,
+    border-color 120ms ease-out;
+}
+.waveform-loop-toggle:hover {
+  color: rgba(255, 222, 196, 0.95);
+  border-color: rgba(255, 222, 196, 0.45);
+}
+.waveform-loop-toggle[data-active="true"] {
+  background: rgba(240, 138, 72, 0.9);
+  color: #1a0e05;
+  border-color: transparent;
+}
 
 /* ── Custom tooltip (replaces native `title=` for hover-visible UI) ──
    Opt-in via `data-dd-tooltip="..."`. The element must have

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -4868,6 +4868,7 @@ body.curve-open #install-video-area #graph {
   scroll-behavior: smooth;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
+  overscroll-behavior-x: contain;
 }
 .lite-tab-body::-webkit-scrollbar { display: none; }
 .lite-tab-section {
@@ -6508,6 +6509,10 @@ body.curve-open #install-video-area #graph {
   scrollbar-width: none;
   padding: 6px 12px 8px;
   -webkit-overflow-scrolling: touch;
+  /* This carousel is nested inside the Mix/Track scroll-snap track.
+     Without containment, swiping the chips chains the scroll out to
+     the parent and snaps back to the Mix tab. */
+  overscroll-behavior-x: contain;
 }
 .lite-track-carousel-scroll::-webkit-scrollbar { display: none; }
 .lite-track-carousel-empty {

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -6734,9 +6734,17 @@ body.curve-open #install-video-area #graph {
   color: rgba(255, 222, 196, 0.62);
   border: 1px solid rgba(255, 222, 196, 0.22);
   cursor: pointer;
+  /* Hidden until the operator hovers the scrub strip (or a loop is
+     active) — so it never sits in the way of a scrub click. */
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease-out, background 120ms ease-out,
+    color 120ms ease-out, border-color 120ms ease-out;
+}
+.waveform-scrub-box:hover .waveform-loop-toggle,
+.waveform-loop-toggle[data-active="true"] {
+  opacity: 1;
   pointer-events: auto;
-  transition: background 120ms ease-out, color 120ms ease-out,
-    border-color 120ms ease-out;
 }
 .waveform-loop-toggle:hover {
   color: rgba(255, 222, 196, 0.95);

--- a/demos/realtime_motion_graph_web/web/components/Performance/CollapsibleTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/CollapsibleTile.tsx
@@ -7,6 +7,13 @@ import { useState, type ReactNode } from "react";
 // closed by default, expand to manage what's inside. The header
 // replaces the wrapped tile's own `.mixer-tile-label` (hidden via CSS
 // while inside `.styles-accordion-body`).
+//
+// Open/closed state persists per `title` for the page's lifetime via a
+// module-level map: switching tabs or closing/reopening the Advanced
+// drawer unmounts these tiles, and a plain useState would forget the
+// user's expansion every time.
+
+const openByTitle = new Map<string, boolean>();
 
 export function CollapsibleTile({
   title,
@@ -17,13 +24,22 @@ export function CollapsibleTile({
   defaultOpen?: boolean;
   children: ReactNode;
 }) {
-  const [open, setOpen] = useState(defaultOpen);
+  const [open, setOpen] = useState(
+    () => openByTitle.get(title) ?? defaultOpen,
+  );
+  const toggle = () => {
+    setOpen((o) => {
+      const next = !o;
+      openByTitle.set(title, next);
+      return next;
+    });
+  };
   return (
     <div className={`styles-accordion${open ? " open" : ""}`}>
       <button
         type="button"
         className="styles-accordion-head"
-        onClick={() => setOpen((o) => !o)}
+        onClick={toggle}
         aria-expanded={open}
       >
         <span className="styles-accordion-caret" aria-hidden="true">

--- a/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
@@ -23,6 +23,18 @@ import {
 
 import { MidiBadge } from "./MidiBadge";
 
+// Show a transient status message that clears itself after 2s — unless a
+// newer message replaced it meanwhile. Used for the import/export toasts,
+// which otherwise stuck on screen indefinitely.
+function flashStatus(message: string): void {
+  const ss = useSessionStore.getState();
+  ss.setStatus(ss.status, message);
+  window.setTimeout(() => {
+    const cur = useSessionStore.getState();
+    if (cur.message === message) cur.setStatus(cur.status, "");
+  }, 2000);
+}
+
 export function OperatorStrip() {
   const activeKey = usePerformanceStore((s) => s.activeKey);
   const activeTimeSignature = usePerformanceStore((s) => s.activeTimeSignature);
@@ -79,7 +91,6 @@ export function OperatorStrip() {
   // operator-edited fields the user didn't touch in the imported file
   // keep their current values.
   async function onConfigFilePicked(file: File): Promise<void> {
-    const { setStatus } = useSessionStore.getState();
     try {
       const text = await file.text();
       const parsed = JSON.parse(text) as Partial<RtmgConfig>;
@@ -88,10 +99,10 @@ export function OperatorStrip() {
       }
       const merged = mergeConfig(getConfig(), parsed);
       applyConfig(merged);
-      setStatus(useSessionStore.getState().status, `Imported ${file.name}`);
+      flashStatus(`Imported ${file.name}`);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      setStatus(useSessionStore.getState().status, `Import failed: ${msg}`);
+      flashStatus(`Import failed: ${msg}`);
     }
   }
 
@@ -112,8 +123,7 @@ export function OperatorStrip() {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-    const { setStatus } = useSessionStore.getState();
-    setStatus(useSessionStore.getState().status, `Exported config`);
+    flashStatus("Exported config");
   }
 
   // The pod's WS URL is allocated by the queue and not user-editable.

--- a/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
@@ -10,7 +10,6 @@ import {
   mergeConfig,
   type RtmgConfig,
 } from "@/lib/config";
-import { LOCAL_MODE } from "@/lib/runtime";
 import { confirm } from "@/store/useConfirmStore";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
@@ -335,42 +334,40 @@ export function OperatorStrip() {
         </div>
       </section>
 
-      {LOCAL_MODE && (
-        <section className="operator-section">
-          <h3 className="operator-section-label">Local dev</h3>
-          <div className="operator-row">
-            <button
-              type="button"
-              className="pause-btn"
-              data-dd-tooltip="Import config from JSON"
-              aria-label="Import config"
-              onClick={() => configFileInputRef.current?.click()}
-            >
-              Import
-            </button>
-            <button
-              type="button"
-              className="pause-btn"
-              data-dd-tooltip="Download current config as JSON"
-              aria-label="Export config"
-              onClick={onExportConfig}
-            >
-              Export
-            </button>
-            <input
-              ref={configFileInputRef}
-              type="file"
-              accept=".json,application/json"
-              style={{ display: "none" }}
-              onChange={(e) => {
-                const file = e.target.files?.[0];
-                e.target.value = "";
-                if (file) void onConfigFilePicked(file);
-              }}
-            />
-          </div>
-        </section>
-      )}
+      <section className="operator-section">
+        <h3 className="operator-section-label">Config</h3>
+        <div className="operator-row">
+          <button
+            type="button"
+            className="pause-btn"
+            data-dd-tooltip="Import config from JSON"
+            aria-label="Import config"
+            onClick={() => configFileInputRef.current?.click()}
+          >
+            Import
+          </button>
+          <button
+            type="button"
+            className="pause-btn"
+            data-dd-tooltip="Download current config as JSON"
+            aria-label="Export config"
+            onClick={onExportConfig}
+          >
+            Export
+          </button>
+          <input
+            ref={configFileInputRef}
+            type="file"
+            accept=".json,application/json"
+            style={{ display: "none" }}
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              e.target.value = "";
+              if (file) void onConfigFilePicked(file);
+            }}
+          />
+        </div>
+      </section>
 
     </div>
   );

--- a/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/ScheduleCurvesOverlay.tsx
@@ -406,7 +406,13 @@ export function ScheduleCurvesOverlay() {
       const remote = session.remote;
       if (player && remote && remote.duration > 0) {
         const t = Math.min(1, Math.max(0, player.positionSec / remote.duration));
-        const { cx: xp } = curveToPx(t, 0, w, h);
+        // The playhead x must line up with the scrub-strip playhead,
+        // which insets 4px (WaveformScrubBox EDGE_PADDING_PX) — not the
+        // 16px inset the curve geometry uses. Both canvases share the
+        // same width + screen-x (their containers' CSS insets match), so
+        // matching the inset makes the two playheads exactly coincident.
+        const SCRUB_EDGE_PX = 4;
+        const xp = SCRUB_EDGE_PX + t * Math.max(1, w - 2 * SCRUB_EDGE_PX);
         const { cy: yTop } = curveToPx(0, 1, w, h);
         const { cy: yBot } = curveToPx(0, 0, w, h);
         ctx.strokeStyle = "rgba(240, 138, 72, 0.85)";

--- a/demos/realtime_motion_graph_web/web/components/Performance/WaveformScrubBox.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/WaveformScrubBox.tsx
@@ -315,6 +315,14 @@ export function WaveformScrubBox() {
     const onDown = (e: PointerEvent) => {
       // Right-click → clear band (handled in contextmenu). Ignore here.
       if (e.button !== 0) return;
+      // A press on the LOOP toggle (a child of this box) must not also
+      // scrub: the native event still bubbles to this listener even
+      // though the button calls React's synthetic stopPropagation.
+      if (
+        (e.target as HTMLElement | null)?.closest?.(".waveform-loop-toggle")
+      ) {
+        return;
+      }
 
       const t = tFromEvent(e);
       const band = bandRef.current;
@@ -504,7 +512,6 @@ export function WaveformScrubBox() {
             ? "Clear the loop"
             : "Arm loop mode, then drag across the waveform to set a loop"
         }
-        onPointerDown={(e) => e.stopPropagation()}
         onClick={(e) => {
           e.stopPropagation();
           toggleLoop();

--- a/demos/realtime_motion_graph_web/web/components/Performance/WaveformScrubBox.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/WaveformScrubBox.tsx
@@ -6,6 +6,7 @@ import { computePeaks, drawPeaks } from "@/engine/curves/waveformPeaks";
 import { frameScheduler } from "@/engine/scheduler/FrameScheduler";
 import { useOneShotTooltip } from "@/hooks/useOneShotTooltip";
 import { useCurveStore } from "@/store/useCurveStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
 
 // Bottom-center scrub strip. Shows the source-track waveform, overlays
@@ -20,11 +21,19 @@ import { useSessionStore } from "@/store/useSessionStore";
 // protocol message is involved — see audio-worklet.js:106 and
 // AudioPlayer.seek():339.
 //
-// Loop bands (v1):
-//   • Shift + drag      → draw a new band (start at down, end at up)
+// Loop bands (v2):
+//   • LOOP button       → arm "loop mode"; while armed a plain drag on
+//                          the waveform draws a band (no Shift needed).
+//                          Click again clears the loop entirely.
+//   • Shift + drag      → draw a band without arming (power-user shortcut)
 //   • Drag band body    → move the whole band
 //   • Drag band edge    → resize that edge
 //   • Right-click band  → clear
+// Band edges snap to the musical grid (bars + beats, from the detected
+// BPM + time signature); hold Alt while dragging for a free, un-snapped
+// adjustment. The grid itself is drawn faintly on the strip so bar
+// boundaries are visible at a glance.
+//
 // All client-side via AudioPlayer.setLoopBand/clearLoopBand, which the
 // AudioWorklet honours by wrapping end→start on each pass.
 
@@ -51,7 +60,14 @@ function ensureCanvasSize(canvas: HTMLCanvasElement): {
   return { w, h, dpr };
 }
 
+/** Snap a time to the nearest beat. `beatSec <= 0` (BPM unknown) → no-op. */
+function snapToBeat(t: number, beatSec: number): number {
+  if (beatSec <= 0) return t;
+  return Math.round(t / beatSec) * beatSec;
+}
+
 type Band = { start: number; end: number };
+type Grid = { beatSec: number; beatsPerBar: number };
 type DragMode =
   | "seek"
   | "draw-band"
@@ -73,6 +89,9 @@ interface DragState {
 export function WaveformScrubBox() {
   const player = useSessionStore((s) => s.player);
   const curvesOpen = useCurveStore((s) => s.overlayOpen);
+  // Musical grid inputs — drive both the drawn grid and edge snapping.
+  const detectedBpm = usePerformanceStore((s) => s.detectedBpm);
+  const timeSignature = usePerformanceStore((s) => s.activeTimeSignature);
   const boxRef = useRef<HTMLDivElement>(null);
   const bgCanvasRef = useRef<HTMLCanvasElement>(null);
   const fgCanvasRef = useRef<HTMLCanvasElement>(null);
@@ -84,6 +103,19 @@ export function WaveformScrubBox() {
   const [bandState, setBandState] = useState<Band | null>(null);
   const bandRef = useRef<Band | null>(null);
   bandRef.current = bandState;
+
+  // Loop mode: when armed, a plain drag on the waveform draws/edits the
+  // band (Shift no longer required). The pointer handlers read the ref.
+  const [loopMode, setLoopMode] = useState(false);
+  const loopModeRef = useRef(false);
+  loopModeRef.current = loopMode;
+
+  // Beat grid, recomputed each render and shared with the rAF tick +
+  // pointer handlers via a ref.
+  const beatsPerBar = Math.max(1, parseInt(String(timeSignature), 10) || 4);
+  const beatSec = detectedBpm && detectedBpm > 0 ? 60 / detectedBpm : 0;
+  const gridRef = useRef<Grid>({ beatSec: 0, beatsPerBar: 4 });
+  gridRef.current = { beatSec, beatsPerBar };
 
   const [hasPeaks, setHasPeaks] = useState(false);
   const hasPlayer = player !== null;
@@ -142,7 +174,7 @@ export function WaveformScrubBox() {
     };
   }, [hasPlayer, player]);
 
-  // ── Foreground canvas: playhead + active band ─────────────────────
+  // ── Foreground canvas: grid + playhead + active band ──────────────
   useEffect(() => {
     if (!hasPlayer) return;
     const canvas = fgCanvasRef.current;
@@ -162,6 +194,26 @@ export function WaveformScrubBox() {
 
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       ctx.clearRect(0, 0, w, h);
+
+      // Beat grid — faint beat lines, brighter bar lines. Lets the
+      // operator see where bars start (and where edges will snap).
+      const grid = gridRef.current;
+      if (grid.beatSec > 0) {
+        const beatPath = new Path2D();
+        const barPath = new Path2D();
+        let i = 0;
+        for (let tb = 0; tb <= duration + 1e-6; tb += grid.beatSec, i++) {
+          const gx = tToX(tb);
+          const path = i % grid.beatsPerBar === 0 ? barPath : beatPath;
+          path.moveTo(gx, 0);
+          path.lineTo(gx, h);
+        }
+        ctx.lineWidth = 1;
+        ctx.strokeStyle = "rgba(255, 255, 255, 0.05)";
+        ctx.stroke(beatPath);
+        ctx.strokeStyle = "rgba(255, 222, 196, 0.20)";
+        ctx.stroke(barPath);
+      }
 
       // Active band — translucent orange rect.
       const band = bandRef.current;
@@ -256,42 +308,41 @@ export function WaveformScrubBox() {
       return p.duration / innerW;
     };
 
+    /** Snap a time to the beat grid unless Alt is held (free adjust). */
+    const snapT = (t: number, e: PointerEvent): number =>
+      e.altKey ? t : snapToBeat(t, gridRef.current.beatSec);
+
     const onDown = (e: PointerEvent) => {
-      // Right-click → clear band (if any). Don't preventDefault here —
-      // contextmenu handler below also fires and is the place to
-      // suppress the browser's native menu.
-      if (e.button === 2) return;
+      // Right-click → clear band (handled in contextmenu). Ignore here.
       if (e.button !== 0) return;
 
       const t = tFromEvent(e);
       const band = bandRef.current;
       const tol = secPerPx() * BAND_EDGE_HIT_PX;
+      // Loop editing is active when the user armed loop mode OR is
+      // holding Shift (the power-user shortcut).
+      const loopEditing = e.shiftKey || loopModeRef.current;
 
       let mode: DragMode = "seek";
       let anchorT = t;
       let startBand: Band | undefined;
 
-      if (e.shiftKey) {
-        // Draw a brand-new band from this point. Clears any existing one
-        // so the user always sees their freshest gesture.
+      if (band && Math.abs(t - band.start) <= tol) {
+        mode = "resize-band-start";
+      } else if (band && Math.abs(t - band.end) <= tol) {
+        mode = "resize-band-end";
+      } else if (band && t >= band.start && t <= band.end) {
+        mode = "move-band";
+        anchorT = t;
+        startBand = { ...band };
+      } else if (loopEditing) {
+        // Draw a brand-new band from this point (snapped to the grid).
         mode = "draw-band";
-        setBandState({ start: t, end: t });
-      } else if (band) {
-        // Existing band — check for edge / body hits.
-        if (Math.abs(t - band.start) <= tol) {
-          mode = "resize-band-start";
-        } else if (Math.abs(t - band.end) <= tol) {
-          mode = "resize-band-end";
-        } else if (t >= band.start && t <= band.end) {
-          mode = "move-band";
-          anchorT = t;
-          startBand = { ...band };
-        } else {
-          // Plain click outside the band — regular seek. Leave the band
-          // in place; the worklet keeps looping it. (Seeks outside the
-          // band fall back into it on the next wrap.)
-          mode = "seek";
-        }
+        anchorT = snapT(t, e);
+        setBandState({ start: anchorT, end: anchorT });
+      } else {
+        // Plain click outside any band → regular seek.
+        mode = "seek";
       }
 
       drag = { mode, anchorT, startBand };
@@ -315,8 +366,9 @@ export function WaveformScrubBox() {
           return;
         case "draw-band": {
           const a = drag.anchorT;
-          const start = Math.max(0, Math.min(a, t));
-          const end = Math.min(duration, Math.max(a, t));
+          const ts = snapT(t, e);
+          const start = Math.max(0, Math.min(a, ts));
+          const end = Math.min(duration, Math.max(a, ts));
           setBandState({ start, end });
           return;
         }
@@ -325,24 +377,27 @@ export function WaveformScrubBox() {
           if (!sb) return;
           const len = sb.end - sb.start;
           const delta = t - drag.anchorT;
-          let start = sb.start + delta;
-          let end = sb.end + delta;
+          let start = snapT(sb.start + delta, e);
+          let end = start + len;
           // Clamp to buffer ends without resizing.
           if (start < 0) {
-            end -= start;
             start = 0;
+            end = len;
           }
           if (end > duration) {
-            start -= end - duration;
             end = duration;
+            start = end - len;
           }
-          setBandState({ start, end: start + len });
+          setBandState({ start, end });
           return;
         }
         case "resize-band-start": {
           const b = bandRef.current;
           if (!b) return;
-          const newStart = Math.min(b.end - MIN_BAND_SEC, Math.max(0, t));
+          const newStart = Math.min(
+            b.end - MIN_BAND_SEC,
+            Math.max(0, snapT(t, e)),
+          );
           setBandState({ start: newStart, end: b.end });
           return;
         }
@@ -351,7 +406,7 @@ export function WaveformScrubBox() {
           if (!b) return;
           const newEnd = Math.max(
             b.start + MIN_BAND_SEC,
-            Math.min(duration, t),
+            Math.min(duration, snapT(t, e)),
           );
           setBandState({ start: b.start, end: newEnd });
           return;
@@ -362,8 +417,8 @@ export function WaveformScrubBox() {
     const onUp = (e: PointerEvent) => {
       if (!drag) return;
       // Draw mode finalises on release: if the user just tap-clicked
-      // with shift (no drag), kill the band so we don't lock playback
-      // to a zero-width sliver.
+      // (no real drag), kill the band so we don't lock playback to a
+      // zero-width sliver.
       if (drag.mode === "draw-band") {
         const b = bandRef.current;
         if (!b || b.end - b.start < MIN_BAND_SEC) {
@@ -400,11 +455,24 @@ export function WaveformScrubBox() {
     };
   }, [hasPlayer]);
 
-  // One-shot tooltip on first hover — teach Shift+drag = loop band.
+  // One-shot tooltip on first hover.
   const tipProps = useOneShotTooltip(
     "waveform-scrub",
-    "Click to scrub · Shift + drag to loop",
+    "Click to scrub · LOOP to set a loop region",
   );
+
+  // LOOP button: with no loop set, arms loop mode (a plain drag then
+  // draws the band). With a loop active, clears it. Mirrors the single
+  // on/off mental model operators expect from a loop toggle.
+  const loopActive = loopMode || bandState !== null;
+  const toggleLoop = () => {
+    if (loopActive) {
+      setLoopMode(false);
+      setBandState(null);
+    } else {
+      setLoopMode(true);
+    }
+  };
 
   // Render the DOM as soon as we have a player so the peak-compute
   // effect can find the canvases in the DOM. The strip stays visually
@@ -418,6 +486,7 @@ export function WaveformScrubBox() {
       data-curves-open={curvesOpen ? "true" : undefined}
       data-ready={hasPeaks ? "true" : undefined}
       data-has-band={bandState ? "true" : undefined}
+      data-loop-mode={loopMode ? "true" : undefined}
       data-dd-tooltip-pos="below"
       role="slider"
       aria-label="Scrub playhead"
@@ -425,6 +494,24 @@ export function WaveformScrubBox() {
     >
       <canvas ref={bgCanvasRef} className="waveform-scrub-bg" aria-hidden="true" />
       <canvas ref={fgCanvasRef} className="waveform-scrub-fg" aria-hidden="true" />
+      <button
+        type="button"
+        className="waveform-loop-toggle"
+        data-active={loopActive ? "true" : undefined}
+        aria-pressed={loopActive}
+        title={
+          loopActive
+            ? "Clear the loop"
+            : "Arm loop mode, then drag across the waveform to set a loop"
+        }
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation();
+          toggleLoop();
+        }}
+      >
+        LOOP
+      </button>
     </div>
   );
 }

--- a/demos/realtime_motion_graph_web/web/lib/config.ts
+++ b/demos/realtime_motion_graph_web/web/lib/config.ts
@@ -475,6 +475,7 @@ export function selectVariant(cfg: RtmgConfig, scale: string | null): RtmgConfig
 export function applyConfig(c: RtmgConfig): void {
   const scale = useSessionStore.getState().checkpointScale;
   const resolved = selectVariant(c, scale);
+  const firstApply = !_configApplied;
   _activeConfig = resolved;
   _configApplied = true;
 
@@ -531,15 +532,47 @@ export function applyConfig(c: RtmgConfig): void {
     });
   }
 
-  // If a setCatalog landed before applyConfig (LibraryTile's mount-time
-  // /api/loras winning the race against /config.json), the lora store
-  // stashed the catalog but skipped seeding because the config wasn't
-  // ready yet. Re-trigger setCatalog with the existing catalog so the
-  // store's own once-per-session gate (`seeded`) runs against the
-  // correct enabled_loras.
+  // LoRA enable/strength state.
+  //
+  // First applyConfig (boot): if a catalog landed before us (LibraryTile's
+  // mount-time /api/loras winning the race against /config.json), the
+  // store stashed the catalog but skipped seeding. Re-trigger setCatalog
+  // so its once-per-session gate runs against the real enabled_loras.
+  //
+  // Later applyConfig (an imported config): the store is already seeded,
+  // so setCatalog's gate would ignore the new enabled_loras. reset()
+  // re-seeds enabled+strengths from the fresh config. The LoRA UI
+  // normally sends enable/disable to the engine on click — an import
+  // bypasses that path, so push the diff to the engine here and
+  // re-encode the prompt so the trigger prefix matches.
   const lora = useLoraStore.getState();
-  if (!lora.seeded && lora.catalog.length > 0) {
-    lora.setCatalog(lora.catalog);
+  if (firstApply) {
+    if (!lora.seeded && lora.catalog.length > 0) {
+      lora.setCatalog(lora.catalog);
+    }
+  } else if (lora.catalog.length > 0) {
+    const before = new Set(lora.enabled);
+    lora.reset();
+    const after = useLoraStore.getState();
+    const remote = useSessionStore.getState().remote;
+    if (remote) {
+      for (const id of before) {
+        if (!after.enabled.has(id)) remote.sendDisableLora(id);
+      }
+      for (const id of after.enabled) {
+        if (!before.has(id)) {
+          remote.sendEnableLora(id, after.strengths[id] ?? 0);
+        }
+      }
+      remote.sendPrompt(
+        resolved.prompts.a,
+        resolved.engine.key,
+        isTimeSignature(resolved.engine.time_signature)
+          ? resolved.engine.time_signature
+          : DEFAULT_TIME_SIGNATURE,
+        resolved.prompts.b,
+      );
+    }
   }
 
   for (const fn of listeners) fn(resolved);

--- a/demos/realtime_motion_graph_web/web/lib/config.ts
+++ b/demos/realtime_motion_graph_web/web/lib/config.ts
@@ -258,7 +258,7 @@ export const DEFAULT_CONFIG: RtmgConfig = {
   },
   controls: {
     denoise: 0.7,
-    hint_strength: 1.4,
+    hint_strength: 1.0,
     feedback: 0.0,
     feedback_depth: 1,
     shift: 3.5,


### PR DESCRIPTION
Bundled rtmg web polish.

### Loop UX
- A **LOOP toggle** on the scrub strip arms "loop mode" — a plain drag then draws the band (no Shift). Hover-reveal so it never blocks a scrub click; click again clears the loop.
- The strip draws a faint **beat grid** with brighter bar lines (detected BPM + time signature); loop edges **snap to the nearest beat**, Alt for free placement.

### Config import / export
- Import now re-applies **LoRAs** (re-seeds + pushes the enable/disable diff + prompt to the engine — an import previously bypassed the click-path that does this).
- The "Imported …/Exported config" status toast auto-clears after 2s.
- Import/Export buttons un-gated from `LOCAL_MODE` into a "Config" section.

### Fixes
- `Structure` (hint_strength) default 1.4 → 1.0 (its slider max is 1.0).
- Tags / LoRA accordions persist their open/closed state across tab switches + drawer reopen.
- Scrub strip aligned to `.schedule-curves-overlay` insets (was ~50px off).
- Scheduled-curve **playhead** aligned exactly with the scrub-strip playhead.
- Mobile **Mix/Track** tabs: the nested track carousel no longer chains its swipe out to the parent (`overscroll-behavior-x: contain`).

Touches `WaveformScrubBox`, `ScheduleCurvesOverlay`, `CollapsibleTile`, `OperatorStrip`, `lib/config.ts`, `globals.css`.