### PR TITLE
fix(trt): write+match metadata for windowed VAE and DreamVAE engines

### DIFF
--- a/acestep/engine/trt/_engine_metadata.py
+++ b/acestep/engine/trt/_engine_metadata.py
@@ -1,0 +1,125 @@
+"""Shared engine-metadata helpers for the TRT engine builders.
+
+Every freshly-built TRT engine writes a sidecar ``<engine>.metadata.json``
+that records the build environment (TRT version, GPU compute capability,
+ONNX file hash, build config). On rebuild, the existing engine is
+compared against the *expected* metadata for the current build env;
+mismatch (e.g. TRT version bump via ``uv sync``) triggers a rebuild.
+
+This module exists so every engine builder — standard VAE/decoder
+(:func:`acestep.engine.trt.build._build_vae_engines`), windowed VAE
+(:func:`acestep.engine.trt.build._build_windowed_vae_decode_engine`),
+and the DreamVAE variants in
+:mod:`acestep.engine.trt.dreamvae_export` — share the same metadata
+contract. Previously the dreamvae/windowed builders skipped engines on
+file existence alone (no metadata read, no metadata write), so when
+TRT was bumped underneath them the stale engines silently rode into
+:warm bakes and FATAL'd at session load:
+
+    IRuntime::deserializeCudaEngine: API Usage Error
+      (The engine plan file is not compatible with this version of
+       TensorRT, expecting library version <new> got <old>)
+
+Sharing the helpers makes the freshness check trivially correct
+everywhere. Avoid circular imports — this module imports nothing
+from ``build.py`` or ``dreamvae_export.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from loguru import logger
+
+
+_ENGINE_METADATA_SCHEMA = 1
+
+
+def _sha256_file(path: str | os.PathLike[str]) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _config_dict(config) -> dict:
+    if is_dataclass(config):
+        return asdict(config)
+    return dict(vars(config))
+
+
+def metadata_path(engine_path: str | os.PathLike[str]) -> Path:
+    return Path(str(engine_path) + ".metadata.json")
+
+
+def expected_metadata(
+    *,
+    component: str,
+    onnx_path: str | os.PathLike[str],
+    config,
+    env: dict,
+) -> dict:
+    gpu = env.get("active_gpu", {})
+    return {
+        "schema_version": _ENGINE_METADATA_SCHEMA,
+        "component": component,
+        "tensorrt_version": env["packages"]["tensorrt"],
+        "gpu_compute_capability": gpu.get("compute_capability"),
+        "gpu_name": gpu.get("name"),
+        "config": _config_dict(config),
+        "onnx_path": str(Path(onnx_path).resolve()),
+        "onnx_sha256": _sha256_file(onnx_path),
+    }
+
+
+def write_metadata(
+    *,
+    engine_path: str | os.PathLike[str],
+    expected: dict,
+    env: dict,
+) -> None:
+    payload = dict(expected)
+    payload["built_at"] = datetime.now(timezone.utc).isoformat()
+    payload["environment"] = env
+    path = metadata_path(engine_path)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    logger.info("Engine metadata saved to {}", path)
+
+
+def metadata_matches(
+    engine_path: str | os.PathLike[str],
+    expected: dict,
+) -> tuple[bool, str]:
+    """Compare on-disk metadata sidecar against ``expected``.
+
+    Returns ``(matches, reason)``. A missing or unreadable sidecar is
+    treated as a non-match so the engine is rebuilt and a fresh
+    sidecar is written. Compares the keys that govern engine
+    compatibility (TRT version, GPU compute capability, build config,
+    ONNX content hash); ignores metadata-only fields like ``built_at``.
+    """
+    path = metadata_path(engine_path)
+    if not path.exists():
+        return False, "missing metadata"
+    try:
+        actual = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return False, f"metadata unreadable: {exc}"
+
+    for key in (
+        "schema_version",
+        "component",
+        "tensorrt_version",
+        "gpu_compute_capability",
+        "config",
+        "onnx_sha256",
+    ):
+        if actual.get(key) != expected.get(key):
+            return False, f"metadata mismatch: {key}"
+    return True, "metadata match"

--- a/acestep/engine/trt/build.py
+++ b/acestep/engine/trt/build.py
@@ -63,9 +63,18 @@ importlib.util.find_spec = _patch
 from loguru import logger
 import torch
 
+from ._engine_metadata import (
+    _ENGINE_METADATA_SCHEMA,
+    _sha256_file,
+    _config_dict,
+    metadata_path as _metadata_path,
+    expected_metadata as _expected_metadata,
+    write_metadata as _write_metadata,
+    metadata_matches as _metadata_matches,
+)
+
 _SUPPORTED_TRT_MIN = (10, 16)
 _SUPPORTED_TRT_MAX = (10, 17)
-_ENGINE_METADATA_SCHEMA = 1
 _DECODER_PRECISION_CHOICES = (
     "auto",
     "fp32",
@@ -205,20 +214,6 @@ def _preflight(device: str) -> dict:
     else:
         logger.warning("No active CUDA GPU detected in torch")
     return env
-
-
-def _sha256_file(path: str | os.PathLike[str]) -> str:
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-
-def _config_dict(config) -> dict:
-    if is_dataclass(config):
-        return asdict(config)
-    return dict(vars(config))
 
 
 def _looks_like_xl_checkpoint(checkpoint: str) -> bool:
@@ -385,66 +380,6 @@ def _patch_decoder_onnx_for_fp8(
             )
         )
     return patched
-
-
-def _metadata_path(engine_path: str | os.PathLike[str]) -> Path:
-    return Path(str(engine_path) + ".metadata.json")
-
-
-def _expected_metadata(
-    *,
-    component: str,
-    onnx_path: str,
-    config,
-    env: dict,
-) -> dict:
-    gpu = env.get("active_gpu", {})
-    return {
-        "schema_version": _ENGINE_METADATA_SCHEMA,
-        "component": component,
-        "tensorrt_version": env["packages"]["tensorrt"],
-        "gpu_compute_capability": gpu.get("compute_capability"),
-        "gpu_name": gpu.get("name"),
-        "config": _config_dict(config),
-        "onnx_path": str(Path(onnx_path).resolve()),
-        "onnx_sha256": _sha256_file(onnx_path),
-    }
-
-
-def _write_metadata(
-    *,
-    engine_path: str,
-    expected: dict,
-    env: dict,
-) -> None:
-    payload = dict(expected)
-    payload["built_at"] = datetime.now(timezone.utc).isoformat()
-    payload["environment"] = env
-    path = _metadata_path(engine_path)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-    logger.info("Engine metadata saved to {}", path)
-
-
-def _metadata_matches(engine_path: str, expected: dict) -> tuple[bool, str]:
-    path = _metadata_path(engine_path)
-    if not path.exists():
-        return False, "missing metadata"
-    try:
-        actual = json.loads(path.read_text(encoding="utf-8"))
-    except Exception as exc:
-        return False, f"metadata unreadable: {exc}"
-
-    for key in (
-        "schema_version",
-        "component",
-        "tensorrt_version",
-        "gpu_compute_capability",
-        "config",
-        "onnx_sha256",
-    ):
-        if actual.get(key) != expected.get(key):
-            return False, f"metadata mismatch: {key}"
-    return True, "metadata match"
 
 
 def _verify_engines(engine_paths: list[tuple[str, str]]):
@@ -785,6 +720,7 @@ def _build_windowed_vae_decode_engine(
     output_dir: str,
     onnx_paths: dict[str, str],
     workspace_gb: float,
+    env: dict,
     force_rebuild: bool = False,
 ) -> tuple[str, str, float, str]:
     """Build the single windowed (3-30 s) VAE decode engine.
@@ -795,6 +731,10 @@ def _build_windowed_vae_decode_engine(
     the user-facing window (5-30 s) plus overlap, never by the full
     song duration. Building it costs ~75 s and saves ~7.7 GB of TRT
     workspace at session-creation time vs the canonical 240 s engine.
+
+    The skip gate compares the sidecar ``.metadata.json`` against the
+    current env — so a TRT bump via ``uv sync`` correctly invalidates
+    a stale engine that previously rode through unchanged.
     """
     from .vae_export import build_vae_decode_engine, VAETRTBuildConfig
     from acestep.paths import (
@@ -807,11 +747,6 @@ def _build_windowed_vae_decode_engine(
     engine_path = os.path.join(engine_dir, f"{name}.engine")
     label = "VAE decode windowed (3-30s)"
 
-    if not force_rebuild and os.path.exists(engine_path):
-        size_mb = os.path.getsize(engine_path) / 1e6
-        logger.info("SKIP {} ({:.0f} MB)", name, size_mb)
-        return (label, engine_path, 0.0, "SKIPPED")
-
     min_f, opt_f, max_f = WINDOWED_VAE_PROFILE_FRAMES
     config = VAETRTBuildConfig(
         workspace_gb=workspace_gb,
@@ -820,6 +755,21 @@ def _build_windowed_vae_decode_engine(
         decode_max_frames=max_f,
     )
 
+    expected = _expected_metadata(
+        component="vae_decode_windowed",
+        onnx_path=onnx_paths["vae_decode"],
+        config=config,
+        env=env,
+    )
+
+    if not force_rebuild and os.path.exists(engine_path):
+        matches, reason = _metadata_matches(engine_path, expected)
+        if matches:
+            size_mb = os.path.getsize(engine_path) / 1e6
+            logger.info("SKIP {} ({:.0f} MB, {})", name, size_mb, reason)
+            return (label, engine_path, 0.0, "SKIPPED")
+        logger.info("REBUILD {} ({})", name, reason)
+
     logger.info("=" * 60)
     logger.info("VAE TRT BUILD (windowed): {} (min={} opt={} max={})",
                 name, min_f, opt_f, max_f)
@@ -827,6 +777,7 @@ def _build_windowed_vae_decode_engine(
 
     t0 = time.time()
     build_vae_decode_engine(onnx_paths["vae_decode"], engine_path, config=config)
+    _write_metadata(engine_path=engine_path, expected=expected, env=env)
     elapsed = time.time() - t0
     logger.info("Built in {:.0f}s", elapsed)
     return (label, engine_path, elapsed, "OK")
@@ -1302,6 +1253,7 @@ def _run_all(args, project_root, onnx_dir, env):
             output_dir=args.output_dir,
             onnx_paths=onnx_paths,
             workspace_gb=args.workspace_gb,
+            env=env,
             force_rebuild=args.force_rebuild,
         ))
 
@@ -1318,11 +1270,13 @@ def _run_all(args, project_root, onnx_dir, env):
             output_dir=args.output_dir,
             durations=durations,
             workspace_gb=args.workspace_gb,
+            env=env,
             force_rebuild=args.force_rebuild,
         ))
         results.append(build_windowed_dreamvae_engine(
             output_dir=args.output_dir,
             workspace_gb=args.workspace_gb,
+            env=env,
             force_rebuild=args.force_rebuild,
         ))
 

--- a/acestep/engine/trt/dreamvae_export.py
+++ b/acestep/engine/trt/dreamvae_export.py
@@ -19,6 +19,11 @@ from typing import Iterable, Optional, Union
 
 from loguru import logger
 
+from ._engine_metadata import (
+    expected_metadata as _expected_metadata,
+    metadata_matches as _metadata_matches,
+    write_metadata as _write_metadata,
+)
 from .onnx_hub import fetch_onnx
 from .vae_export import VAETRTBuildConfig, build_vae_decode_engine
 
@@ -158,23 +163,25 @@ def build_dreamvae_engine(
     *,
     output_dir: Union[str, Path],
     duration_s: int,
+    env: dict,
     onnx_path: Optional[Union[str, Path]] = None,
     workspace_gb: float = 8.0,
     force_rebuild: bool = False,
 ) -> tuple[Path, str]:
     """Build a single dreamvae TRT engine for one duration.
 
+    The skip gate compares the sidecar ``.metadata.json`` against the
+    current env (TRT version, GPU compute capability, ONNX hash). A
+    TRT bump via ``uv sync`` correctly invalidates a stale engine
+    instead of silently riding it through.
+
     Returns ``(engine_path, status)`` where status is ``"OK"`` if the
-    engine was built this call, or ``"SKIPPED"`` if it already existed.
+    engine was built this call, or ``"SKIPPED"`` if a matching
+    engine + metadata already existed.
     """
     output_dir = Path(output_dir)
     name = dreamvae_engine_filename(duration_s)
     engine_path = output_dir / name / f"{name}.engine"
-
-    if engine_path.exists() and not force_rebuild:
-        size_mb = engine_path.stat().st_size / (1 << 20)
-        logger.info("SKIP {} ({:.0f} MB)", name, size_mb)
-        return engine_path, "SKIPPED"
 
     if onnx_path is None:
         onnx_path = fetch_dreamvae_onnx(output_dir)
@@ -185,18 +192,35 @@ def build_dreamvae_engine(
         decode_max_frames=int(duration_s) * 25,  # 25 latent frames/sec
     )
 
+    expected = _expected_metadata(
+        component=f"dreamvae_decode_{int(duration_s)}s",
+        onnx_path=onnx_path,
+        config=config,
+        env=env,
+    )
+
+    if engine_path.exists() and not force_rebuild:
+        matches, reason = _metadata_matches(engine_path, expected)
+        if matches:
+            size_mb = engine_path.stat().st_size / (1 << 20)
+            logger.info("SKIP {} ({:.0f} MB, {})", name, size_mb, reason)
+            return engine_path, "SKIPPED"
+        logger.info("REBUILD {} ({})", name, reason)
+
     logger.info("=" * 60)
     logger.info("DREAMVAE TRT BUILD: {} (max_duration={}s)", name, duration_s)
     logger.info("=" * 60)
 
     engine_path.parent.mkdir(parents=True, exist_ok=True)
     build_vae_decode_engine(onnx_path, engine_path, config=config)
+    _write_metadata(engine_path=engine_path, expected=expected, env=env)
     return engine_path, "OK"
 
 
 def build_windowed_dreamvae_engine(
     *,
     output_dir: Union[str, Path],
+    env: dict,
     onnx_path: Optional[Union[str, Path]] = None,
     workspace_gb: float = 8.0,
     force_rebuild: bool = False,
@@ -207,6 +231,10 @@ def build_windowed_dreamvae_engine(
     for the distilled student decoder. The two engines share the same
     profile shape (75/125/750 frames) so they're interchangeable from
     the runtime's POV; only the weights differ.
+
+    The skip gate compares the sidecar ``.metadata.json`` against the
+    current env, so TRT bumps invalidate stale engines instead of
+    silently shipping them.
 
     Returns ``(label, engine_path, elapsed_s, status)`` matching the
     shape used by the other dreamvae builders so the result can be
@@ -224,11 +252,6 @@ def build_windowed_dreamvae_engine(
     engine_path = output_dir / name / f"{name}.engine"
     label = "DreamVAE decode windowed (3-30s)"
 
-    if engine_path.exists() and not force_rebuild:
-        size_mb = engine_path.stat().st_size / (1 << 20)
-        logger.info("SKIP {} ({:.0f} MB)", name, size_mb)
-        return (label, str(engine_path), 0.0, "SKIPPED")
-
     if onnx_path is None:
         onnx_path = fetch_dreamvae_onnx(output_dir)
     onnx_path = Path(onnx_path)
@@ -241,6 +264,21 @@ def build_windowed_dreamvae_engine(
         decode_max_frames=max_f,
     )
 
+    expected = _expected_metadata(
+        component="dreamvae_decode_windowed",
+        onnx_path=onnx_path,
+        config=config,
+        env=env,
+    )
+
+    if engine_path.exists() and not force_rebuild:
+        matches, reason = _metadata_matches(engine_path, expected)
+        if matches:
+            size_mb = engine_path.stat().st_size / (1 << 20)
+            logger.info("SKIP {} ({:.0f} MB, {})", name, size_mb, reason)
+            return (label, str(engine_path), 0.0, "SKIPPED")
+        logger.info("REBUILD {} ({})", name, reason)
+
     logger.info("=" * 60)
     logger.info("DREAMVAE TRT BUILD (windowed): {} (min={} opt={} max={})",
                 name, min_f, opt_f, max_f)
@@ -250,6 +288,7 @@ def build_windowed_dreamvae_engine(
     t0 = _time.time()
     try:
         build_vae_decode_engine(onnx_path, engine_path, config=config)
+        _write_metadata(engine_path=engine_path, expected=expected, env=env)
         elapsed = _time.time() - t0
         logger.info("Built in {:.0f}s", elapsed)
         return (label, str(engine_path), elapsed, "OK")
@@ -261,11 +300,17 @@ def build_windowed_dreamvae_engine(
 def build_dreamvae_engines(
     *,
     output_dir: Union[str, Path],
+    env: dict,
     durations: Iterable[int] = (60, 120, 240),
     workspace_gb: float = 8.0,
     force_rebuild: bool = False,
 ) -> list[tuple[str, str, float, str]]:
     """Build the canonical dreamvae engine matrix.
+
+    ``env`` is the preflight environment snapshot (see
+    :func:`acestep.engine.trt.build._preflight`) — threaded down so
+    each per-duration build can write a matching ``.metadata.json``
+    sidecar for the skip-gate freshness check.
 
     Returns a list of ``(label, engine_path, elapsed_seconds, status)``
     matching the shape used by the standard VAE/decoder builders in
@@ -287,6 +332,7 @@ def build_dreamvae_engines(
             engine_path, status = build_dreamvae_engine(
                 output_dir=output_dir,
                 duration_s=dur,
+                env=env,
                 onnx_path=onnx_path,
                 workspace_gb=workspace_gb,
                 force_rebuild=force_rebuild,


### PR DESCRIPTION
## Summary

The standard VAE/decoder builders in `build.py` gate their `SKIP` path on a sidecar `*.metadata.json` (TRT version, GPU compute capability, build config, ONNX content hash). When `uv sync` bumps TensorRT, the metadata mismatch triggers a rebuild — correct.

**Three engine builders did not follow this pattern.** They `SKIP` on file-existence alone, and they don't write metadata when they do build:

- `_build_windowed_vae_decode_engine` (`vae_decode_fp16_3to30s`)
- `build_dreamvae_engine` (`dreamvae_decode_fp16_{60,120,240}s`)
- `build_windowed_dreamvae_engine` (`dreamvae_decode_fp16_3to30s`)

That guarantees engines from a prior bake ride into the next one unconditionally, even when TRT was bumped underneath and the engines no longer deserialize.

## Production hit (2026-05-27)

A fresh L40S pod launched from a freshly-baked `:warm-4090` FATAL'd at session load:

```
IRuntime::deserializeCudaEngine: API Usage Error
  (The engine plan file is not compatible with this version of TensorRT,
   expecting library version 10.16.1.11 got [empty])
while loading vae_decode_fp16_3to30s.engine
```

Root cause: `uv sync` had bumped TRT to 10.16.1.11, but `vae_decode_fp16_3to30s` (and the four DreamVAE engines) had ridden through from the source image with no metadata sidecar, were marked `[exists]` / `SKIPPED`, and got baked into the new `:warm-4090` unchanged. The bake-script-side defense in demon-public-demo (https://github.com/daydreamlive/demon-public-demo/pull/281) wipes them by detecting the missing sidecar — but the upstream fix belongs here, in DEMON.

## Changes

- **New `acestep/engine/trt/_engine_metadata.py`** — extracts the metadata helpers (schema constant, sha256, dict serialization, write, match, path) from `build.py` with no behavior change. Self-contained — no upward imports — so `dreamvae_export.py` can use it without a circular import on `build.py`.
- **`build.py`** imports from `_engine_metadata`; the local copies of `_metadata_path` / `_expected_metadata` / `_write_metadata` / `_metadata_matches` / `_sha256_file` / `_config_dict` / `_ENGINE_METADATA_SCHEMA` are removed. Existing internal references keep working (all re-exported under the same names).
- **`_build_windowed_vae_decode_engine`** now takes `env=`, computes the expected metadata, gates `SKIP` on `_metadata_matches` (logs `REBUILD <name> (<reason>)` on mismatch — same shape as `_build_vae_engines`), and writes metadata after a successful build.
- **`build_dreamvae_engine`** and **`build_windowed_dreamvae_engine`**: same treatment. Both now take `env=` to compute expected metadata. `build_dreamvae_engines` (the matrix wrapper) threads `env=` through to each per-duration call.
- **All three call sites in `build.py`** (`_run_matrix` ~lines 1252 / 1269 / 1276) updated to pass `env=env`.

`build_dreamvae_engines` and `build_dreamvae_engine` gained a new required `env` parameter. Outside callers (downstream of `build.py` only — these functions are private-style internal builders) need to thread an env dict that contains at minimum `{"packages": {"tensorrt": <version>}, "active_gpu": {...}, "schema_version": 1}`. In practice every existing caller is internal and was updated in this PR.

## Test plan

- [ ] On a fresh workspace: `python -m acestep.engine.trt.build --all --duration 60 120 240 --decoder-mixed --decoder-refit --with-dreamvae` → expect 14 `OK`, 0 `SKIPPED`, **14 `*.metadata.json` sidecars on disk**.
- [ ] Re-run with no source change → expect 14 `SKIPPED`, each with reason `metadata match`.
- [ ] Force a "TRT bump" simulation: edit the `tensorrt_version` field inside one sidecar → expect that engine to `REBUILD` with reason `metadata mismatch: tensorrt_version`.
- [ ] Trigger a `:warm-h100` or `:warm-4090` bake post-merge — engine build summary should `REBUILD` any metadata-less engine inherited from the source image (instead of silently keeping it), and a fresh pod from the resulting tag should not FATAL on `vae_decode_fp16_3to30s.engine` load.
