### PR TITLE
fix(rtmg/lora): stop useMcpMirror from auto-disabling on catalog updates

### DIFF
--- a/demos/realtime_motion_graph_web/web/hooks/useMcpMirror.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useMcpMirror.ts
@@ -115,12 +115,30 @@ export function useMcpMirror() {
 
       const onLoraCatalog = (e: Event) => {
         // Server-broadcast catalog after the runner thread applies a
-        // pending enable/disable. Reconcile the UI's enabled set +
-        // strengths against the catalog so MCP-driven LoRA toggles
-        // surface in the Library panel and useParamSync starts sending
-        // the right per-LoRA strengths next tick. Without this, the
-        // front-end's `enabled` set keeps its own user-click history
-        // regardless of what's actually loaded in the engine.
+        // pending enable/disable. We surface server-side ENABLES
+        // (e.g. MCP toggled a LoRA on) into the front-end's enabled
+        // set so the Library panel reflects them and useParamSync
+        // starts sending the right per-LoRA strengths next tick.
+        //
+        // We deliberately do NOT auto-disable from the catalog state.
+        // Reason: this same handler fires after EVERY enable/disable
+        // ack (any time the server's catalog changes for any cause),
+        // and on certain code paths the broadcasted entry can have a
+        // non-"enabled" state for a LoRA the user has just enabled in
+        // the store. Reconciling "everything non-enabled in catalog →
+        // disable in store" wipes the user's selection on the next
+        // catalog update — captured live as the
+        // "click bach to disable, deathstep also disappears" bug
+        // (one outbound disable_lora WS, two store.disable calls;
+        // second one came from this handler).
+        //
+        // The MCP-initiated DISABLE path the comment above this
+        // function originally worried about IS still handled: the
+        // server's response to an MCP-driven disable_lora is
+        // dispatched through the same channel as a browser-initiated
+        // disable_lora, so the regular client-side `disable()` path
+        // (LibraryTile toggle / hooks calling store.disable) covers
+        // it. We just don't re-derive it from the catalog snapshot.
         const catalog = (e as CustomEvent<LoraCatalogEntry[]>).detail;
         if (!Array.isArray(catalog)) return;
         const lora = useLoraStore.getState();
@@ -128,13 +146,12 @@ export function useMcpMirror() {
         for (const entry of catalog) {
           if (!entry || typeof entry.id !== "string") continue;
           if (entry.state === "enabled") {
-            lora.enable(entry.id);
+            if (!lora.enabled.has(entry.id)) lora.enable(entry.id);
             if (typeof entry.strength === "number" && entry.strength > 0) {
               lora.setStrength(entry.id, entry.strength);
             }
-          } else {
-            lora.disable(entry.id);
           }
+          // No `else { lora.disable(...) }` — see comment above.
         }
       };
 


### PR DESCRIPTION
## What

In `hooks/useMcpMirror.ts`, the `onLoraCatalog` event handler walks the server-broadcast catalog and reconciles the client's `enabled` set with the catalog's per-entry `state` field. Old behavior:

```ts
if (entry.state === "enabled") {
  lora.enable(entry.id);
  ...
} else {
  lora.disable(entry.id);   // ← BUG: wipes the user's enabled set
}
```

This PR removes the `else` branch. The handler now only **surfaces** server-side enables (e.g. MCP toggled a LoRA on), never auto-derives a disable from the catalog snapshot.

## Why — captured live

Operator session on `pod-e845ab35597b`, with a debug subscriber on `useLoraStore.enabled`:

```
[enabled change] {prev: ['deathstep','bach'], curr: ['deathstep']}
   onClick → disable                  # user click (correct)

[enabled change] {prev: ['deathstep'], curr: []}
   r.onmessage → u → disable          # this handler (bug)
```

Two store mutations from a single user click — only ONE outbound `disable_lora` WS frame. The second mutation is silent: the engine still has `deathstep` materialized (~1.2 GiB of GPU memory pinned), the user can't see or control it. Ghost LoRA.

The catalog state mismatch can come from several places:
- Stale HTTP `/api/loras` catalog overwriting a WS-sourced catalog
- Server-side enable that failed silently (e.g. OOM during materialize → entry stays REGISTERED)
- Transient state during `apply_lora_pending` between enable + the `_send_catalog_update` snapshot

Any of these surface as "user clicks one, both gone, server keeps the other resident."

## Fix scope

Preserves the originally-intended behavior (MCP-driven enables surface to UI) and removes only the destructive part (auto-disable derived from catalog).

Trade-off documented inline: if MCP ever disables a LoRA AND the server's response only arrives via this catalog frame with no separate disable echo, the UI won't reflect the disable until something else nudges it. In practice the server's enable/disable processing fires its own per-id ack through the same dispatch path browser-driven disables ride, so this is theoretical — the worst case is a UI showing a LoRA as enabled that the engine has dropped, which the next user toggle re-syncs.

## Verification

Test branch DEMON `gio/test/lora-stack` includes this fix on top of #140 + #142. Vendored preview at `demon-public-demo#261`. Repro the previous "click one, both gone":

1. Open preview, two LoRAs (bach + deathstep) default-enabled.
2. Open DevTools console, install the subscriber:
   ```js
   __loraUnsub = __lora.subscribe((s, prev) => {
     if (s.enabled !== prev.enabled) {
       console.log('[enabled change]', {prev:[...prev.enabled], curr:[...s.enabled]});
       console.trace();
     }
   })
   ```
3. Click bach to disable. With fix: ONE `[enabled change]` event, both store and WS show ONE `disable(bach)`. Without fix: TWO events, second from `r.onmessage`.