### PR TITLE
streaming(4/5): repoint stale backend.py references

### DIFF
--- a/acestep/engine/trt/profile_manager.py
+++ b/acestep/engine/trt/profile_manager.py
@@ -175,11 +175,11 @@ class TRTProfileManager:
         to ``walk_window_s``, vae_encode sized to ``source_duration_s``.
 
         Mirrors the initial walk-mode wiring in
-        ``demos/realtime_motion_graph_web/backend.py`` (the runner only
-        sees walk_window_s of latent at a time, but VAE-encode still
-        needs to ingest the full song once at load). When a long-track
-        swap happens mid-session this is the right swap shape: keeping
-        the 60s decoder on the line, only resizing vae_encode.
+        ``acestep/streaming/session.py`` (the runner only sees
+        walk_window_s of latent at a time, but VAE-encode still needs
+        to ingest the full song once at load). When a long-track swap
+        happens mid-session this is the right swap shape: keeping the
+        60s decoder on the line, only resizing vae_encode.
 
         Falls through to :meth:`ensure_profile` semantics if the request
         doesn't actually need a mix (source fits the walk profile).

--- a/acestep/streaming/encode.py
+++ b/acestep/streaming/encode.py
@@ -3,9 +3,6 @@
 Pure, transport-agnostic helpers for building the (silence, full) cond
 pair against a given timbre reference and lerping between them on the
 live timbre-strength slider.
-
-``session`` is taken as an explicit parameter; ``backend.py`` keeps a
-1-line closure wrapper so the existing call sites don't change.
 """
 
 from acestep.constants import TASK_INSTRUCTIONS

--- a/acestep/streaming/pipeline_runner.py
+++ b/acestep/streaming/pipeline_runner.py
@@ -172,7 +172,7 @@ class PipelineRunner:
         self.walk_window_T = int(round(self.walk_window_s * 25.0))
 
         # Negative conditioning for the RCFG path. Encoded once at session
-        # start (see backend.py / fixtures.py) and reused across all ticks.
+        # start (see StreamingSession.create) and reused across all ticks.
         # Required for ``rcfg_mode in {"full", "initialize"}``; ignored
         # by ``rcfg_mode == "self"`` (virtual uncond) and ``"off"``.
         # ``None`` is safe — modes that need it become quiet no-ops.

--- a/demos/realtime_motion_graph_web/README.md
+++ b/demos/realtime_motion_graph_web/README.md
@@ -153,10 +153,8 @@ demos/realtime_motion_graph_web/
 ├── __main__.py               # `python -m demos.realtime_motion_graph_web`
 ├── run.py                    # launcher: backend + Next.js dev server
 ├── server.py                 # HTTP API + WebSocket multiplex on one port
-├── backend.py                # GPU handle_client coroutine
-├── pipeline.py               # PipelineRunner (graph-driven streaming loop)
-├── audio_engine.py           # server-side audio buffer
-├── knobs.py                  # MIDI knob bank definitions
+├── ws_adapter.py             # per-WebSocket coroutine; wraps StreamingSession
+├── audio_codec.py            # per-subscriber slice codec + stem payload
 ├── protocol.py               # wire format (Python source of truth)
 ├── videos/                   # user-supplied .mp4/.webm/.mov drop-in (optional)
 └── web/                      # Next.js front-end (React + zustand)
@@ -176,7 +174,8 @@ of truth that `web/engine/protocol.ts` mirrors):
 
 `server.py` multiplexes the JSON HTTP API, fixture/video file serving,
 and the WebSocket upgrade onto one TCP port; the WS handshake hands
-off to `backend.handle_client`.
+off to `ws_adapter.handle_client`, which wraps a
+`acestep.streaming.session.StreamingSession`.
 
 ## Audio-reactive video
 

--- a/demos/realtime_motion_graph_web/benchmark.py
+++ b/demos/realtime_motion_graph_web/benchmark.py
@@ -4,7 +4,8 @@ This mirrors the server-side inference path used by
 ``demos.realtime_motion_graph_web`` without HTTP, WebSocket, browser, or
 audio-device overhead:
 
-1. Resolve the same accel/checkpoint/TRT engine combination as backend.py.
+1. Resolve the same accel/checkpoint/TRT engine combination as the
+   streaming session.
 2. Load the same fixture/config defaults as the web demo.
 3. Build Session -> prepare_source -> encode_text -> stream.
 4. Time stream.tick() and optional VAE decode per completed generation.
@@ -598,12 +599,10 @@ def main() -> None:
 
     audio_buffer: _BenchAudioBuffer | None = None
     if args.audio_mix:
-        # Initial buffer matches the demo's: ``waveform.numpy().T`` is the
-        # [samples, channels] layout AudioEngine.__init__ consumes (see
-        # backend.py's ``src_np = waveform.numpy().T`` before AudioEngine
-        # construction). Crop to mirror runner behaviour when crop_seconds
-        # would be set; this bench has no crop so the full source is the
-        # buffer.
+        # Initial buffer matches the streaming session's: ``waveform.numpy().T``
+        # is the [samples, channels] layout AudioEngine.__init__ consumes.
+        # Crop to mirror runner behaviour when crop_seconds would be set;
+        # this bench has no crop so the full source is the buffer.
         audio_buffer = _BenchAudioBuffer(waveform.numpy().T)
         print(
             f"[Run] audio-mix on: buffer {audio_buffer.current.shape} "

--- a/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
@@ -28,7 +28,7 @@ export interface DecodedStemAssets {
 }
 
 // Server-side latent pool size (1920 * 5 = 9600 samples = 0.2 s at
-// 48 kHz). backend.py and the sidecar precompute both align to this;
+// 48 kHz). The streaming session and the sidecar precompute both align to this;
 // trimming the decoded fixture to the same boundary keeps the runtime
 // `samples` count matching the sidecar's recorded `samples` field, so
 // `_try_load_sidecar` accepts the cached BPM / key / latents instead
@@ -64,8 +64,8 @@ async function decodeArrayBuffer(bytes: ArrayBuffer): Promise<DecodedFixture> {
   const channels = 2;
 
   // Length normalize: trim to a multiple of the server's latent pool
-  // (1920 * 5 = 9600 samples = 0.2 s at 48 kHz, mirroring backend.py's
-  // `pool` and scripts/precompute_fixture_sidecars.py's POOL). Browsers'
+  // (1920 * 5 = 9600 samples = 0.2 s at 48 kHz, mirroring the
+  // streaming session's `pool` and scripts/precompute_fixture_sidecars.py's POOL). Browsers'
   // decodeAudioData honours the mp3 encoder-padding header and returns
   // a non-pool-aligned sample count for many real-world files (e.g. a
   // 142.96 s mp3 with 23 ms of priming silence at the head). The

--- a/demos/realtime_motion_graph_web/web/lib/audio/trimAudioBuffer.ts
+++ b/demos/realtime_motion_graph_web/web/lib/audio/trimAudioBuffer.ts
@@ -1,6 +1,6 @@
 import type { DecodedFixture } from "@/engine/audio/loadFixture";
 
-// Server-side latent pool size, mirroring loadFixture.ts and backend.py.
+// Server-side latent pool size, mirroring loadFixture.ts and acestep.streaming.session.
 // Trim boundaries MUST be multiples of this so the sliced buffer still
 // satisfies the VAE-encode constraint.
 const SAMPLE_POOL = 9600;

--- a/demos/realtime_motion_graph_web/web/types/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/types/protocol.ts
@@ -1,5 +1,5 @@
 // WS wire protocol shapes. Mirrors the Python side
-// (DEMON/demos/realtime_motion_graph_web/protocol.py + backend.py).
+// (DEMON/demos/realtime_motion_graph_web/protocol.py + ws_adapter.py).
 
 /** Normalized LoRA metadata mirrored from the Python sidecar loader
  *  (`acestep/lora_metadata.py`). Always shipped — fields are null when

--- a/docs/TRT.md
+++ b/docs/TRT.md
@@ -505,8 +505,8 @@ uv run python -u -m demos.realtime_motion_graph_web --port 8765 --accel eager --
 
 ### How The Demo Picks TRT Engines
 
-`demos/realtime_motion_graph_web/backend.py` chooses engines at client
-connection time. It measures the uploaded or fixture audio duration, then calls:
+`acestep/streaming/session.py` chooses engines at session-create time.
+It measures the uploaded or fixture audio duration, then calls:
 
 ```python
 available_trt_engines(

--- a/scripts/calibration/precompute_fixture_sidecars.py
+++ b/scripts/calibration/precompute_fixture_sidecars.py
@@ -17,8 +17,9 @@ are preserved (so an operator override survives a re-run). Pass
 
 Pipeline per fixture:
   1. Download the WAV (cache hit if already present).
-  2. Apply the same audio-level truncation backend.py applies before
-     prepare_source: stereo cap + drop the trailing samples below a
+  2. Apply the same audio-level truncation the streaming session
+     applies before prepare_source: stereo cap + drop trailing samples
+     below a
      1920*5-sample boundary. The TRT max-profile cap is intentionally
      NOT applied here so the precompute is profile-agnostic; the
      runtime only uses the cache when the live truncated length
@@ -70,11 +71,11 @@ from acestep.nodes.types import Audio
 from acestep.paths import checkpoints_dir
 
 SAMPLE_RATE = 48000  # matches demos.realtime_motion_graph_web.protocol.SAMPLE_RATE
-POOL = 1920 * 5  # 9600 samples = 5 latent frames at 25 fps; matches backend.py
+POOL = 1920 * 5  # 9600 samples = 5 latent frames at 25 fps; matches acestep.streaming.session
 
 
 def truncate_audio(waveform: torch.Tensor) -> torch.Tensor:
-    """Stereo cap + mod-9600-sample drop, mirroring backend.py.
+    """Stereo cap + mod-9600-sample drop, mirroring acestep.streaming.session.
 
     Does not apply the runtime's TRT-profile-based duration cap: the
     precompute is profile-agnostic and relies on a length check at


### PR DESCRIPTION
## Summary

PR 5 of 5: clean up stale `backend.py` references introduced by the
deletion in Phase 3. Comment and doc updates only; no code logic
changes.

## Changes

- `docs/TRT.md`: engine-selection prose now points at
  `acestep/streaming/session.py` instead of the deleted
  `backend.py`.
- `demos/realtime_motion_graph_web/README.md`: directory tree
  updated (removed `backend.py`, `pipeline.py`, `audio_engine.py`,
  `knobs.py`; added `ws_adapter.py`, `audio_codec.py`); the WS
  handshake line now points at `ws_adapter.handle_client` +
  `StreamingSession`.
- `demos/realtime_motion_graph_web/benchmark.py`: docstring +
  audio-mix comment repointed.
- `demos/realtime_motion_graph_web/web/types/protocol.ts`: leading
  comment now references `ws_adapter.py`.
- `acestep/streaming/encode.py`: dropped the now-stale "backend.py
  keeps a 1-line closure wrapper" sentence (no such wrapper after
  the cut).
- `acestep/streaming/pipeline_runner.py`: negative-conditioning
  comment now points at `StreamingSession.create`.
- `acestep/engine/trt/profile_manager.py`: walk-mode comment points
  at `acestep/streaming/session.py`.
- `scripts/calibration/precompute_fixture_sidecars.py`: pool /
  truncate comments point at the streaming session.
- `web/engine/audio/loadFixture.ts` +
  `web/lib/audio/trimAudioBuffer.ts`: same pool-comment repointing.

## Why

These references all said "mirrors backend.py" or "see backend.py";
the file no longer exists. Repointing them now keeps grep working
and prevents future readers from chasing dead names.

## Reviewer focus

Nothing functional. Skim to confirm no comment got mis-pointed at
the wrong new location.

## Test plan

- [ ] No new code paths; `rg backend.py` returns only the
      `_handle_client_body` internal-function references inside
      `ws_adapter.py` (the internal function name carried over from
      the cut).

Stacked on Phase 3.
