### PR TITLE
feat(rtmg/mobile): redesign mobile performance surface

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -4943,13 +4943,20 @@ body.curve-open #install-video-area #graph {
   left: 0;
   right: 0;
   bottom: 0;
-  /* Clear the side fader rails so we don't overlap them. */
-  margin-inline: calc(var(--stepper-rail-w, 64px));
+  /* Full-width bay on every mobile size. The previous
+   * ``margin-inline: var(--stepper-rail-w)`` kept the bay clear of
+   * the edge fader rails, but it shrank the usable surface on
+   * tablets / wide phones and left ugly L/R margins. The rails are
+   * still mounted underneath at left/right: 0; they show through
+   * the gradient bg but don't block touches (the bay sits at
+   * z-index 8, above the rails). Safe-area only — env() so notched
+   * landscape phones don't push the bay under the chin. */
+  margin-inline: 0;
   padding:
     10px
-    14px
+    max(14px, env(safe-area-inset-left, 0px))
     calc(env(safe-area-inset-bottom, 0px) + 12px)
-    14px;
+    max(14px, env(safe-area-inset-right, 0px));
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -4979,15 +4986,8 @@ body.curve-open #install-video-area #graph {
     display: flex;
   }
 }
-@media (max-width: 380px) {
-  /* Narrowest phones — pull the side margins back to the safe-area
-     edge to win every pixel for the faders. The rails still anchor at
-     left/right: 0 so they overlap visually but the controls stay usable. */
-  .lite-controls {
-    margin-left: max(env(safe-area-inset-left, 0px), 4px);
-    margin-right: max(env(safe-area-inset-right, 0px), 4px);
-  }
-}
+/* (No narrow-phone-specific override needed — the main rule above
+ * already runs the bay full-width with safe-area padding only.) */
 
 /* Wave 13.4 lite tabs — Mix / Track pill row sitting at the top of
    the bay. Small mono-caps cells with frame-line outline; active cell
@@ -5070,15 +5070,15 @@ body.curve-open #install-video-area #graph {
   align-items: center;
 }
 
-/* Track row — horizontal scroll carousel of fixtures + upload chip.
-   Sits across the top of the bay; the carousel itself owns its own
-   gutters and scroll behaviour. */
+/* Track row — single native <select> spanning the full width of the
+ * bay. Sits across the top; the picker owns its own padding and
+ * chevron, so the wrapper just expands to full width. */
 .lite-row--track {
   flex: 0 0 auto;
   width: 100%;
   min-width: 0;
 }
-.lite-row--track > .lite-track-carousel {
+.lite-row--track > .lite-track-picker {
   flex: 1 1 auto;
   min-width: 0;
 }
@@ -5119,8 +5119,13 @@ body.curve-open #install-video-area #graph {
   flex: 1 1 auto;
   min-height: 140px;
 }
-.lite-row--main .slider-track::before { width: 6px; }
-.lite-row--main .slider-fill { width: 6px; }
+/* The visible track + fill are as wide as the thumb so the fader
+ * reads as a single chunky column instead of a thin line with a
+ * disc floating on it. The thumb still sits centered over the
+ * track and the contrast (muted track vs accent-bordered thumb)
+ * carries the "this is the handle" affordance. */
+.lite-row--main .slider-track::before { width: 28px; }
+.lite-row--main .slider-fill { width: 28px; }
 .lite-row--main .slider-thumb {
   width: 28px;
   height: 28px;
@@ -6701,99 +6706,76 @@ body.curve-open #install-video-area #graph {
   background: transparent;
 }
 
-/* ── Lite track carousel ──────────────────────────────────────────────── */
-.lite-track-carousel {
+/* ── Lite track picker (native <select>) ─────────────────────────────── */
+/* Replaces the previous scroll-snap carousel of chips. Letting the OS
+ * draw the picker on tap gives a one-thumb friendly chooser (iOS
+ * wheel / Android dialog) with built-in scrolling, search, and
+ * accessibility for free. The CSS below dresses the closed-state
+ * select to match the bay's mono-caps aesthetic; ``appearance: none``
+ * strips the OS chrome but the picker still pops on tap. */
+.lite-track-picker {
   flex: 0 0 auto;
-  position: relative;
-  margin: 0 -16px;
-  padding: 0 4px;
-  /* Fade the edges so chips bleed off without a hard cut. */
-  -webkit-mask-image: linear-gradient(90deg,
-    transparent, black 20px, black calc(100% - 20px), transparent);
-          mask-image: linear-gradient(90deg,
-    transparent, black 20px, black calc(100% - 20px), transparent);
-}
-.lite-track-carousel-scroll {
   display: flex;
-  gap: 8px;
-  overflow-x: auto;
-  scroll-snap-type: x proximity;
-  scrollbar-width: none;
-  padding: 6px 12px 8px;
-  -webkit-overflow-scrolling: touch;
-  /* This carousel is nested inside the Mix/Track scroll-snap track.
-     Without containment, swiping the chips chains the scroll out to
-     the parent and snaps back to the Mix tab. */
-  overscroll-behavior-x: contain;
+  flex-direction: column;
+  gap: 4px;
+  padding: 2px 2px 0;
 }
-.lite-track-carousel-scroll::-webkit-scrollbar { display: none; }
-.lite-track-carousel-empty {
+.lite-track-picker-label {
   font-family: var(--font-mono);
-  font-size: 0.74em;
+  font-size: 0.66em;
   letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
   color: var(--text-dim);
-  padding: 12px 8px;
+  padding-left: 2px;
 }
-
-.lite-track-chip {
-  scroll-snap-align: center;
-  flex: 0 0 auto;
-  /* WCAG 2.5.5 floor (44x44) — chip is taller than tall, hugs label width. */
-  min-height: 48px;
-  min-width: 64px;
-  padding: 0 14px;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  background: transparent;
+.lite-track-picker-field {
+  /* Positioning anchor for the chevron — the native select doesn't
+   * give us a hook to draw one inside, so it lives as an absolutely
+   * positioned span layered on top with pointer-events: none. */
+  position: relative;
+  display: flex;
+}
+.lite-track-picker-select {
+  flex: 1 1 auto;
+  min-height: 48px; /* WCAG 2.5.5 touch-target floor */
+  padding: 0 36px 0 14px;
+  background: rgba(255, 255, 255, 0.04);
   border: 1px solid var(--frame-line);
-  border-radius: 999px;
-  color: var(--text-dim);
+  border-radius: var(--radius-md);
+  color: var(--text);
   font: inherit;
   font-family: var(--font-mono);
-  font-size: 0.74em;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 0.78em;
+  letter-spacing: 0.04em;
+  /* Strip default browser chrome — the chevron span on the right
+   * carries the affordance. iOS/Android still open the native picker
+   * on tap regardless. */
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
   cursor: pointer;
+  width: 100%;
+  text-overflow: ellipsis;
   white-space: nowrap;
-  transition: color 120ms, border-color 120ms, background 120ms,
-              transform 120ms, box-shadow 120ms;
+  overflow: hidden;
 }
-.lite-track-chip:hover {
-  color: var(--accent);
-  border-color: var(--accent-line);
-}
-.lite-track-chip:active {
-  transform: scale(0.96);
-}
-.lite-track-chip--current {
-  color: var(--text);
+.lite-track-picker-select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
   border-color: var(--accent);
-  background: var(--accent-soft);
-  box-shadow: 0 0 12px var(--accent-glow);
 }
-.lite-track-chip--custom {
-  /* Subtle hint that this is user-uploaded. */
-  border-style: dashed;
-}
-.lite-track-chip--upload {
-  color: var(--accent);
-  border-color: var(--accent-line);
-  border-style: dashed;
-}
-.lite-track-chip--upload:disabled {
+.lite-track-picker-select:disabled {
   opacity: 0.6;
   cursor: progress;
 }
-.lite-track-chip-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-.lite-track-chip-label {
-  max-width: 18ch;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.lite-track-picker-chevron {
+  position: absolute;
+  right: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-dim);
+  pointer-events: none;
+  font-size: 0.85em;
 }
 
 /* ── Lite actions row (replaces .lite-row--prompt after reshuffle) ──── */

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -1849,6 +1849,14 @@ body[data-mode="graph"]::before {
   /* Vertical room for the 14px thumb knob without growing the row.
      The track itself stays 6px tall; the thumb floats above and below. */
   margin: 4px 7px;
+  /* The slider lives inside the MobileFullSheet, whose .mobile-sheet-track
+   * uses ``scroll-snap-type: x mandatory`` to swipe between tabs. Without
+   * ``touch-action: none``, a horizontal drag on the slider is interpreted
+   * by the browser as a scroll gesture on the parent — the sheet snaps to
+   * the next tab instead of moving the strength value. ``none`` tells the
+   * browser "this element handles all touch gestures itself", so the
+   * dispatcher's pointer-capture wins and the sheet stays put. */
+  touch-action: none;
 }
 .lora-strength-track:hover { background: rgba(255, 255, 255, 0.14); }
 .lora-strength-fill {
@@ -7034,13 +7042,21 @@ body.curve-open #install-video-area #graph {
    itself sits at top:18 + height:42 = bottom 60, so 70 leaves a 10px
    gap. */
 @media (max-width: 768px) {
+  /* On mobile the scrub strip fills the screen between the brand
+   * header and the slider bay rather than sitting as a thin line at
+   * the top — gives the user a generous scrub target and turns the
+   * waveform itself into the primary visual instead of a hidden
+   * detail. Anchored top+bottom (no fixed height) so it stretches
+   * with viewport: top below the brand mark, bottom above the
+   * lite-controls bay which occupies the lower ~half of the
+   * viewport. Full width — no rail clearance — matching the bay's
+   * full-width treatment. */
   .waveform-scrub-box {
     top: max(env(safe-area-inset-top, 0px) + 70px, 70px);
-    left: calc(var(--stepper-rail-w, 64px)
-               + max(env(safe-area-inset-left, 0px), 8px));
-    right: calc(var(--stepper-rail-w, 64px)
-                + max(env(safe-area-inset-right, 0px), 8px));
-    height: 44px;
+    left: max(env(safe-area-inset-left, 0px), 8px);
+    right: max(env(safe-area-inset-right, 0px), 8px);
+    bottom: 50vh;
+    height: auto;
     /* Sit above the install-stage background but below modals and the
        LiteControls bay. */
     z-index: 5;

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -6976,6 +6976,14 @@ body.curve-open #install-video-area #graph {
     opacity 240ms ease-out,
     left 320ms cubic-bezier(.2, .7, .2, 1);
   pointer-events: auto;
+  /* Critical on mobile: without this the browser interprets a
+   * horizontal touch drag as panning and yanks the pointer event
+   * stream away from JS mid-scrub (setPointerCapture is too late to
+   * keep ownership). Symptom was a touch-scrub that worked for ~10
+   * px then stopped, and loop-drawing was effectively impossible.
+   * ``none`` gives the component exclusive control of every gesture
+   * on the strip. */
+  touch-action: none;
 }
 .waveform-scrub-box[data-ready="true"] {
   opacity: 1;
@@ -7057,6 +7065,12 @@ body.curve-open #install-video-area #graph {
     right: max(env(safe-area-inset-right, 0px), 8px);
     bottom: 50vh;
     height: auto;
+    /* Inner breathing room — the canvases (position:absolute;
+     * inset:0) anchor to the padding box, so this pulls the
+     * waveform graphic away from the container edges. Equal
+     * top/bottom keeps the waveform vertically centered. */
+    padding: 18px 14px;
+    box-sizing: border-box;
     /* Sit above the install-stage background but below modals and the
        LiteControls bay. */
     z-index: 5;

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -200,6 +200,17 @@ body.cursor-hidden nextjs-portal * {
 
 body.cursor-idle .cursor-canvas { opacity: 0; }
 
+/* Hide the custom cursor entirely on touch-only devices. The cursor
+ * was designed as a desktop mouse trail — on mobile, every tap left
+ * a white dot under the user's finger which read as a stray artefact
+ * over their own touch input. Matched via the hover/pointer media
+ * features so it triggers on any touch-only device regardless of
+ * viewport width (covers tablets in landscape and unusual aspect
+ * ratios that the 768 px breakpoint would miss). */
+@media (hover: none) and (pointer: coarse) {
+  .cursor-canvas { display: none; }
+}
+
 /* ── Performance screen + Play overlay ───────────────────────────────────── */
 #performance {
   position: fixed;
@@ -5130,8 +5141,18 @@ body.curve-open #install-video-area #graph {
  * disc floating on it. The thumb still sits centered over the
  * track and the contrast (muted track vs accent-bordered thumb)
  * carries the "this is the handle" affordance. */
-.lite-row--main .slider-track::before { width: 28px; }
-.lite-row--main .slider-fill { width: 28px; }
+/* Pill-rounded top + bottom on the mobile track so the circular
+ * thumb sits flush inside the column at the min/max ends (the
+ * thumb radius == half the track width, so border-radius: 14px on
+ * both the recess and the fill closes the corners exactly). */
+.lite-row--main .slider-track::before {
+  width: 28px;
+  border-radius: 14px;
+}
+.lite-row--main .slider-fill {
+  width: 28px;
+  border-radius: 14px;
+}
 .lite-row--main .slider-thumb {
   width: 28px;
   height: 28px;

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -5103,6 +5103,12 @@ body.curve-open #install-video-area #graph {
   display: flex;
   flex-direction: column;
   align-items: center;
+  /* Bigger gap than the desktop 6px because the mobile thumb is
+   * 28 px tall and its anchor is its center — at max value the thumb
+   * pokes ~14 px above the track top, which previously slid right
+   * over the slider-label. 18 px clears the half-thumb with a small
+   * buffer. */
+  gap: 18px;
 }
 .lite-row--main .slider-group .slider-label {
   font-size: 10px;
@@ -5130,6 +5136,24 @@ body.curve-open #install-video-area #graph {
   width: 28px;
   height: 28px;
   border-width: 2px;
+  /* Circular cap — same skeuomorphic gradient + bevel shadows as the
+   * desktop rectangular thumb, just rounded. The center-line
+   * indicator (.slider-thumb::before) reshapes into a tiny dot below
+   * so the cap still surfaces its per-value tint. */
+  border-radius: 50%;
+}
+.lite-row--main .slider-thumb::before {
+  /* On the circular mobile thumb, the desktop horizontal indicator
+   * line would float untethered across the cap. Replace it with a
+   * small accent-tinted center dot — same job (shows the per-value
+   * colour), shape that fits a disc. */
+  left: 50%;
+  right: auto;
+  top: 50%;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
 }
 
 /* Action row — REC on the left, "More" on the right. Both 44px tall to
@@ -5516,7 +5540,13 @@ body.curve-open #install-video-area #graph {
 }
 
 /* Pill-style tab bar — sliding active background on tap, snappy scale
-   feedback so the swipe-to-tap interaction feels lively. */
+   feedback so the swipe-to-tap interaction feels lively.
+   Horizontally scrollable: the six labels (Core / Styles / Mod /
+   Channels / Saved / Config) don't fit on a narrow phone with their
+   full text. ``flex: 1 1 0`` used to squeeze them in, which clipped
+   the last tab ("Config") off the right edge on small viewports.
+   Now each tab is content-sized and the strip scrolls horizontally;
+   swipe to reach tabs that don't fit. */
 .mobile-sheet-tabs {
   flex-shrink: 0;
   display: flex;
@@ -5524,13 +5554,22 @@ body.curve-open #install-video-area #graph {
   padding: 8px 12px calc(8px + env(safe-area-inset-bottom, 0px));
   border-top: 1px solid var(--frame-line);
   background: var(--frame);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none; /* Firefox */
+  /* Keep the swipe-to-scroll local — without this, swiping past the
+   * last tab chains into the parent and closes the sheet. */
+  overscroll-behavior-x: contain;
 }
+.mobile-sheet-tabs::-webkit-scrollbar { display: none; }
 .mobile-sheet-tab {
-  flex: 1 1 0;
+  /* Sized to fit its label (was ``flex: 1 1 0`` which clipped on
+   * narrow phones — see the .mobile-sheet-tabs comment above). */
+  flex: 0 0 auto;
   appearance: none;
   background: transparent;
   border: 0;
-  padding: 10px 8px;
+  padding: 10px 14px;
   border-radius: 999px;
   color: var(--text-dim);
   font-family: var(--font-mono);
@@ -5538,6 +5577,7 @@ body.curve-open #install-video-area #graph {
   letter-spacing: var(--tracking-wide);
   text-transform: uppercase;
   cursor: pointer;
+  white-space: nowrap;
   transition: color 180ms ease, background 180ms ease, transform 80ms ease;
 }
 .mobile-sheet-tab:hover { color: var(--text); }

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -4933,28 +4933,42 @@ body.curve-open #install-video-area #graph {
   }
 }
 .lite-controls {
-  /* Wave 13.5: tabbed + swipeable mobile mixer. Bay has a fixed
-     width clamp so each tab section can snap to it. Two sections
-     live side-by-side in a horizontal scroll-snap track inside the
-     body. */
+  /* Mobile-only performance bay. Pinned to the bottom safe-area and sized
+     to fill the lower ~half of the viewport so the operator can see and
+     reach the full surface without paging through tabs: track carousel
+     up top, the four main faders mid-body, REC + "All controls" at the
+     bottom. The visualizer remains visible (dimmed) above through the
+     transparent gap. */
   position: fixed;
-  left: 50%;
-  transform: translateX(-50%);
-  bottom: max(env(safe-area-inset-bottom, 0px) + 8px, 8px);
-  width: clamp(320px, 92vw, 560px);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  /* Clear the side fader rails so we don't overlap them. */
+  margin-inline: calc(var(--stepper-rail-w, 64px));
+  padding:
+    10px
+    14px
+    calc(env(safe-area-inset-bottom, 0px) + 12px)
+    14px;
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 6px;
-  padding: 6px 10px 8px;
-  background: rgba(6, 6, 12, 0.62);
-  border: 1px solid var(--frame-line);
-  border-radius: var(--radius-md);
+  gap: 8px;
+  background: linear-gradient(
+    to top,
+    rgba(6, 6, 12, 0.94) 0%,
+    rgba(6, 6, 12, 0.82) 65%,
+    rgba(6, 6, 12, 0.62) 100%
+  );
+  border-top: 1px solid var(--frame-line);
+  border-left: 1px solid var(--frame-line);
+  border-right: 1px solid var(--frame-line);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.04),
-    0 4px 14px rgba(0, 0, 0, 0.4);
-  -webkit-backdrop-filter: blur(8px);
-          backdrop-filter: blur(8px);
+    0 -4px 14px rgba(0, 0, 0, 0.4);
+  -webkit-backdrop-filter: blur(10px);
+          backdrop-filter: blur(10px);
   z-index: 8;
   /* Only render on mobile — desktop has the inset Full Controls panel
      and the HeroMacros bay instead. */
@@ -4963,6 +4977,15 @@ body.curve-open #install-video-area #graph {
 @media (max-width: 768px) {
   .lite-controls {
     display: flex;
+  }
+}
+@media (max-width: 380px) {
+  /* Narrowest phones — pull the side margins back to the safe-area
+     edge to win every pixel for the faders. The rails still anchor at
+     left/right: 0 so they overlap visually but the controls stay usable. */
+  .lite-controls {
+    margin-left: max(env(safe-area-inset-left, 0px), 4px);
+    margin-right: max(env(safe-area-inset-right, 0px), 4px);
   }
 }
 
@@ -5047,33 +5070,42 @@ body.curve-open #install-video-area #graph {
   align-items: center;
 }
 
-.lite-row--main {
+/* Track row — horizontal scroll carousel of fixtures + upload chip.
+   Sits across the top of the bay; the carousel itself owns its own
+   gutters and scroll behaviour. */
+.lite-row--track {
   flex: 0 0 auto;
-  min-height: 0;
-  gap: 16px;
-  justify-content: center;
-  padding: 4px 4px 4px;
-  /* Vertical alignment so the four faders share one baseline. */
-  align-items: flex-end;
+  width: 100%;
+  min-width: 0;
+}
+.lite-row--track > .lite-track-carousel {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
-/* Utility cluster sits to the right of the fader block. Track
-   carousel on top, REC + "All controls" on the bottom row. */
-.lite-utility {
+.lite-row--main {
+  /* Take whatever vertical space is left between the track row and the
+     action row — the four faders should breathe on tall phones. */
+  flex: 1 1 auto;
+  min-height: 0;
+  gap: 12px;
+  justify-content: space-around;
+  padding: 6px 0 4px;
+  /* Vertical alignment so the four faders share one baseline. */
+  align-items: stretch;
+}
+
+.lite-row--main .slider-group {
+  flex: 1 1 0;
+  min-width: 0;
+  /* Each fader column stretches to the full row height so the track
+     gets every available pixel — that's where the touch precision lives. */
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  gap: 6px;
-  min-width: 0;
-  flex: 1 1 auto;
-}
-.lite-utility .lite-track-carousel { min-width: 0; }
-.lite-row--main .slider-group {
-  flex: 0 0 46px;
-  min-width: 0;
+  align-items: center;
 }
 .lite-row--main .slider-group .slider-label {
-  font-size: 0.55em;
+  font-size: 10px;
   letter-spacing: 0.04em;
   white-space: nowrap;
   overflow: hidden;
@@ -5081,36 +5113,59 @@ body.curve-open #install-video-area #graph {
   max-width: 100%;
 }
 .lite-row--main .slider-track {
-  width: 36px;
-  min-height: 100px;
+  width: 44px;
+  /* min-height instead of fixed height so the fader stretches with
+     viewport. The flex parent gives us the room. */
+  flex: 1 1 auto;
+  min-height: 140px;
 }
-.lite-row--main .slider-track::before { width: 5px; }
-.lite-row--main .slider-fill { width: 5px; }
+.lite-row--main .slider-track::before { width: 6px; }
+.lite-row--main .slider-fill { width: 6px; }
 .lite-row--main .slider-thumb {
-  width: 22px;
-  height: 22px;
+  width: 28px;
+  height: 28px;
   border-width: 2px;
 }
-.lite-row--main {
-  gap: 6px;
+
+/* Action row — REC on the left, "More" on the right. Both 44px tall to
+   meet the iOS HIG touch-target minimum. */
+.lite-row--actions {
+  flex: 0 0 auto;
+  width: 100%;
+  justify-content: space-between;
+  gap: 10px;
+  padding-top: 4px;
 }
-/* Lite-controls "All controls" — icon-only on mobile. The label was
-   eating significant horizontal real estate next to 4 faders; an
-   arrow-only chip with a tooltip stays discoverable. */
-.lite-tab-section .lite-all-controls {
+.lite-row--actions > * {
+  flex: 0 0 auto;
+}
+.lite-row--actions .lite-all-controls {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  padding: 6px 10px;
-  min-width: 36px;
-  height: 36px;
-  flex-shrink: 0;
-  font-size: 14px;
-  line-height: 1;
+  gap: 6px;
+  padding: 0 14px;
+  min-width: 80px;
+  height: 44px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  background: transparent;
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: color 120ms, border-color 120ms, background 120ms;
 }
-.lite-tab-section .lite-all-controls .lite-all-controls-arrow {
-  font-size: 16px;
+.lite-row--actions .lite-all-controls:hover,
+.lite-row--actions .lite-all-controls:active {
+  color: var(--text-strong);
+  border-color: var(--accent-line);
+  background: rgba(255, 255, 255, 0.04);
+}
+.lite-row--actions .lite-all-controls .lite-all-controls-arrow {
+  font-size: 14px;
   line-height: 1;
 }
 
@@ -6928,6 +6983,33 @@ body.curve-open #install-video-area #graph {
   border-color: transparent;
 }
 
+/* Mobile waveform strip. Sits below the DEMON brand mark and inside the
+   side fader rails. Slim height keeps the scrub-line UX while leaving
+   the visualizer + control surface room to breathe. The desktop CSS
+   uses --hud-thickness offsets that are zero on mobile (no HUD frame
+   on phones) so we re-anchor from the top instead. The brand mark
+   itself sits at top:18 + height:42 = bottom 60, so 70 leaves a 10px
+   gap. */
+@media (max-width: 768px) {
+  .waveform-scrub-box {
+    top: max(env(safe-area-inset-top, 0px) + 70px, 70px);
+    left: calc(var(--stepper-rail-w, 64px)
+               + max(env(safe-area-inset-left, 0px), 8px));
+    right: calc(var(--stepper-rail-w, 64px)
+                + max(env(safe-area-inset-right, 0px), 8px));
+    height: 44px;
+    /* Sit above the install-stage background but below modals and the
+       LiteControls bay. */
+    z-index: 5;
+  }
+  /* Mobile sliders are touch-only — the LOOP toggle's hover-reveal would
+     never fire, so keep it permanently visible (faint until armed). */
+  .waveform-scrub-box .waveform-loop-toggle {
+    opacity: 0.85;
+    pointer-events: auto;
+  }
+}
+
 /* ── Custom tooltip (replaces native `title=` for hover-visible UI) ──
    Opt-in via `data-dd-tooltip="..."`. The element must have
    `position: relative` (most of our chrome already does because of
@@ -8482,13 +8564,10 @@ body.curve-open #install-video-area #graph {
   #install-video-area #graph-wrap .graph-lane-labels {
     display: none;
   }
-  /* Waveform scrub strip is hidden on mobile — it eats vertical space
-     that the squished graph needs, and the scrubbing precision is
-     poor at touch resolution anyway. Scrubbing remains available via
-     the full controls sheet. */
-  .waveform-scrub-box {
-    display: none;
-  }
+  /* Waveform strip now ships on mobile too — see the dedicated
+     positioning block earlier in this file. The previous hide-on-mobile
+     rule was the workaround from when there was no touch-friendly
+     scrub UI. */
 }
 
 /* Static wordmark — when the LibraryButton retired in Wave 10, the

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -657,6 +657,27 @@ body[data-mode="graph"].drawer-open #install-stage {
    --bloom-amount). Using --hud-thickness as the gap scales the breathing
    room with the rest of the HUD. */
 #install-video-area #graph-wrap { position: absolute; inset: calc(var(--hud-thickness) * 2 + var(--ribbon-bleed)); z-index: 2; }
+@media (max-width: 768px) {
+  /* On mobile the bottom of the moving-lines canvas was getting
+   * tucked under the LiteControls bay. Anchor the bottom inset to
+   * the live bay height (see ``--lite-controls-h``, set by
+   * LiteControls' ResizeObserver). top stays at the default
+   * (hud-thickness * 2 + ribbon-bleed); only the bottom is
+   * overridden so the lines never disappear behind the bay. */
+  #install-video-area #graph-wrap {
+    inset: calc(var(--hud-thickness) * 2 + var(--ribbon-bleed))
+           calc(var(--hud-thickness) * 2 + var(--ribbon-bleed))
+           calc(var(--lite-controls-h, 50vh) + 8px)
+           calc(var(--hud-thickness) * 2 + var(--ribbon-bleed));
+  }
+  /* Heavier top/bottom feathering on phones so the line ends don't
+   * read as a hard horizontal cut against the visualizer below. The
+   * desktop default 36 px gets lost on the larger relative-feather
+   * area mobile uses; 80 px gives a calmer fade against the bay. */
+  #install-video-area #graph {
+    --graph-feather-y: 80px;
+  }
+}
 #install-video-area #graph {
   width: 100%; height: 100%; display: block;
   /* Stronger feathering: the centered playhead exposes both edges, and
@@ -7063,7 +7084,12 @@ body.curve-open #install-video-area #graph {
     top: max(env(safe-area-inset-top, 0px) + 70px, 70px);
     left: max(env(safe-area-inset-left, 0px), 8px);
     right: max(env(safe-area-inset-right, 0px), 8px);
-    bottom: 50vh;
+    /* Anchor the bottom to the actual top edge of the LiteControls
+     * bay (var written by LiteControls' ResizeObserver). Fallback to
+     * 50vh for the brief moment before the bay measures itself or
+     * if LiteControls isn't mounted for some reason. +8 px breathing
+     * gap so the strip never visually touches the bay. */
+    bottom: calc(var(--lite-controls-h, 50vh) + 8px);
     height: auto;
     /* Inner breathing room — the canvases (position:absolute;
      * inset:0) anchor to the padding box, so this pulls the

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteControls.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteControls.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useState } from "react";
-
 import { LiteTrackCarousel } from "./LiteTrackCarousel";
 import { RecordToggle } from "./RecordToggle";
 import { SliderGroup } from "./SliderGroup";
@@ -15,90 +13,49 @@ interface Props {
   unsavedDot?: boolean;
 }
 
-type LiteTab = "mix" | "track";
-
-const TABS: LiteTab[] = ["mix", "track"];
-const TAB_LABELS: Record<LiteTab, string> = {
-  mix: "Mix",
-  track: "Track",
-};
-
-// Mobile mixer bay. A simple two-pill tab strip switches between two
-// content sections — Mix and Track — that render conditionally (only
-// the active one is mounted). The previous scroll-snap carousel
-// implementation overlapped both sections on iOS Safari and let the
-// inner track-carousel swipe leak out to the outer scroller; replacing
-// it with conditional render eliminates both classes of bug at the
-// cost of losing the swipe-to-switch gesture.
+// Mobile mixer bay. Everything in one panel — no MIX/TRACK tab switch.
+// The bay grows to fill the bottom half of the viewport so the operator
+// sees the full performance surface at once: track picker on top, the
+// four main faders mid-body, REC + "All controls" on the action row.
 //
-//   MIX   — 4 faders (denoise / structure / feedback / lora_blend) +
-//           "All controls" gateway to the full 7-tab sheet.
-//   TRACK — track carousel (upload + mic inside the picker) + REC.
+// The previous tabbed layout hid either the track or the faders behind
+// a pill toggle, which on a one-thumb mobile session meant the operator
+// kept paging back and forth. Surfacing both rows is the cheap win;
+// progressive disclosure still hides Mod/Channels/Styles behind the
+// "All controls" sheet.
 export function LiteControls({ onOpenAllControls, unsavedDot }: Props) {
-  const [tab, setTab] = useState<LiteTab>("mix");
-
   return (
     <div className="lite-controls">
-      <div
-        className="lite-tabs"
-        role="tablist"
-        aria-label="Mobile mixer"
-      >
-        {TABS.map((t) => (
-          <button
-            key={t}
-            type="button"
-            role="tab"
-            aria-selected={tab === t}
-            className={`lite-tab${tab === t ? " lite-tab--active" : ""}`}
-            onClick={() => setTab(t)}
-          >
-            {TAB_LABELS[t]}
-            {/* Unsaved dot surfaces on whichever pill isn't currently
-                active — so the cue is visible regardless of context. */}
-            {unsavedDot && tab !== t && t === "mix" && (
-              <span
-                className="lite-tab-dot"
-                aria-label="Unsaved changes"
-              />
-            )}
-          </button>
-        ))}
+      <div className="lite-row lite-row--track">
+        <LiteTrackCarousel />
       </div>
-      <div className="lite-tab-body" data-active-tab={tab}>
-        {tab === "mix" ? (
-          <section data-tab="mix" className="lite-tab-section">
-            <div className="lite-row lite-row--main">
-              <SliderGroup param="denoise" label="denoise" />
-              <SliderGroup param="hint_strength" label="structure" />
-              <SliderGroup param="feedback" label="feedback" />
-              <SliderGroup param="lora_blend" label="blend" />
-            </div>
-            <button
-              type="button"
-              className="lite-all-controls"
-              onClick={onOpenAllControls}
-              aria-label="All controls"
-              data-dd-tooltip="All controls"
-              data-dd-tooltip-pos="below"
-            >
-              {unsavedDot && (
-                <span
-                  className="lite-all-controls-dot"
-                  aria-label="Unsaved changes"
-                />
-              )}
-              <span className="lite-all-controls-arrow" aria-hidden="true">
-                →
-              </span>
-            </button>
-          </section>
-        ) : (
-          <section data-tab="track" className="lite-tab-section">
-            <LiteTrackCarousel />
-            <RecordToggle />
-          </section>
-        )}
+      <div className="lite-row lite-row--main">
+        <SliderGroup param="denoise" label="denoise" />
+        <SliderGroup param="hint_strength" label="structure" />
+        <SliderGroup param="feedback" label="feedback" />
+        <SliderGroup param="lora_blend" label="blend" />
+      </div>
+      <div className="lite-row lite-row--actions">
+        <RecordToggle />
+        <button
+          type="button"
+          className="lite-all-controls"
+          onClick={onOpenAllControls}
+          aria-label="All controls"
+          data-dd-tooltip="All controls"
+          data-dd-tooltip-pos="above"
+        >
+          {unsavedDot && (
+            <span
+              className="lite-all-controls-dot"
+              aria-label="Unsaved changes"
+            />
+          )}
+          <span className="lite-all-controls-label">More</span>
+          <span className="lite-all-controls-arrow" aria-hidden="true">
+            →
+          </span>
+        </button>
       </div>
     </div>
   );

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteControls.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteControls.tsx
@@ -59,8 +59,8 @@ export function LiteControls({ onOpenAllControls, unsavedDot }: Props) {
       <div className="lite-row lite-row--main">
         <SliderGroup param="denoise" label="denoise" />
         <SliderGroup param="hint_strength" label="structure" />
-        <SliderGroup param="feedback" label="feedback" />
-        <SliderGroup param="lora_blend" label="blend" />
+        <SliderGroup param="timbre_strength" label="timbre" />
+        <SliderGroup param="shift" label="shift" />
       </div>
       <div className="lite-row lite-row--actions">
         <RecordToggle />

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteControls.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteControls.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef } from "react";
+
 import { LiteTrackCarousel } from "./LiteTrackCarousel";
 import { RecordToggle } from "./RecordToggle";
 import { SliderGroup } from "./SliderGroup";
@@ -23,9 +25,34 @@ interface Props {
 // kept paging back and forth. Surfacing both rows is the cheap win;
 // progressive disclosure still hides Mod/Channels/Styles behind the
 // "All controls" sheet.
+//
+// Side effect: a ResizeObserver writes the live bay height to
+// ``--lite-controls-h`` on the documentElement so the waveform-scrub
+// strip and the graph wrap can anchor their bottoms to the actual top
+// of the bay instead of guessing 50vh. Without this the bay was
+// hiding the bottom of both on tall phones / unusual aspect ratios.
 export function LiteControls({ onOpenAllControls, unsavedDot }: Props) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    const root = document.documentElement;
+    const apply = () => {
+      root.style.setProperty("--lite-controls-h", `${el.offsetHeight}px`);
+    };
+    apply();
+    const ro = new ResizeObserver(apply);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      // Clear the var so consumers fall back to their CSS default
+      // when the bay unmounts (e.g. operator rotates to landscape
+      // and the lite controls flip off).
+      root.style.removeProperty("--lite-controls-h");
+    };
+  }, []);
   return (
-    <div className="lite-controls">
+    <div ref={rootRef} className="lite-controls">
       <div className="lite-row lite-row--track">
         <LiteTrackCarousel />
       </div>

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
@@ -22,35 +22,24 @@ import { WaveformTrimDialog } from "./WaveformTrimDialog";
 
 const DEFAULT_TRIM_CAP_S = 120;
 
-// Mobile Lite-controls track picker. A horizontal scroll-snap row of fixture
-// chips followed by an "Upload your own" chip. Reuses the same fixture
-// catalog, custom-tracks store, and decodeAudioFile path as AudioSourceCrate
-// so a track switch from either surface looks identical to useFixtureSwap.
+// Mobile Lite-controls track picker. Renders as a native <select> so
+// the OS picker (iOS wheel / Android dialog) opens on tap — the user
+// gets a one-thumb friendly chooser with built-in scrolling, search,
+// and accessibility instead of the horizontal scroll-snap row of chips
+// the old carousel forced. The library + uploads + an "Upload your
+// own…" sentinel all live in the same select, with optgroups to keep
+// them visually grouped. Reuses the same fixture catalog,
+// custom-tracks store, and decodeAudioFile path as AudioSourceCrate so
+// a track switch from either surface looks identical to useFixtureSwap.
+//
+// (Component name kept as ``LiteTrackCarousel`` to preserve the import
+// site in ``LiteControls.tsx``; the carousel itself is gone.)
 
-interface TrackOption {
-  name: string;
-  kind: "fixture" | "custom";
-}
-
-function UploadIcon() {
-  return (
-    <svg
-      viewBox="0 0 16 16"
-      width={18}
-      height={18}
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.6}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M8 10V2" />
-      <path d="M4.5 5.5L8 2l3.5 3.5" />
-      <path d="M2.5 10v3a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3" />
-    </svg>
-  );
-}
+// Sentinel value: selecting it triggers the file picker instead of
+// trying to swap to a fixture named "__upload__". The select stays
+// controlled on ``fixture``, so React re-renders and snaps the
+// visible selection back to the active track immediately.
+const UPLOAD_VALUE = "__upload__";
 
 export function LiteTrackCarousel() {
   const fixture = usePerformanceStore((s) => s.fixture);
@@ -78,7 +67,6 @@ export function LiteTrackCarousel() {
   const trimCapS =
     useConfig().engine.max_source_duration_s ?? DEFAULT_TRIM_CAP_S;
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const scrollerRef = useRef<HTMLDivElement | null>(null);
 
   // Daydream-webapp queue-admit gate: standalone DEMON has no queue
   // (LOCAL_MODE), so we skip the wait there.
@@ -95,21 +83,8 @@ export function LiteTrackCarousel() {
       .catch(() => setFixtures([]));
   }, [setFixture, sessionWsUrl]);
 
-  // Auto-scroll the current chip into view when fixture changes from
-  // elsewhere (e.g. AudioSourceCrate, MobileFullSheet config tab).
-  useEffect(() => {
-    const root = scrollerRef.current;
-    if (!root || !fixture) return;
-    const target = root.querySelector<HTMLElement>(
-      `[data-track-name="${CSS.escape(fixture)}"]`,
-    );
-    if (target)
-      target.scrollIntoView({
-        behavior: "smooth",
-        block: "nearest",
-        inline: "center",
-      });
-  }, [fixture]);
+  // Native <select> handles its own current-option-in-view, so the
+  // scroll-into-view dance the carousel needed is gone.
 
   async function onFilePicked(file: File) {
     const { setStatus } = useSessionStore.getState();
@@ -168,55 +143,66 @@ export function LiteTrackCarousel() {
     setPending(null);
   }
 
-  const tracks: TrackOption[] = [
-    ...fixtures.map((name) => ({ name, kind: "fixture" as const })),
-    ...customNames.map((name) => ({ name, kind: "custom" as const })),
-  ];
+  const totalTracks = fixtures.length + customNames.length;
 
   return (
-    <div className="lite-track-carousel" role="tablist" aria-label="Audio track">
-      <div ref={scrollerRef} className="lite-track-carousel-scroll">
-        {tracks.length === 0 && (
-          <div className="lite-track-carousel-empty">Loading…</div>
-        )}
-        {tracks.map((t) => {
-          const isCurrent = t.name === fixture;
-          return (
-            <button
-              key={`${t.kind}:${t.name}`}
-              type="button"
-              role="tab"
-              aria-selected={isCurrent}
-              data-track-name={t.name}
-              className={[
-                "lite-track-chip",
-                isCurrent ? "lite-track-chip--current" : "",
-                t.kind === "custom" ? "lite-track-chip--custom" : "",
-              ]
-                .filter(Boolean)
-                .join(" ")}
-              onClick={() => setFixture(t.name)}
-              title={t.name}
-            >
-              <span className="lite-track-chip-label">{t.name}</span>
-            </button>
-          );
-        })}
-        <button
-          type="button"
-          className="lite-track-chip lite-track-chip--upload"
+    <div className="lite-track-picker">
+      <label
+        htmlFor="lite-track-select"
+        className="lite-track-picker-label"
+      >
+        Track
+      </label>
+      <div className="lite-track-picker-field">
+        <select
+          id="lite-track-select"
+          className="lite-track-picker-select"
+          value={fixture ?? ""}
           disabled={uploading}
-          onClick={() => fileInputRef.current?.click()}
-          data-dd-tooltip="Upload audio track"
-          aria-label="Upload audio track"
+          aria-label="Audio track"
+          onChange={(e) => {
+            const v = e.target.value;
+            if (v === UPLOAD_VALUE) {
+              // Don't actually setFixture("__upload__"); the controlled
+              // ``value=fixture`` re-render snaps the visible selection
+              // back to the active track while the file picker opens
+              // in front.
+              fileInputRef.current?.click();
+              return;
+            }
+            if (v) setFixture(v);
+          }}
         >
-          <span className="lite-track-chip-icon" aria-hidden="true">
-            <UploadIcon />
-          </span>
-          <span className="lite-track-chip-label">
-            {uploading ? "Decoding…" : "Upload"}
-          </span>
-        </button>
+          {totalTracks === 0 && (
+            <option value="" disabled>
+              Loading…
+            </option>
+          )}
+          {fixtures.length > 0 && (
+            <optgroup label="Library">
+              {fixtures.map((name) => (
+                <option key={`fixture:${name}`} value={name}>
+                  {name}
+                </option>
+              ))}
+            </optgroup>
+          )}
+          {customNames.length > 0 && (
+            <optgroup label="Your tracks">
+              {customNames.map((name) => (
+                <option key={`custom:${name}`} value={name}>
+                  {name}
+                </option>
+              ))}
+            </optgroup>
+          )}
+          <option value={UPLOAD_VALUE}>
+            {uploading ? "Decoding…" : "↑  Upload your own…"}
+          </option>
+        </select>
+        <span className="lite-track-picker-chevron" aria-hidden="true">
+          ▾
+        </span>
       </div>
 
       <input

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
@@ -18,6 +18,7 @@ import { useSessionStore } from "@/store/useSessionStore";
 import type { TimeSignature } from "@/types/engine";
 
 import { AlmostReadyDialog } from "./AlmostReadyDialog";
+import { MicRecorder } from "./MicRecorder";
 import { WaveformTrimDialog } from "./WaveformTrimDialog";
 
 const DEFAULT_TRIM_CAP_S = 120;
@@ -26,20 +27,22 @@ const DEFAULT_TRIM_CAP_S = 120;
 // the OS picker (iOS wheel / Android dialog) opens on tap — the user
 // gets a one-thumb friendly chooser with built-in scrolling, search,
 // and accessibility instead of the horizontal scroll-snap row of chips
-// the old carousel forced. The library + uploads + an "Upload your
-// own…" sentinel all live in the same select, with optgroups to keep
-// them visually grouped. Reuses the same fixture catalog,
-// custom-tracks store, and decodeAudioFile path as AudioSourceCrate so
-// a track switch from either surface looks identical to useFixtureSwap.
+// the old carousel forced. The library + uploads + record-from-mic +
+// the "Upload your own…" sentinel all live in the same select, with
+// optgroups to keep them visually grouped. Reuses the same fixture
+// catalog, custom-tracks store, decodeAudioFile path, and MicRecorder
+// modal as AudioSourceCrate so a track switch from either surface
+// looks identical to useFixtureSwap.
 //
 // (Component name kept as ``LiteTrackCarousel`` to preserve the import
 // site in ``LiteControls.tsx``; the carousel itself is gone.)
 
-// Sentinel value: selecting it triggers the file picker instead of
-// trying to swap to a fixture named "__upload__". The select stays
-// controlled on ``fixture``, so React re-renders and snaps the
-// visible selection back to the active track immediately.
+// Sentinel values: selecting them triggers a side-effect instead of a
+// fixture swap. The select stays controlled on ``fixture``, so React
+// re-renders and snaps the visible selection back to the active track
+// immediately while the modal opens in front.
 const UPLOAD_VALUE = "__upload__";
+const MIC_VALUE = "__mic__";
 
 export function LiteTrackCarousel() {
   const fixture = usePerformanceStore((s) => s.fixture);
@@ -51,6 +54,7 @@ export function LiteTrackCarousel() {
   const addCustomTrack = useCustomTracksStore((s) => s.add);
 
   const [uploading, setUploading] = useState(false);
+  const [micOpen, setMicOpen] = useState(false);
   // Mirrors AudioSourceCrate's two-stage flow: trim first, then the
   // AlmostReadyDialog. Keeps the previously playing track alive
   // through both steps.
@@ -170,6 +174,13 @@ export function LiteTrackCarousel() {
               fileInputRef.current?.click();
               return;
             }
+            if (v === MIC_VALUE) {
+              // Same sentinel pattern as UPLOAD_VALUE — open the
+              // MicRecorder modal; the controlled select snaps back
+              // to the active track on the next render.
+              setMicOpen(true);
+              return;
+            }
             if (v) setFixture(v);
           }}
         >
@@ -196,6 +207,9 @@ export function LiteTrackCarousel() {
               ))}
             </optgroup>
           )}
+          <option value={MIC_VALUE}>
+            ●  Record from microphone…
+          </option>
           <option value={UPLOAD_VALUE}>
             {uploading ? "Decoding…" : "↑  Upload your own…"}
           </option>
@@ -242,6 +256,20 @@ export function LiteTrackCarousel() {
             setTimeout(() => fileInputRef.current?.click(), 0);
           }}
           onClose={() => setPending(null)}
+        />
+      )}
+
+      {micOpen && (
+        <MicRecorder
+          onComplete={(file) => {
+            setMicOpen(false);
+            // Recorded clip flows through the same decode →
+            // AlmostReadyDialog → addCustomTrack pipeline as a file
+            // upload. MicRecorder emits a wav File so onFilePicked's
+            // decodeAudioFile handles it identically.
+            void onFilePicked(file);
+          }}
+          onClose={() => setMicOpen(false)}
         />
       )}
     </div>

--- a/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
@@ -157,7 +157,7 @@ export function PerformanceShell() {
 
       <LiveIndicator />
 
-      {!isMobile && <WaveformScrubBox />}
+      <WaveformScrubBox />
 
       <NetworkIndicator />
 


### PR DESCRIPTION
The mobile Performance UI hid the waveform/playhead and packed the four main faders into a small tabbed bay that the operator had to flip between MIX and TRACK to reach. Single-thumb users couldn't see the playhead, couldn't scrub, and lost the track picker every time they touched a fader.

This change:

- Renders <WaveformScrubBox/> unconditionally and adds a mobile-tuned positioning block (sits below the brand mark, between the side fader rails, 44 px tall). Drops the old "hide on mobile" CSS workaround.
- Replaces the MIX/TRACK tab switch inside LiteControls with a single panel that surfaces the track carousel, the four faders (Denoise / Structure / Feedback / Blend, taller + bigger thumbs), and a REC + "More" action row simultaneously.
- Expands the lite-controls bay to a full-width bottom panel with a vertical gradient bg and 44 px touch-target action buttons; the bay margin clears the existing edge fader rails. Narrower phones (<= 380 px) drop the rail clearance and use safe-area only.

Desktop is unaffected: LiteControls is mobile-only via AdvancedDrawer's isMobile branch, and the mobile CSS overrides live entirely inside @media (max-width: 768px).