### PR TITLE
feat(rtmg/lora): concurrent-LoRA cap config

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1745,6 +1745,20 @@ body[data-mode="graph"]::before {
   border-color: var(--accent);
   color: #ffffff;
 }
+/* Cap-blocked rows look reachable but inert. The native :disabled
+ * already filters pointer events; we just dim and tint the "—" badge
+ * so the operator's eye understands "you can interact, but only by
+ * freeing a slot first" — the tooltip carries the verbal explanation.
+ * Enabled rows are never cap-blocked (toggling them OFF is allowed),
+ * so the .enabled rule above takes precedence on visited slots. */
+.lora-browse-row.cap-blocked {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.lora-browse-row.cap-blocked .lora-browse-add {
+  color: var(--text-dim);
+  border-color: var(--border-dim);
+}
 .lora-browse-desc {
   font-size: 10px;
   line-height: 1.35;

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -315,6 +315,12 @@ function useLoraToggle() {
         disable(id);
         remote?.sendDisableLora(id);
       } else {
+        // Cap-aware: consult the store BEFORE the WS round-trip so we
+        // don't ship a sendEnableLora for a LoRA the store will refuse
+        // to add (server would materialize ~1.2 GB of refit state for
+        // a UI that won't reflect it). The store's enable() also
+        // enforces the cap defensively — this is the visible side.
+        if (!useLoraStore.getState().canEnableMore()) return;
         enable(id);
         const s = useLoraStore.getState().strengths[id] ?? 0;
         remote?.sendEnableLora(id, s);
@@ -505,6 +511,16 @@ function ActiveLoraRow({ entry }: { entry: LoraCatalogEntry }) {
 function BrowseLoraRow({ entry }: { entry: LoraCatalogEntry }) {
   const { id } = entry;
   const enabled = useLoraStore((s) => s.enabled.has(id));
+  // Subscribe to the cap state so the row re-renders when another LoRA
+  // is enabled/disabled elsewhere and our affordance needs to flip
+  // between "+" (clickable) and "max" (disabled).
+  const atCap = useLoraStore(
+    (s) =>
+      s.maxEnabled !== null &&
+      s.maxEnabled >= 0 &&
+      s.enabled.size >= s.maxEnabled,
+  );
+  const cap = useLoraStore((s) => s.maxEnabled);
   const toggle = useLoraToggle();
 
   const md = entry.metadata;
@@ -521,22 +537,33 @@ function BrowseLoraRow({ entry }: { entry: LoraCatalogEntry }) {
     [id, trigger, flashConfirm],
   );
 
+  // Cap blocks new enables, never disables. So a row that's already
+  // enabled stays clickable (so the user can free a slot); only the
+  // disabled-and-cap-reached rows become inert.
+  const capBlocked = atCap && !enabled;
+  const rowTitle = capBlocked
+    ? `Maximum ${cap} LoRAs active — disable one to enable this`
+    : displayName;
+
   return (
     <>
       <button
         ref={rowRef}
         type="button"
-        className={`lora-browse-row${enabled ? " enabled" : ""}`}
+        className={`lora-browse-row${enabled ? " enabled" : ""}${capBlocked ? " cap-blocked" : ""}`}
         onClick={() => toggle(id, enabled)}
         onContextMenu={onContextMenu}
         aria-pressed={enabled}
+        aria-disabled={capBlocked}
+        disabled={capBlocked}
+        title={rowTitle}
       >
         <span className="lora-browse-main">
           <span className="lora-browse-name" title={displayName}>
             {confirmMsg ?? displayName}
           </span>
           <span className="lora-browse-add" aria-hidden="true">
-            {enabled ? "✓" : "+"}
+            {enabled ? "✓" : capBlocked ? "—" : "+"}
           </span>
         </span>
         {desc && <span className="lora-browse-desc">{desc}</span>}

--- a/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
@@ -3,8 +3,9 @@
 import { useEffect, useRef } from "react";
 
 import { loadFixtureAudio } from "@/engine/audio/loadFixture";
-import { getConfig } from "@/lib/config";
+import { getConfig, resolveLoraCapForSource } from "@/lib/config";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
+import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
 import { isTimeSignature } from "@/types/engine";
@@ -65,6 +66,15 @@ export function useFixtureSwap() {
             key?: string;
             time_signature?: string;
           }>).detail;
+          // Recompute the duration-aware LoRA cap against the new
+          // source. protocol.ts already set ``remote.duration`` from
+          // the swap_ready message; reading it here gives the
+          // authoritative value. Tiers swap to the right cap (e.g.
+          // 60s→3 LoRAs, 240s→2) before the user can interact with
+          // the new source, so no over-cap state is reachable.
+          useLoraStore
+            .getState()
+            .setMaxEnabled(resolveLoraCapForSource(remote.duration));
           session.player?.swap(detail.interleaved, detail.channels);
           // Worklet's swap message keeps `position` untouched, so a swap
           // at 1:30 into the old track would otherwise resume at 1:30 of

--- a/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
@@ -3,9 +3,12 @@
 import { useEffect, useRef } from "react";
 
 import { loadFixtureAudio } from "@/engine/audio/loadFixture";
-import { getConfig, resolveLoraCapForSource } from "@/lib/config";
+import {
+  applyLoraCapWithServerSync,
+  getConfig,
+  resolveLoraCapForSource,
+} from "@/lib/config";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
-import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
 import { isTimeSignature } from "@/types/engine";
@@ -70,11 +73,17 @@ export function useFixtureSwap() {
           // source. protocol.ts already set ``remote.duration`` from
           // the swap_ready message; reading it here gives the
           // authoritative value. Tiers swap to the right cap (e.g.
-          // 60s→3 LoRAs, 240s→2) before the user can interact with
-          // the new source, so no over-cap state is reachable.
-          useLoraStore
-            .getState()
-            .setMaxEnabled(resolveLoraCapForSource(remote.duration));
+          // 60s→3 LoRAs, 240s→1) before the user can interact with
+          // the new source.
+          //
+          // Critical: use the server-syncing helper, not setMaxEnabled
+          // alone. A tightening cap (60s→240s source swap) clips the
+          // client's enabled set, but if we don't WS-disable the
+          // dropped LoRAs the server keeps them materialized — the
+          // ghost-LoRA leak. The helper sends disable_lora for each
+          // dropped id and re-issues the prompt so the trigger
+          // prefix drops their triggers too.
+          applyLoraCapWithServerSync(resolveLoraCapForSource(remote.duration));
           session.player?.swap(detail.interleaved, detail.channels);
           // Worklet's swap message keeps `position` untouched, so a swap
           // at 1:30 into the old track would otherwise resume at 1:30 of

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -10,7 +10,7 @@ import { defaultWsUrl } from "@/engine/podUrl";
 import { RemoteBackend, SLICE_FLAG_DELTA } from "@/engine/protocol";
 import { getApiKey } from "@/engine/rtmgConfig";
 import { WsReconnector } from "@/engine/wsReconnect";
-import { getConfig } from "@/lib/config";
+import { getConfig, resolveLoraCapForSource } from "@/lib/config";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore, type RefSource } from "@/store/usePerformanceStore";
@@ -508,6 +508,12 @@ export function useStartSession() {
           if (remote.loraCatalog.length > 0) {
             useLoraStore.getState().setCatalog(remote.loraCatalog);
           }
+          // Recompute the duration-aware LoRA cap against the (re)bound
+          // source. The reconnect path may land on a different-duration
+          // source than the prior session — tiers swap to match.
+          useLoraStore
+            .getState()
+            .setMaxEnabled(resolveLoraCapForSource(remote.duration));
           useSessionStore.getState().setSession(remote, player);
           // Rebuild the network-quality monitor against the new
           // remote — the old one was bound to the dropped backend's
@@ -599,6 +605,14 @@ export function useStartSession() {
     if (remote.loraCatalog.length > 0) {
       useLoraStore.getState().setCatalog(remote.loraCatalog);
     }
+    // First cap-recompute against the actual source duration now that
+    // ready landed (remote.duration was set by the ready handshake).
+    // applyConfig's boot-time setMaxEnabled used the most-permissive
+    // tier; this nails the cap to whatever engine workspace this
+    // particular source actually loads.
+    useLoraStore
+      .getState()
+      .setMaxEnabled(resolveLoraCapForSource(remote.duration));
 
     // "Hear the source first" gate: when enabled in config.json, every
     // session start snaps engine denoise to 0 and plays a visual-only

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -10,7 +10,11 @@ import { defaultWsUrl } from "@/engine/podUrl";
 import { RemoteBackend, SLICE_FLAG_DELTA } from "@/engine/protocol";
 import { getApiKey } from "@/engine/rtmgConfig";
 import { WsReconnector } from "@/engine/wsReconnect";
-import { getConfig, resolveLoraCapForSource } from "@/lib/config";
+import {
+  applyLoraCapWithServerSync,
+  getConfig,
+  resolveLoraCapForSource,
+} from "@/lib/config";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { useLoraStore } from "@/store/useLoraStore";
 import { usePerformanceStore, type RefSource } from "@/store/usePerformanceStore";
@@ -511,9 +515,11 @@ export function useStartSession() {
           // Recompute the duration-aware LoRA cap against the (re)bound
           // source. The reconnect path may land on a different-duration
           // source than the prior session — tiers swap to match.
-          useLoraStore
-            .getState()
-            .setMaxEnabled(resolveLoraCapForSource(remote.duration));
+          // Uses the server-syncing helper so any over-cap LoRAs from
+          // the prior session also get a WS disable_lora (avoids
+          // ghost-LoRA leak when the reconnected source's tier is
+          // tighter than what was previously enabled).
+          applyLoraCapWithServerSync(resolveLoraCapForSource(remote.duration));
           useSessionStore.getState().setSession(remote, player);
           // Rebuild the network-quality monitor against the new
           // remote — the old one was bound to the dropped backend's
@@ -610,9 +616,13 @@ export function useStartSession() {
     // applyConfig's boot-time setMaxEnabled used the most-permissive
     // tier; this nails the cap to whatever engine workspace this
     // particular source actually loads.
-    useLoraStore
-      .getState()
-      .setMaxEnabled(resolveLoraCapForSource(remote.duration));
+    //
+    // Server-syncing helper: if the user-driven default seed enabled
+    // more LoRAs than the active source's tier allows, the helper
+    // sends disable_lora for each that gets clipped, preventing the
+    // ghost-LoRA leak where the server keeps them materialized
+    // server-side after they vanish from the UI.
+    applyLoraCapWithServerSync(resolveLoraCapForSource(remote.duration));
 
     // "Hear the source first" gate: when enabled in config.json, every
     // session start snaps engine denoise to 0 and plays a visual-only

--- a/demos/realtime_motion_graph_web/web/lib/config.ts
+++ b/demos/realtime_motion_graph_web/web/lib/config.ts
@@ -77,6 +77,23 @@ export interface RtmgConfigEngine {
    *  no declared scale are shown either way — we don't hide what we
    *  can't classify. */
   show_incompatible_loras?: boolean;
+  /** Maximum number of LoRAs that can be enabled simultaneously.
+   *  Null / undefined / non-positive means "no cap" — every LoRA in
+   *  the catalog can be enabled at once (the OSS default; preserves
+   *  parity for local-DEMON users).
+   *
+   *  Set this on a hosted deployment that wants a hard ceiling — each
+   *  enabled LoRA materializes a refit-state buffer (~1.2 GB on the
+   *  current acestep-v15-turbo checkpoint) on top of decoder + VAE
+   *  engines, so on a 32 GB card you can OOM cleanly after the third
+   *  one when paired with a long-source vae_encode profile.
+   *
+   *  Enforcement is honoured by ``useLoraStore.enable`` and by the
+   *  catalog auto-enable seed (config-driven defaults beyond the cap
+   *  are silently clipped). Disabling is never blocked.
+   *  ``canEnableMore()`` on the store exposes the predicate so the
+   *  UI can render disabled "+" buttons with a "Max N active" hint. */
+  max_concurrent_loras?: number | null;
   /** XL (5B) variant overrides. When the active checkpoint scale is
    *  "5B", these win over their base siblings at applyConfig time.
    *  Absent / undefined falls through to the base field. Selection
@@ -546,12 +563,19 @@ export function applyConfig(c: RtmgConfig): void {
   // bypasses that path, so push the diff to the engine here and
   // re-encode the prompt so the trigger prefix matches.
   const lora = useLoraStore.getState();
+  // Push the cap on every applyConfig (boot and import alike) so the
+  // store can enforce it on every enable() and so setCatalog's seed
+  // gate clips an over-cap enabled_loras list. null = uncapped (the
+  // OSS default — preserves local-DEMON parity).
+  lora.setMaxEnabled(resolved.engine.max_concurrent_loras ?? null);
   if (firstApply) {
     if (!lora.seeded && lora.catalog.length > 0) {
       lora.setCatalog(lora.catalog);
     }
   } else if (lora.catalog.length > 0) {
     const before = new Set(lora.enabled);
+    // setMaxEnabled above already re-clipped any over-cap entries from
+    // the prior session; reset() now re-seeds against the new config.
     lora.reset();
     const after = useLoraStore.getState();
     const remote = useSessionStore.getState().remote;

--- a/demos/realtime_motion_graph_web/web/lib/config.ts
+++ b/demos/realtime_motion_graph_web/web/lib/config.ts
@@ -423,6 +423,60 @@ export function resolveLoraCapForSource(
   return typeof fallback === "number" && fallback >= 0 ? fallback : null;
 }
 
+/** Apply a freshly-resolved cap to the LoRA store AND tell the server
+ *  about any LoRAs the cap kicks off the enabled list.
+ *
+ *  ``setMaxEnabled`` alone is purely a client-store mutation — it
+ *  clips ``enabled`` down to the new cap (oldest insertion order
+ *  wins, newest are dropped). But the SERVER is unaware of the
+ *  clip: those dropped LoRAs stay materialized in GPU memory (~1.2
+ *  GiB each), invisible to the user, eating the very budget the
+ *  smaller cap was trying to free. ``ghost LoRAs.``
+ *
+ *  This helper composes the two correctly:
+ *   1. Snapshot the current enabled set.
+ *   2. Diff against the post-clip view to identify the dropped ids.
+ *   3. For each dropped id: ``remote.sendDisableLora(id)`` so the
+ *      engine actually frees the refit-state buffer.
+ *   4. Re-send the prompt so the trigger prefix drops the now-
+ *      disabled LoRAs' triggers (useLoraTriggerSync debounce-sends
+ *      automatically when ``enabled`` mutates, but we issue an
+ *      immediate send here so the prompt and the disables hit the
+ *      server in the same logical step).
+ *   5. Finally call ``setMaxEnabled`` to clip the store.
+ *
+ *  When ``remote`` is null (boot path before any session), skips the
+ *  WS sends — no server to notify. The store-side clip still applies. */
+export function applyLoraCapWithServerSync(cap: number | null): void {
+  const lora = useLoraStore.getState();
+  const before = lora.enabled;
+  const remote = useSessionStore.getState().remote;
+
+  // Match useLoraStore.clipEnabledToCap semantics: drop the
+  // most-recently-added entries (everything past index ``cap``).
+  if (
+    remote &&
+    typeof cap === "number" &&
+    cap >= 0 &&
+    before.size > cap
+  ) {
+    const ids = Array.from(before);
+    const toDrop = ids.slice(cap);
+    for (const id of toDrop) {
+      remote.sendDisableLora(id);
+    }
+    const perf = usePerformanceStore.getState();
+    remote.sendPrompt(
+      perf.promptA,
+      perf.activeKey,
+      perf.activeTimeSignature,
+      perf.promptB,
+    );
+  }
+
+  lora.setMaxEnabled(cap);
+}
+
 /** Whether applyConfig() has been called at least once. Once-per-session
  *  seed paths (useLoraStore.setCatalog → computeSeed) gate on this so a
  *  catalog fetch that beats the config fetch doesn't seed against

--- a/demos/realtime_motion_graph_web/web/lib/config.ts
+++ b/demos/realtime_motion_graph_web/web/lib/config.ts
@@ -88,12 +88,44 @@ export interface RtmgConfigEngine {
    *  engines, so on a 32 GB card you can OOM cleanly after the third
    *  one when paired with a long-source vae_encode profile.
    *
+   *  Used as a constant cap when ``max_concurrent_loras_tiers`` is
+   *  absent. With tiers present, this field is the FALLBACK cap used
+   *  when no tier matches the current source duration (e.g. before a
+   *  source is loaded, or a source longer than every tier threshold).
+   *
    *  Enforcement is honoured by ``useLoraStore.enable`` and by the
    *  catalog auto-enable seed (config-driven defaults beyond the cap
    *  are silently clipped). Disabling is never blocked.
    *  ``canEnableMore()`` on the store exposes the predicate so the
    *  UI can render disabled "+" buttons with a "Max N active" hint. */
   max_concurrent_loras?: number | null;
+  /** Source-duration-aware cap tiers. The active cap is the ``cap``
+   *  field of the FIRST tier whose ``up_to_s`` is ≥ the current source
+   *  duration; when no tier matches, falls back to
+   *  ``max_concurrent_loras`` (else uncapped).
+   *
+   *  Why duration-aware: the 240s ``vae_encode`` engine reserves a
+   *  ~16 GiB workspace at runtime, which leaves less room for LoRA
+   *  materializations than the 60s or 120s engines. A hosted
+   *  deployment can keep the cap relaxed (e.g. 3) for short sources
+   *  that load the 60s engine and tighten it (e.g. 2) for sources
+   *  that trigger the 240s engine.
+   *
+   *  Example:
+   *  ```json
+   *  "max_concurrent_loras_tiers": [
+   *    { "up_to_s": 60,  "cap": 3 },
+   *    { "up_to_s": 120, "cap": 3 },
+   *    { "up_to_s": 240, "cap": 2 }
+   *  ]
+   *  ```
+   *  Order doesn't matter — the resolver sorts by ``up_to_s`` ascending.
+   *  Recomputed on session start AND on every source swap so the cap
+   *  tracks the live engine workspace. */
+  max_concurrent_loras_tiers?: Array<{
+    up_to_s: number;
+    cap: number;
+  }> | null;
   /** XL (5B) variant overrides. When the active checkpoint scale is
    *  "5B", these win over their base siblings at applyConfig time.
    *  Absent / undefined falls through to the base field. Selection
@@ -353,6 +385,44 @@ export function getConfig(): RtmgConfig {
   return _activeConfig;
 }
 
+/** Resolve the LoRA cap for a given source duration. Tiers (when
+ *  present) take precedence: pick the smallest ``up_to_s`` that's ≥
+ *  ``durationS``. When no tier matches (durationS larger than all
+ *  thresholds, or tiers absent), fall back to
+ *  ``engine.max_concurrent_loras``. ``null`` return = uncapped.
+ *
+ *  Passing ``durationS = 0`` (no source loaded yet) selects the most
+ *  permissive tier — short-source assumptions hold at boot before the
+ *  first session config arrives. Callers that want a conservative
+ *  boot-time cap can pass the static fallback value directly. */
+export function resolveLoraCapForSource(
+  durationS: number,
+  engine: Pick<
+    RtmgConfigEngine,
+    "max_concurrent_loras" | "max_concurrent_loras_tiers"
+  > = _activeConfig.engine,
+): number | null {
+  const tiers = engine.max_concurrent_loras_tiers;
+  if (tiers && tiers.length > 0) {
+    // Sort by threshold ascending; pick the first tier whose ceiling
+    // is ≥ durationS. Defensive sort so config-side order doesn't
+    // matter to the runtime.
+    const sorted = [...tiers]
+      .filter((t) => typeof t?.up_to_s === "number" && typeof t?.cap === "number")
+      .sort((a, b) => a.up_to_s - b.up_to_s);
+    for (const tier of sorted) {
+      if (durationS <= tier.up_to_s) return tier.cap;
+    }
+    // durationS exceeds every tier ceiling — fall through to the
+    // static fallback. The fallback is intentionally separate from
+    // the last-tier cap so an operator can express "anything past
+    // 240s is uncapped" or "anything past 240s is fully blocked"
+    // depending on which fallback they set.
+  }
+  const fallback = engine.max_concurrent_loras;
+  return typeof fallback === "number" && fallback >= 0 ? fallback : null;
+}
+
 /** Whether applyConfig() has been called at least once. Once-per-session
  *  seed paths (useLoraStore.setCatalog → computeSeed) gate on this so a
  *  catalog fetch that beats the config fetch doesn't seed against
@@ -563,11 +633,14 @@ export function applyConfig(c: RtmgConfig): void {
   // bypasses that path, so push the diff to the engine here and
   // re-encode the prompt so the trigger prefix matches.
   const lora = useLoraStore.getState();
-  // Push the cap on every applyConfig (boot and import alike) so the
-  // store can enforce it on every enable() and so setCatalog's seed
-  // gate clips an over-cap enabled_loras list. null = uncapped (the
-  // OSS default — preserves local-DEMON parity).
-  lora.setMaxEnabled(resolved.engine.max_concurrent_loras ?? null);
+  // Push the boot-time cap. We don't yet know the source duration so
+  // resolve against 0 — selects the most-permissive tier. Once a
+  // session starts (useStartSession) or a source swap completes
+  // (useFixtureSwap), the cap is recomputed against the actual
+  // duration via ``resolveLoraCapForSource``. Static
+  // ``max_concurrent_loras`` (no tiers) is duration-independent so
+  // the boot value persists.
+  lora.setMaxEnabled(resolveLoraCapForSource(0, resolved.engine));
   if (firstApply) {
     if (!lora.seeded && lora.catalog.length > 0) {
       lora.setCatalog(lora.catalog);

--- a/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
@@ -208,6 +208,15 @@ interface LoraState {
   enabled: Set<string>;
   /** Whether default-on LoRAs have already been seeded for this session. */
   seeded: boolean;
+  /** Optional ceiling on the concurrent ``enabled.size``. ``null`` means
+   *  uncapped (the OSS-DEMON default). Pushed by ``applyConfig`` from
+   *  ``engine.max_concurrent_loras``. The store enforces it on
+   *  ``enable``, ``toggle`` (when toggling on), and the catalog auto-
+   *  enable seed; ``disable`` and ``toggle`` (toggling off) are never
+   *  blocked. ``canEnableMore()`` exposes the predicate so UI can grey
+   *  out "+" affordances. See ``RtmgConfigEngine.max_concurrent_loras``
+   *  for the rationale. */
+  maxEnabled: number | null;
 
   setCatalog: (catalog: LoraCatalogEntry[]) => void;
   setStrength: (id: string, value: number) => void;
@@ -215,13 +224,37 @@ interface LoraState {
   disable: (id: string) => void;
   toggle: (id: string) => void;
   reset: () => void;
+  /** Push the cap from config. Pass ``null`` for uncapped. Also clips
+   *  any currently-enabled set that's now over-cap (e.g. an import
+   *  lowered the ceiling). Drops the LATEST-added entries first
+   *  (Set insertion order), so user-curated picks early in the
+   *  session survive a tightening. */
+  setMaxEnabled: (n: number | null) => void;
+  /** True when another LoRA can be enabled — uncapped, or
+   *  ``enabled.size < maxEnabled``. UI/toggle callers should consult
+   *  this before firing ``sendEnableLora`` on the WS so a denied
+   *  enable can't leak a doomed server-side materialization. */
+  canEnableMore: () => boolean;
 }
 
-export const useLoraStore = create<LoraState>((set) => ({
+/** Pure helper: clip a Set down to the first N entries in insertion
+ *  order. ``cap === null`` returns the input untouched. Used by
+ *  ``setMaxEnabled`` and ``setCatalog`` so the cap is enforced once
+ *  consistently. */
+function clipEnabledToCap(
+  enabled: Set<string>,
+  cap: number | null,
+): Set<string> {
+  if (cap === null || cap < 0 || enabled.size <= cap) return enabled;
+  return new Set(Array.from(enabled).slice(0, cap));
+}
+
+export const useLoraStore = create<LoraState>((set, get) => ({
   catalog: [],
   strengths: {},
   enabled: new Set(),
   seeded: false,
+  maxEnabled: null,
 
   setCatalog: (incomingCatalog) =>
     set((s) => {
@@ -250,7 +283,10 @@ export const useLoraStore = create<LoraState>((set) => ({
       const shouldSeed =
         !s.seeded && catalog.length > 0 && isConfigApplied();
       const enabled = shouldSeed
-        ? new Set<string>([...s.enabled, ...fresh.enabled])
+        ? clipEnabledToCap(
+            new Set<string>([...s.enabled, ...fresh.enabled]),
+            s.maxEnabled,
+          )
         : s.enabled;
       // Note: seeding a LoRA does NOT mutate promptA/promptB. Trigger
       // words are injected onto the WS `prompt` message at send-time by
@@ -268,6 +304,18 @@ export const useLoraStore = create<LoraState>((set) => ({
   enable: (id) =>
     set((s) => {
       if (s.enabled.has(id)) return {} as Partial<LoraState>;
+      // Cap honoured here so every code path that ends in store.enable
+      // (LibraryTile click, useEdgeLoraBinding auto-pair, MCP mirror,
+      // import re-seed) gets the same ceiling. Callers should consult
+      // ``canEnableMore()`` BEFORE issuing the matching
+      // ``remote.sendEnableLora`` to avoid an orphaned WS materialize.
+      if (
+        s.maxEnabled !== null &&
+        s.maxEnabled >= 0 &&
+        s.enabled.size >= s.maxEnabled
+      ) {
+        return {} as Partial<LoraState>;
+      }
       const next = new Set(s.enabled);
       next.add(id);
       // The LoRA's trigger word is NOT written into promptA/promptB.
@@ -289,8 +337,19 @@ export const useLoraStore = create<LoraState>((set) => ({
   toggle: (id) =>
     set((s) => {
       const next = new Set(s.enabled);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        // Toggling ON respects the cap; toggling OFF is always allowed.
+        if (
+          s.maxEnabled !== null &&
+          s.maxEnabled >= 0 &&
+          s.enabled.size >= s.maxEnabled
+        ) {
+          return {} as Partial<LoraState>;
+        }
+        next.add(id);
+      }
       return { enabled: next };
     }),
   reset: () =>
@@ -303,6 +362,31 @@ export const useLoraStore = create<LoraState>((set) => ({
       // defaults", not "lose the catalog".
       const catalog = sortCatalogForDisplay(s.catalog);
       const { strengths, enabled } = computeSeed(catalog);
-      return { catalog, strengths, enabled };
+      return {
+        catalog,
+        strengths,
+        enabled: clipEnabledToCap(enabled, s.maxEnabled),
+      };
     }),
+  setMaxEnabled: (n) =>
+    set((s) => {
+      const cap = n === null || (typeof n === "number" && n >= 0) ? n : null;
+      // Same-value no-op so subscribers don't re-render on every
+      // applyConfig pass. Identity-compare the enabled set only if we
+      // also clip; otherwise reuse to keep zustand's shallow change
+      // detection happy.
+      if (cap === s.maxEnabled) return {} as Partial<LoraState>;
+      const enabled = clipEnabledToCap(s.enabled, cap);
+      return enabled === s.enabled
+        ? { maxEnabled: cap }
+        : { maxEnabled: cap, enabled };
+    }),
+  canEnableMore: () => {
+    const s = get();
+    return (
+      s.maxEnabled === null ||
+      s.maxEnabled < 0 ||
+      s.enabled.size < s.maxEnabled
+    );
+  },
 }));


### PR DESCRIPTION
## What

Adds an optional ceiling on the number of LoRAs that can be enabled simultaneously. Null/undefined — the OSS-DEMON default — preserves today's behavior: every LoRA in the catalog can be enabled at once. A hosted deployment that sets `engine.max_concurrent_loras=N` in its `config.json` gets a hard ceiling honoured everywhere.

## Why
```
17:02:32  WS dispatch error: CUDA out of memory.
          Tried to allocate 46 MiB. GPU 0 has 3.25 MiB free.
          process has 31.32 GiB / 31.36 GiB in use.
17:02:32  enable_lora(techno-v1) failed: TRT refit failed
17:02:43  Client disconnected (388,349 generations)
```

Each materialized LoRA pins ~1.2 GB of refit state on top of decoder + VAE engines. With walk-mode's mixed-engine profile (60 s decoder + full-source `vae_encode`), the 32 GB card sits at ~28 GB before LoRAs and OOMs on the next allocation past 2-3 enabled.

## Where it lands

| File | Change |
| --- | --- |
| `web/lib/config.ts` | `RtmgConfigEngine.max_concurrent_loras?: number \| null`; `applyConfig` pushes it to the store on every apply (boot + import) |
| `web/store/useLoraStore.ts` | `maxEnabled: number \| null` state, `setMaxEnabled(n)`, `canEnableMore()` predicate; `enable()`, `toggle()`, the catalog auto-enable seed, and `reset()` all honour the cap; `clipEnabledToCap()` helper does the actual clipping |
| `web/components/Performance/LibraryTile.tsx` | `useLoraToggle` consults `canEnableMore()` before the WS round-trip (so we don't ship a `sendEnableLora` for a refused enable); `BrowseLoraRow` renders disabled with a "Max N — disable one first" tooltip when at cap |
| `web/app/globals.css` | `.lora-browse-row.cap-blocked` — 0.45 opacity + dimmed "—" badge |

## Semantics

- **Disabling is never blocked.** A cap-blocked browse row that's *already* enabled stays clickable — the operator can free a slot. Only catalog rows you'd add NEW become inert.
- **Toggle direction-aware.** `toggle(id)` on an enabled LoRA always proceeds (turns it off). `toggle(id)` on a disabled LoRA respects the cap.
- **Seed clip.** If `config.engine.enabled_loras` lists more entries than the cap, auto-enable stops at the cap; the rest stay in the catalog but disabled.
- **Live re-clip.** Lowering the cap mid-session (e.g. an Import) clips the over-cap entries off, dropping the latest-added ones first (Set insertion order) so the user's earlier picks survive.
- **Defense-in-depth.** The UI checks `canEnableMore()` BEFORE the WS message; the store also re-checks in `enable()`. A bypassed caller (MCP mirror, future automation) still can't push past the ceiling.
