### PR TITLE
rtmg/mobile — fix Lite Mix/Track overlap + recursion + audio-resume hang

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -4978,24 +4978,19 @@ body.curve-open #install-video-area #graph {
    IntersectionObserver mirrors scroll position back into React
    state. Hide the native scrollbar so the track reads as content,
    not a scroller. */
+/* The tab body simply hosts the active section — Mix or Track. The
+   previous scroll-snap carousel left both sections rendering on top
+   of each other on iOS Safari and let the inner track-carousel swipe
+   leak out to the outer scroller; LiteControls now mounts one
+   section at a time, so the container just needs to host it. */
 .lite-tab-body {
   display: flex;
-  flex-direction: row;
-  overflow-x: auto;
-  overflow-y: hidden;
-  scroll-snap-type: x mandatory;
-  scroll-behavior: smooth;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
-  overscroll-behavior-x: contain;
+  flex-direction: column;
+  min-height: 0;
 }
-.lite-tab-body::-webkit-scrollbar { display: none; }
 .lite-tab-section {
-  flex: 0 0 100%;
   width: 100%;
   box-sizing: border-box;
-  scroll-snap-align: start;
-  scroll-snap-stop: always;
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteControls.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteControls.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useRef } from "react";
-
-import { useScrollSyncedTabs } from "@/hooks/useScrollSyncedTabs";
+import { useState } from "react";
 
 import { LiteTrackCarousel } from "./LiteTrackCarousel";
 import { RecordToggle } from "./RecordToggle";
@@ -25,21 +23,19 @@ const TAB_LABELS: Record<LiteTab, string> = {
   track: "Track",
 };
 
-// Wave 13.5: tabbed + swipeable. Two sections live side-by-side in a
-// scroll-snap track; tap a tab pill or swipe horizontally to switch.
-// IntersectionObserver mirrors the scroll-position back into `tab` so
-// the active pill stays in sync regardless of input method.
+// Mobile mixer bay. A simple two-pill tab strip switches between two
+// content sections — Mix and Track — that render conditionally (only
+// the active one is mounted). The previous scroll-snap carousel
+// implementation overlapped both sections on iOS Safari and let the
+// inner track-carousel swipe leak out to the outer scroller; replacing
+// it with conditional render eliminates both classes of bug at the
+// cost of losing the swipe-to-switch gesture.
 //
 //   MIX   — 4 faders (denoise / structure / feedback / lora_blend) +
 //           "All controls" gateway to the full 7-tab sheet.
 //   TRACK — track carousel (upload + mic inside the picker) + REC.
 export function LiteControls({ onOpenAllControls, unsavedDot }: Props) {
-  const trackRef = useRef<HTMLDivElement | null>(null);
-  const { activeTab: tab, gotoTab } = useScrollSyncedTabs<LiteTab>(
-    trackRef,
-    TABS,
-    { attribute: "tab", initial: "mix" },
-  );
+  const [tab, setTab] = useState<LiteTab>("mix");
 
   return (
     <div className="lite-controls">
@@ -55,7 +51,7 @@ export function LiteControls({ onOpenAllControls, unsavedDot }: Props) {
             role="tab"
             aria-selected={tab === t}
             className={`lite-tab${tab === t ? " lite-tab--active" : ""}`}
-            onClick={() => gotoTab(t)}
+            onClick={() => setTab(t)}
           >
             {TAB_LABELS[t]}
             {/* Unsaved dot surfaces on whichever pill isn't currently
@@ -69,37 +65,40 @@ export function LiteControls({ onOpenAllControls, unsavedDot }: Props) {
           </button>
         ))}
       </div>
-      <div ref={trackRef} className="lite-tab-body">
-        <section data-tab="mix" className="lite-tab-section">
-          <div className="lite-row lite-row--main">
-            <SliderGroup param="denoise" label="denoise" />
-            <SliderGroup param="hint_strength" label="structure" />
-            <SliderGroup param="feedback" label="feedback" />
-            <SliderGroup param="lora_blend" label="lora blend" />
-          </div>
-          <button
-            type="button"
-            className="lite-all-controls"
-            onClick={onOpenAllControls}
-            aria-label="All controls"
-            data-dd-tooltip="All controls"
-            data-dd-tooltip-pos="below"
-          >
-            {unsavedDot && (
-              <span
-                className="lite-all-controls-dot"
-                aria-label="Unsaved changes"
-              />
-            )}
-            <span className="lite-all-controls-arrow" aria-hidden="true">
-              →
-            </span>
-          </button>
-        </section>
-        <section data-tab="track" className="lite-tab-section">
-          <LiteTrackCarousel />
-          <RecordToggle />
-        </section>
+      <div className="lite-tab-body" data-active-tab={tab}>
+        {tab === "mix" ? (
+          <section data-tab="mix" className="lite-tab-section">
+            <div className="lite-row lite-row--main">
+              <SliderGroup param="denoise" label="denoise" />
+              <SliderGroup param="hint_strength" label="structure" />
+              <SliderGroup param="feedback" label="feedback" />
+              <SliderGroup param="lora_blend" label="blend" />
+            </div>
+            <button
+              type="button"
+              className="lite-all-controls"
+              onClick={onOpenAllControls}
+              aria-label="All controls"
+              data-dd-tooltip="All controls"
+              data-dd-tooltip-pos="below"
+            >
+              {unsavedDot && (
+                <span
+                  className="lite-all-controls-dot"
+                  aria-label="Unsaved changes"
+                />
+              )}
+              <span className="lite-all-controls-arrow" aria-hidden="true">
+                →
+              </span>
+            </button>
+          </section>
+        ) : (
+          <section data-tab="track" className="lite-tab-section">
+            <LiteTrackCarousel />
+            <RecordToggle />
+          </section>
+        )}
       </div>
     </div>
   );

--- a/demos/realtime_motion_graph_web/web/engine/audio/AudioPlayer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/AudioPlayer.ts
@@ -390,7 +390,33 @@ export class AudioPlayer {
   }
 
   async resume(): Promise<void> {
-    if (this.ctx?.state === "suspended") await this.ctx.resume();
+    const ctx = this.ctx;
+    if (!ctx || ctx.state !== "suspended") return;
+    // Android Chrome quirk: AudioContext.resume() can leave its promise
+    // pending forever even after the context has actually transitioned
+    // to "running". Awaiting that promise stalled useStartSession past
+    // the setStatus("ready", "Playing") line, so the StatusBar stayed
+    // stuck on "STARTING AUDIO…" and useParamSync (gated on "ready")
+    // never sent slider updates — even though audio was audibly playing.
+    //
+    // Race the resume() promise against a `statechange` listener and a
+    // hard 2s fallback so this method always resolves; callers can
+    // re-check ctx.state if they care.
+    await new Promise<void>((resolve) => {
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        ctx.removeEventListener("statechange", onState);
+        resolve();
+      };
+      const onState = () => {
+        if (ctx.state !== "suspended") finish();
+      };
+      ctx.addEventListener("statechange", onState);
+      ctx.resume().then(finish, finish);
+      window.setTimeout(finish, 2000);
+    });
   }
 
   /**

--- a/demos/realtime_motion_graph_web/web/hooks/useEdgeLoraBinding.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useEdgeLoraBinding.ts
@@ -161,11 +161,18 @@ export function useEdgeLoraBinding(): void {
       const blendChanged = blend !== lastBlend;
       if (!pairChanged && !blendChanged) return;
 
-      applyMobileRightEdge(blend, a, b);
-      fanOutBlend(blend, a, b);
+      // Stash the new guard values BEFORE the side-effect calls. fanOutBlend
+      // calls useLoraStore.setStrength, which synchronously re-fires this
+      // very subscriber — if lastA/lastB/lastBlend are still the previous
+      // values, the recursive apply() sees `pairChanged === true` and
+      // recurses forever (Maximum call stack size exceeded). Updating the
+      // guards first makes the recursive call bail at the early return.
       lastBlend = blend;
       lastA = a;
       lastB = b;
+
+      applyMobileRightEdge(blend, a, b);
+      fanOutBlend(blend, a, b);
     };
 
     apply();

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -598,9 +598,11 @@ export function useStartSession() {
     usePerformanceStore
       .getState()
       .setDetected(remote.detectedBpm, remote.detectedKey, detectedTs);
+    setStatus("connecting", "Starting audio… [c1/setDetected]");
     if (remote.loraCatalog.length > 0) {
       useLoraStore.getState().setCatalog(remote.loraCatalog);
     }
+    setStatus("connecting", "Starting audio… [c2/setCatalog]");
 
     // "Hear the source first" gate: when enabled in config.json, every
     // session start snaps engine denoise to 0 and plays a visual-only
@@ -626,7 +628,9 @@ export function useStartSession() {
     } else if (gate.enabled) {
       const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
       perfState.setSliderDirect("denoise", 0);
+      setStatus("connecting", "Starting audio… [c3/setSliderDirect]");
       perfState.animateSliderDisplayFrom("denoise", prevDenoise, gate.glide_ms);
+      setStatus("connecting", "Starting audio… [c4/animate]");
     }
     perfState.setRemixStarted(false);
     setStatus("connecting", "Starting audio… [d/setSession]");

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -577,14 +577,12 @@ export function useStartSession() {
       return;
     }
 
-    setStatus("connecting", "Starting audio… [a/init]");
+    setStatus("connecting", "Starting audio…");
 
     const player = new AudioPlayer();
     try {
       await player.init(remote.initialBuffer, remote.channels);
-      setStatus("connecting", "Starting audio… [b/resume]");
       await player.resume();
-      setStatus("connecting", "Starting audio… [c/sync]");
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       setStatus("error", `Audio failed to start: ${msg}`);
@@ -598,11 +596,9 @@ export function useStartSession() {
     usePerformanceStore
       .getState()
       .setDetected(remote.detectedBpm, remote.detectedKey, detectedTs);
-    setStatus("connecting", "Starting audio… [c1/setDetected]");
     if (remote.loraCatalog.length > 0) {
       useLoraStore.getState().setCatalog(remote.loraCatalog);
     }
-    setStatus("connecting", "Starting audio… [c2/setCatalog]");
 
     // "Hear the source first" gate: when enabled in config.json, every
     // session start snaps engine denoise to 0 and plays a visual-only
@@ -628,12 +624,9 @@ export function useStartSession() {
     } else if (gate.enabled) {
       const prevDenoise = perfState.sliderTargets["denoise"] ?? 0;
       perfState.setSliderDirect("denoise", 0);
-      setStatus("connecting", "Starting audio… [c3/setSliderDirect]");
       perfState.animateSliderDisplayFrom("denoise", prevDenoise, gate.glide_ms);
-      setStatus("connecting", "Starting audio… [c4/animate]");
     }
     perfState.setRemixStarted(false);
-    setStatus("connecting", "Starting audio… [d/setSession]");
 
     setSession(remote, player);
     setStatus("ready", "Playing");

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -577,12 +577,14 @@ export function useStartSession() {
       return;
     }
 
-    setStatus("connecting", "Starting audio…");
+    setStatus("connecting", "Starting audio… [a/init]");
 
     const player = new AudioPlayer();
     try {
       await player.init(remote.initialBuffer, remote.channels);
+      setStatus("connecting", "Starting audio… [b/resume]");
       await player.resume();
+      setStatus("connecting", "Starting audio… [c/sync]");
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       setStatus("error", `Audio failed to start: ${msg}`);
@@ -627,6 +629,7 @@ export function useStartSession() {
       perfState.animateSliderDisplayFrom("denoise", prevDenoise, gate.glide_ms);
     }
     perfState.setRemixStarted(false);
+    setStatus("connecting", "Starting audio… [d/setSession]");
 
     setSession(remote, player);
     setStatus("ready", "Playing");


### PR DESCRIPTION
Three mobile bugs that compounded into "audio plays but nothing responds":

## 1. Lite Mix/Track sections overlapping (`b831f5d`)

The horizontal scroll-snap carousel for the Lite Mix/Track tabs left both sections rendering on top of each other on iOS Safari — Mix sliders sitting over the Track chips even when Mix was the active tab — and let the inner LiteTrackCarousel swipe leak out to the outer scroller.

`LiteControls` now mounts a single tab section at a time (`useState` instead of `useScrollSyncedTabs`); the pill row still switches. The swipe-to-switch gesture goes away — traded for no overlap and no nested-scroller fight.

Also: `lora blend` fader label shortened to `blend` (the 0.55em / 46px-wide cell clipped the longer text to "ORA BLEN").

## 2. AudioContext.resume() hanging on Android Chrome (`583cf16`)

`AudioPlayer.resume()` was awaiting `ctx.resume()` directly; on some Android Chrome builds that promise never settles even after the context goes to `running`. The session got stuck on "STARTING AUDIO…" — audio could eventually start, but nothing past the resume gate would run.

`resume()` now races the resume promise against (a) the `statechange` event firing with `state === "running"` and (b) a 2 s timeout. First-to-resolve wins; the session proceeds as soon as the context is actually usable.

## 3. Infinite recursion in useEdgeLoraBinding (`4900cbe`)

Real-session stack trace: `Maximum call stack size exceeded — setStrength → apply → setStrength → apply → …`.

The `apply()` subscriber updated its `lastBlend / lastA / lastB` guards **after** calling `applyMobileRightEdge` + `fanOutBlend`. Since `fanOutBlend` calls `setStrength` synchronously, the very next subscriber invocation saw the old guard values, ran `apply` again, and so on.

Fix: stash the new guard values **before** the side-effect calls. The recursive `apply()` now hits its early-return on `!pairChanged && !blendChanged` and the chain terminates.

The two `debug(mobile)` commits in this PR's history were the staging markers I used to localize the recursion — the recursion-fix commit also reverts them, so the branch tip is debug-marker-free. Squash-merge will collapse the whole thing anyway.

## Companion PR

Vendored sync lives at daydreamlive/demon-public-demo#257 (currently WIP) — I'll repoint at a fresh `sync-ui` branch off main once this lands.