### PR TITLE
fix(trt): purge stale vae_encode entries on bind+swap — fixes swap_failed + VRAM leak

### DIFF
--- a/acestep/engine/trt/profile_manager.py
+++ b/acestep/engine/trt/profile_manager.py
@@ -128,10 +128,42 @@ class TRTProfileManager:
         profile and skip the swap when the same profile would be
         picked. ``paths`` should be the dict returned from
         :meth:`resolve`; ``picked_dur`` the second tuple element.
+
+        Also evicts any stale ``vae_encode`` engines left in the
+        module-level cache by a previous session's profile manager.
+        Without this, the very first VAE-encode call of this session
+        could be served by a leaked prior-session engine (see the
+        long comment in :meth:`_swap` for the full failure mode);
+        the swap-time purge there only fires if the user actually
+        triggers a swap.
         """
         self._diffusion_engine = diffusion_engine
         self._loaded_dur = float(picked_dur)
         self._loaded_paths = dict(paths)
+        if self._vae_tensorrt:
+            self._purge_stale_vae_encode_cache(paths.get("vae_encode"))
+
+    @staticmethod
+    def _purge_stale_vae_encode_cache(active_enc: Optional[str]) -> None:
+        """Evict every cached ``vae_encode_*`` / ``dreamvae_encode_*``
+        engine that isn't ``active_enc``. See :meth:`_swap` for why.
+
+        Scoped to encode only — vae_decode engines have a different
+        lifecycle (session.__init__ owns the windowed swap) and
+        evicting one mid-session would break the live runner.
+        """
+        import os
+        from acestep.nodes.vae_nodes import _evict_trt_vae, _trt_vae_cache
+
+        encode_prefixes = ("vae_encode_", "dreamvae_encode_")
+        active_abs = os.path.abspath(active_enc) if active_enc else None
+        for cached_path in list(_trt_vae_cache.keys()):
+            basename = os.path.basename(cached_path).lower()
+            if not basename.startswith(encode_prefixes):
+                continue
+            if active_abs is not None and os.path.abspath(cached_path) == active_abs:
+                continue
+            _evict_trt_vae(cached_path)
 
     def ensure_walk_profile(
         self,
@@ -261,12 +293,28 @@ class TRTProfileManager:
             engine.unload_trt_engine()
 
         if self._vae_tensorrt:
-            from acestep.nodes.vae_nodes import _evict_trt_vae
-
-            old_enc = prior_paths.get("vae_encode")
             new_enc = target_paths.get("vae_encode")
-            if old_enc and old_enc != new_enc:
-                _evict_trt_vae(old_enc)
+            # Purge every stale vae_encode_* / dreamvae_encode_* in the
+            # module-level cache that isn't the engine we're about to
+            # install. The old code only evicted `prior_paths.get(
+            # "vae_encode")` — the entry THIS profile manager remembered
+            # from bind(). Engines left in the cache by a *previous*
+            # session's profile manager (or by runtime_init at session
+            # start, before bind()) stay invisible to it and never get
+            # evicted by name. That bites twice:
+            #   (1) _find_best_vae_engine walks the cache in insertion
+            #       order and returns the FIRST match — so a stale
+            #       prior-session entry silently shadows the engine
+            #       we actually want, surfacing as "TRT VAE encode
+            #       rejected input shape" when the source duration
+            #       doesn't fit the accidentally-picked engine;
+            #   (2) those stale entries pin several GB of execution-
+            #       context VRAM each, so long-uptime pods leak memory
+            #       across session lifecycles and eventually OOM on
+            #       swap.
+            # The cache invariant we want is "at most one vae_encode-
+            # class entry resident at a time" — restored on every swap.
+            self._purge_stale_vae_encode_cache(new_enc)
 
         if decoder_changed:
             engine.load_trt_engine(new_decoder)


### PR DESCRIPTION
## What

Single-file fix in `acestep/engine/trt/profile_manager.py`. Introduces a `_purge_stale_vae_encode_cache(active_enc)` helper that drops every `vae_encode_*` / `dreamvae_encode_*` left in the module-level `_trt_vae_cache` other than the engine the current profile manager owns. Called from `bind()` (on session entry) and from `_swap()` (replaces the old single-prior-entry eviction).

## The bug — caught live on a fleet pod

Pod 37612815 (`pod-2bde3b1d53bb`, `:warm`, RTX 5090, 23h uptime, many sessions of mixed durations) reported `swap_failed: TRT VAE encode rejected input shape: (1, 2, 7516800)` on a 157 s upload. The pod has the full `60 / 120 / 240` engine set baked in — no missing engine, no nested `trt_engines/trt_engines/`. Server log of the exact swap:

```
15:29:39.568  TRT walk-profile swap: decoder=60s, vae_encode for 157s source
15:29:39.608  Evicted TRT VAE engine: vae_encode_fp16_60s
15:29:39.901  Loaded  TRT VAE engine: vae_encode_fp16_240s    ← correctly loaded
15:29:40.938  VAE encode via TRT
[E] setInputShape: condition satisfyProfile failed.
    Set dimension [1,2,7516800] does not satisfy any profile.
    Valid range for profile 0: [1,2,240000]..[1,2,5760000]    ← that's the 120s engine, NOT 240s
[Server] Swap error: TRT VAE encode rejected input shape: (1, 2, 7516800)
```

The 240s engine was loaded — but `_find_best_vae_engine("vae_encode")` returned a **leaked 120 s entry** that an earlier session on the same pod loaded hours before. `_swap()`'s eviction logic only knew about `prior_paths.get("vae_encode")` (the current profile manager's own bound path); the leaked entry was invisible to it.

## The VRAM-leak counterpart

Same root cause, counted from the same pod's log:

```
Loaded events:  12
Evicted events:  4
Unique loaded:   vae_decode_fp16_3to30s, vae_encode_fp16_{60,120,240}s
Unique evicted:  vae_encode_fp16_60s only
```

The process held **5.7 GiB of GPU memory** for a single live session that should fit in ~2-3 GiB. Each leaked execution context pins several GB. Long-uptime pods accumulate engines from prior sessions and eventually OOM on swap.

## Why scope to encode only

`vae_decode_3to30s` shows up in the same leak list, but it has a different lifecycle — `session.__init__` swaps the live decoder to the windowed 3-to-30 s engine and the runner keeps using it across source swaps. Evicting it mid-session would break the windowed decoder. Decode-side cleanup belongs in session teardown, not in `_swap()`.

## Where it runs

- `bind()` — first VAE encode of a new session sees a clean cache, so `_find_best_vae_engine` returns the right engine without needing a swap to trigger cleanup.
- `_swap()` — replaces the old single-prior-entry eviction. Same invariant ("at most one vae_encode-class entry resident at a time"), now enforced against the entire cache rather than just the path this manager remembers.

## Cost

Negligible startup impact. Cold boot is unaffected (cache empty → nothing to purge). The only measurable cost is on a warm session that happens to need the same engine a prior session loaded *and* whose entry got purged by an in-between swap — that case becomes a ~300 ms-1 s page-cache reload instead of an in-memory hit.

## Hotpatch path

`scp` the single changed file into `/workspace/demon/acestep/engine/trt/profile_manager.py` on each fleet pod; the wrapper respawns the python process. Durable fix is the next `:warm` rebake. Both `:warm` and `:warm-4090` need it.

## Verification

After hotpatch on the failing pod, repeat the user's flow: upload a 157 s source with `walk_window=true` in config. Expected: log shows `_purge_stale_vae_encode_cache` evicting the leaked entries beyond the prior_paths one; VAE encode succeeds; `swap_ready` message goes back to client; `nvidia-smi` process memory drops to single-active-engine footprint (~2-3 GiB).