### PR TITLE
fix(rtmg/lora): reclaim VRAM cache on disable_lora — fixes cumulative-rotation OOM

### DIFF
--- a/acestep/engine/lora.py
+++ b/acestep/engine/lora.py
@@ -465,6 +465,36 @@ class LoRAManagerBase(abc.ABC):
 
         if was_contributing:
             self._refit_weights(affected_params)
+
+        # Return the just-freed GPU delta mirror to the CUDA driver.
+        # _on_disabled drops the only Python references to the mirror
+        # tensors, but PyTorch's caching allocator retains the
+        # underlying VRAM segments in its pool to amortize future
+        # alloc cost. For LoRA disables that's the wrong trade:
+        # nvidia-smi still reports the memory as "used" (e.g. a
+        # 1.2 GB delta footprint sits resident), and worse, the pool
+        # fragments across a session of mixed-size enable/disable
+        # cycles. The fragmentation surface manifests on a fleet pod
+        # as a mid-session OOM after a few LoRA rotations:
+        #
+        #   [Server] WS dispatch error: CUDA out of memory.
+        #     Tried to allocate 32 MiB. GPU 0 has 13.25 MiB free.
+        #     process using 31.31 GiB / 31.36 GiB.
+        #     PyTorch allocated 12.98 GiB, 435.36 MiB reserved but
+        #     unallocated.  ← the cached pool we want to reclaim
+        #
+        # The PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True env
+        # also avoids fragmentation but is global-process and
+        # opt-in. Calling empty_cache() here is precise (only fires
+        # on the actual free event), cheap (microseconds-to-low-ms
+        # since refs are already dropped), and doesn't require an
+        # operator action. Cap PR (#140 in demon-public-demo)
+        # bounds concurrent enables; this commit handles the
+        # cumulative-rotation pattern that the cap alone can't
+        # prevent.
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
         logger.info(
             "Disabled LoRA {} (was_contributing={})",
             lora_id, was_contributing,


### PR DESCRIPTION
## What

One-line behavior change in `LoRAManager.disable_lora`: call `torch.cuda.empty_cache()` after the GPU delta mirror is dropped, so the freed VRAM is actually returned to the CUDA driver instead of sitting in PyTorch's caching allocator pool.

## Why — caught live with continuous monitoring

```
18:12:12-22  Materialize 5 LoRAs (hip_hop, rap, alternative,
             alternative_rock, emo) — 6.0 GB cumulative
18:12:41     Materialize acoustic-v1 — 7.2 GB
18:12:45-52  Disable all 6
18:13:30     Source swap 156s walk-window → OK (purge fix #139 worked)
18:14:41     Materialize deep_house-v1 (a 7th)
18:14:42     WS dispatch error: CUDA out of memory.
              Tried to allocate 32.00 MiB. GPU 0 has 13.25 MiB free.
              Process using 31.31 GiB / 31.36 GiB.
              PyTorch allocated 12.98 GiB, 435.36 MiB reserved but unallocated.
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                            ← the cached pool we want to reclaim
```

The OOM message's hint about `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` is the same root cause from a different angle — fragmentation of mixed-size frees in the allocator pool.

After session close, the pod recovers cleanly:
```
18:15:17  Client disconnected (529 generations) → Marco's #141 close-evict fires
18:15:20  VRAM=662 MiB     ← session.close()'s gc.collect() + empty_cache() works
```

So the gap is specifically **mid-session disable**, which never reaches a close.

## Why it's the right place to fix

- **Precise**: only fires on actual LoRA frees, not every tick.
- **Cheap**: `empty_cache()` walks the allocator's free segments — microseconds to low-ms once refs are already dropped (and `_on_disabled` dropped them just above).
- **No env-var dance**: doesn't require operators to set `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` on every pod. The cure is in-code.
- **Scope-correct**: `enable_lora` doesn't free anything; `set_lora_strength` doesn't free; only `disable_lora` is the natural reclaim point.

## How this stacks with the other PRs

| PR | Layer | Fixes |
| --- | --- | --- |
| #139 | TRT cache (engines) | Cross-session vae_encode leak + wrong-engine `rejected input shape` |
| #140 | webapp config (LoRA cap) | Bounds *concurrent* enabled LoRAs at a hosted ceiling |
| #141 (Marco) | Session.close | Evicts session's vae_encode/vae_decode at teardown |
| #142 | webapp UI (slider lock) | Honest UX for refit latency |
| **this** | LoRA manager (disable) | Reclaims cached VRAM mid-session so cumulative rotations don't OOM |

#140 caps the *count* at any one time; this commit reclaims *across time*. They're complementary — even with cap=3, a session rotating A→B→C→A→D→E… would still accumulate fragmented cache without this fix.

## Verification

After hotpatch on the failing pod, the same rotation pattern should NOT trip OOM:
1. Enable 3 LoRAs, disable, enable 3 different ones, repeat ×5
2. `nvidia-smi --query-gpu=memory.used` should stay roughly flat across cycles (modulo the active 3 × ~1.2 GB resident)
3. A walk-window 157 s source upload between rotations still succeeds (no regression to #139)