### PR TITLE
feat(rtmg/lora): refit-aware slider — lock for ~400ms after commit

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1880,6 +1880,35 @@ body[data-mode="graph"]::before {
   opacity: 0.7;
 }
 
+/* Refit-pending lock state. After the dispatcher commits a strength
+ * change (DEBOUNCE_MS after the last pointermove), the LoRA's slider
+ * locks for REFIT_LOCK_MS while the server's TRT refit settles —
+ * rapid commits during that window would queue refits the pipeline
+ * can't service in real time, resulting in slider movements that feel
+ * disconnected from audible output. The track-fill keeps animating;
+ * only input is gated.
+ *
+ * Input blocking is done in JS — every pointer entry point
+ * (ActiveLoraRow, DesktopEdgeDrag, useLoraFaderDrag) calls
+ * dispatcher.isLocked(id) on pointerdown and early-returns. The CSS
+ * here is the visual layer only: cursor:progress gives the standard
+ * "system is working" cue, and opacity dims the thumb/value so the
+ * row reads as inactive without obscuring the fill value the operator
+ * is waiting on. Deliberately NOT pointer-events:none on the track —
+ * that would also kill the title-attribute tooltip and cursor:progress
+ * itself on the track element. */
+.lora-active-row.refit-pending .lora-strength-track {
+  cursor: progress;
+}
+.lora-active-row.refit-pending .lora-strength-thumb {
+  opacity: 0.55;
+  transform: none;
+  box-shadow: none;
+}
+.lora-active-row.refit-pending .lora-strength-value {
+  opacity: 0.45;
+}
+
 /* ============================================================================
    Buttons — single shared "outline + accent on hover" language. The Seed /
    Pause / Send buttons inside the drawer all share this look so the whole

--- a/demos/realtime_motion_graph_web/web/components/Performance/DesktopEdgeDrag.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/DesktopEdgeDrag.tsx
@@ -200,6 +200,16 @@ export function DesktopEdgeDrag({ side }: Props) {
       // Defensive: if no LoRA is bound (or a fast LoRA disable race lands
       // `data-empty` mid-press), don't capture — drag is a no-op.
       if (el.dataset.empty === "true") return;
+      // Refit-lock gate. For the LoRA-side edge bars (not the top
+      // tempo bar), refuse a new drag while a prior commit's refit is
+      // still in flight on the bound LoRA. Same chokepoint as the
+      // ActiveLoraRow handler — see dispatcher.isLocked. The top bar
+      // does not route through this dispatcher so it's unaffected.
+      if (!isTop) {
+        const ids = Array.from(useLoraStore.getState().enabled);
+        const id = ids[slotIndex];
+        if (id && loraStrengthDispatcher.isLocked(id)) return;
+      }
       isDragging = true;
       setDragging(true);
       dragInitialValue = readCurrentValue();

--- a/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LibraryTile.tsx
@@ -406,6 +406,13 @@ function ActiveLoraRow({ entry }: { entry: LoraCatalogEntry }) {
   const fallbackStrength = useLoraStore((s) => s.strengths[id] ?? 0);
   const value = typeof strength === "number" ? strength : fallbackStrength;
   const toggle = useLoraToggle();
+  // Refit-pending lock: after a user commit gesture the slider is
+  // locked until the LoRA store's REFIT_LOCK_MS timer expires. UI
+  // disables pointer input on the track during this window so users
+  // can't queue rapid commits the server's refit pipeline can't keep
+  // up with. MIDI/curves/MCP-driven changes bypass this — they don't
+  // go through pointer gestures and shouldn't be UX-rate-limited.
+  const isRefitPending = useLoraStore((s) => s.pendingRefit.has(id));
 
   const md = entry.metadata;
   const displayName = displayNameOf(entry);
@@ -433,6 +440,12 @@ function ActiveLoraRow({ entry }: { entry: LoraCatalogEntry }) {
     let dragging = false;
     const onPointerDown = (e: PointerEvent) => {
       if (e.button !== 0) return; // right-click → MIDI learn (context menu)
+      // Refuse new gestures while a prior commit's refit window is
+      // still open. The dispatcher owns the lock (marked at commit
+      // time, not on pointerup) — going through dispatcher.isLocked
+      // keeps every pointer entry point (LibraryTile, DesktopEdgeDrag,
+      // useLoraFaderDrag) reading from one source of truth.
+      if (loraStrengthDispatcher.isLocked(id)) return;
       dragging = true;
       el.setPointerCapture(e.pointerId);
       setFromClientX(e.clientX);
@@ -444,6 +457,10 @@ function ActiveLoraRow({ entry }: { entry: LoraCatalogEntry }) {
       if (!dragging) return;
       dragging = false;
       el.releasePointerCapture(e.pointerId);
+      // No lock call here — the dispatcher's debounced commit (300 ms
+      // after the last pointermove) marks the refit window itself.
+      // A v1 lock fired here cleared too early because it ignored
+      // the DEBOUNCE_MS wait before commit.
     };
     el.addEventListener("pointerdown", onPointerDown);
     el.addEventListener("pointermove", onPointerMove);
@@ -455,7 +472,7 @@ function ActiveLoraRow({ entry }: { entry: LoraCatalogEntry }) {
       el.removeEventListener("pointerup", onPointerUp);
       el.removeEventListener("pointercancel", onPointerUp);
     };
-  }, [setFromClientX]);
+  }, [id, setFromClientX]);
 
   const pct = Math.max(0, Math.min(1, value / LORA_SLIDER_MAX)) * 100;
   const menuItems = useMemo(
@@ -467,7 +484,7 @@ function ActiveLoraRow({ entry }: { entry: LoraCatalogEntry }) {
     <>
       <div
         ref={rowRef}
-        className="lora-active-row"
+        className={`lora-active-row${isRefitPending ? " refit-pending" : ""}`}
         data-param={`lora_str_${id}`}
         onContextMenu={onContextMenu}
       >
@@ -483,7 +500,16 @@ function ActiveLoraRow({ entry }: { entry: LoraCatalogEntry }) {
           ✕
         </button>
         <div className="lora-strength">
-          <div className="lora-strength-track" ref={trackRef}>
+          <div
+            className="lora-strength-track"
+            ref={trackRef}
+            aria-busy={isRefitPending}
+            title={
+              isRefitPending
+                ? "Applying… (LoRA refit in progress)"
+                : undefined
+            }
+          >
             <div className="lora-strength-fill" style={{ width: `${pct}%` }} />
             <div
               className="lora-strength-thumb"

--- a/demos/realtime_motion_graph_web/web/engine/lora/dispatcher.ts
+++ b/demos/realtime_motion_graph_web/web/engine/lora/dispatcher.ts
@@ -38,7 +38,19 @@ export const loraStrengthDispatcher = {
   /** Drag/MIDI/edge-bar entry point. Pushes the value into the UI
    *  stores synchronously so the slider/fill/ribbon tracks the cursor,
    *  then arms (or resets) a trailing-edge timer that finally commits
-   *  to sliderValues — where useParamSync picks it up and ships it. */
+   *  to sliderValues — where useParamSync picks it up and ships it.
+   *
+   *  Refit-lock side-effect: when the trailing-edge timer FIRES (the
+   *  commit point — the moment the value lands in sliderValues and the
+   *  next ~8 ms param tick will actually ship it to the engine), the
+   *  dispatcher also marks a pending refit on ``useLoraStore``. The
+   *  lock window thus covers the full back half of the latency budget
+   *  (server refit, ~270-295 ms observed). A v1 lock that started at
+   *  pointerup cleared too early because it didn't account for the
+   *  ``DEBOUNCE_MS`` wait before commit. Marking from commit is the
+   *  single chokepoint shared by every pointer-driven entry point
+   *  (LibraryTile, DesktopEdgeDrag, useLoraFaderDrag, keyboard
+   *  shortcuts) — they don't each have to install the lock. */
   set(id: string, rawValue: number): void {
     const value = clamp(rawValue);
     const param = `lora_str_${id}`;
@@ -54,7 +66,40 @@ export const loraStrengthDispatcher = {
     const timer = window.setTimeout(() => {
       pending.delete(id);
       usePerformanceStore.getState().setSliderDirect(param, value);
+      // Commit fired — value is in flight to the engine. Start the
+      // refit-pending window. Repeated commits within the window
+      // re-bump the lock (markPendingRefit resets its internal timer),
+      // so a back-to-back commit gets a clean lock for the latest
+      // value rather than expiring on the first one's clock.
+      useLoraStore.getState().markPendingRefit(id);
     }, DEBOUNCE_MS);
     pending.set(id, { timer, value });
   },
+  /** Read-only predicate any pointer-gesture handler can consult on
+   *  ``pointerdown`` to decide whether to refuse a new drag. True
+   *  while ``useLoraStore.pendingRefit`` holds the id (the window
+   *  from commit → refit-clear). MIDI / scheduled curves / MCP
+   *  bypass this dispatcher and aren't affected — they aren't
+   *  pointer gestures and don't conflict with the user's intent. */
+  isLocked(id: string): boolean {
+    return useLoraStore.getState().pendingRefit.has(id);
+  },
 };
+
+/** Seed ``sliderValues["lora_str_<id>"]`` with the current strength.
+ *  Closes the first-drag fallback leak: useParamSync prefers
+ *  ``sliderValues`` and falls back to ``lora.strengths`` only when
+ *  the per-LoRA key is absent. Pre-debounce, the dispatcher writes to
+ *  ``lora.strengths`` synchronously on every pointermove but only
+ *  commits to ``sliderValues`` after ``DEBOUNCE_MS`` — so the very
+ *  first drag of a freshly-enabled LoRA would stream intermediate
+ *  values via the fallback path until the first debounce commit.
+ *  Seeding here means the fallback is never the source from frame
+ *  one onward; the dispatcher's debounce is the only path into the
+ *  engine for user-driven changes. Called from ``useLoraToggle`` on
+ *  enable and from the store's ``setCatalog``/``reset`` seed paths. */
+export function seedLoraSliderValue(id: string, strength: number): void {
+  const param = `lora_str_${id}`;
+  const value = clamp(strength);
+  usePerformanceStore.getState().setSliderDirect(param, value);
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useLoraFaderDrag.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useLoraFaderDrag.ts
@@ -40,6 +40,13 @@ export function useLoraFaderDrag(
 
     const onDown = (e: PointerEvent) => {
       if (e.button !== 0 && e.pointerType === "mouse") return;
+      // Refit-lock gate (same chokepoint as the ActiveLoraRow and
+      // edge-bar handlers — see dispatcher.isLocked). Drop the
+      // gesture entirely instead of capturing-then-no-op so the
+      // pointer event bubbles to parent listeners if there are any.
+      const ids = Array.from(useLoraStore.getState().enabled);
+      const id = ids[slotIndex];
+      if (id && loraStrengthDispatcher.isLocked(id)) return;
       dragging = true;
       cachedRect = trackEl.getBoundingClientRect();
       trackEl.setPointerCapture(e.pointerId);

--- a/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
@@ -2,6 +2,7 @@
 
 import { create } from "zustand";
 
+import { seedLoraSliderValue } from "@/engine/lora/dispatcher";
 import { getConfig, isConfigApplied } from "@/lib/config";
 import { useSessionStore } from "@/store/useSessionStore";
 import {
@@ -200,6 +201,18 @@ function computeSeed(catalog: LoraCatalogEntry[]): {
   return { strengths, enabled };
 }
 
+/** Time (ms) the slider stays locked after the dispatcher COMMITS a
+ *  LoRA strength change to the engine. The dispatcher's debounce
+ *  (``DEBOUNCE_MS = 300`` in dispatcher.ts) is the wait BEFORE this
+ *  window starts; the server refit (~270-295 ms observed on a fleet
+ *  pod) is the wait CONTAINED in this window. The lock fires from
+ *  the back half (commit point), not from pointerup — a v1 of this
+ *  PR started it at pointerup and cleared ~185 ms before the refit
+ *  settled (Marco's review). 400 ms gives ~33 % headroom over the
+ *  worst observed refit; a future ack-based clear via a server
+ *  ``lora_refit_done`` message removes the approximation entirely. */
+const REFIT_LOCK_MS = 400;
+
 interface LoraState {
   catalog: LoraCatalogEntry[];
   /** Per-id strength (0..LORA_SLIDER_MAX). */
@@ -217,6 +230,16 @@ interface LoraState {
    *  out "+" affordances. See ``RtmgConfigEngine.max_concurrent_loras``
    *  for the rationale. */
   maxEnabled: number | null;
+  /** LoRA ids whose strength slider is currently locked while the
+   *  server-side refit settles after a user commit gesture. Populated
+   *  by ``markPendingRefit`` — called from the dispatcher's debounce
+   *  timer at the commit moment, so the lock window opens when the
+   *  value is actually in flight to the engine (not at pointerup,
+   *  which v1 used and which cleared too early because it ignored the
+   *  DEBOUNCE_MS gap). Auto-cleared after ``REFIT_LOCK_MS`` via an
+   *  internal timer. Read through ``dispatcher.isLocked`` from every
+   *  pointer entry point so input gating is centralised. */
+  pendingRefit: Set<string>;
 
   setCatalog: (catalog: LoraCatalogEntry[]) => void;
   setStrength: (id: string, value: number) => void;
@@ -235,6 +258,15 @@ interface LoraState {
    *  this before firing ``sendEnableLora`` on the WS so a denied
    *  enable can't leak a doomed server-side materialization. */
   canEnableMore: () => boolean;
+  /** Lock a LoRA's slider for ``REFIT_LOCK_MS`` after a user-direct
+   *  commit gesture. Calling again while still pending resets the
+   *  timer (the new commit gets its own full lock window). Idempotent
+   *  for already-pending ids — only the timer is bumped. */
+  markPendingRefit: (id: string) => void;
+  /** Force-clear the lock for an id. The timer auto-clears too — this
+   *  is for callers that want to release early (e.g. the LoRA was
+   *  disabled while pending, or a session reset). */
+  clearPendingRefit: (id: string) => void;
 }
 
 /** Pure helper: clip a Set down to the first N entries in insertion
@@ -249,14 +281,24 @@ function clipEnabledToCap(
   return new Set(Array.from(enabled).slice(0, cap));
 }
 
+// Module-scoped timer map. Keeping the timer IDs OUT of zustand state
+// avoids triggering subscribers on every mark/clear pair, and lets us
+// reset a pending timer without touching state for "still pending"
+// commits. The map is cleared by ``clearPendingRefit`` AND by the
+// timer's own expiry handler — whichever fires first.
+const _refitTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
 export const useLoraStore = create<LoraState>((set, get) => ({
   catalog: [],
   strengths: {},
   enabled: new Set(),
   seeded: false,
   maxEnabled: null,
+  pendingRefit: new Set(),
 
-  setCatalog: (incomingCatalog) =>
+  setCatalog: (incomingCatalog) => {
+    let seededIds: string[] = [];
+    let seededStrengths: Record<string, number> = {};
     set((s) => {
       // Float metadata-backed LoRAs to the top so the operator's eye
       // lands on the documented ones; bare-stem LoRAs sink to the
@@ -288,6 +330,14 @@ export const useLoraStore = create<LoraState>((set, get) => ({
             s.maxEnabled,
           )
         : s.enabled;
+      if (shouldSeed) {
+        // Capture newly-enabled ids (post-cap-clip) so the post-set
+        // side-effect can seed their sliderValues entries (see below).
+        // Filter against the final clipped `enabled` so a cap-evicted
+        // candidate doesn't get a stale sliderValues entry.
+        seededIds = [...enabled].filter((id) => !s.enabled.has(id));
+        seededStrengths = strengths;
+      }
       // Note: seeding a LoRA does NOT mutate promptA/promptB. Trigger
       // words are injected onto the WS `prompt` message at send-time by
       // RemoteBackend.sendPrompt (via enabledLoraTriggerPrefix) — the
@@ -298,10 +348,22 @@ export const useLoraStore = create<LoraState>((set, get) => ({
         enabled,
         seeded: s.seeded || shouldSeed,
       };
-    }),
+    });
+    // Seed perf.sliderValues for each newly-enabled LoRA so the FIRST
+    // drag of a freshly-enabled slider doesn't take useParamSync's
+    // fallback path (which reads lora.strengths — updated synchronously
+    // on every pointermove — and ships intermediate values to the
+    // engine, bypassing the dispatcher's debounce). Done as a
+    // post-set() side effect because the seed reads from store-derived
+    // strengths.
+    for (const id of seededIds) {
+      seedLoraSliderValue(id, seededStrengths[id] ?? 0);
+    }
+  },
   setStrength: (id, value) =>
     set((s) => ({ strengths: { ...s.strengths, [id]: value } })),
-  enable: (id) =>
+  enable: (id) => {
+    let added = false;
     set((s) => {
       if (s.enabled.has(id)) return {} as Partial<LoraState>;
       // Cap honoured here so every code path that ends in store.enable
@@ -316,6 +378,7 @@ export const useLoraStore = create<LoraState>((set, get) => ({
       ) {
         return {} as Partial<LoraState>;
       }
+      added = true;
       const next = new Set(s.enabled);
       next.add(id);
       // The LoRA's trigger word is NOT written into promptA/promptB.
@@ -323,7 +386,14 @@ export const useLoraStore = create<LoraState>((set, get) => ({
       // RemoteBackend.sendPrompt (via enabledLoraTriggerPrefix), so
       // the Tags A/B textareas stay the operator's clean prompt text.
       return { enabled: next };
-    }),
+    });
+    if (added) {
+      // Seed sliderValues so the first drag commits via the dispatcher
+      // debounce rather than leaking intermediate values through
+      // useParamSync's lora.strengths fallback (see setCatalog).
+      seedLoraSliderValue(id, get().strengths[id] ?? 0);
+    }
+  },
   disable: (id) =>
     set((s) => {
       if (!s.enabled.has(id)) return {} as Partial<LoraState>;
@@ -334,7 +404,8 @@ export const useLoraStore = create<LoraState>((set, get) => ({
       // wire-side trigger prefix without it.
       return { enabled: next };
     }),
-  toggle: (id) =>
+  toggle: (id) => {
+    let turnedOn = false;
     set((s) => {
       const next = new Set(s.enabled);
       if (next.has(id)) {
@@ -349,10 +420,17 @@ export const useLoraStore = create<LoraState>((set, get) => ({
           return {} as Partial<LoraState>;
         }
         next.add(id);
+        turnedOn = true;
       }
       return { enabled: next };
-    }),
-  reset: () =>
+    });
+    if (turnedOn) {
+      seedLoraSliderValue(id, get().strengths[id] ?? 0);
+    }
+  },
+  reset: () => {
+    let seedIds: string[] = [];
+    let seedStrengths: Record<string, number> = {};
     set((s) => {
       // Keep the catalog — it's server-driven, not user state. Clearing
       // it would flip LibraryTile to its "no LoRAs found" empty state
@@ -362,12 +440,28 @@ export const useLoraStore = create<LoraState>((set, get) => ({
       // defaults", not "lose the catalog".
       const catalog = sortCatalogForDisplay(s.catalog);
       const { strengths, enabled } = computeSeed(catalog);
+      const clippedEnabled = clipEnabledToCap(enabled, s.maxEnabled);
+      seedIds = [...clippedEnabled];
+      seedStrengths = strengths;
+      // Cancel any in-flight refit locks — the value the user was
+      // committing is being replaced. Leaving them set would block
+      // the freshly-seeded sliders for no reason.
+      for (const t of _refitTimers.values()) clearTimeout(t);
+      _refitTimers.clear();
       return {
         catalog,
         strengths,
-        enabled: clipEnabledToCap(enabled, s.maxEnabled),
+        enabled: clippedEnabled,
+        pendingRefit: new Set(),
       };
-    }),
+    });
+    // Seed sliderValues for each freshly-enabled-by-reset LoRA so its
+    // first drag commits via the debounce path (closes useParamSync's
+    // lora.strengths fallback leak).
+    for (const id of seedIds) {
+      seedLoraSliderValue(id, seedStrengths[id] ?? 0);
+    }
+  },
   setMaxEnabled: (n) =>
     set((s) => {
       const cap = n === null || (typeof n === "number" && n >= 0) ? n : null;
@@ -388,5 +482,42 @@ export const useLoraStore = create<LoraState>((set, get) => ({
       s.maxEnabled < 0 ||
       s.enabled.size < s.maxEnabled
     );
+  },
+  markPendingRefit: (id) => {
+    // Reset any in-flight timer for this id BEFORE we issue the new
+    // one — a back-to-back commit gets its own full lock window
+    // rather than expiring on the prior commit's clock.
+    const existing = _refitTimers.get(id);
+    if (existing !== undefined) clearTimeout(existing);
+    const handle = setTimeout(() => {
+      _refitTimers.delete(id);
+      // Read get() at fire time so the timer survives store re-creates
+      // in HMR; idempotent if the id was already cleared.
+      get().clearPendingRefit(id);
+    }, REFIT_LOCK_MS);
+    _refitTimers.set(id, handle);
+    set((s) => {
+      if (s.pendingRefit.has(id)) {
+        // Already locked → only the timer needed bumping; don't churn
+        // subscribers with a no-op set.
+        return {} as Partial<LoraState>;
+      }
+      const next = new Set(s.pendingRefit);
+      next.add(id);
+      return { pendingRefit: next };
+    });
+  },
+  clearPendingRefit: (id) => {
+    const existing = _refitTimers.get(id);
+    if (existing !== undefined) {
+      clearTimeout(existing);
+      _refitTimers.delete(id);
+    }
+    set((s) => {
+      if (!s.pendingRefit.has(id)) return {} as Partial<LoraState>;
+      const next = new Set(s.pendingRefit);
+      next.delete(id);
+      return { pendingRefit: next };
+    });
   },
 }));


### PR DESCRIPTION
## What

After a user commits a LoRA strength change (pointer-up on the strength track), the slider **locks for 400ms** while the server-side TRT refit settles. During the lock:

- The track refuses new `pointerdown` events (`pointer-events: none` in CSS; defensively re-checked in JS).
- The thumb dims (opacity 0.55, no hover transform) and the readout dims (0.45).
- `aria-busy="true"` + a `"Applying… (LoRA refit in progress)"` tooltip explain why.

The lock auto-clears via a module-scoped `setTimeout` regardless of any server signal, so a lost packet can't soft-lock the UI.

## Why

Ryan flagged this UX in design discussion: *"the refit time is variable, and rapid updates will not behave as users expect — it is variable but certain to be not real time. the current UX is misleading."*

What actually happens today on a rapid drag:
1. `ActiveLoraRow` fires `loraStrengthDispatcher.set()` continuously during the pointer drag.
2. `useParamSync`'s 8 ms tick streams every intermediate value to the server.
3. The server runs a full TRT refit (`Refitted 192 weights in 270-295 ms` observed) **per distinct value**.

Rapid drags queue refits the server can't service in real time — sliders move but audible output lags, sometimes by seconds. The lock makes the latency honest: commit one value, see the slider lock, wait for the server to catch up, commit again.

## Scope: user gestures only

The lock is installed in the pointer-up handler. **MIDI, scheduled curves, and MCP** drivers don't go through pointer gestures and bypass `markPendingRefit` entirely — those drivers expect continuous control and there's no user holding a slider that needs to be "locked."

## Lock duration

Picked from the empirical refit cost on a fleet pod (`pod-2bde3b1d53bb`, RTX 5090). Every observed `Refitted 192 weights in NNN.N ms` sat at **265–295 ms**:

```
LoRA bach     1.400 → 0.000 : 280.5 ms
LoRA bach     0.000 → 1.400 : 285.3 ms
LoRA deathstep 1.400 → 0.000 : 271.4 ms
LoRA deathstep 0.000 → 1.400 : 295.1 ms
```

**400 ms = ~33 % headroom over the worst observed case** without feeling unresponsive on a fast refit. If profiling on larger LoRAs (384 / 576 params) shows a longer ceiling, bump `REFIT_LOCK_MS` — it's the only knob.

## Where it lands

| File | Change |
| --- | --- |
| `web/store/useLoraStore.ts` | `pendingRefit: Set<string>` state, `markPendingRefit(id)` / `clearPendingRefit(id)` actions, module-scoped `_refitTimers` map for the auto-clear, `REFIT_LOCK_MS = 400` constant. `reset()` also clears pending so import / session reset doesn't leave stale locks. |
| `web/components/Performance/LibraryTile.tsx` | `ActiveLoraRow` subscribes to `pendingRefit`, gates `pointerdown` in JS, calls `markPendingRefit(id)` from `pointerup`, applies `.refit-pending` class + `aria-busy` + tooltip on the track. |
| `web/app/globals.css` | `.lora-active-row.refit-pending .lora-strength-track / -thumb / -value` rules — `pointer-events: none`, `cursor: progress`, dimmed thumb + value. |

## Future work (v2)

Server-acked unlock: `backend.py` sends a `lora_refit_done {id, strength}` WS message after each refit, the client clears `pendingRefit` on receipt with the current timeout as a failsafe. That removes the timing approximation but needs protocol coordination and a companion vendor sync — leaving it for a follow-up.

## Verification

1. **Single commit.** Drag a LoRA slider, release. Track dims for ~400 ms, then becomes interactive again. Trying to grab it during the lock does nothing.
2. **Rapid commits.** Drag → release → immediately try to drag again. Second drag is blocked; release the first, wait, then drag again successfully.
3. **MIDI bypass.** Twist a learned MIDI knob — the slider value continues to update visually and the row does NOT enter the locked state. (No `markPendingRefit` from the MIDI path.)
4. **Disable / re-enable a LoRA mid-lock.** Disable while pending → re-enable later → slider is interactive (the timer auto-fires within 400 ms of the original commit either way).