### PR TITLE
streaming(1/5): extract pure helpers from backend.py

### DIFF
--- a/acestep/streaming/encode.py
+++ b/acestep/streaming/encode.py
@@ -1,0 +1,59 @@
+"""Conditioning encode + timbre-blend helpers.
+
+Pure, transport-agnostic helpers for building the (silence, full) cond
+pair against a given timbre reference and lerping between them on the
+live timbre-strength slider.
+
+``session`` is taken as an explicit parameter; ``backend.py`` keeps a
+1-line closure wrapper so the existing call sites don't change.
+"""
+
+from acestep.constants import TASK_INSTRUCTIONS
+from acestep.engine.session import Session
+
+
+def encode_cond_pair(
+    session: Session,
+    tags,
+    refer_latent,
+    bpm,
+    duration,
+    key,
+    time_signature,
+):
+    # WYSIWYG: the encoder sees exactly the text the UI sent. LoRA
+    # trigger words land in `tags` via the client's visible-prepend
+    # logic (see web/store/useLoraStore + the auto_prepend_lora_triggers
+    # config flag) so the user can edit or remove them like any other
+    # prompt token. The server intentionally does NOT inject anything
+    # behind the user's back.
+    cs = session.encode_text(
+        tags=tags,
+        lyrics="[Instrumental]",
+        instruction=TASK_INSTRUCTIONS["cover"],
+        refer_latent=None,
+        bpm=bpm, duration=duration, key=key,
+        time_signature=time_signature,
+    )
+    cf = session.encode_text(
+        tags=tags,
+        lyrics="[Instrumental]",
+        instruction=TASK_INSTRUCTIONS["cover"],
+        refer_latent=refer_latent,
+        bpm=bpm, duration=duration, key=key,
+        time_signature=time_signature,
+    )
+    return cs, cf
+
+
+def blend_for_strength(cs, cf, strength):
+    from acestep.nodes.cond_nodes import ConditioningBlend
+    if strength >= 0.999:
+        return cf
+    if strength <= 0.001:
+        return cs
+    return ConditioningBlend().execute(
+        conditioning_a=cs,
+        conditioning_b=cf,
+        alpha=float(strength),
+    )["conditioning"]

--- a/acestep/streaming/source.py
+++ b/acestep/streaming/source.py
@@ -1,0 +1,225 @@
+"""Source / conditioning resolver helpers (sidecar-aware).
+
+Pure, transport-agnostic helpers for turning a (fixture-name, audio)
+input pair into a ``PreparedSource`` plus the BPM / key / time-signature
+needed by the text encoder.
+"""
+
+import struct
+
+import numpy as np
+import torch
+
+from acestep.audio.key_detection import detect_key
+from acestep.constants import VALID_TIME_SIGNATURES
+from acestep.engine.obs import logger
+from acestep.engine.session import PreparedSource, Session
+from acestep.fixtures import FixtureSidecar, fixture_sidecar, audio_fixture
+from acestep.nodes.types import Audio, Latent
+
+
+# Audio sample rate the ACE-Step v1.5 family is trained on. Duplicated
+# from ``demos/realtime_motion_graph_web/protocol.py`` (and many other
+# call sites — see tests/, scripts/) so this module stays free of demo
+# imports.
+SAMPLE_RATE = 48000
+
+
+def _try_load_sidecar(
+    fixture_name: str | None, *, samples: int,
+) -> FixtureSidecar | None:
+    """Look up a fixture sidecar; return None on miss / mismatch.
+
+    Length check guards against runtime truncation that disagrees with
+    what the sidecar was precomputed for (e.g. a smaller TRT profile
+    cap kicking in). The caller falls back to live computation in that
+    case so cached tensor shapes can't poison the streaming pipeline.
+
+    Sidecars are not checkpoint-gated; the VAE and semantic
+    tokenizer/detokenizer that produce the cached tensors are shared
+    across the ACE-Step v1.5 family.
+    """
+    if not fixture_name:
+        return None
+    try:
+        sc = fixture_sidecar(fixture_name)
+    except Exception as e:
+        logger.warning(
+            "sidecar_lookup_failed fixture={} error={}", fixture_name, e,
+        )
+        return None
+    if sc is None:
+        return None
+    if sc.samples != samples:
+        logger.warning(
+            "sidecar_length_mismatch fixture={} sidecar_samples={} "
+            "runtime_samples={}",
+            fixture_name, sc.samples, samples,
+        )
+        return None
+    return sc
+
+
+def _decode_audio_msg(audio_msg: bytes) -> torch.Tensor:
+    """Parse a binary audio frame into a [≤2, N] float32 tensor.
+
+    Wire format (shared by the init handshake, ``swap_source``,
+    ``set_timbre_source``, ``set_structure_source``): little-endian
+    ``<II`` header carrying (channels, samples), followed by interleaved
+    float32 PCM. Returns the waveform clipped to stereo (the model only
+    consumes 2 channels).
+    """
+    ch, n = struct.unpack("<II", audio_msg[:8])
+    arr = np.frombuffer(audio_msg[8:], dtype=np.float32).reshape(n, ch)
+    return torch.from_numpy(arr.T.copy())[:2]
+
+
+def _load_known_fixture_waveform(name: str) -> torch.Tensor:
+    """Load a known fixture's audio from the pod's own fixture cache and
+    return it in the exact shape ``_decode_audio_msg`` produces
+    (``[≤2, N]`` float32 at ``SAMPLE_RATE``).
+
+    The pod already serves this file at ``/fixtures/<name>``; for known
+    fixtures the browser shouldn't have to download → decode → re-upload
+    ~20 MB of PCM over the WebSocket (~11 s on the measured cold path).
+    Same uniform-path output as the upload route, so every downstream
+    consumer (sidecar resolve, echoed initial buffer, prepare_source
+    fallback) is unchanged.
+    """
+    path = str(audio_fixture(name))  # resolves to the on-disk cache
+    try:
+        import soundfile as sf
+        data, sr = sf.read(path, dtype="float32", always_2d=True)  # (n, ch)
+    except Exception:
+        import librosa
+        mono, sr = librosa.load(path, sr=None, mono=True)
+        data = np.stack([mono, mono], axis=1).astype(np.float32)
+    if sr != SAMPLE_RATE:
+        import librosa
+        data = librosa.resample(
+            data.T, orig_sr=sr, target_sr=SAMPLE_RATE
+        ).T.astype(np.float32)
+    if data.ndim == 1:
+        data = data[:, None]
+    return torch.from_numpy(np.ascontiguousarray(data.T, dtype=np.float32))[:2]
+
+
+_VALID_TIME_SIG_STRS = frozenset(str(s) for s in VALID_TIME_SIGNATURES)
+
+
+def _normalize_time_signature(value: object) -> str | None:
+    """Coerce a wire-side time-signature value to one of
+    ``VALID_TIME_SIGNATURES`` as a string. Returns ``None`` for
+    unrecognized input (caller falls back to the sidecar / default
+    instead of poisoning the encoder with junk)."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        s = str(int(value))
+        return s if s in _VALID_TIME_SIG_STRS else None
+    if isinstance(value, str):
+        s = value.strip()
+        return s if s in _VALID_TIME_SIG_STRS else None
+    return None
+
+
+def _resolve_bpm_key_source(
+    session: Session,
+    *,
+    audio_in: Audio,
+    fixture_name: str | None,
+    samples: int,
+    key_override: str | None = None,
+    time_signature_override: str | None = None,
+) -> tuple[PreparedSource, int, str, str]:
+    """Resolve (source, bpm, key, time_signature) for a (fixture, audio) pair.
+
+    For known fixtures with a sidecar present (JSON+safetensors in the
+    dataset or local staging dir, matching audio length), returns the
+    cached source latent + context_latent and reads BPM, key, and
+    time_signature from the sidecar JSON. Skips librosa beat tracking,
+    CNN key detection, and ``Session.prepare_source`` — the
+    prompt-independent half of the per-connect work.
+
+    Conditioning is *not* cached (see fixtures.py). Callers run
+    ``Session.encode_text`` against ``source.latent`` themselves; with
+    the source latent already on GPU this is ~60ms warm.
+
+    Falls through to live librosa + detect_key + prepare_source when:
+      - ``fixture_name`` is None / unknown
+      - sidecar files aren't in the dataset yet
+      - audio-length truncation mismatch (e.g. operator's TRT profile
+        cap is smaller than the natural fixture length)
+
+    ``key_override`` and ``time_signature_override`` are the operator's
+    manual choices coming from the swap_source path. They are **only**
+    consulted on the live path: when a sidecar hits, the sidecar's
+    recorded values are authoritative for the test fixture (a previous
+    fixture's dropdown value or any other client-side staleness must
+    not be allowed to mask the fixture's recorded ground truth). After
+    the swap, post-hoc dropdown edits flow through ``mtype == "prompt"``
+    instead, where overrides do apply.
+    """
+    sc = _try_load_sidecar(fixture_name, samples=samples)
+
+    if sc is not None:
+        device = session.handler.device
+        dtype = session.handler.dtype
+        source = PreparedSource(
+            latent=Latent(tensor=sc.latent.to(device, dtype).contiguous()),
+            context_latent=Latent(tensor=sc.context_latent.to(device, dtype).contiguous()),
+        )
+        bpm = sc.bpm
+        # Sidecar is the source of truth for known fixtures; do NOT
+        # apply key_override here. (Earlier this read
+        # `key = key_override or sc.key`, which let the previous
+        # fixture's dropdown value, sent on swap_source, beat the new
+        # fixture's recorded key — e.g. a swap from low_fi (G minor)
+        # to prog_rock (E minor) printed
+        # `sidecar hit (prog_rock_..._enm.wav) ... key='G minor'`.)
+        key = sc.key
+        if key_override and key_override != sc.key:
+            logger.info(
+                "sidecar_override_ignored fixture={} field=key "
+                "override={} sidecar={}",
+                fixture_name, key_override, sc.key,
+            )
+        # Same precedence rule for time signature: sidecar.time_signature
+        # beats any client-supplied override on a hit.
+        time_signature = sc.time_signature
+        if (
+            time_signature_override
+            and time_signature_override != sc.time_signature
+        ):
+            logger.info(
+                "sidecar_override_ignored fixture={} field=time_signature "
+                "override={} sidecar={}",
+                fixture_name, time_signature_override, sc.time_signature,
+            )
+        logger.info(
+            "sidecar_hit fixture={} bpm={} key={} time_signature={}",
+            fixture_name, bpm, key, time_signature,
+        )
+        return source, bpm, key, time_signature
+
+    # Live path: librosa BPM, CNN key detection, full prepare_source.
+    # No automated time-signature detector today; the operator override
+    # wins, otherwise we default to "4" (matches the model's most-
+    # supported meter).
+    import librosa
+    logger.info("bpm_key_detect_start")
+    mono_np = audio_in.waveform.mean(dim=0).numpy()
+    bpm_raw, _ = librosa.beat.beat_track(y=mono_np, sr=SAMPLE_RATE)
+    bpm = int(round(float(np.asarray(bpm_raw).flat[0])))
+    key = key_override or detect_key(mono_np, SAMPLE_RATE)
+    time_signature = time_signature_override or "4"
+    logger.info(
+        "bpm_key_detected bpm={} key={} time_signature={}",
+        bpm, key, time_signature,
+    )
+
+    logger.info("prepare_source_start")
+    source = session.prepare_source(audio_in)
+    return source, bpm, key, time_signature

--- a/acestep/streaming/warmup.py
+++ b/acestep/streaming/warmup.py
@@ -1,0 +1,156 @@
+"""Startup self-warmup that drives one synthetic session through the
+WebSocket handler at boot to pay one-time engine costs before real
+traffic arrives.
+
+Measured 2026-05-18: a cold first session on a fresh engine takes ~40s to
+``ready`` (TRT decoder-engine load ~3s + LoRA-refit manager ~7s + Session /
+ModelContext / conditioning ~10s + first-tick pipeline build), while the
+*second* session on the same warm engine is ~5-6s. ~30s of the cold path is
+one-time-after-engine-start state that persists in the process. Driving one
+synthetic default-fixture session through the WS handler at boot, before
+the pod accepts real traffic, pays that once so every real "begin" gets the
+warm path. Behaviour-neutral for real clients; the warmup session is fully
+torn down by the WS handler's own finally.
+
+``handle_client`` is injected as a positional parameter so this module
+doesn't import the demo.
+"""
+
+import json
+import struct
+import time
+from typing import Callable
+
+import numpy as np
+from websockets.exceptions import ConnectionClosed
+
+from acestep.engine.obs import logger
+from acestep.fixtures import audio_fixture
+
+
+WARMUP_STATE: dict = {"done": False, "error": None, "seconds": None}
+
+_WARMUP_FIXTURE = "low_fi_Gm_loop_60s_gnm.wav"  # PREFERRED_DEFAULT_FIXTURE
+_WARMUP_PROMPT = "ambient electronic, warm pads"
+
+
+class _WarmupWS:
+    """In-process synthetic WebSocket that drives one default-fixture
+    session through the handler to warm one-time engine state.
+
+    Scripts the init handshake (config JSON, then the audio frame),
+    lets the streaming loop spin long enough to build the pipeline +
+    run the first generation tick, then raises ConnectionClosed so the
+    handler's teardown path frees all per-session GPU state.
+    """
+
+    def __init__(self, config_json: str, audio_frame: bytes, budget_s: float = 35.0):
+        self._queue = [config_json, audio_frame]
+        self._t0 = time.monotonic()
+        self._budget_s = budget_s
+        self._initial_seen_at = None
+        self.closed = False
+
+    def recv(self, timeout=None):
+        if self._queue:
+            return self._queue.pop(0)
+        # Spin until warm budget elapsed, then end the session.
+        # Mimic "no client message" via TimeoutError when the caller
+        # passed a timeout (the streaming loop polls that way); raise
+        # ConnectionClosed once warmed so every recv site unwinds into
+        # the handler's finally (which closes the session).
+        now = time.monotonic()
+        warm_enough = (
+            now - self._t0 > self._budget_s
+            or (self._initial_seen_at is not None
+                and now - self._initial_seen_at > 10.0)
+        )
+        if warm_enough:
+            raise ConnectionClosed(None, None)
+        if timeout is not None:
+            time.sleep(min(timeout, 0.05))
+            raise TimeoutError
+        time.sleep(0.1)
+        raise TimeoutError
+
+    def send(self, msg):
+        # The initial buffer is a large binary frame (the echoed source);
+        # spotting it tells us the init handshake finished so we can
+        # bound how long the streaming loop spins after.
+        if isinstance(msg, (bytes, bytearray)) and len(msg) > 1_000_000:
+            if self._initial_seen_at is None:
+                self._initial_seen_at = time.monotonic()
+
+    def close(self, *args, **kwargs):
+        self.closed = True
+
+
+def _load_warmup_audio_frame() -> bytes:
+    """Build the wire frame (<II channels,samples> + interleaved f32)
+    for the default fixture, matching the browser's upload format."""
+    path = str(audio_fixture(_WARMUP_FIXTURE))
+    try:
+        import soundfile as sf
+        data, _sr = sf.read(path, dtype="float32", always_2d=True)  # (n, ch)
+    except Exception:
+        import librosa
+        mono, _sr = librosa.load(path, sr=None, mono=True)
+        data = np.stack([mono, mono], axis=1).astype(np.float32)
+    if data.ndim == 1:
+        data = np.stack([data, data], axis=1)
+    if data.shape[1] == 1:
+        data = np.repeat(data, 2, axis=1)
+    ch = int(data.shape[1])
+    samples = int(data.shape[0])
+    interleaved = np.ascontiguousarray(data, dtype=np.float32).reshape(-1)
+    return struct.pack("<II", ch, samples) + interleaved.tobytes()
+
+
+def run_startup_warmup(
+    handle_client: Callable,
+    *,
+    decoder_backend: str,
+    vae_backend: str,
+    checkpoint: str,
+    offload_text_encoder: bool,
+) -> None:
+    """Drive one synthetic default-fixture session at boot. Never raises:
+    a failed warmup must not stop the server from serving.
+
+    ``handle_client`` is injected (rather than imported from
+    ``demos/realtime_motion_graph_web/backend.py``) so this module stays
+    free of demo imports.
+    """
+    t0 = time.monotonic()
+    warm_log = logger.bind(component="warmup")
+    warm_log.info("warmup_start fixture={}", _WARMUP_FIXTURE)
+    try:
+        cfg = {
+            "fixture_name": _WARMUP_FIXTURE,
+            "prompt": _WARMUP_PROMPT,
+            "steps": 8,
+            "depth": 4,
+            "lora": False,
+            "enabled_loras": [],
+        }
+        frame = _load_warmup_audio_frame()
+        ws = _WarmupWS(json.dumps(cfg), frame)
+        handle_client(
+            ws,
+            decoder_backend=decoder_backend,
+            vae_backend=vae_backend,
+            checkpoint=checkpoint,
+            offload_text_encoder=offload_text_encoder,
+        )
+        WARMUP_STATE["done"] = True
+        WARMUP_STATE["seconds"] = round(time.monotonic() - t0, 1)
+        warm_log.info(
+            "warmup_done elapsed_s={}", WARMUP_STATE["seconds"],
+        )
+    except Exception as exc:
+        WARMUP_STATE["error"] = repr(exc)
+        WARMUP_STATE["seconds"] = round(time.monotonic() - t0, 1)
+        warm_log.opt(exception=True).error(
+            "warmup_failed elapsed_s={} error={}",
+            WARMUP_STATE["seconds"], exc,
+        )

--- a/demos/realtime_motion_graph_web/backend.py
+++ b/demos/realtime_motion_graph_web/backend.py
@@ -30,14 +30,11 @@ torch._dynamo.config.disable = True
 
 from websockets.exceptions import ConnectionClosed
 
-from acestep.audio.key_detection import detect_key
-from acestep.constants import TASK_INSTRUCTIONS, VALID_TIME_SIGNATURES
+from acestep.constants import TASK_INSTRUCTIONS
 from acestep.engine.obs import logger, spawn_thread
 from acestep.engine.session import PreparedSource, Session
 from acestep.engine.trt.profile_manager import TRTProfileManager
-from acestep.fixtures import (
-    FixtureSidecar, KNOWN_FIXTURES, audio_fixture, fixture_sidecar,
-)
+from acestep.fixtures import KNOWN_FIXTURES, audio_fixture
 from acestep.nodes.types import Audio, Latent
 from acestep.lora_metadata import load_lora_metadata
 from acestep.paths import (
@@ -68,110 +65,14 @@ from .protocol import (
 )
 from acestep.streaming.pipeline_runner import PipelineRunner
 from acestep.streaming import registry as session_registry
-
-
-# ---------------------------------------------------------------------------
-# Source / conditioning resolver (sidecar-aware)
-# ---------------------------------------------------------------------------
-
-def _try_load_sidecar(
-    fixture_name: str | None, *, samples: int,
-) -> FixtureSidecar | None:
-    """Look up a fixture sidecar; return None on miss / mismatch.
-
-    Length check guards against runtime truncation that disagrees with
-    what the sidecar was precomputed for (e.g. a smaller TRT profile
-    cap kicking in). The caller falls back to live computation in that
-    case so cached tensor shapes can't poison the streaming pipeline.
-
-    Sidecars are not checkpoint-gated; the VAE and semantic
-    tokenizer/detokenizer that produce the cached tensors are shared
-    across the ACE-Step v1.5 family.
-    """
-    if not fixture_name:
-        return None
-    try:
-        sc = fixture_sidecar(fixture_name)
-    except Exception as e:
-        logger.warning(
-            "sidecar_lookup_failed fixture={} error={}", fixture_name, e,
-        )
-        return None
-    if sc is None:
-        return None
-    if sc.samples != samples:
-        logger.warning(
-            "sidecar_length_mismatch fixture={} sidecar_samples={} "
-            "runtime_samples={}",
-            fixture_name, sc.samples, samples,
-        )
-        return None
-    return sc
-
-
-def _decode_audio_msg(audio_msg: bytes) -> torch.Tensor:
-    """Parse a binary audio frame into a [≤2, N] float32 tensor.
-
-    Wire format (shared by the init handshake, ``swap_source``,
-    ``set_timbre_source``, ``set_structure_source``): little-endian
-    ``<II`` header carrying (channels, samples), followed by interleaved
-    float32 PCM. Returns the waveform clipped to stereo (the model only
-    consumes 2 channels).
-    """
-    ch, n = struct.unpack("<II", audio_msg[:8])
-    arr = np.frombuffer(audio_msg[8:], dtype=np.float32).reshape(n, ch)
-    return torch.from_numpy(arr.T.copy())[:2]
-
-
-def _load_known_fixture_waveform(name: str) -> torch.Tensor:
-    """Load a known fixture's audio from the pod's own fixture cache and
-    return it in the exact shape ``_decode_audio_msg`` produces
-    (``[≤2, N]`` float32 at ``SAMPLE_RATE``).
-
-    The pod already serves this file at ``/fixtures/<name>``; for known
-    fixtures the browser shouldn't have to download → decode → re-upload
-    ~20 MB of PCM over the WebSocket (~11 s on the measured cold path).
-    Same uniform-path output as the upload route, so every downstream
-    consumer (sidecar resolve, echoed initial buffer, prepare_source
-    fallback) is unchanged.
-    """
-    path = str(audio_fixture(name))  # resolves to the on-disk cache
-    try:
-        import soundfile as sf
-        data, sr = sf.read(path, dtype="float32", always_2d=True)  # (n, ch)
-    except Exception:
-        import librosa
-        mono, sr = librosa.load(path, sr=None, mono=True)
-        data = np.stack([mono, mono], axis=1).astype(np.float32)
-    if sr != SAMPLE_RATE:
-        import librosa
-        data = librosa.resample(
-            data.T, orig_sr=sr, target_sr=SAMPLE_RATE
-        ).T.astype(np.float32)
-    if data.ndim == 1:
-        data = data[:, None]
-    return torch.from_numpy(np.ascontiguousarray(data.T, dtype=np.float32))[:2]
-
-
-_VALID_TIME_SIG_STRS = frozenset(str(s) for s in VALID_TIME_SIGNATURES)
-
-
-def _normalize_time_signature(value: object) -> str | None:
-    """Coerce a wire-side time-signature value to one of
-    ``VALID_TIME_SIGNATURES`` as a string. Returns ``None`` for
-    unrecognized input (caller falls back to the sidecar / default
-    instead of poisoning the encoder with junk)."""
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, (int, float)):
-        s = str(int(value))
-        return s if s in _VALID_TIME_SIG_STRS else None
-    if isinstance(value, str):
-        s = value.strip()
-        return s if s in _VALID_TIME_SIG_STRS else None
-    return None
+from acestep.streaming.source import (
+    _decode_audio_msg,
+    _load_known_fixture_waveform,
+    _normalize_time_signature,
+    _resolve_bpm_key_source,
+    _try_load_sidecar,
+)
+from acestep.streaming.encode import blend_for_strength, encode_cond_pair
 
 
 def _send_stem_payload(
@@ -237,106 +138,6 @@ def _extract_and_select_upload_stem(
             log_context or None, exc,
         )
         return None, str(exc), source, waveform
-
-
-def _resolve_bpm_key_source(
-    session: Session,
-    *,
-    audio_in: Audio,
-    fixture_name: str | None,
-    samples: int,
-    key_override: str | None = None,
-    time_signature_override: str | None = None,
-) -> tuple[PreparedSource, int, str, str]:
-    """Resolve (source, bpm, key, time_signature) for a (fixture, audio) pair.
-
-    For known fixtures with a sidecar present (JSON+safetensors in the
-    dataset or local staging dir, matching audio length), returns the
-    cached source latent + context_latent and reads BPM, key, and
-    time_signature from the sidecar JSON. Skips librosa beat tracking,
-    CNN key detection, and ``Session.prepare_source`` — the
-    prompt-independent half of the per-connect work.
-
-    Conditioning is *not* cached (see fixtures.py). Callers run
-    ``Session.encode_text`` against ``source.latent`` themselves; with
-    the source latent already on GPU this is ~60ms warm.
-
-    Falls through to live librosa + detect_key + prepare_source when:
-      - ``fixture_name`` is None / unknown
-      - sidecar files aren't in the dataset yet
-      - audio-length truncation mismatch (e.g. operator's TRT profile
-        cap is smaller than the natural fixture length)
-
-    ``key_override`` and ``time_signature_override`` are the operator's
-    manual choices coming from the swap_source path. They are **only**
-    consulted on the live path: when a sidecar hits, the sidecar's
-    recorded values are authoritative for the test fixture (a previous
-    fixture's dropdown value or any other client-side staleness must
-    not be allowed to mask the fixture's recorded ground truth). After
-    the swap, post-hoc dropdown edits flow through ``mtype == "prompt"``
-    instead, where overrides do apply.
-    """
-    sc = _try_load_sidecar(fixture_name, samples=samples)
-
-    if sc is not None:
-        device = session.handler.device
-        dtype = session.handler.dtype
-        source = PreparedSource(
-            latent=Latent(tensor=sc.latent.to(device, dtype).contiguous()),
-            context_latent=Latent(tensor=sc.context_latent.to(device, dtype).contiguous()),
-        )
-        bpm = sc.bpm
-        # Sidecar is the source of truth for known fixtures; do NOT
-        # apply key_override here. (Earlier this read
-        # `key = key_override or sc.key`, which let the previous
-        # fixture's dropdown value, sent on swap_source, beat the new
-        # fixture's recorded key — e.g. a swap from low_fi (G minor)
-        # to prog_rock (E minor) printed
-        # `sidecar hit (prog_rock_..._enm.wav) ... key='G minor'`.)
-        key = sc.key
-        if key_override and key_override != sc.key:
-            logger.info(
-                "sidecar_override_ignored fixture={} field=key "
-                "override={} sidecar={}",
-                fixture_name, key_override, sc.key,
-            )
-        # Same precedence rule for time signature: sidecar.time_signature
-        # beats any client-supplied override on a hit.
-        time_signature = sc.time_signature
-        if (
-            time_signature_override
-            and time_signature_override != sc.time_signature
-        ):
-            logger.info(
-                "sidecar_override_ignored fixture={} field=time_signature "
-                "override={} sidecar={}",
-                fixture_name, time_signature_override, sc.time_signature,
-            )
-        logger.info(
-            "sidecar_hit fixture={} bpm={} key={} time_signature={}",
-            fixture_name, bpm, key, time_signature,
-        )
-        return source, bpm, key, time_signature
-
-    # Live path: librosa BPM, CNN key detection, full prepare_source.
-    # No automated time-signature detector today; the operator override
-    # wins, otherwise we default to "4" (matches the model's most-
-    # supported meter).
-    import librosa
-    logger.info("bpm_key_detect_start")
-    mono_np = audio_in.waveform.mean(dim=0).numpy()
-    bpm_raw, _ = librosa.beat.beat_track(y=mono_np, sr=SAMPLE_RATE)
-    bpm = int(round(float(np.asarray(bpm_raw).flat[0])))
-    key = key_override or detect_key(mono_np, SAMPLE_RATE)
-    time_signature = time_signature_override or "4"
-    logger.info(
-        "bpm_key_detected bpm={} key={} time_signature={}",
-        bpm, key, time_signature,
-    )
-
-    logger.info("prepare_source_start")
-    source = session.prepare_source(audio_in)
-    return source, bpm, key, time_signature
 
 
 # ---------------------------------------------------------------------------
@@ -918,42 +719,17 @@ def _handle_client_body(
     # forward pass per slider tick. Same approximation already used for
     # prompt crossfades. Recomputed on prompt change, on swap_source,
     # and on set_timbre_source / clear_timbre_source.
+    #
+    # Thin closure wrapper around acestep.streaming.encode.encode_cond_pair
+    # so existing call sites in this function keep the original
+    # (session-captured) signature. ``blend_for_strength`` has no
+    # captures and is aliased verbatim.
     def _encode_cond_pair(tags, refer_latent, bpm, duration, key, time_signature):
-        # WYSIWYG: the encoder sees exactly the text the UI sent. LoRA
-        # trigger words land in `tags` via the client's visible-prepend
-        # logic (see web/store/useLoraStore + the auto_prepend_lora_triggers
-        # config flag) so the user can edit or remove them like any other
-        # prompt token. The server intentionally does NOT inject anything
-        # behind the user's back.
-        cs = session.encode_text(
-            tags=tags,
-            lyrics="[Instrumental]",
-            instruction=TASK_INSTRUCTIONS["cover"],
-            refer_latent=None,
-            bpm=bpm, duration=duration, key=key,
-            time_signature=time_signature,
+        return encode_cond_pair(
+            session, tags, refer_latent, bpm, duration, key, time_signature,
         )
-        cf = session.encode_text(
-            tags=tags,
-            lyrics="[Instrumental]",
-            instruction=TASK_INSTRUCTIONS["cover"],
-            refer_latent=refer_latent,
-            bpm=bpm, duration=duration, key=key,
-            time_signature=time_signature,
-        )
-        return cs, cf
 
-    def _blend_for_strength(cs, cf, strength):
-        from acestep.nodes.cond_nodes import ConditioningBlend
-        if strength >= 0.999:
-            return cf
-        if strength <= 0.001:
-            return cs
-        return ConditioningBlend().execute(
-            conditioning_a=cs,
-            conditioning_b=cf,
-            alpha=float(strength),
-        )["conditioning"]
+    _blend_for_strength = blend_for_strength
 
     logger.info("text_encode_start variant=silence_and_self")
     cond_silence, cond_full = _encode_cond_pair(
@@ -2376,138 +2152,3 @@ def _handle_client_body(
         # explicit __exit__ calls here.
 
 
-# ---------------------------------------------------------------------------
-# Startup self-warmup
-#
-# Measured 2026-05-18: a cold first session on a fresh engine takes ~40s to
-# `ready` (TRT decoder-engine load ~3s + LoRA-refit manager ~7s + Session /
-# ModelContext / conditioning ~10s + first-tick pipeline build), while the
-# *second* session on the same warm engine is ~5-6s. ~30s of the cold path is
-# one-time-after-engine-start state that persists in the process. Driving one
-# synthetic default-fixture session through `handle_client` at boot — before
-# the pod accepts real traffic — pays that once so every real "begin" gets the
-# warm path. Behaviour-neutral for real clients; the warmup session is fully
-# torn down (stream.close()+session.close()) by handle_client's own finally.
-# ---------------------------------------------------------------------------
-
-WARMUP_STATE: dict = {"done": False, "error": None, "seconds": None}
-
-_WARMUP_FIXTURE = "low_fi_Gm_loop_60s_gnm.wav"  # PREFERRED_DEFAULT_FIXTURE
-_WARMUP_PROMPT = "ambient electronic, warm pads"
-
-
-class _WarmupWS:
-    """In-process synthetic WebSocket that drives one default-fixture
-    session through handle_client to warm one-time engine state.
-
-    Scripts the Phase-1 handshake (config JSON, then the audio frame),
-    lets Phase-2 spin long enough to build the pipeline + run the first
-    generation tick, then raises ConnectionClosed so handle_client's
-    teardown path frees all per-session GPU state.
-    """
-
-    def __init__(self, config_json: str, audio_frame: bytes, budget_s: float = 35.0):
-        self._queue = [config_json, audio_frame]
-        self._t0 = time.monotonic()
-        self._budget_s = budget_s
-        self._initial_seen_at = None
-        self.closed = False
-
-    def recv(self, timeout=None):
-        if self._queue:
-            return self._queue.pop(0)
-        # Phase-2: spin until warm budget elapsed, then end the session.
-        # Mimic "no client message" via TimeoutError when the caller
-        # passed a timeout (the streaming loop polls that way); raise
-        # ConnectionClosed once warmed so every recv site unwinds into
-        # handle_client's finally (which closes the session).
-        now = time.monotonic()
-        warm_enough = (
-            now - self._t0 > self._budget_s
-            or (self._initial_seen_at is not None
-                and now - self._initial_seen_at > 10.0)
-        )
-        if warm_enough:
-            raise ConnectionClosed(None, None)
-        if timeout is not None:
-            time.sleep(min(timeout, 0.05))
-            raise TimeoutError
-        time.sleep(0.1)
-        raise TimeoutError
-
-    def send(self, msg):
-        # The initial buffer is a large binary frame (the echoed source);
-        # spotting it tells us Phase-1 finished so we can bound Phase-2.
-        if isinstance(msg, (bytes, bytearray)) and len(msg) > 1_000_000:
-            if self._initial_seen_at is None:
-                self._initial_seen_at = time.monotonic()
-
-    def close(self, *args, **kwargs):
-        self.closed = True
-
-
-def _load_warmup_audio_frame() -> bytes:
-    """Build the wire frame (<II channels,samples> + interleaved f32)
-    for the default fixture, matching the browser's upload format."""
-    from acestep.fixtures import audio_fixture
-
-    path = str(audio_fixture(_WARMUP_FIXTURE))
-    try:
-        import soundfile as sf
-        data, _sr = sf.read(path, dtype="float32", always_2d=True)  # (n, ch)
-    except Exception:
-        import librosa
-        mono, _sr = librosa.load(path, sr=None, mono=True)
-        data = np.stack([mono, mono], axis=1).astype(np.float32)
-    if data.ndim == 1:
-        data = np.stack([data, data], axis=1)
-    if data.shape[1] == 1:
-        data = np.repeat(data, 2, axis=1)
-    ch = int(data.shape[1])
-    samples = int(data.shape[0])
-    interleaved = np.ascontiguousarray(data, dtype=np.float32).reshape(-1)
-    return struct.pack("<II", ch, samples) + interleaved.tobytes()
-
-
-def run_startup_warmup(
-    *,
-    decoder_backend: str,
-    vae_backend: str,
-    checkpoint: str,
-    offload_text_encoder: bool,
-) -> None:
-    """Drive one synthetic default-fixture session at boot. Never raises
-    — a failed warmup must not stop the server from serving."""
-    t0 = time.monotonic()
-    warm_log = logger.bind(component="warmup")
-    warm_log.info("warmup_start fixture={}", _WARMUP_FIXTURE)
-    try:
-        cfg = {
-            "fixture_name": _WARMUP_FIXTURE,
-            "prompt": _WARMUP_PROMPT,
-            "steps": 8,
-            "depth": 4,
-            "lora": False,
-            "enabled_loras": [],
-        }
-        frame = _load_warmup_audio_frame()
-        ws = _WarmupWS(json.dumps(cfg), frame)
-        handle_client(
-            ws,
-            decoder_backend=decoder_backend,
-            vae_backend=vae_backend,
-            checkpoint=checkpoint,
-            offload_text_encoder=offload_text_encoder,
-        )
-        WARMUP_STATE["done"] = True
-        WARMUP_STATE["seconds"] = round(time.monotonic() - t0, 1)
-        warm_log.info(
-            "warmup_done elapsed_s={}", WARMUP_STATE["seconds"],
-        )
-    except Exception as exc:
-        WARMUP_STATE["error"] = repr(exc)
-        WARMUP_STATE["seconds"] = round(time.monotonic() - t0, 1)
-        warm_log.opt(exception=True).error(
-            "warmup_failed elapsed_s={} error={}",
-            WARMUP_STATE["seconds"], exc,
-        )

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -121,12 +121,15 @@ def _process_request(connection, request):
     # API: server-info — lets the client know whether the backend is up.
     if path_only == "/api/server-info":
         # Surface startup-warmup state so the pool can gate "free" on a
-        # warmed engine. Read only if backend is already imported — don't
-        # force the heavy import in --no-backend mode.
+        # warmed engine. Read only if the warmup module is already
+        # imported — don't force the heavy chain in --no-backend mode
+        # (importing acestep.streaming.warmup is cheap on its own, but
+        # the warmup state is only populated once the backend imports
+        # and runs).
         _warm = None
-        _be = sys.modules.get("demos.realtime_motion_graph_web.backend")
-        if _be is not None:
-            _warm = getattr(_be, "WARMUP_STATE", None)
+        _wm = sys.modules.get("acestep.streaming.warmup")
+        if _wm is not None:
+            _warm = getattr(_wm, "WARMUP_STATE", None)
         body = json.dumps({
             "no_backend": _NO_BACKEND,
             "kiosk": _KIOSK,
@@ -481,9 +484,12 @@ def main():
         # routed real users until it's warm. Disable with
         # DEMON_STARTUP_WARMUP=0.
         if os.environ.get("DEMON_STARTUP_WARMUP", "1") != "0":
-            from .backend import run_startup_warmup
+            from acestep.streaming.warmup import run_startup_warmup
 
+            # handle_client is injected so warmup stays free of demo
+            # imports; see acestep.streaming.warmup.run_startup_warmup.
             run_startup_warmup(
+                handle_client,
                 decoder_backend=decoder_accel,
                 vae_backend=vae_accel,
                 checkpoint=checkpoint,


### PR DESCRIPTION
## Summary

PR 2 of 5 in the API-layer excision stack. Extracts pure helpers out
of `backend.py` into transport-agnostic modules under
`acestep/streaming/`. Behavior-preserving.

## Changes

- `acestep/streaming/source.py`: `_decode_audio_msg`,
  `_load_known_fixture_waveform`, `_normalize_time_signature`,
  `_resolve_bpm_key_source`, `_try_load_sidecar`.
- `acestep/streaming/encode.py`: `encode_cond_pair`,
  `blend_for_strength`.
- `acestep/streaming/warmup.py`: `run_startup_warmup`, the
  `_WarmupWS` synthetic-WebSocket shim, fixture load helper. The
  handler is injected as a positional parameter so this module stays
  free of demo imports.
- `backend.py` shrinks roughly 400 lines, gains thin closure wrappers
  pointing at the extracted helpers so call sites don't change.
- `server.py` wires up `run_startup_warmup` with the injected handler.

## Why

These helpers are pure (no transport state, no mutable session cells)
and have other consumers: `warmup.py` needs them at boot, and the
future `StreamingSession` constructor will need them at session
create. Pulling them out is a precondition for Phases 2 and 3.

## Reviewer focus

- `_resolve_bpm_key_source` sidecar-precedence rule (sidecar wins over
  override on hit; override wins over default on miss). A prior bug
  had override beating sidecar on hit; this PR must preserve the
  post-fix order verbatim.
- `_normalize_time_signature` is called from three paths (init
  handshake, prompt update, swap source). All three must coerce
  identically.
- `_decode_audio_msg` wire layout: `<II>` (channels, samples) +
  interleaved float32, returns `torch.Tensor[<=2, N]`.

## Test plan

- [ ] Demo plays the default fixture end to end.
- [ ] Headless bench wall-time within noise.
- [ ] Warmup completes before `server_ready` with
      `DEMON_STARTUP_WARMUP=1`.

Stacked on Phase 0.
