### PR TITLE
fix(rtmg/mobile): scope --lite-controls-h to #performance

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteControls.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteControls.tsx
@@ -27,18 +27,29 @@ interface Props {
 // "All controls" sheet.
 //
 // Side effect: a ResizeObserver writes the live bay height to
-// ``--lite-controls-h`` on the documentElement so the waveform-scrub
-// strip and the graph wrap can anchor their bottoms to the actual top
-// of the bay instead of guessing 50vh. Without this the bay was
-// hiding the bottom of both on tall phones / unusual aspect ratios.
+// ``--lite-controls-h`` on ``#performance`` (the scene root) so the
+// waveform-scrub strip and the graph wrap can anchor their bottoms
+// to the actual top of the bay instead of guessing 50vh. Without
+// this the bay was hiding the bottom of both on tall phones /
+// unusual aspect ratios.
+//
+// We deliberately scope this var to ``#performance`` (not
+// ``documentElement``): per PERFORMANCE.md, writing a CSS var on
+// documentElement forces a whole-document style recalc + paint
+// cascade that on Android Chromium briefly blanks consumers with
+// backdrop-filter / mask-image (this bay has both, and so does
+// #graph). Scoping the write to #performance keeps the recalc inside
+// the scene subtree.
 export function LiteControls({ onOpenAllControls, unsavedDot }: Props) {
   const rootRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     const el = rootRef.current;
     if (!el) return;
-    const root = document.documentElement;
+    const host =
+      (document.getElementById("performance") as HTMLElement | null) ??
+      document.documentElement;
     const apply = () => {
-      root.style.setProperty("--lite-controls-h", `${el.offsetHeight}px`);
+      host.style.setProperty("--lite-controls-h", `${el.offsetHeight}px`);
     };
     apply();
     const ro = new ResizeObserver(apply);
@@ -48,7 +59,7 @@ export function LiteControls({ onOpenAllControls, unsavedDot }: Props) {
       // Clear the var so consumers fall back to their CSS default
       // when the bay unmounts (e.g. operator rotates to landscape
       // and the lite controls flip off).
-      root.style.removeProperty("--lite-controls-h");
+      host.style.removeProperty("--lite-controls-h");
     };
   }, []);
   return (


### PR DESCRIPTION
## Summary

Fixes an Android-only "screen briefly blanks on every slider drag" regression that landed with the mobile redesign in #146. Desktop and iOS Safari are unaffected.

`LiteControls.tsx`'s `ResizeObserver` writes the live bay height to a CSS var. That var was being written on `document.documentElement` — a direct PERFORMANCE.md violation:

> Don't set CSS variables on `documentElement` or any ancestor of `<body>` when consumers use `filter: drop-shadow`, `box-shadow`, `backdrop-filter`, or other paint-pipeline-affecting properties.

Consumers downstream are paint-cascade-sensitive: the bay has `backdrop-filter: blur(10px)`; `#graph` has a gradient `mask-image`; `.install-ribbons` are `drop-shadow`-haloed. Each documentElement var-write triggers a whole-document style recalc + paint cascade — on Android Chromium that's enough to stall the compositor and produce a black frame.

**Fix:** scope the var write to `#performance` (the scene root), with a `documentElement` fallback. Consumers in `globals.css` (`#install-video-area #graph-wrap` inset, `.waveform-scrub-box` bottom) still see the var via inherited cascade — no other CSS needs to change. No visual difference anywhere.

## Test plan

- [ ] Android Chrome: drag Strength/Structure/Timbre/Shift on the mobile lite-controls bay — scene no longer blanks.
- [ ] iOS Safari: same drag, confirm no regression (was already fine).
- [ ] Desktop: bay only renders on `@media max-width: 768px`, so desktop is by definition unaffected.
- [ ] Orientation change: rotate phone landscape -> portrait -> landscape; `--lite-controls-h` should set/clear cleanly on `#performance`.

Generated with [Claude Code](https://claude.com/claude-code)