### PR TITLE
feat(rtmg/midi): gate Web MIDI behind a user-toggled "MIDI in" jack

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3642,22 +3642,38 @@ body.drawer-open .hud-help-readout {
   border-radius: 4px;
 }
 .midi-in-toggle-led {
-  /* The LED itself — a 10 px round well sunk into the panel. The
-   * ::after layers the lit dot inside; off state hides ::after and
-   * shows only the dim recess. */
+  /* The LED itself — a round glass dome sunk into the panel. Even
+   * when OFF, we want the dome to read as a physical object hit by
+   * ambient room light from above, not a flat dot that disappears
+   * into the panel. Layered backgrounds achieve that:
+   *   1. A top-anchored specular highlight (linear, lighter at top
+   *      → darker at bottom) — sells the curved glass surface.
+   *   2. The dark recess (radial) — the unpowered lens body.
+   * The outer ring (1 px lighter outline) carves the dome out of
+   * the panel so its silhouette is always readable. */
   position: relative;
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
-  background: radial-gradient(
-    circle at 50% 55%,
-    rgba(0, 0, 0, 0.7) 0%,
-    rgba(8, 6, 6, 0.95) 100%
-  );
+  background:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.22) 0%,
+      rgba(255, 255, 255, 0.06) 35%,
+      rgba(0, 0, 0, 0) 60%
+    ),
+    radial-gradient(
+      circle at 50% 55%,
+      rgba(40, 30, 30, 0.85) 0%,
+      rgba(12, 10, 10, 0.98) 100%
+    );
   box-shadow:
-    inset 0 1px 1px rgba(0, 0, 0, 0.85),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.04),
-    0 0 0 1px rgba(0, 0, 0, 0.6);
+    inset 0 1px 1px rgba(0, 0, 0, 0.6),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.05),
+    /* Subtle outer ring acts as a polished bezel: catches "light"
+     * so the dome stays visible against a dark panel even unpowered. */
+    0 0 0 1px rgba(255, 255, 255, 0.1),
+    0 1px 1px rgba(0, 0, 0, 0.5);
 }
 .midi-in-toggle-led::after {
   content: "";

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3652,8 +3652,8 @@ body.drawer-open .hud-help-readout {
    * The outer ring (1 px lighter outline) carves the dome out of
    * the panel so its silhouette is always readable. */
   position: relative;
-  width: 12px;
-  height: 12px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background:
     linear-gradient(

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3603,6 +3603,110 @@ body.drawer-open .hud-help-readout {
   color: var(--text-strong);
   border-color: var(--accent-line);
 }
+
+/* ─── MIDI in jack toggle ─────────────────────────────────────────────
+   Sits under Full Controls in the right-side tools cluster. NOT a
+   button-styled cell like Record / Curve Editor / Full Controls; just
+   a small red LED with a mono-caps "MIDI in" label next to it. Click
+   flips the store's ``enabled`` flag, which gates the browser's
+   ``requestMIDIAccess`` permission prompt — so a fresh visitor never
+   sees the prompt unless they explicitly turn MIDI on here.
+   Skeuomorphic LED: layered radial gradient (lit core + ambient halo)
+   over a dark inset bezel. Off state strips the gradients and shows
+   a dim recess so the jack reads as "unpowered". */
+.midi-in-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  /* Transparent — no card chrome. Lives flush against the panel like
+   * a labelled jack on a hardware rack, not a button to click. */
+  background: transparent;
+  border: 0;
+  padding: 6px 2px;
+  margin: 0;
+  cursor: pointer;
+  font: inherit;
+  color: var(--text-dim);
+  -webkit-appearance: none;
+          appearance: none;
+  transition: color 140ms ease-out;
+}
+.midi-in-toggle:hover { color: var(--text); }
+.midi-in-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+.midi-in-toggle-led {
+  /* The LED itself — a 10 px round well sunk into the panel. The
+   * ::after layers the lit dot inside; off state hides ::after and
+   * shows only the dim recess. */
+  position: relative;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 50% 55%,
+    rgba(0, 0, 0, 0.7) 0%,
+    rgba(8, 6, 6, 0.95) 100%
+  );
+  box-shadow:
+    inset 0 1px 1px rgba(0, 0, 0, 0.85),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.04),
+    0 0 0 1px rgba(0, 0, 0, 0.6);
+}
+.midi-in-toggle-led::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 40% 40%,
+    rgba(255, 240, 230, 0.95) 0%,
+    rgba(255, 80, 50, 1) 40%,
+    rgba(140, 18, 10, 1) 100%
+  );
+  box-shadow:
+    0 0 4px rgba(255, 80, 50, 0.85),
+    0 0 10px rgba(255, 60, 40, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  opacity: 0;
+  transition: opacity 140ms ease-out;
+}
+.midi-in-toggle--on .midi-in-toggle-led::after,
+.midi-in-toggle--warn .midi-in-toggle-led::after {
+  opacity: 1;
+}
+.midi-in-toggle--warn .midi-in-toggle-led::after {
+  /* Permission denied / no Web MIDI — amber LED so the user can tell
+   * the toggle is on but the platform isn't delivering. Distinct from
+   * the "off" dark state and the "on" healthy red. */
+  background: radial-gradient(
+    circle at 40% 40%,
+    rgba(255, 240, 200, 0.95) 0%,
+    rgba(230, 180, 60, 1) 40%,
+    rgba(120, 80, 10, 1) 100%
+  );
+  box-shadow:
+    0 0 4px rgba(230, 180, 60, 0.85),
+    0 0 10px rgba(220, 160, 40, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+.midi-in-toggle-label {
+  font-family: var(--font-mono);
+  font-size: 0.62em;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  line-height: 1;
+}
+/* Hide on touch-only devices — phones have nothing to gain from MIDI
+ * (no controllers, no hardware) and the toggle would just clutter the
+ * mobile chrome. The useMidi hook also guards against
+ * ``navigator.requestMIDIAccess`` being absent, but hiding the
+ * affordance keeps the surface honest. */
+@media (hover: none) and (pointer: coarse) {
+  .midi-in-toggle { display: none; }
+}
 /* When the drawer is open the knob row hides (params live in the
    drawer's CORE tab now) but the toggle button stays — it's the
    only way to close the drawer with the bottom handle gone. */

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -3618,6 +3618,10 @@ body.drawer-open .hud-help-readout {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  /* Center inside .hero-macros-tools' column so the jack reads as
+   * a standalone affordance rather than a left-aligned sibling of
+   * the Full Controls button. */
+  align-self: center;
   /* Transparent — no card chrome. Lives flush against the panel like
    * a labelled jack on a hardware rack, not a button to click. */
   background: transparent;

--- a/demos/realtime_motion_graph_web/web/components/Performance/HeroMacros.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/HeroMacros.tsx
@@ -21,6 +21,7 @@ import { useStemOverlayStore } from "@/store/useStemOverlayStore";
 import { LORA_SLIDER_MAX } from "@/types/engine";
 
 import { Knob } from "./Knob";
+import { MidiInToggle } from "./MidiInToggle";
 import { SeedKnob } from "./SeedKnob";
 import { defaultLabelFor, kbdHintFor } from "./SliderTile";
 
@@ -383,6 +384,7 @@ export function HeroMacros() {
             {drawerOpen ? "◂" : "▸"}
           </span>
         </button>
+        <MidiInToggle />
       </div>
     </div>
   );

--- a/demos/realtime_motion_graph_web/web/components/Performance/MidiInToggle.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/MidiInToggle.tsx
@@ -41,8 +41,8 @@ export function MidiInToggle() {
       aria-label={enabled ? "Disable MIDI in" : "Enable MIDI in"}
       title={title}
     >
-      <span className="midi-in-toggle-led" aria-hidden="true" />
       <span className="midi-in-toggle-label">MIDI in</span>
+      <span className="midi-in-toggle-led" aria-hidden="true" />
     </button>
   );
 }

--- a/demos/realtime_motion_graph_web/web/components/Performance/MidiInToggle.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/MidiInToggle.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useMidiStore } from "@/store/useMidiStore";
+
+// Skeuomorphic "MIDI in" jack toggle. Sits in the right-side tools
+// cluster (HeroMacros' hero-macros-tools) under the Full Controls
+// button. A red LED with a label — lit means MIDI is on, dark means
+// off. Click flips the store's ``enabled`` flag; ``useMidi`` watches
+// that and only calls ``navigator.requestMIDIAccess`` when it's true,
+// so the browser permission prompt fires only on an explicit
+// user-initiated enable.
+//
+// Hidden on touch-only devices via CSS — phones have nothing to gain
+// from MIDI and the toggle would just clutter the chrome.
+
+export function MidiInToggle() {
+  const enabled = useMidiStore((s) => s.enabled);
+  const status = useMidiStore((s) => s.status);
+  const setEnabled = useMidiStore((s) => s.setEnabled);
+
+  // Three visual states for the LED: off (dark) / on-armed
+  // (steady red — access granted, listening) / on-denied (steady
+  // amber — user enabled but browser rejected / Web MIDI N/A).
+  // Status tone is the existing channel for "warn" / "off" → mirror
+  // that into the LED color rather than introducing a new field.
+  const ledState: "off" | "on" | "warn" =
+    !enabled ? "off"
+      : status.tone === "warn" || status.tone === "off" ? "warn"
+      : "on";
+
+  const title = enabled
+    ? `MIDI in: ${status.message}. Click to disable.`
+    : "MIDI in: off. Click to enable (the browser will ask for permission).";
+
+  return (
+    <button
+      type="button"
+      className={`midi-in-toggle midi-in-toggle--${ledState}`}
+      onClick={() => setEnabled(!enabled)}
+      aria-pressed={enabled}
+      aria-label={enabled ? "Disable MIDI in" : "Enable MIDI in"}
+      title={title}
+    >
+      <span className="midi-in-toggle-led" aria-hidden="true" />
+      <span className="midi-in-toggle-label">MIDI in</span>
+    </button>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/hooks/useMidi.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useMidi.ts
@@ -195,8 +195,27 @@ function bindInput(input: MIDIInput): void {
 }
 
 export function useMidi() {
+  // Subscribe to the user's toggle. Web MIDI's permission prompt
+  // fires the moment ``requestMIDIAccess`` is called — running it on
+  // mount used to interrupt every desktop visit with an OS-modal
+  // "Allow MIDI?" dialog, and on mobile the prompt is pure noise
+  // (no controllers, the user is on a phone). Now we wait for an
+  // explicit toggle via MidiInToggle, persisted to localStorage.
+  const enabled = useMidiStore((s) => s.enabled);
+
   useEffect(() => {
+    // ``available: false`` for the lifetime of the no-MIDI state —
+    // every consumer (MidiBadge etc.) reads this and renders an "off"
+    // affordance accordingly.
+    if (!enabled) {
+      useMidiStore.getState().setAvailable(false);
+      useMidiStore.getState().setStatus("MIDI off", "off");
+      return;
+    }
     if (typeof navigator === "undefined" || !navigator.requestMIDIAccess) {
+      // The browser has no Web MIDI at all (Safari < 18, mobile
+      // Safari, hostile environments). Keep the toggle visible but
+      // tell the user the platform can't deliver.
       useMidiStore.getState().setStatus("MIDI N/A", "off");
       return;
     }
@@ -309,5 +328,8 @@ export function useMidi() {
         access.onstatechange = null;
       }
     };
-  }, []);
+    // Re-run on enable flip so toggling MidiInToggle off releases the
+    // device bindings and toggling on re-prompts (or, if previously
+    // approved, silently reconnects).
+  }, [enabled]);
 }

--- a/demos/realtime_motion_graph_web/web/store/useMidiStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useMidiStore.ts
@@ -42,6 +42,28 @@ function saveMap(m: MidiMap): void {
   } catch {}
 }
 
+// Persist the user's MIDI-in toggle decision so a desktop operator who
+// flipped it on once doesn't have to re-enable + re-approve the browser
+// permission every page load. Stored separately from the MIDI map so
+// the import/export flows can stay map-only.
+const MIDI_ENABLED_KEY = "demon:midi:enabled";
+
+function loadEnabled(): boolean {
+  if (typeof localStorage === "undefined") return false;
+  try {
+    return localStorage.getItem(MIDI_ENABLED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function saveEnabled(b: boolean): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(MIDI_ENABLED_KEY, b ? "1" : "0");
+  } catch {}
+}
+
 interface LearnState {
   kind: "cc" | "note";
   target: string;
@@ -53,9 +75,16 @@ interface MidiState {
   status: { message: string; tone: "ok" | "warn" | "info" | "off" };
   learn: LearnState | null;
   available: boolean;
+  /** User-opt-in gate on the Web MIDI permission prompt. The MIDI-in
+   *  jack toggle (HeroMacros' MidiInToggle) flips this; useMidi only
+   *  calls navigator.requestMIDIAccess when this is true. Default
+   *  false so a fresh page-load never auto-prompts. Persisted in
+   *  localStorage so a user who turned it on stays on across loads. */
+  enabled: boolean;
 
   setStatus: (message: string, tone?: MidiState["status"]["tone"]) => void;
   setAvailable: (b: boolean) => void;
+  setEnabled: (b: boolean) => void;
 
   startLearn: (
     kind: LearnState["kind"],
@@ -74,9 +103,14 @@ export const useMidiStore = create<MidiState>((set, get) => ({
   status: { message: "MIDI", tone: "off" },
   learn: null,
   available: false,
+  enabled: loadEnabled(),
 
   setStatus: (message, tone = "info") => set({ status: { message, tone } }),
   setAvailable: (b) => set({ available: b }),
+  setEnabled: (b) => {
+    saveEnabled(b);
+    set({ enabled: b });
+  },
 
   startLearn: (kind, target, el) => {
     const prev = get().learn;


### PR DESCRIPTION
## Summary

Stop calling ``navigator.requestMIDIAccess`` on every page load. The browser's "Allow MIDI?" OS prompt was firing on every fresh visit — interrupting desktop users and being pure noise on mobile (no MIDI hardware to plug into, no Web MIDI on iOS Safari, but the prompt fired anyway).

The new flow:

1. **Off by default.** A first-time visitor never sees the MIDI prompt.
2. **Opt-in via a skeuomorphic "MIDI in" LED toggle** in the right-side hero-macros tools cluster, beneath the "Full Controls" button. Clicking it sets ``useMidiStore.enabled = true`` and ``useMidi`` then calls ``requestMIDIAccess`` — which is the first time the permission prompt fires.
3. **Persisted.** A returning operator who already approved the permission stays connected across reloads (``demon:midi:enabled`` in localStorage).
4. **Mobile gets nothing.** The toggle is hidden under ``@media (hover: none) and (pointer: coarse)`` and ``useMidi`` no-ops on platforms missing ``navigator.requestMIDIAccess`` — so phones never see the prompt nor the toggle.

## UI

NOT a button-styled cell like Record / Curve Editor / Full Controls. Just a 10 px red LED in a sunken bezel + a mono-caps "MIDI in" label next to it. Reads as a labelled jack on a hardware rack.

LED states:
- **Off** — dark recess
- **On** — red, ``MIDI N dev`` in status
- **Warn** — amber, permission denied or Web MIDI N/A (status text surfaces the cause)

## Files

| File | Change |
| --- | --- |
| ``store/useMidiStore.ts`` | + ``enabled`` field + ``setEnabled`` setter, persisted in localStorage |
| ``hooks/useMidi.ts`` | subscribe to ``enabled``; only call ``requestMIDIAccess`` when true; re-run on flip |
| ``components/Performance/MidiInToggle.tsx`` | NEW — the LED toggle |
| ``components/Performance/HeroMacros.tsx`` | mount ``<MidiInToggle />`` under Full Controls |
| ``app/globals.css`` | ``.midi-in-toggle*`` chrome + mobile hide |

## Test plan

- [ ] Fresh visit, no localStorage: NO MIDI prompt. LED dark.
- [ ] Click MIDI in: prompt fires, approve → LED turns red, ``MIDI N dev`` status. Existing MIDI-learn right-click + CC routing still works.
- [ ] Click MIDI in again to disable: LED goes dark, devices released. No prompt re-fires when toggling.
- [ ] Reload after enabling: still enabled (no prompt unless browser purged permission), LED red.
- [ ] Click MIDI in then deny browser permission: LED amber, status reads ``MIDI denied``.
- [ ] Browser without Web MIDI (Safari, Firefox sometimes): click to enable → LED amber, ``MIDI N/A`` status.
- [ ] Mobile / touch-only device: no LED, no prompt, no chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)