### PR TITLE
Fixes broken social preview on project page (poster-hero)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,8 +11,15 @@
   <meta property="og:description" content="A streaming diffusion engine for real-time music generation, built on ACE-Step v1.5. Per-frame parametric control of the diffusion process on a single consumer GPU.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://daydreamlive.github.io/DEMON/">
-  <meta property="og:image" content="assets/img/og-image.jpg">
+  <meta property="og:image" content="https://daydreamlive.github.io/DEMON/assets/img/poster-hero.jpg">
+  <meta property="og:image:width" content="1280">
+  <meta property="og:image:height" content="720">
+  <meta property="og:image:alt" content="DEMON: Diffusion Engine for Musical Orchestrated Noise — streaming diffusion engine for real-time music generation.">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="DEMON: Diffusion Engine for Musical Orchestrated Noise">
+  <meta name="twitter:description" content="A streaming diffusion engine for real-time music generation, built on ACE-Step v1.5. Per-frame parametric control of the diffusion process on a single consumer GPU.">
+  <meta name="twitter:image" content="https://daydreamlive.github.io/DEMON/assets/img/poster-hero.jpg">
+  <meta name="twitter:image:alt" content="DEMON: Diffusion Engine for Musical Orchestrated Noise — streaming diffusion engine for real-time music generation.">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- `og:image` on [docs/index.html](docs/index.html) was pointing to `assets/img/og-image.jpg`, which doesn't exist under `/docs/assets/img/` — so Twitter/X, LinkedIn, Slack, iMessage, etc. were rendering the project page with a blank/broken social card.
- Repoints `og:image` to the hero poster that's already shipped (`poster-hero.jpg`, 1280×720) and uses an absolute URL so crawlers don't have to resolve from the canonical.
- Adds explicit `twitter:image` / `twitter:title` / `twitter:description` so crawlers that don't fall back to OG still get something, plus `og:image:width` / `og:image:height` and `*:image:alt` for accessibility.

Diff is 8 added / 1 changed line in `docs/index.html`. No other files touched.

## Test plan
- [ ] Once GitHub Pages picks up the change (or via a preview deploy), paste `https://daydreamlive.github.io/DEMON/` into the [Twitter/X Card Validator](https://cards-dev.twitter.com/validator) and confirm `poster-hero.jpg` renders as a `summary_large_image`.
- [ ] Paste the same URL into the [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) and confirm the OG preview shows `poster-hero.jpg` at 1280×720.
- [ ] Drop the URL in a Slack/Discord channel and visually confirm the unfurl looks correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)