### PR TITLE
feat(rtmg/upload): interactive waveform-trim on every upload, cap configurable

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -7759,6 +7759,107 @@ body.curve-open #install-video-area #graph {
 .almost-ready-btn--ghost:hover { color: var(--text); }
 
 /* ─────────────────────────────────────────────────────────────────────
+   WaveformTrimDialog — interactive trim that runs between
+   decodeAudioFile and the AlmostReadyDialog. Reuses the
+   ``.almost-ready-overlay/card/header/footer`` chrome so the two
+   dialogs share their fade-in animation and the modal feels like a
+   single multi-step flow. Only the trim-specific bits below are new.
+   ───────────────────────────────────────────────────────────────────── */
+.waveform-trim-card {
+  /* Wider than the AlmostReadyDialog so the waveform has room to
+   * read without horizontal cramping. */
+  max-width: 720px;
+  width: min(720px, 92vw);
+}
+.waveform-trim-container {
+  position: relative;
+  width: 100%;
+  height: 120px;
+  margin: 18px 0 10px;
+  border: 1px solid var(--accent-line);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  cursor: grab;
+  touch-action: none; /* prevent the browser scrolling while dragging */
+  user-select: none;
+}
+.waveform-trim-container:active { cursor: grabbing; }
+.waveform-trim-canvas {
+  position: absolute;
+  inset: 0;
+  display: block;
+  pointer-events: none; /* drag binds to the container, not the canvas */
+}
+.waveform-trim-dim {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.55);
+  pointer-events: none;
+}
+.waveform-trim-selection {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: rgba(255, 209, 102, 0.12); /* accent at 12% */
+  border-left: 1px solid var(--accent);
+  border-right: 1px solid var(--accent);
+  box-shadow: 0 0 0 1px rgba(255, 209, 102, 0.15) inset;
+  cursor: grab;
+}
+.waveform-trim-selection:active { cursor: grabbing; }
+.waveform-trim-handle {
+  /* The visible bar is 4px but the hit-box stretches to 14px so the
+   * handle is still grabbable on touch / coarse pointers without
+   * widening the visual chrome. */
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  width: 14px;
+  margin-left: -7px;
+  cursor: ew-resize;
+  touch-action: none;
+}
+.waveform-trim-handle::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 4px;
+  transform: translateX(-50%);
+  background: var(--accent);
+  border-radius: 2px;
+  box-shadow: 0 0 6px rgba(255, 209, 102, 0.55);
+}
+.waveform-trim-readout {
+  display: flex;
+  gap: 22px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-bottom: 14px;
+}
+.waveform-trim-readout-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+  opacity: 0.7;
+  margin-right: 4px;
+}
+.waveform-trim-readout-selected {
+  color: var(--text);
+  margin-left: auto;
+}
+.waveform-trim-readout-selected.at-cap { color: var(--accent); }
+.waveform-trim-readout-cap {
+  margin-left: 4px;
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
    ConfirmDialog — generic yes/no replacement for window.confirm().
    Mirrors .almost-ready-* sizing/animations but narrower (≈380px)
    since the body is just a message + two buttons. z-index 110 puts it

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -7761,15 +7761,21 @@ body.curve-open #install-video-area #graph {
 /* ─────────────────────────────────────────────────────────────────────
    WaveformTrimDialog — interactive trim that runs between
    decodeAudioFile and the AlmostReadyDialog. Reuses the
-   ``.almost-ready-overlay/card/header/footer`` chrome so the two
-   dialogs share their fade-in animation and the modal feels like a
-   single multi-step flow. Only the trim-specific bits below are new.
+   ``.almost-ready-backdrop / -modal / -header / -body / -footer / -btn``
+   chrome so the two dialogs share their fade-in animation and the
+   upload flow reads as one multi-step modal. Only the trim-specific
+   bits below are new.
    ───────────────────────────────────────────────────────────────────── */
-.waveform-trim-card {
-  /* Wider than the AlmostReadyDialog so the waveform has room to
-   * read without horizontal cramping. */
-  max-width: 720px;
-  width: min(720px, 92vw);
+.waveform-trim-modal {
+  /* Override .almost-ready-modal's 540 px width so the waveform has
+   * room to read without horizontal cramping. */
+  width: min(720px, 100%);
+}
+.waveform-trim-hint {
+  margin: 0 0 12px;
+  color: var(--text-dim);
+  font-size: 0.92em;
+  line-height: 1.45;
 }
 .waveform-trim-container {
   position: relative;

--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -9,6 +9,8 @@ import {
   type DecodedFixture,
   type StemSourceMode,
 } from "@/engine/audio/loadFixture";
+import { trimAudioBuffer } from "@/lib/audio/trimAudioBuffer";
+import { useConfig } from "@/lib/config";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
@@ -17,6 +19,9 @@ import type { TimeSignature } from "@/types/engine";
 
 import { AlmostReadyDialog } from "./AlmostReadyDialog";
 import { MicRecorder } from "./MicRecorder";
+import { WaveformTrimDialog } from "./WaveformTrimDialog";
+
+const DEFAULT_TRIM_CAP_S = 120;
 
 // Bottom-left counterpart to the bottom-right turntable. Replaces the plain
 // fixture <select> as the primary track-picker — that dropdown hid the fact
@@ -102,15 +107,24 @@ export function AudioSourceCrate() {
   const [open, setOpen] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [micOpen, setMicOpen] = useState(false);
-  // After decode, the dialog gates the actual fixture swap so the user
-  // can confirm the trim (if any) and pick a key before playback
-  // crossfades.
+  // Upload flow is two-stage: ``trimming`` opens the interactive
+  // WaveformTrimDialog right after decode, ``pending`` opens the
+  // AlmostReadyDialog (source-mode + key) once the user has chosen
+  // their trim window. Splitting them keeps the previously-playing
+  // song alive through both — neither addCustomTrack nor setFixture
+  // runs until the AlmostReadyDialog "Continue" lands.
+  const [trimming, setTrimming] = useState<{
+    decoded: DecodedFixture;
+    fileName: string;
+    originalFile: File;
+  } | null>(null);
   const [pending, setPending] = useState<{
     decoded: DecodedFixture;
     fileName: string;
-    wasTrimmed: boolean;
     originalFile: File;
   } | null>(null);
+  const trimCapS =
+    useConfig().engine.max_source_duration_s ?? DEFAULT_TRIM_CAP_S;
 
   // Auto-collapse: the dock folds to a small play bubble 2s after it's
   // left alone, and expands back on hover / focus. `collapsed` drives
@@ -165,7 +179,7 @@ export function AudioSourceCrate() {
   // 2s after the last interaction. The timeout is cleared on any
   // re-activation so it only fires once the dock is truly idle.
   const dockActive =
-    hovered || open || micOpen || uploading || pending !== null;
+    hovered || open || micOpen || uploading || pending !== null || trimming !== null;
   useEffect(() => {
     if (dockActive) {
       setCollapsed(false);
@@ -180,18 +194,18 @@ export function AudioSourceCrate() {
     setUploading(true);
     setStatus(useSessionStore.getState().status, `Loading ${file.name}…`);
     try {
-      const { decoded, wasTrimmed } = await decodeAudioFile(file);
+      const decoded = await decodeAudioFile(file);
       const baseName = file.name;
       let chosen = baseName;
       let i = 1;
       while (useCustomTracksStore.getState().has(chosen)) {
         chosen = `${baseName} (${i++})`;
       }
-      // Hand the decoded buffer + trim flag to the dialog. We DON'T add
-      // it to the custom-tracks store yet, and we DON'T setFixture()
-      // yet — that all happens on Continue so the previously playing
-      // song keeps playing if the user cancels.
-      setPending({ decoded, fileName: chosen, wasTrimmed, originalFile: file });
+      // Hand the full-length decoded buffer to the trim dialog. We
+      // don't touch the custom-tracks store or setFixture() until
+      // after BOTH the trim dialog and the AlmostReadyDialog confirm,
+      // so cancelling either step keeps the previous song playing.
+      setTrimming({ decoded, fileName: chosen, originalFile: file });
       setStatus(useSessionStore.getState().status, "");
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -199,6 +213,17 @@ export function AudioSourceCrate() {
     } finally {
       setUploading(false);
     }
+  }
+
+  function onTrimConfirm(startS: number, endS: number) {
+    if (!trimming) return;
+    const trimmed = trimAudioBuffer(trimming.decoded, startS, endS);
+    setPending({
+      decoded: trimmed,
+      fileName: trimming.fileName,
+      originalFile: trimming.originalFile,
+    });
+    setTrimming(null);
   }
 
   function commitPending(
@@ -386,10 +411,19 @@ export function AudioSourceCrate() {
         }}
       />
 
+      {trimming && (
+        <WaveformTrimDialog
+          decoded={trimming.decoded}
+          fileName={trimming.fileName}
+          capS={trimCapS}
+          onConfirm={onTrimConfirm}
+          onCancel={() => setTrimming(null)}
+        />
+      )}
       {pending && (
         <AlmostReadyDialog
           fileName={pending.fileName}
-          wasTrimmed={pending.wasTrimmed}
+          wasTrimmed={false}
           defaultKey={usePerformanceStore.getState().activeKey}
           defaultTimeSignature={
             usePerformanceStore.getState().activeTimeSignature

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
@@ -9,6 +9,8 @@ import {
   type DecodedFixture,
   type StemSourceMode,
 } from "@/engine/audio/loadFixture";
+import { trimAudioBuffer } from "@/lib/audio/trimAudioBuffer";
+import { useConfig } from "@/lib/config";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
@@ -16,6 +18,9 @@ import { useSessionStore } from "@/store/useSessionStore";
 import type { TimeSignature } from "@/types/engine";
 
 import { AlmostReadyDialog } from "./AlmostReadyDialog";
+import { WaveformTrimDialog } from "./WaveformTrimDialog";
+
+const DEFAULT_TRIM_CAP_S = 120;
 
 // Mobile Lite-controls track picker. A horizontal scroll-snap row of fixture
 // chips followed by an "Upload your own" chip. Reuses the same fixture
@@ -57,12 +62,21 @@ export function LiteTrackCarousel() {
   const addCustomTrack = useCustomTracksStore((s) => s.add);
 
   const [uploading, setUploading] = useState(false);
+  // Mirrors AudioSourceCrate's two-stage flow: trim first, then the
+  // AlmostReadyDialog. Keeps the previously playing track alive
+  // through both steps.
+  const [trimming, setTrimming] = useState<{
+    decoded: DecodedFixture;
+    fileName: string;
+    originalFile: File;
+  } | null>(null);
   const [pending, setPending] = useState<{
     decoded: DecodedFixture;
     fileName: string;
-    wasTrimmed: boolean;
     originalFile: File;
   } | null>(null);
+  const trimCapS =
+    useConfig().engine.max_source_duration_s ?? DEFAULT_TRIM_CAP_S;
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
 
@@ -102,16 +116,17 @@ export function LiteTrackCarousel() {
     setUploading(true);
     setStatus(useSessionStore.getState().status, `Loading ${file.name}…`);
     try {
-      const { decoded, wasTrimmed } = await decodeAudioFile(file);
+      const decoded = await decodeAudioFile(file);
       const baseName = file.name;
       let chosen = baseName;
       let i = 1;
       while (useCustomTracksStore.getState().has(chosen)) {
         chosen = `${baseName} (${i++})`;
       }
-      // Defer commit to the AlmostReadyDialog so cancel leaves the
-      // previously playing track alone.
-      setPending({ decoded, fileName: chosen, wasTrimmed, originalFile: file });
+      // Interactive trim first; ``onTrimConfirm`` below slices the
+      // window and hands the trimmed buffer to the AlmostReadyDialog
+      // for the source-mode + key step.
+      setTrimming({ decoded, fileName: chosen, originalFile: file });
       setStatus(useSessionStore.getState().status, "");
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -119,6 +134,17 @@ export function LiteTrackCarousel() {
     } finally {
       setUploading(false);
     }
+  }
+
+  function onTrimConfirm(startS: number, endS: number) {
+    if (!trimming) return;
+    const trimmed = trimAudioBuffer(trimming.decoded, startS, endS);
+    setPending({
+      decoded: trimmed,
+      fileName: trimming.fileName,
+      originalFile: trimming.originalFile,
+    });
+    setTrimming(null);
   }
 
   function commitPending(
@@ -205,10 +231,19 @@ export function LiteTrackCarousel() {
         }}
       />
 
+      {trimming && (
+        <WaveformTrimDialog
+          decoded={trimming.decoded}
+          fileName={trimming.fileName}
+          capS={trimCapS}
+          onConfirm={onTrimConfirm}
+          onCancel={() => setTrimming(null)}
+        />
+      )}
       {pending && (
         <AlmostReadyDialog
           fileName={pending.fileName}
-          wasTrimmed={pending.wasTrimmed}
+          wasTrimmed={false}
           defaultKey={usePerformanceStore.getState().activeKey}
           defaultTimeSignature={
             usePerformanceStore.getState().activeTimeSignature

--- a/demos/realtime_motion_graph_web/web/components/Performance/RefControl.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RefControl.tsx
@@ -183,13 +183,13 @@ export function RefControl({ kind }: { kind: RefKind }) {
     setBusy(true);
     setStatus("ready", `Loading ${bind.statusPrefix} ${file.name}…`);
     try {
-      // decodeAudioFile now returns { decoded, wasTrimmed } since the
-      // soft-trim-to-MAX_FIXTURE_DURATION_S feature landed. Unwrap before
-      // passing to add() / bind.send(), which still expect a bare
-      // DecodedFixture. wasTrimmed is informational only here — the
-      // ref-track upload UX doesn't surface a trim warning the way the
-      // main AudioSourceCrate flow does.
-      const { decoded } = await decodeAudioFile(file);
+      // decodeAudioFile returns a bare DecodedFixture — no auto-trim.
+      // Ref tracks (timbre / structure) intentionally skip the
+      // interactive trim dialog the main AudioSourceCrate / Lite flow
+      // shows: a reference is conceptually the whole clip the model
+      // should imitate, not a slice. The MAX_UPLOAD_DURATION_S
+      // browser-memory ceiling inside decodeAudioFile still applies.
+      const decoded = await decodeAudioFile(file);
       // Mirror AudioSourceCrate's de-dup naming so uploads land in the
       // shared "your tracks" pool without colliding.
       const baseName = file.name;

--- a/demos/realtime_motion_graph_web/web/components/Performance/TrackPicker.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/TrackPicker.tsx
@@ -9,6 +9,8 @@ import {
   type DecodedFixture,
   type StemSourceMode,
 } from "@/engine/audio/loadFixture";
+import { trimAudioBuffer } from "@/lib/audio/trimAudioBuffer";
+import { useConfig } from "@/lib/config";
 import { LOCAL_MODE } from "@/lib/runtime";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { usePerformanceStore } from "@/store/usePerformanceStore";
@@ -17,6 +19,9 @@ import type { TimeSignature } from "@/types/engine";
 
 import { AlmostReadyDialog } from "./AlmostReadyDialog";
 import { RefSelect } from "./RefSelect";
+import { WaveformTrimDialog } from "./WaveformTrimDialog";
+
+const DEFAULT_TRIM_CAP_S = 120;
 
 // Inline track picker — a caption + dropdown + sibling upload icon
 // living at the top of the CORE tab so power users don't have to leave
@@ -38,12 +43,22 @@ export function TrackPicker() {
   const addCustomTrack = useCustomTracksStore((s) => s.add);
 
   const [uploading, setUploading] = useState(false);
+  // Upload flow is two-stage: first the interactive trim dialog
+  // (``trimming``), then the AlmostReadyDialog (``pending``). The
+  // trim step is always on — short uploads still get the dialog so
+  // users can pick a section of their 30 s loop instead of the head.
+  const [trimming, setTrimming] = useState<{
+    decoded: DecodedFixture;
+    fileName: string;
+    originalFile: File;
+  } | null>(null);
   const [pending, setPending] = useState<{
     decoded: DecodedFixture;
     fileName: string;
-    wasTrimmed: boolean;
     originalFile: File;
   } | null>(null);
+  const trimCapS =
+    useConfig().engine.max_source_duration_s ?? DEFAULT_TRIM_CAP_S;
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -65,14 +80,18 @@ export function TrackPicker() {
     setUploading(true);
     setStatus(useSessionStore.getState().status, `Loading ${file.name}…`);
     try {
-      const { decoded, wasTrimmed } = await decodeAudioFile(file);
+      const decoded = await decodeAudioFile(file);
       const baseName = file.name;
       let chosen = baseName;
       let i = 1;
       while (useCustomTracksStore.getState().has(chosen)) {
         chosen = `${baseName} (${i++})`;
       }
-      setPending({ decoded, fileName: chosen, wasTrimmed, originalFile: file });
+      // First stop: the user picks the trim window. The pre-trim
+      // DecodedFixture stays in memory only as long as this dialog
+      // is open; ``onTrimConfirm`` below slices it down to the
+      // selected window and drops the original.
+      setTrimming({ decoded, fileName: chosen, originalFile: file });
       setStatus(useSessionStore.getState().status, "");
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -80,6 +99,17 @@ export function TrackPicker() {
     } finally {
       setUploading(false);
     }
+  }
+
+  function onTrimConfirm(startS: number, endS: number) {
+    if (!trimming) return;
+    const trimmed = trimAudioBuffer(trimming.decoded, startS, endS);
+    setPending({
+      decoded: trimmed,
+      fileName: trimming.fileName,
+      originalFile: trimming.originalFile,
+    });
+    setTrimming(null);
   }
 
   function commitPending(
@@ -137,10 +167,19 @@ export function TrackPicker() {
           if (file) void onFilePicked(file);
         }}
       />
+      {trimming && (
+        <WaveformTrimDialog
+          decoded={trimming.decoded}
+          fileName={trimming.fileName}
+          capS={trimCapS}
+          onConfirm={onTrimConfirm}
+          onCancel={() => setTrimming(null)}
+        />
+      )}
       {pending && (
         <AlmostReadyDialog
           fileName={pending.fileName}
-          wasTrimmed={pending.wasTrimmed}
+          wasTrimmed={false}
           defaultKey={usePerformanceStore.getState().activeKey}
           defaultTimeSignature={
             usePerformanceStore.getState().activeTimeSignature

--- a/demos/realtime_motion_graph_web/web/components/Performance/WaveformTrimDialog.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/WaveformTrimDialog.tsx
@@ -126,8 +126,13 @@ export function WaveformTrimDialog({
   const widthPx = Math.max(0, endPx - startPx);
 
   const clampStart = (next: number, currentEnd: number): number => {
+    // The cap-floor (currentEnd - capS) is the bug fix: without it, a
+    // user could body-drag the window so endS sits at durationS, then
+    // pull the start handle backward past endS - capS and create a
+    // > capS window.
+    const lower = Math.max(0, currentEnd - capS);
     const upper = Math.min(currentEnd - minS, durationS - minS);
-    return Math.max(0, Math.min(upper, next));
+    return Math.max(lower, Math.min(upper, next));
   };
   const clampEnd = (next: number, currentStart: number): number => {
     const lower = Math.max(currentStart + minS, minS);

--- a/demos/realtime_motion_graph_web/web/components/Performance/WaveformTrimDialog.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/WaveformTrimDialog.tsx
@@ -37,8 +37,6 @@ export interface WaveformTrimDialogProps {
   onCancel: () => void;
 }
 
-// Match AlmostReadyDialog's portal-mount tick so the overlay's
-// transition (opacity, transform) gets a chance to animate in.
 const MIN_S_DEFAULT = 3;
 
 function fmtMMSS(seconds: number): string {
@@ -60,16 +58,11 @@ export function WaveformTrimDialog({
   const initialEnd = Math.min(capS, durationS);
   const [startS, setStartS] = useState(0);
   const [endS, setEndS] = useState(initialEnd);
-  const [mounted, setMounted] = useState(false);
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const peaksRef = useRef<Float32Array | null>(null);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   // Measure container width — drives both canvas pixel sizing and
   // the px↔seconds mapping. ResizeObserver covers viewport changes
@@ -218,9 +211,15 @@ export function WaveformTrimDialog({
   }, [onCancel, onConfirm, startS, endS]);
 
   if (typeof document === "undefined") return null;
+  // Reuses the AlmostReadyDialog's modal chrome
+  // (.almost-ready-backdrop / -modal / -header / -body / -footer /
+  // -btn--*) so the two dialogs share their fade/pop animations and
+  // sizing — the upload flow reads as one multi-step modal. Only the
+  // waveform area and the per-component sizing in
+  // .waveform-trim-modal are local to this dialog.
   return createPortal(
     <div
-      className={`almost-ready-overlay${mounted ? " mounted" : ""}`}
+      className="almost-ready-backdrop"
       onClick={(e) => {
         if (e.target === e.currentTarget) onCancel();
       }}
@@ -228,91 +227,98 @@ export function WaveformTrimDialog({
       aria-modal="true"
       aria-label="Trim upload"
     >
-      <div className="almost-ready-card waveform-trim-card">
-        <header className="almost-ready-header">
-          <h2 className="almost-ready-title">Trim upload</h2>
-          <p className="almost-ready-sub">
-            <strong>{fileName}</strong> — {fmtMMSS(durationS)} total.
-            {" "}
-            {fileShorterThanCap
-              ? "Pick any section."
-              : `Max ${fmtMMSS(capS)} of audio per session.`}
-          </p>
-        </header>
-
-        <div
-          ref={containerRef}
-          className="waveform-trim-container"
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
-          onPointerCancel={onPointerUp}
-        >
-          <canvas ref={canvasRef} className="waveform-trim-canvas" />
-          {containerWidth > 0 && (
-            <>
-              {/* Dimmed regions outside the selection. Pointer events
-                  pass through to the container so a stray pointerdown
-                  on a dimmed region doesn't break the drag. */}
-              <div
-                className="waveform-trim-dim"
-                style={{ left: 0, width: startPx }}
-              />
-              <div
-                className="waveform-trim-dim"
-                style={{ left: endPx, right: 0 }}
-              />
-              {/* Selection box — draggable body, with two grab handles
-                  poking out at the edges. */}
-              <div
-                className="waveform-trim-selection"
-                style={{ left: startPx, width: widthPx }}
-                onPointerDown={onPointerDown("body")}
-              />
-              <div
-                className="waveform-trim-handle waveform-trim-handle-start"
-                style={{ left: startPx }}
-                onPointerDown={onPointerDown("start")}
-                aria-label="Trim start"
-                role="slider"
-                aria-valuemin={0}
-                aria-valuemax={Math.floor(durationS)}
-                aria-valuenow={Math.floor(startS)}
-              />
-              <div
-                className="waveform-trim-handle waveform-trim-handle-end"
-                style={{ left: endPx }}
-                onPointerDown={onPointerDown("end")}
-                aria-label="Trim end"
-                role="slider"
-                aria-valuemin={0}
-                aria-valuemax={Math.floor(durationS)}
-                aria-valuenow={Math.floor(endS)}
-              />
-            </>
-          )}
-        </div>
-
-        <div className="waveform-trim-readout">
-          <span>
-            <span className="waveform-trim-readout-label">Start</span>{" "}
-            {fmtMMSS(startS)}
-          </span>
-          <span>
-            <span className="waveform-trim-readout-label">End</span>{" "}
-            {fmtMMSS(endS)}
-          </span>
-          <span
-            className={`waveform-trim-readout-selected${atCap ? " at-cap" : ""}`}
+      <div className="almost-ready-modal waveform-trim-modal">
+        <div className="almost-ready-header">
+          <h2 className="almost-ready-title">Trim upload — step 1 of 2</h2>
+          <button
+            type="button"
+            className="config-modal-close"
+            onClick={onCancel}
+            aria-label="Cancel upload"
           >
-            <span className="waveform-trim-readout-label">Selected</span>{" "}
-            {fmtMMSS(selectedS)}
-            {atCap && !fileShorterThanCap && (
-              <span className="waveform-trim-readout-cap"> (max)</span>
+            ×
+          </button>
+        </div>
+        <div className="almost-ready-body">
+          <div className="almost-ready-filename" title={fileName}>
+            {fileName} · {fmtMMSS(durationS)} total
+          </div>
+
+          <p className="waveform-trim-hint">
+            {fileShorterThanCap
+              ? "Drag the handles or the highlighted window to pick the section to send to the engine."
+              : `Max ${fmtMMSS(capS)} per session — drag to position the window over the section you want to send.`}
+          </p>
+
+          <div
+            ref={containerRef}
+            className="waveform-trim-container"
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+            onPointerCancel={onPointerUp}
+          >
+            <canvas ref={canvasRef} className="waveform-trim-canvas" />
+            {containerWidth > 0 && (
+              <>
+                <div
+                  className="waveform-trim-dim"
+                  style={{ left: 0, width: startPx }}
+                />
+                <div
+                  className="waveform-trim-dim"
+                  style={{ left: endPx, right: 0 }}
+                />
+                <div
+                  className="waveform-trim-selection"
+                  style={{ left: startPx, width: widthPx }}
+                  onPointerDown={onPointerDown("body")}
+                />
+                <div
+                  className="waveform-trim-handle waveform-trim-handle-start"
+                  style={{ left: startPx }}
+                  onPointerDown={onPointerDown("start")}
+                  aria-label="Trim start"
+                  role="slider"
+                  aria-valuemin={0}
+                  aria-valuemax={Math.floor(durationS)}
+                  aria-valuenow={Math.floor(startS)}
+                />
+                <div
+                  className="waveform-trim-handle waveform-trim-handle-end"
+                  style={{ left: endPx }}
+                  onPointerDown={onPointerDown("end")}
+                  aria-label="Trim end"
+                  role="slider"
+                  aria-valuemin={0}
+                  aria-valuemax={Math.floor(durationS)}
+                  aria-valuenow={Math.floor(endS)}
+                />
+              </>
             )}
-          </span>
+          </div>
+
+          <div className="waveform-trim-readout">
+            <span>
+              <span className="waveform-trim-readout-label">Start</span>{" "}
+              {fmtMMSS(startS)}
+            </span>
+            <span>
+              <span className="waveform-trim-readout-label">End</span>{" "}
+              {fmtMMSS(endS)}
+            </span>
+            <span
+              className={`waveform-trim-readout-selected${atCap ? " at-cap" : ""}`}
+            >
+              <span className="waveform-trim-readout-label">Selected</span>{" "}
+              {fmtMMSS(selectedS)}
+              {atCap && !fileShorterThanCap && (
+                <span className="waveform-trim-readout-cap"> (max)</span>
+              )}
+            </span>
+          </div>
         </div>
 
-        <footer className="almost-ready-footer">
+        <div className="almost-ready-footer">
           <button
             type="button"
             className="almost-ready-btn almost-ready-btn--secondary"
@@ -327,7 +333,7 @@ export function WaveformTrimDialog({
           >
             Use this section
           </button>
-        </footer>
+        </div>
       </div>
     </div>,
     document.body,

--- a/demos/realtime_motion_graph_web/web/components/Performance/WaveformTrimDialog.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/WaveformTrimDialog.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { computePeaks } from "@/engine/curves/waveformPeaks";
+import type { DecodedFixture } from "@/engine/audio/loadFixture";
+
+// Interactive trim step that runs between decodeAudioFile and the
+// AlmostReadyDialog for every upload. The user picks a window of up
+// to ``capS`` seconds from the decoded waveform; only the slice is
+// passed downstream. Replaces the prior silent head-trim behaviour
+// (decodeAudioFile used to clip anything over 240 s and just tell the
+// user "we trimmed it" after the fact).
+//
+// Why always-on (not just for over-cap uploads):
+//   - A 5-minute upload obviously needs trimming.
+//   - A 30-second upload often ALSO benefits from trimming — pick
+//     the chorus / drop instead of feeding the intro.
+//   - Consistent UX: there's one trim step, not two flows the user
+//     has to memorise.
+//
+// The cap (``capS``) comes from config — see
+// ``engine.max_source_duration_s`` in lib/config.ts.
+
+export interface WaveformTrimDialogProps {
+  decoded: DecodedFixture;
+  fileName: string;
+  /** Max length of the selected window, in seconds. The dialog
+   *  refuses to let the user expand the window past this. */
+  capS: number;
+  /** Minimum selectable window. Set by the smallest TRT profile +
+   *  pool alignment; well below this and the slice can't even fill
+   *  one engine forward pass. */
+  minS?: number;
+  onConfirm: (startS: number, endS: number) => void;
+  onCancel: () => void;
+}
+
+// Match AlmostReadyDialog's portal-mount tick so the overlay's
+// transition (opacity, transform) gets a chance to animate in.
+const MIN_S_DEFAULT = 3;
+
+function fmtMMSS(seconds: number): string {
+  const total = Math.max(0, Math.round(seconds));
+  const m = Math.floor(total / 60);
+  const s = total - m * 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export function WaveformTrimDialog({
+  decoded,
+  fileName,
+  capS,
+  minS = MIN_S_DEFAULT,
+  onConfirm,
+  onCancel,
+}: WaveformTrimDialogProps) {
+  const durationS = decoded.frames / decoded.sampleRate;
+  const initialEnd = Math.min(capS, durationS);
+  const [startS, setStartS] = useState(0);
+  const [endS, setEndS] = useState(initialEnd);
+  const [mounted, setMounted] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const peaksRef = useRef<Float32Array | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Measure container width — drives both canvas pixel sizing and
+  // the px↔seconds mapping. ResizeObserver covers viewport changes
+  // (mobile rotate, drawer resize) without redrawing the waveform
+  // unless the width actually changes.
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => setContainerWidth(el.clientWidth);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Compute peaks once per (decoded, width) — the file doesn't change
+  // mid-dialog but width can on resize. ``computePeaks`` returns
+  // alternating min/max pairs; the canvas draw below treats them as
+  // vertical bars per pixel column.
+  useEffect(() => {
+    if (!containerWidth || !canvasRef.current) return;
+    const dpr = window.devicePixelRatio || 1;
+    const cssW = containerWidth;
+    const cssH = 120;
+    const canvas = canvasRef.current;
+    canvas.width = Math.floor(cssW * dpr);
+    canvas.height = Math.floor(cssH * dpr);
+    canvas.style.width = `${cssW}px`;
+    canvas.style.height = `${cssH}px`;
+    const peaks = computePeaks(
+      decoded.interleaved,
+      decoded.channels,
+      cssW,
+    );
+    peaksRef.current = peaks;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssW, cssH);
+    // Background bars use a muted tone; the selection overlay above
+    // re-paints the in-window region in the accent colour.
+    ctx.fillStyle = "rgba(255,255,255,0.18)";
+    const mid = cssH / 2;
+    const amp = mid - 4;
+    for (let i = 0; i < cssW; i++) {
+      const mn = peaks[i * 2] ?? 0;
+      const mx = peaks[i * 2 + 1] ?? 0;
+      const y0 = mid - mx * amp;
+      const y1 = mid - mn * amp;
+      const h = Math.max(1, y1 - y0);
+      ctx.fillRect(i, y0, 1, h);
+    }
+  }, [containerWidth, decoded]);
+
+  const pxPerSecond = containerWidth > 0 && durationS > 0
+    ? containerWidth / durationS
+    : 0;
+  const startPx = startS * pxPerSecond;
+  const endPx = endS * pxPerSecond;
+  const widthPx = Math.max(0, endPx - startPx);
+
+  const clampStart = (next: number, currentEnd: number): number => {
+    const upper = Math.min(currentEnd - minS, durationS - minS);
+    return Math.max(0, Math.min(upper, next));
+  };
+  const clampEnd = (next: number, currentStart: number): number => {
+    const lower = Math.max(currentStart + minS, minS);
+    const upper = Math.min(durationS, currentStart + capS);
+    return Math.max(lower, Math.min(upper, next));
+  };
+
+  type DragKind = "start" | "end" | "body" | null;
+  const dragRef = useRef<{
+    kind: DragKind;
+    pointerId: number;
+    grabPx: number;
+    grabStartS: number;
+    grabEndS: number;
+  }>({ kind: null, pointerId: -1, grabPx: 0, grabStartS: 0, grabEndS: 0 });
+
+  function onPointerDown(kind: Exclude<DragKind, null>) {
+    return (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      dragRef.current = {
+        kind,
+        pointerId: e.pointerId,
+        grabPx: e.clientX,
+        grabStartS: startS,
+        grabEndS: endS,
+      };
+    };
+  }
+
+  function onPointerMove(e: React.PointerEvent<HTMLDivElement>) {
+    const d = dragRef.current;
+    if (d.kind === null || e.pointerId !== d.pointerId || pxPerSecond === 0) {
+      return;
+    }
+    const deltaPx = e.clientX - d.grabPx;
+    const deltaS = deltaPx / pxPerSecond;
+    if (d.kind === "start") {
+      setStartS(clampStart(d.grabStartS + deltaS, d.grabEndS));
+    } else if (d.kind === "end") {
+      setEndS(clampEnd(d.grabEndS + deltaS, d.grabStartS));
+    } else {
+      // Body drag: translate both, clamping so neither edge escapes.
+      const windowS = d.grabEndS - d.grabStartS;
+      let nextStart = d.grabStartS + deltaS;
+      if (nextStart < 0) nextStart = 0;
+      if (nextStart + windowS > durationS) nextStart = durationS - windowS;
+      setStartS(nextStart);
+      setEndS(nextStart + windowS);
+    }
+  }
+
+  function onPointerUp(e: React.PointerEvent<HTMLDivElement>) {
+    const d = dragRef.current;
+    if (d.kind === null || e.pointerId !== d.pointerId) return;
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      // Ignore — releasePointerCapture throws if the capture was lost
+      // (e.g. drag dragged off-screen).
+    }
+    dragRef.current = { kind: null, pointerId: -1, grabPx: 0, grabStartS: 0, grabEndS: 0 };
+  }
+
+  const selectedS = endS - startS;
+  // The cap and the file length are independent constraints. Surface
+  // whichever ceiling the user is actually pressing against so the
+  // hint reads naturally ("max 2:00" for cap, "end of track" for short
+  // file).
+  const atCap = Math.abs(selectedS - Math.min(capS, durationS)) < 0.5;
+  const fileShorterThanCap = durationS < capS;
+
+  useEffect(() => {
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key === "Escape") onCancel();
+      if (ev.key === "Enter") onConfirm(startS, endS);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onCancel, onConfirm, startS, endS]);
+
+  if (typeof document === "undefined") return null;
+  return createPortal(
+    <div
+      className={`almost-ready-overlay${mounted ? " mounted" : ""}`}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Trim upload"
+    >
+      <div className="almost-ready-card waveform-trim-card">
+        <header className="almost-ready-header">
+          <h2 className="almost-ready-title">Trim upload</h2>
+          <p className="almost-ready-sub">
+            <strong>{fileName}</strong> — {fmtMMSS(durationS)} total.
+            {" "}
+            {fileShorterThanCap
+              ? "Pick any section."
+              : `Max ${fmtMMSS(capS)} of audio per session.`}
+          </p>
+        </header>
+
+        <div
+          ref={containerRef}
+          className="waveform-trim-container"
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+        >
+          <canvas ref={canvasRef} className="waveform-trim-canvas" />
+          {containerWidth > 0 && (
+            <>
+              {/* Dimmed regions outside the selection. Pointer events
+                  pass through to the container so a stray pointerdown
+                  on a dimmed region doesn't break the drag. */}
+              <div
+                className="waveform-trim-dim"
+                style={{ left: 0, width: startPx }}
+              />
+              <div
+                className="waveform-trim-dim"
+                style={{ left: endPx, right: 0 }}
+              />
+              {/* Selection box — draggable body, with two grab handles
+                  poking out at the edges. */}
+              <div
+                className="waveform-trim-selection"
+                style={{ left: startPx, width: widthPx }}
+                onPointerDown={onPointerDown("body")}
+              />
+              <div
+                className="waveform-trim-handle waveform-trim-handle-start"
+                style={{ left: startPx }}
+                onPointerDown={onPointerDown("start")}
+                aria-label="Trim start"
+                role="slider"
+                aria-valuemin={0}
+                aria-valuemax={Math.floor(durationS)}
+                aria-valuenow={Math.floor(startS)}
+              />
+              <div
+                className="waveform-trim-handle waveform-trim-handle-end"
+                style={{ left: endPx }}
+                onPointerDown={onPointerDown("end")}
+                aria-label="Trim end"
+                role="slider"
+                aria-valuemin={0}
+                aria-valuemax={Math.floor(durationS)}
+                aria-valuenow={Math.floor(endS)}
+              />
+            </>
+          )}
+        </div>
+
+        <div className="waveform-trim-readout">
+          <span>
+            <span className="waveform-trim-readout-label">Start</span>{" "}
+            {fmtMMSS(startS)}
+          </span>
+          <span>
+            <span className="waveform-trim-readout-label">End</span>{" "}
+            {fmtMMSS(endS)}
+          </span>
+          <span
+            className={`waveform-trim-readout-selected${atCap ? " at-cap" : ""}`}
+          >
+            <span className="waveform-trim-readout-label">Selected</span>{" "}
+            {fmtMMSS(selectedS)}
+            {atCap && !fileShorterThanCap && (
+              <span className="waveform-trim-readout-cap"> (max)</span>
+            )}
+          </span>
+        </div>
+
+        <footer className="almost-ready-footer">
+          <button
+            type="button"
+            className="almost-ready-btn almost-ready-btn--secondary"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="almost-ready-btn almost-ready-btn--primary"
+            onClick={() => onConfirm(startS, endS)}
+          >
+            Use this section
+          </button>
+        </footer>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
@@ -124,53 +124,30 @@ export async function loadFixtureAudio(name: string): Promise<DecodedFixture> {
   return decodeArrayBuffer(bytes);
 }
 
-// Cap user-supplied audio at DEMON's largest TRT engine profile
-// (240 s; see acestep/paths.py:_TRT_ENGINE_PROFILES). Anything longer
-// would fail server-side at session init regardless of WS frame size.
-// The server's websockets.serve(max_size=...) is sized to fit this
-// duration with a comfortable margin.
-export const MAX_FIXTURE_DURATION_S = 240;
-
-export interface DecodeFileResult {
-  decoded: DecodedFixture;
-  /** True iff the input was longer than MAX_FIXTURE_DURATION_S and we
-   *  trimmed the head. The UI surfaces this so users know the upload
-   *  was clipped. */
-  wasTrimmed: boolean;
-}
-
-/** Soft-trim to fit DEMON's swap-source limit. Tracks ≤ 240 s pass
- *  through unchanged; longer tracks are clipped to the largest
- *  pool-aligned length ≤ 240 s. Pool alignment matches the rule in
- *  decodeArrayBuffer (multiple of SAMPLE_POOL = 9600), so the trimmed
- *  buffer still satisfies backend.py's VAE-encode constraint. */
-function trimToSwapLimit(decoded: DecodedFixture): DecodeFileResult {
-  const seconds = decoded.frames / decoded.sampleRate;
-  if (seconds <= MAX_FIXTURE_DURATION_S) return { decoded, wasTrimmed: false };
-
-  const maxFramesRaw = MAX_FIXTURE_DURATION_S * decoded.sampleRate;
-  const targetFrames = Math.floor(maxFramesRaw / SAMPLE_POOL) * SAMPLE_POOL;
-  const trimmed = new Float32Array(targetFrames * decoded.channels);
-  trimmed.set(decoded.interleaved.subarray(0, targetFrames * decoded.channels));
-  return {
-    decoded: {
-      interleaved: trimmed,
-      channels: decoded.channels,
-      frames: targetFrames,
-      sampleRate: decoded.sampleRate,
-    },
-    wasTrimmed: true,
-  };
-}
+// Hard upper bound on upload length. The interactive trim dialog
+// (WaveformTrimDialog) lets the user pick any window of up to
+// engine.max_source_duration_s, so tracks longer than this just give
+// the user more room to pick FROM — they aren't passed to the engine
+// at full length. The cap here exists purely to keep one giant decode
+// from exhausting the browser's memory; 10 min of 48 kHz stereo
+// Float32 is already ~115 MiB.
+export const MAX_UPLOAD_DURATION_S = 600;
 
 /** Decode a user-supplied audio File (mp3, wav, flac, ogg — anything the
- *  browser supports). Used by the upload affordances.
- *  Auto-trims to MAX_FIXTURE_DURATION_S when the source is longer; the UI
- *  shows a "we trimmed your upload" message when wasTrimmed is true. */
-export async function decodeAudioFile(file: File): Promise<DecodeFileResult> {
+ *  browser supports). Used by the upload affordances. Returns the
+ *  full-length decoded buffer; the caller (TrackPicker /
+ *  AudioSourceCrate) drives the interactive trim dialog and only the
+ *  trimmed slice ever reaches the engine. */
+export async function decodeAudioFile(file: File): Promise<DecodedFixture> {
   const bytes = await file.arrayBuffer();
   const decoded = await decodeArrayBuffer(bytes);
-  return trimToSwapLimit(decoded);
+  const seconds = decoded.frames / decoded.sampleRate;
+  if (seconds > MAX_UPLOAD_DURATION_S) {
+    throw new Error(
+      `Upload too long — max ${Math.round(MAX_UPLOAD_DURATION_S / 60)} min, got ${seconds.toFixed(0)} s.`,
+    );
+  }
+  return decoded;
 }
 
 /** Fetch the pod's whitelist of fixture names.

--- a/demos/realtime_motion_graph_web/web/lib/audio/trimAudioBuffer.ts
+++ b/demos/realtime_motion_graph_web/web/lib/audio/trimAudioBuffer.ts
@@ -1,0 +1,43 @@
+import type { DecodedFixture } from "@/engine/audio/loadFixture";
+
+// Server-side latent pool size, mirroring loadFixture.ts and backend.py.
+// Trim boundaries MUST be multiples of this so the sliced buffer still
+// satisfies the VAE-encode constraint.
+const SAMPLE_POOL = 9600;
+
+/** Slice a DecodedFixture to a [startS, endS] window, aligned to the
+ *  server's sample-pool boundary. Returns a fresh Float32Array — the
+ *  original buffer is not retained. Used by WaveformTrimDialog after
+ *  the user confirms the trim window.
+ *
+ *  Pool alignment matches the rule in loadFixture.decodeArrayBuffer:
+ *  start floor-aligns to the previous pool boundary, end floor-aligns
+ *  to a pool boundary at-or-before endS. The resulting length is at
+ *  least one pool (0.2 s at 48 kHz) — caller is responsible for not
+ *  passing a window narrower than that. */
+export function trimAudioBuffer(
+  decoded: DecodedFixture,
+  startS: number,
+  endS: number,
+): DecodedFixture {
+  const { interleaved, channels, sampleRate, frames } = decoded;
+  const startFrameRaw = Math.max(0, Math.round(startS * sampleRate));
+  const endFrameRaw = Math.min(frames, Math.round(endS * sampleRate));
+  const startFrame = Math.floor(startFrameRaw / SAMPLE_POOL) * SAMPLE_POOL;
+  const endFrameAligned =
+    Math.floor(endFrameRaw / SAMPLE_POOL) * SAMPLE_POOL;
+  const newFrames = Math.max(SAMPLE_POOL, endFrameAligned - startFrame);
+  const out = new Float32Array(newFrames * channels);
+  out.set(
+    interleaved.subarray(
+      startFrame * channels,
+      (startFrame + newFrames) * channels,
+    ),
+  );
+  return {
+    interleaved: out,
+    channels,
+    frames: newFrames,
+    sampleRate,
+  };
+}

--- a/demos/realtime_motion_graph_web/web/lib/config.ts
+++ b/demos/realtime_motion_graph_web/web/lib/config.ts
@@ -126,6 +126,21 @@ export interface RtmgConfigEngine {
     up_to_s: number;
     cap: number;
   }> | null;
+  /** Hard ceiling on how long a slice of audio the engine will accept
+   *  as a source. The upload UI shows an interactive trim dialog
+   *  (WaveformTrimDialog) on every upload — the dialog clamps the
+   *  selectable window to this value, and only the trimmed slice is
+   *  ever sent to the engine.
+   *
+   *  Default is 120 s: the 60 s and 120 s TRT engines are the stable
+   *  pair on current GPUs. The 240 s vae_encode engine reserves
+   *  ~16 GiB workspace at runtime which has driven CUDA-OOM crashes
+   *  on 32 GiB cards; keeping the cap at 120 s avoids that profile
+   *  until the OOM and the related context-creation-returns-None
+   *  crash in acestep/nodes/vae_nodes.py are addressed. Operators
+   *  with bigger cards (≥48 GiB) who want the 240 s profile can set
+   *  this to 240 in their override config. */
+  max_source_duration_s?: number;
   /** XL (5B) variant overrides. When the active checkpoint scale is
    *  "5B", these win over their base siblings at applyConfig time.
    *  Absent / undefined falls through to the base field. Selection
@@ -294,6 +309,7 @@ export const DEFAULT_CONFIG: RtmgConfig = {
     fast_vae: false,
     walk_window: false,
     walk_window_s: 60,
+    max_source_duration_s: 120,
     key: "G# minor",
     time_signature: DEFAULT_TIME_SIGNATURE,
     enabled_loras: [],


### PR DESCRIPTION
## Summary

Replace the silent 240 s head-trim with an **interactive trim dialog** on every audio upload. Canvas waveform, two draggable handles, draggable selection body — the user picks the exact slice that reaches the engine.

The selectable window is capped by a new config field, **`engine.max_source_duration_s`** (default **120 s**). Operators with bigger cards can push it back to 240.

## Why default to 120 s

The 240 s `vae_encode` TRT profile reserves ~16 GiB workspace at runtime, which has driven CUDA-OOM crashes on 32 GiB cards. Observed today on a fleet pod:

```
ERROR pipeline_error error='NoneType' object has no attribute 'set_input_shape'
  acestep/nodes/vae_nodes.py:121
```

— the TRT context creation OOMed and the unguarded return value crashed VAE decode. Capping uploads at 120 s avoids the 240 s profile entirely, sidestepping that engine until the OOM + the unguarded-None-ctx bug are fixed. Both are worth a follow-up PR.

## What's gone

- `MAX_FIXTURE_DURATION_S = 240` and `trimToSwapLimit` in `engine/audio/loadFixture.ts`
- The `wasTrimmed`-conditional "we trimmed your upload" message in `AlmostReadyDialog` (still rendered when the prop is `true`, but no caller sends `true` anymore — trim is explicit)

## What's new

- `lib/audio/trimAudioBuffer.ts` — pool-aligned Float32 slice helper
- `components/Performance/WaveformTrimDialog.tsx` — modal dialog. Shares `.almost-ready-overlay` chrome + animation so the upload flow reads as one multi-step modal
- `app/globals.css` — `.waveform-trim-*` styling
- `engine/audio/loadFixture.ts` — `decodeAudioFile` returns bare `DecodedFixture`, with a 10-min browser-memory upper bound (`MAX_UPLOAD_DURATION_S = 600`)
- `lib/config.ts` — `max_source_duration_s?: number` on `RtmgConfigEngine`, default 120

Surfaces wired:
- `TrackPicker` (CORE tab inline picker)
- `AudioSourceCrate` (bottom-left crate)
- `LiteTrackCarousel` (mobile lite)
- `RefControl` (timbre / structure ref uploads) intentionally NOT wired — refs are conceptually the whole clip, not a slice. That code just unwraps the new return type.

## Test plan

- [ ] Upload < cap (e.g. 30 s loop): trim dialog opens, user can shrink window or accept full length
- [ ] Upload ≈ cap (90 s): selection initialises to full track; max selectable equals file length
- [ ] Upload > cap (5 min): selection initialises to first 120 s; sliding handles can never exceed cap
- [ ] Upload > 10 min: rejected with clean error
- [ ] Pool alignment: slice frame count is a multiple of 9600 (verified via server sidecar lookup hitting bpm/key cache instead of CNN fallback)
- [ ] Cancel: previously playing track keeps playing, no fixture swap
- [ ] Drag body of selection: window translates as one unit
- [ ] Esc cancels, Enter confirms
- [ ] Ref-track upload (timbre / structure) unaffected — no trim dialog, same one-step UX as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)