### PR TITLE
feat(rtmg): onboarding hint for Upload button (#156)

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -6635,6 +6635,19 @@ body.curve-open #install-video-area #graph {
 .audio-source-upload-btn {
   border-radius: 0;
 }
+/* Wrapper around the placard + upload-btn pair — the two ways to
+ * swap input audio. Serves as the positioning context for the
+ * UploadOnboardingHint so its arrow centers above the combined
+ * affordance area (not just one button). Mic stays outside this
+ * wrapper because it's a separate input mode, not a track-swap.
+ * Transparent to layout: inline-flex + align-items: stretch so the
+ * inner buttons still fill the dock body vertically. */
+.audio-source-track-controls {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0;
+}
 .audio-source-mic-btn {
   border-radius: 0 var(--radius-md) var(--radius-md) 0;
 }
@@ -7092,16 +7105,23 @@ body.curve-open #install-video-area #graph {
  *  Sequel to StrengthOnboardingHint — surfaces once the user has moved
  *  Strength, pointing at the bottom-right Upload button (Issue #156).
  *  Same vocabulary as the Strength hint: white italic caption + hand-
- *  drawn arrow gif. Anchored inside .audio-source-dock so the arrow
- *  head lands just left of the dock body, irrespective of viewport
- *  width. Vertical centering picks up the dock's mid-line, which is
- *  where the Upload button sits.
+ *  drawn arrow gif.
  *
- *  Layout: hint sits to the LEFT of the dock with the arrow at its
- *  right end. ``right: 100%`` puts the right edge of the hint flush
- *  with the dock's left edge; ``transform: translate(-10px, -50%)``
- *  nudges left so the arrow's head reads as pointing AT the dock,
- *  not into it.
+ *  Positioning context: .audio-source-track-controls (a relative-
+ *  positioned span wrapping placard + upload). Anchoring above the
+ *  pair (not just upload-btn) matches the copy — "Select another
+ *  track or upload your own" covers both buttons, so the arrow head
+ *  lands at their seam rather than picking one and ignoring the
+ *  other.
+ *
+ *  Layout: hint sits ABOVE the placard/upload pair, horizontally
+ *  centered, with text on top and a downward-pointing arrow below
+ *  tapping at the seam. ``bottom: 100%`` rests the hint on the
+ *  pair's top edge; ``left: 50%`` + ``translate(-50%, -8px)``
+ *  centers + lifts. The arrow gif points right by default;
+ *  ``rotate: 90deg`` (CSS individual transform — doesn't conflict
+ *  with the animated ``transform: translate``) flips it to point
+ *  down.
  *
  *  Desktop only — the mobile Lite drawer already surfaces Upload
  *  inline via LiteTrackCarousel; no need for a tutorial overlay.
@@ -7116,22 +7136,27 @@ body.curve-open #install-video-area #graph {
   z-index: 6;
   pointer-events: none;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: center;
+  /* Real gap so the arrow's resting position (top of its downward
+   * bob arc) never collides with the text. The bob translates the
+   * arrow DOWN only, so the closest text/arrow approach is at rest. */
   gap: 4px;
-  top: 50%;
-  right: 100%;
-  transform: translate(-10px, -50%);
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, -8px);
   white-space: nowrap;
   animation: upload-onboarding-hint-in 280ms ease-out;
 }
 @keyframes upload-onboarding-hint-in {
-  from { opacity: 0; transform: translate(-4px, -50%); }
-  to   { opacity: 1; transform: translate(-10px, -50%); }
+  from { opacity: 0; transform: translate(-50%, -2px); }
+  to   { opacity: 1; transform: translate(-50%, -8px); }
 }
 @keyframes upload-onboarding-hint-bob {
   0%, 100% { transform: translate(0, 0); }
-  50%      { transform: translate(-3px, 0); }
+  /* Bob DOWN toward the button instead of sideways — the arrow is
+   * now vertical, so the tap-tap motion follows its axis. */
+  50%      { transform: translate(0, 3px); }
 }
 .upload-onboarding-hint-text {
   font-family: var(--font-mono);
@@ -7145,8 +7170,13 @@ body.curve-open #install-video-area #graph {
 }
 .upload-onboarding-hint-arrow {
   flex: 0 0 auto;
-  width: 68px;
-  height: 68px;
+  width: 48px;
+  height: 48px;
+  /* Rotate the right-pointing arrow gif so the head points down at
+   * the Upload button below. ``rotate`` is the individual transform
+   * property, kept separate from the animated ``transform: translate``
+   * so the two compose without overriding each other. */
+  rotate: 90deg;
   animation: upload-onboarding-hint-bob 2200ms ease-in-out infinite;
   user-select: none;
   pointer-events: none;

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -7088,6 +7088,84 @@ body.curve-open #install-video-area #graph {
   }
 }
 
+/* ─── UploadOnboardingHint ────────────────────────────────────────────
+ *  Sequel to StrengthOnboardingHint — surfaces once the user has moved
+ *  Strength, pointing at the bottom-right Upload button (Issue #156).
+ *  Same vocabulary as the Strength hint: white italic caption + hand-
+ *  drawn arrow gif. Anchored inside .audio-source-dock so the arrow
+ *  head lands just left of the dock body, irrespective of viewport
+ *  width. Vertical centering picks up the dock's mid-line, which is
+ *  where the Upload button sits.
+ *
+ *  Layout: hint sits to the LEFT of the dock with the arrow at its
+ *  right end. ``right: 100%`` puts the right edge of the hint flush
+ *  with the dock's left edge; ``transform: translate(-10px, -50%)``
+ *  nudges left so the arrow's head reads as pointing AT the dock,
+ *  not into it.
+ *
+ *  Desktop only — the mobile Lite drawer already surfaces Upload
+ *  inline via LiteTrackCarousel; no need for a tutorial overlay.
+ *  Also hidden when the dock is collapsed-to-bubble: pointing at an
+ *  empty patch of screen reads as broken. (AudioSourceCrate folds
+ *  uploadHint.visible into dockActive so this case only fires if the
+ *  visibility flag races the collapse animation.) */
+.upload-onboarding-hint {
+  position: absolute;
+  /* Same z-index as the Strength hint — above knob/dock chrome but
+   * below the modal stack (.almost-ready-* at 100+). */
+  z-index: 6;
+  pointer-events: none;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  top: 50%;
+  right: 100%;
+  transform: translate(-10px, -50%);
+  white-space: nowrap;
+  animation: upload-onboarding-hint-in 280ms ease-out;
+}
+@keyframes upload-onboarding-hint-in {
+  from { opacity: 0; transform: translate(-4px, -50%); }
+  to   { opacity: 1; transform: translate(-10px, -50%); }
+}
+@keyframes upload-onboarding-hint-bob {
+  0%, 100% { transform: translate(0, 0); }
+  50%      { transform: translate(-3px, 0); }
+}
+.upload-onboarding-hint-text {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.05em;
+  font-style: italic;
+  white-space: nowrap;
+  color: #fff;
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.55);
+  animation: upload-onboarding-hint-bob 2200ms ease-in-out infinite;
+}
+.upload-onboarding-hint-arrow {
+  flex: 0 0 auto;
+  width: 68px;
+  height: 68px;
+  animation: upload-onboarding-hint-bob 2200ms ease-in-out infinite;
+  user-select: none;
+  pointer-events: none;
+}
+/* Hide on touch-only devices — mobile already surfaces Upload via the
+ * Lite drawer's track carousel and doesn't need a tutorial overlay. */
+@media (hover: none) and (pointer: coarse) {
+  .upload-onboarding-hint { display: none; }
+}
+/* Hide while the dock has collapsed to a bubble — see comment above. */
+.audio-source-dock[data-collapsed] .upload-onboarding-hint { display: none; }
+@media (prefers-reduced-motion: reduce) {
+  .upload-onboarding-hint,
+  .upload-onboarding-hint-text,
+  .upload-onboarding-hint-arrow {
+    animation: none;
+  }
+}
+
 /* ── Persistent "live" dot ──────────────────────────────────────────── */
 .live-indicator {
   position: fixed;

--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -302,53 +302,70 @@ export function AudioSourceCrate() {
           <NoteIcon size={18} />
         </button>
         <div className="audio-source-dock-body">
-        <button
-          ref={placardRef}
-          type="button"
-          className={`audio-source-crate${open ? " audio-source-crate--open" : ""}`}
-          onClick={() => setOpen((v) => !v)}
-          aria-haspopup="menu"
-          aria-expanded={open}
-          aria-label={`Pick audio track. Current: ${displayedName}`}
-          data-dd-tooltip={`Audio source: ${displayedName}`}
-        >
-          <span className="audio-source-marquee-rows">
-            <span className="audio-source-marquee-label">
-              {open ? "Pick a track" : "▶ Now playing"}
+        {/* Placard + Upload form the "track controls" pair (the two
+            ways to swap input audio — pick from library, or upload).
+            Wrapping them in a relative-positioned span lets
+            UploadOnboardingHint anchor above their combined width,
+            since the hint's copy ("Select another track or upload
+            your own") covers BOTH affordances. Mic stays outside the
+            wrapper — it's a separate input mode, not a track-swap. */}
+        <span className="audio-source-track-controls">
+          <UploadOnboardingHint visible={uploadHint.visible} />
+          <button
+            ref={placardRef}
+            type="button"
+            className={`audio-source-crate${open ? " audio-source-crate--open" : ""}`}
+            onClick={() => {
+              // Placard click opens the fan picker — that's the
+              // "select another track" half of the hint's copy, so
+              // clicking it counts as discovery (matches the upload
+              // button's behaviour).
+              uploadHint.dismiss();
+              setOpen((v) => !v);
+            }}
+            aria-haspopup="menu"
+            aria-expanded={open}
+            aria-label={`Pick audio track. Current: ${displayedName}`}
+            data-dd-tooltip={`Audio source: ${displayedName}`}
+          >
+            <span className="audio-source-marquee-rows">
+              <span className="audio-source-marquee-label">
+                {open ? "Pick a track" : "▶ Now playing"}
+              </span>
+              <span className="audio-source-marquee-name" title={displayedName}>
+                {open ? "or upload your own" : displayedName}
+              </span>
             </span>
-            <span className="audio-source-marquee-name" title={displayedName}>
-              {open ? "or upload your own" : displayedName}
+            <span className="audio-source-crate-caret" aria-hidden="true">
+              <svg viewBox="0 0 10 10" width={10} height={10} fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+                <path d="M2 6.5L5 3.5L8 6.5" />
+              </svg>
             </span>
-          </span>
-          <span className="audio-source-crate-caret" aria-hidden="true">
-            <svg viewBox="0 0 10 10" width={10} height={10} fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
-              <path d="M2 6.5L5 3.5L8 6.5" />
-            </svg>
-          </span>
-        </button>
-        {/* Always-visible upload affordance. Discoverability beats the
-            "Upload your own" sleeve hidden inside the fan — same handler,
-            same dialog gate, just one click closer. */}
-        <button
-          ref={uploadBtnRef}
-          type="button"
-          className="audio-source-upload-btn"
-          disabled={uploading}
-          onClick={() => {
-            // Clicking dismisses the onboarding hint — the user has
-            // clearly found the button, even if they cancel the
-            // picker.
-            uploadHint.dismiss();
-            fileInputRef.current?.click();
-          }}
-          aria-label="Upload your own audio track"
-          data-dd-tooltip={uploading ? "Decoding…" : "Upload your own audio track"}
-        >
-          <UploadIcon size={16} />
-          <span className="audio-source-upload-label">
-            {uploading ? "Decoding…" : "Upload"}
-          </span>
-        </button>
+          </button>
+          {/* Always-visible upload affordance. Discoverability beats
+              the "Upload your own" sleeve hidden inside the fan —
+              same handler, same dialog gate, just one click closer. */}
+          <button
+            ref={uploadBtnRef}
+            type="button"
+            className="audio-source-upload-btn"
+            disabled={uploading}
+            onClick={() => {
+              // Clicking dismisses the onboarding hint — the user has
+              // clearly found the button, even if they cancel the
+              // picker.
+              uploadHint.dismiss();
+              fileInputRef.current?.click();
+            }}
+            aria-label="Upload your own audio track"
+            data-dd-tooltip={uploading ? "Decoding…" : "Upload your own audio track"}
+          >
+            <UploadIcon size={16} />
+            <span className="audio-source-upload-label">
+              {uploading ? "Decoding…" : "Upload"}
+            </span>
+          </button>
+        </span>
         <button
           type="button"
           className="audio-source-mic-btn"
@@ -361,10 +378,6 @@ export function AudioSourceCrate() {
           <span className="audio-source-upload-label">Mic</span>
         </button>
         </div>
-        {/* Anchored to the dock so the arrow lands just left of the
-            Upload button. dockActive includes uploadHint.visible so
-            the dock stays expanded as long as the hint is up. */}
-        <UploadOnboardingHint visible={uploadHint.visible} />
       </div>
 
       {open && (

--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -9,6 +9,7 @@ import {
   type DecodedFixture,
   type StemSourceMode,
 } from "@/engine/audio/loadFixture";
+import { useUploadOnboardingHint } from "@/hooks/useUploadOnboardingHint";
 import { trimAudioBuffer } from "@/lib/audio/trimAudioBuffer";
 import { useConfig } from "@/lib/config";
 import { LOCAL_MODE } from "@/lib/runtime";
@@ -19,6 +20,7 @@ import type { TimeSignature } from "@/types/engine";
 
 import { AlmostReadyDialog } from "./AlmostReadyDialog";
 import { MicRecorder } from "./MicRecorder";
+import { UploadOnboardingHint } from "./UploadOnboardingHint";
 import { WaveformTrimDialog } from "./WaveformTrimDialog";
 
 const DEFAULT_TRIM_CAP_S = 120;
@@ -132,6 +134,13 @@ export function AudioSourceCrate() {
   const [collapsed, setCollapsed] = useState(false);
   const [hovered, setHovered] = useState(false);
 
+  // First-visit nudge pointing at the Upload button — sequel to the
+  // StrengthOnboardingHint. See useUploadOnboardingHint for the
+  // reveal/dismiss state machine. We fold its `visible` into
+  // `dockActive` below so the dock can't auto-collapse out from
+  // under the hint mid-display.
+  const uploadHint = useUploadOnboardingHint();
+
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const placardRef = useRef<HTMLButtonElement | null>(null);
   const uploadBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -179,7 +188,13 @@ export function AudioSourceCrate() {
   // 2s after the last interaction. The timeout is cleared on any
   // re-activation so it only fires once the dock is truly idle.
   const dockActive =
-    hovered || open || micOpen || uploading || pending !== null || trimming !== null;
+    hovered ||
+    open ||
+    micOpen ||
+    uploading ||
+    pending !== null ||
+    trimming !== null ||
+    uploadHint.visible;
   useEffect(() => {
     if (dockActive) {
       setCollapsed(false);
@@ -319,7 +334,13 @@ export function AudioSourceCrate() {
           type="button"
           className="audio-source-upload-btn"
           disabled={uploading}
-          onClick={() => fileInputRef.current?.click()}
+          onClick={() => {
+            // Clicking dismisses the onboarding hint — the user has
+            // clearly found the button, even if they cancel the
+            // picker.
+            uploadHint.dismiss();
+            fileInputRef.current?.click();
+          }}
           aria-label="Upload your own audio track"
           data-dd-tooltip={uploading ? "Decoding…" : "Upload your own audio track"}
         >
@@ -340,6 +361,10 @@ export function AudioSourceCrate() {
           <span className="audio-source-upload-label">Mic</span>
         </button>
         </div>
+        {/* Anchored to the dock so the arrow lands just left of the
+            Upload button. dockActive includes uploadHint.visible so
+            the dock stays expanded as long as the hint is up. */}
+        <UploadOnboardingHint visible={uploadHint.visible} />
       </div>
 
       {open && (

--- a/demos/realtime_motion_graph_web/web/components/Performance/UploadOnboardingHint.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/UploadOnboardingHint.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+// Onboarding affordance for the bottom-right Upload button — appears
+// after the Strength hint dismisses (see useUploadOnboardingHint).
+// Issue #156: users reported the Upload button is hard to find tucked
+// in the corner. Mirrors StrengthOnboardingHint's visual treatment
+// (white "label + arrow gif") so the two reads as the same
+// vocabulary.
+//
+// Pure presentational — visibility/lifecycle owned by AudioSourceCrate
+// via useUploadOnboardingHint so the dock can keep itself expanded
+// while the hint is on screen (the dock otherwise auto-collapses to a
+// music-note bubble after 2s of idle pointer).
+
+export function UploadOnboardingHint({ visible }: { visible: boolean }) {
+  if (!visible) return null;
+  return (
+    <div className="upload-onboarding-hint" aria-hidden="true">
+      <span className="upload-onboarding-hint-text">Upload your own track</span>
+      <img
+        className="upload-onboarding-hint-arrow"
+        src="/strength-onboarding-arrow.gif"
+        alt=""
+        width={68}
+        height={68}
+      />
+    </div>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/components/Performance/UploadOnboardingHint.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/UploadOnboardingHint.tsx
@@ -16,7 +16,9 @@ export function UploadOnboardingHint({ visible }: { visible: boolean }) {
   if (!visible) return null;
   return (
     <div className="upload-onboarding-hint" aria-hidden="true">
-      <span className="upload-onboarding-hint-text">Upload your own track</span>
+      <span className="upload-onboarding-hint-text">
+        Select another track or upload your own
+      </span>
       <img
         className="upload-onboarding-hint-arrow"
         src="/strength-onboarding-arrow.gif"

--- a/demos/realtime_motion_graph_web/web/hooks/useUploadOnboardingHint.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useUploadOnboardingHint.ts
@@ -1,0 +1,157 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useCustomTracksStore } from "@/store/useCustomTracksStore";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
+
+// Sequel to the StrengthOnboardingHint — points at the bottom-right
+// Upload button in the AudioSourceCrate dock. Issue #156: users
+// reported "Upload" is hard to spot tucked into the corner.
+//
+// We chain it AFTER the Strength hint dismisses (== denoise rose
+// above the settled threshold) so the user only sees one piece of
+// onboarding noise at a time. The Strength hint teaches "what
+// strength does"; this hint then teaches "you can bring your own
+// track."
+//
+// Trigger conditions (all must hold to reveal):
+//   - localStorage flag is unset (first-time visitor for this hint),
+//   - the user has no custom tracks yet (returning visitors who've
+//     already uploaded once don't need the nudge),
+//   - the session-start gate has settled denoise to ~0 (we've
+//     observed it cross BELOW the threshold), AND THEN denoise has
+//     risen back above the threshold. The two-phase latch is the
+//     same one StrengthOnboardingHint uses: the gate's slow glide
+//     from 0.7 → 0 shouldn't be misread as "user moved Strength."
+//
+// Dismissal:
+//   - customCount rises above its at-reveal baseline (== upload
+//     completed), OR
+//   - dismiss() is called explicitly (e.g. the user clicks the
+//     Upload button — they've clearly found it, the hint's job is
+//     done even if they cancel the picker).
+//
+// Both dismissal paths persist the localStorage flag so the hint
+// never re-appears.
+
+const STORAGE_KEY = "demon:hint:upload-onboarding-v1";
+const SETTLED_THRESHOLD = 0.01;
+// Delay between Strength-hint dismissal and Upload-hint reveal so the
+// two transitions don't visually overlap. The Strength hint has no
+// fade-out animation, but a brief beat reads as deliberate sequencing
+// rather than a swap.
+const REVEAL_DELAY_MS = 700;
+
+function hintDismissed(): boolean {
+  if (typeof localStorage === "undefined") return false;
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function persistDismissed(): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, "1");
+  } catch {
+    // localStorage disabled — hint re-shows next session. OK.
+  }
+}
+
+export interface UploadOnboardingHint {
+  visible: boolean;
+  dismiss: () => void;
+}
+
+export function useUploadOnboardingHint(): UploadOnboardingHint {
+  const denoise = usePerformanceStore((s) => s.sliderTargets["denoise"] ?? 0);
+  const customCount = useCustomTracksStore((s) => s.names.length);
+  const [visible, setVisible] = useState(false);
+  // Custom-track count latched at reveal time. Any later rise dismisses
+  // the hint (== they successfully completed an upload).
+  const baselineCustomCount = useRef<number | null>(null);
+  const revealTimer = useRef<number | null>(null);
+  // Latched to make the dismiss/persist decision idempotent — once we
+  // dismiss we don't want subsequent effect runs to second-guess.
+  const dismissed = useRef(false);
+  // Mirrors StrengthOnboardingHint's settled-latch: only after we've
+  // observed denoise cross BELOW the threshold (== the session-start
+  // glide finished) does a rise back above it count as user input.
+  // Without this, the gate's 0.7 → 0 glide would prematurely trigger
+  // the reveal timer because denoise > THRESHOLD is true for most of
+  // the glide.
+  const settled = useRef(false);
+
+  const dismiss = useCallback(() => {
+    if (dismissed.current) return;
+    dismissed.current = true;
+    persistDismissed();
+    setVisible(false);
+    if (revealTimer.current !== null) {
+      window.clearTimeout(revealTimer.current);
+      revealTimer.current = null;
+    }
+  }, []);
+
+  // Reveal gate: phase 1 waits for the session-start glide to settle
+  // denoise to ~0, phase 2 watches for the user to lift it back above
+  // the threshold, then schedules a one-shot reveal.
+  useEffect(() => {
+    if (dismissed.current) return;
+    if (visible) return;
+    if (hintDismissed()) {
+      dismissed.current = true;
+      return;
+    }
+    if (customCount > 0) {
+      // Returning visitor (or first-session user who somehow uploaded
+      // before this hint mounted). They've found Upload — suppress
+      // forever.
+      dismiss();
+      return;
+    }
+    if (!settled.current) {
+      if (denoise <= SETTLED_THRESHOLD) settled.current = true;
+      return;
+    }
+    if (denoise <= SETTLED_THRESHOLD) return;
+    if (revealTimer.current !== null) return;
+    revealTimer.current = window.setTimeout(() => {
+      revealTimer.current = null;
+      if (dismissed.current) return;
+      if (hintDismissed()) return;
+      if (useCustomTracksStore.getState().names.length > 0) {
+        // User uploaded during the delay — they don't need the hint.
+        dismiss();
+        return;
+      }
+      baselineCustomCount.current =
+        useCustomTracksStore.getState().names.length;
+      setVisible(true);
+    }, REVEAL_DELAY_MS);
+  }, [denoise, customCount, visible, dismiss]);
+
+  // Cleanup any pending reveal timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (revealTimer.current !== null) {
+        window.clearTimeout(revealTimer.current);
+        revealTimer.current = null;
+      }
+    };
+  }, []);
+
+  // Dismiss on successful upload.
+  useEffect(() => {
+    if (!visible) return;
+    if (baselineCustomCount.current === null) return;
+    if (customCount > baselineCustomCount.current) {
+      dismiss();
+    }
+  }, [customCount, visible, dismiss]);
+
+  return { visible, dismiss };
+}


### PR DESCRIPTION
## Summary

Several users have reported that the **Upload** button in the bottom-right `AudioSourceCrate` dock is hard to find tucked into the corner ([daydreamlive/DEMON#156](https://github.com/daydreamlive/DEMON/issues/156)). This adds a sequel to the existing `StrengthOnboardingHint` — once the user has moved Strength, a white italic caption + hand-drawn arrow gif appears to the left of the dock pointing at "Upload your own track."

The progression is intentional: Strength hint teaches the first knob; once dismissed, the Upload hint teaches the next discoverability bump. One piece of onboarding noise at a time.

## What it does

**Reveal** is gated on all of:
- localStorage flag unset (first-time visitor for this hint),
- no custom tracks yet (returning visitors who've already uploaded don't need the nudge),
- the session-start denoise glide has settled below threshold **and then** the user has lifted it back above. The two-phase latch mirrors `StrengthOnboardingHint`'s — without the "settled first" gate, the glide from 0.7 → 0 would itself trigger the reveal timer.

**Dismissal** persists the flag forever. Triggered by either:
- a successful upload (custom-track count rises), or
- clicking the Upload button (== they found it, even if they cancel the picker).

**Misc**
- The dock's auto-collapse-to-bubble behavior would otherwise hide the button mid-hint, so `uploadHint.visible` is folded into `dockActive` in `AudioSourceCrate`. CSS also defensively hides the hint when `[data-collapsed]` is set.
- Hidden on touch-only devices via `@media (hover: none) and (pointer: coarse)` — mobile already surfaces Upload inline via the Lite drawer's `LiteTrackCarousel`.
- `prefers-reduced-motion` disables the bob + intro animations.

## Files

- `hooks/useUploadOnboardingHint.ts` — reveal/dismiss state machine, localStorage persistence.
- `components/Performance/UploadOnboardingHint.tsx` — pure presentational, mirrors `StrengthOnboardingHint`'s visual vocabulary.
- `components/Performance/AudioSourceCrate.tsx` — wires the hook in, dismisses on Upload click, keeps the dock expanded while the hint is up.
- `app/globals.css` — `.upload-onboarding-hint{,-text,-arrow}` styles + animations.

Closes [daydreamlive/DEMON#156](https://github.com/daydreamlive/DEMON/issues/156).

## Test plan

- [ ] Fresh localStorage, fresh session: Strength hint shows. Move Strength → Strength hint dismisses, Upload hint slides in ~700ms later pointing at the corner.
- [ ] Click Upload (without uploading): hint dismisses. Refresh: hint stays gone.
- [ ] Fresh localStorage, complete an upload via the existing `Upload` button or in-fan sleeve before triggering the hint: hint should never appear (skipped — `customCount > 0`).
- [ ] Move Strength then complete an upload during the 700ms reveal delay: hint should never appear (timer's safety check dismisses + persists).
- [ ] Touch device (or DevTools "Toggle device toolbar" mobile): hint is hidden via the `(hover: none) and (pointer: coarse)` media query.
- [ ] `prefers-reduced-motion: reduce` (DevTools rendering emulation): bob animation stops, intro animation stops.
- [ ] Dock collapses to bubble while hint is queued: hint shouldn't appear; once expanded again it should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)