### PR TITLE
rtmg/graph: tall-canvas adaptive lane count + LoRA label overflow fixes

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -798,6 +798,17 @@ body[data-mode="graph"] #install-video-area .focal-side-blur { display: none; }
   opacity: 0.4;
   transition: opacity 200ms cubic-bezier(.2, .8, .2, 1);
 }
+/* Lanes-mode safety net for label overflow. The gutter is 168 px;
+   pills are inset 8 px from the canvas left and have ~12 px of
+   horizontal padding + border, so ~148 px of text room. Cap max-width
+   slightly tighter so very long labels (long LoRA names that the
+   lora_str_ prefix strip didn't fully fix) clip with an ellipsis
+   instead of bleeding past the gutter divider into the envelope. */
+.graph-lane-labels--lanes .graph-lane-label {
+  max-width: 144px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 /* "+N more" overflow chip — rendered below the stack when more lanes
    qualify than MAX_LANES (10). Neutral palette: no param-color border
    or text, because this isn't a lane, it's a continuation marker. The

--- a/demos/realtime_motion_graph_web/web/components/Performance/GraphLaneLabels.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/GraphLaneLabels.tsx
@@ -54,6 +54,22 @@ interface DisplayPill {
 // across ticks (the count changes but the chip is the same DOM node).
 const MORE_PILL_PARAM = "__hidden_more__";
 
+// Display label for a param when rendering a lane pill in the gutter.
+// The gutter is ~168px wide; long lora_str_<id> names overflow even
+// after the v2 widening. The colored track tag inside the gutter
+// already conveys "this is a LoRA, here's its family color", so the
+// "LORA STR" prefix on the label is redundant noise. Strip it and let
+// the LoRA's own name carry the pill.
+//
+// Sliders elsewhere in the mixer keep the full defaultLabelFor name
+// (they have more horizontal room) — this override is graph-only.
+function laneDisplayFor(param: string): string {
+  if (param.startsWith("lora_str_")) {
+    return param.slice("lora_str_".length).replace(/[_-]/g, " ");
+  }
+  return defaultLabelFor(param);
+}
+
 export function GraphLaneLabels() {
   const [pills, setPills] = useState<DisplayPill[]>([]);
   const [mode, setMode] = useState<DisplayMode>("polylines");
@@ -99,7 +115,7 @@ export function GraphLaneLabels() {
           if (!b || !b.name) continue;
           next.push({
             param: b.name,
-            display: defaultLabelFor(b.name),
+            display: laneDisplayFor(b.name),
             x: 0,
             y: b.bandTop + b.bandHeight / 2,
             color: `rgb(${b.color[0]},${b.color[1]},${b.color[2]})`,

--- a/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
@@ -269,7 +269,20 @@ const SPARK_DODGE_PX = 5;
 // LANE_MIN_H and LANE_MAX_H. Inter-lane padding gives lanes their
 // "channel" feel without becoming a tight rack of bars.
 // ---------------------------------------------------------------
-const MAX_LANES = 10;
+// MAX_LANES is the HARD CEILING used to pre-allocate the scratch
+// buffers. Per-frame, _drawLanes picks a smaller `effectiveMaxLanes`
+// based on canvas height (see LANE_TARGET_H below) so tall canvases
+// show more lanes than short ones. 20 is enough headroom for the
+// ~30 params an active session typically touches.
+const MAX_LANES = 20;
+// Target height per lane when computing how many fit on this canvas.
+// Lanes grow up to LANE_MAX_H or shrink to LANE_MIN_H based on
+// activeCount, but the EFFECTIVE max-lanes count is derived from the
+// canvas height so we use the available vertical space. Clamped at
+// LANE_HARD_MIN_COUNT below so very short canvases still show a
+// usable rack.
+const LANE_TARGET_H = 30;
+const LANE_HARD_MIN_COUNT = 8;
 const LANE_TOP_PAD = 18;
 const LANE_BOTTOM_PAD = 10;
 const LANE_INTER_PAD = 3;
@@ -1024,9 +1037,27 @@ export class GraphRenderer {
     pulse: number,
     now: number,
   ): void {
+    // Per-frame effective cap: derive how many lanes fit comfortably on
+    // THIS canvas height. Targets LANE_TARGET_H per lane, clamps in
+    // [LANE_HARD_MIN_COUNT, MAX_LANES]. Tall canvases show more
+    // lanes (up to the buffer ceiling); short canvases still keep a
+    // usable rack.
+    const availableHForCount = Math.max(
+      0,
+      h - LANE_TOP_PAD - LANE_BOTTOM_PAD,
+    );
+    const computedMax = Math.floor(
+      (availableHForCount + LANE_INTER_PAD) /
+        (LANE_TARGET_H + LANE_INTER_PAD),
+    );
+    const effectiveMaxLanes = Math.max(
+      LANE_HARD_MIN_COUNT,
+      Math.min(MAX_LANES, computedMax),
+    );
+
     // Step 1+2: collect active lanes into the pre-allocated scratch
     // buffer. When the pool is full, evict the lane with the oldest
-    // lastFire if this candidate is more recent (linear scan, n ≤ 10).
+    // lastFire if this candidate is more recent (linear scan, n ≤ 20).
     // Also count totalEligible so we know how many qualifying lanes
     // didn't fit — surfaces as a "+N more" pill via the labels overlay.
     let activeCount = 0;
@@ -1040,14 +1071,14 @@ export class GraphRenderer {
       // dormant LoRAs / unused params, would only add noise.
       if (headV < 0.005 && lastFire === 0) continue;
       totalEligible++;
-      if (activeCount < MAX_LANES) {
+      if (activeCount < effectiveMaxLanes) {
         this._laneNameBuf[activeCount] = name;
         this._laneLastFireBuf[activeCount] = lastFire;
         activeCount++;
       } else {
         let oldestIdx = 0;
         let oldestVal = this._laneLastFireBuf[0];
-        for (let i = 1; i < MAX_LANES; i++) {
+        for (let i = 1; i < effectiveMaxLanes; i++) {
           if (this._laneLastFireBuf[i] < oldestVal) {
             oldestVal = this._laneLastFireBuf[i];
             oldestIdx = i;

--- a/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
@@ -270,17 +270,28 @@ const SPARK_DODGE_PX = 5;
 // "channel" feel without becoming a tight rack of bars.
 // ---------------------------------------------------------------
 // MAX_LANES is the HARD CEILING used to pre-allocate the scratch
-// buffers. Per-frame, _drawLanes picks a smaller `effectiveMaxLanes`
-// based on canvas height (see LANE_TARGET_H below) so tall canvases
-// show more lanes than short ones. 20 is enough headroom for the
-// ~30 params an active session typically touches.
-const MAX_LANES = 20;
+// buffers (_laneNameBuf, _laneLastFireBuf). It is INTENTIONALLY
+// generous (32) so the per-frame `effectiveMaxLanes` calculation —
+// not this buffer — is what governs how many lanes show on screen.
+// On a 1440p+ monitor with the drawer closed, the canvas can fit
+// well over 20 lanes; capping the buffer at 20 would silently stop
+// the resize-reactive lane count from scaling up. 32 slots × (one
+// string + one float) ≈ 280 bytes; negligible. Bumping this further
+// only matters if a single session ever surfaces > 32 simultaneously-
+// touched parameters, which the engine doesn't approach today.
+const MAX_LANES = 32;
 // Target height per lane when computing how many fit on this canvas.
-// Lanes grow up to LANE_MAX_H or shrink to LANE_MIN_H based on
-// activeCount, but the EFFECTIVE max-lanes count is derived from the
-// canvas height so we use the available vertical space. Clamped at
-// LANE_HARD_MIN_COUNT below so very short canvases still show a
-// usable rack.
+// `effectiveMaxLanes` is recomputed EVERY frame from the live canvas
+// height (`this.h`, which the ResizeObserver in `_resize` keeps in
+// sync with the canvas's CSS box). That means lane count adapts on:
+//   - window resize / drawer open-close (canvas box changes)
+//   - moving the window between monitors (CSS box re-flows)
+//   - browser zoom changes
+//   - mobile portrait↔landscape rotation
+// No additional listeners needed — the per-frame `_drawLanes` already
+// reads the freshest `this.h`. Lanes individually clamp to
+// [LANE_MIN_H, LANE_MAX_H], so on tall canvases with few active params
+// the stack is vertically centered rather than stretched.
 const LANE_TARGET_H = 30;
 const LANE_HARD_MIN_COUNT = 8;
 const LANE_TOP_PAD = 18;
@@ -1057,7 +1068,7 @@ export class GraphRenderer {
 
     // Step 1+2: collect active lanes into the pre-allocated scratch
     // buffer. When the pool is full, evict the lane with the oldest
-    // lastFire if this candidate is more recent (linear scan, n ≤ 20).
+    // lastFire if this candidate is more recent (linear scan, n ≤ effectiveMaxLanes).
     // Also count totalEligible so we know how many qualifying lanes
     // didn't fit — surfaces as a "+N more" pill via the labels overlay.
     let activeCount = 0;

--- a/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
+++ b/demos/realtime_motion_graph_web/web/engine/render/GraphRenderer.ts
@@ -294,6 +294,35 @@ const MAX_LANES = 32;
 // the stack is vertically centered rather than stretched.
 const LANE_TARGET_H = 30;
 const LANE_HARD_MIN_COUNT = 8;
+// Reserve at the bottom of the canvas to keep the lane stack clear of
+// the <HeroMacros/> floating panel. Hero macros are `position: fixed`
+// at the bottom of the viewport with z-index 5 — they paint OVER the
+// graph canvas (which is z-index 2) without affecting graph-wrap's
+// inset, so the lane stack would otherwise extend into their region.
+//
+// Sizing: we want the visible bottom gap (stack bottom → macros panel
+// top) to equal the visible top gap (canvas top → stack top, which
+// equals LANE_TOP_PAD when uncentered). The macros panel sticks UP
+// into the canvas by ≈ `delta_macros` pixels, where:
+//
+//     delta_macros = macros_height + 24 − hud_thickness − ribbon_bleed
+//
+// For typical desktop (macros_height ≈ 100 px, hud_thickness ≈ 56–90 px
+// via `clamp(56px, 6vmin, 90px)`, ribbon_bleed ≈ 2 px), `delta_macros`
+// lands in the 30–70 px range, ≈ 55 px on a mid-size viewport.
+//
+// To make the visible top and bottom gaps symmetric, this reserve
+// needs to be (LANE_TOP_PAD − LANE_BOTTOM_PAD + delta_macros) ≈ 64 px.
+// A fixed constant is "near right" across viewport sizes — the
+// remaining 5–15 px asymmetry on extreme viewports is acceptable for
+// the prototype. If precise symmetry matters, switch to measuring
+// `.hero-macros` getBoundingClientRect on resize.
+//
+// Hero macros are hidden under 768 px viewport width (mobile gets
+// <LiteControls/> instead, and graph-wrap's media-query inset already
+// accounts for the LiteControls bay). So this reserve only applies on
+// desktop — read via matchMedia in _drawLanes.
+const LANE_HERO_MACROS_RESERVE = 64;
 const LANE_TOP_PAD = 18;
 const LANE_BOTTOM_PAD = 10;
 const LANE_INTER_PAD = 3;
@@ -1053,9 +1082,20 @@ export class GraphRenderer {
     // [LANE_HARD_MIN_COUNT, MAX_LANES]. Tall canvases show more
     // lanes (up to the buffer ceiling); short canvases still keep a
     // usable rack.
+    //
+    // `macrosReserve` keeps the lane stack clear of the HeroMacros
+    // floating panel (desktop only — the panel matches the same
+    // 768 px breakpoint). On mobile, graph-wrap's media-query inset
+    // already accounts for LiteControls, so no reserve here.
+    const macrosReserve =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(min-width: 768px)").matches
+        ? LANE_HERO_MACROS_RESERVE
+        : 0;
     const availableHForCount = Math.max(
       0,
-      h - LANE_TOP_PAD - LANE_BOTTOM_PAD,
+      h - LANE_TOP_PAD - LANE_BOTTOM_PAD - macrosReserve,
     );
     const computedMax = Math.floor(
       (availableHForCount + LANE_INTER_PAD) /
@@ -1123,19 +1163,28 @@ export class GraphRenderer {
     }
 
     // Step 4: lane geometry + gradient cache.
-    const usableH = Math.max(0, h - LANE_TOP_PAD - LANE_BOTTOM_PAD);
+    // Both lane-height computation and vertical centering use the
+    // SAME macros-reserved available area as the count cap above —
+    // otherwise the stack would still extend into the macros zone
+    // when active lanes < cap.
+    const usableH = Math.max(
+      0,
+      h - LANE_TOP_PAD - LANE_BOTTOM_PAD - macrosReserve,
+    );
     const idealLaneH =
       (usableH - (activeCount - 1) * LANE_INTER_PAD) / activeCount;
     const laneH = Math.max(LANE_MIN_H, Math.min(LANE_MAX_H, idealLaneH));
-    // Vertical centering. Lane heights are clamped at LANE_MAX_H so a
-    // tall canvas with few active lanes leaves dead space at the bottom
-    // if we anchor the stack at LANE_TOP_PAD. Compute the stack's total
-    // height and offset the top so the unused vertical space splits
-    // evenly above and below — feels balanced regardless of canvas
-    // height. Falls back to LANE_TOP_PAD when the stack would already
-    // overflow.
+    // Vertical centering within the lane area (above any macros zone).
+    // Lane heights clamp at LANE_MAX_H so a tall canvas with few active
+    // lanes leaves dead space — center the stack vertically in the
+    // available area (LANE_TOP_PAD → h − LANE_BOTTOM_PAD − macrosReserve)
+    // so it feels balanced and never bleeds into the macros region.
     const stackH = activeCount * laneH + (activeCount - 1) * LANE_INTER_PAD;
-    const stackTop = Math.max(LANE_TOP_PAD, (h - stackH) / 2);
+    const availableBottom = h - LANE_BOTTOM_PAD - macrosReserve;
+    const stackTop = Math.max(
+      LANE_TOP_PAD,
+      (LANE_TOP_PAD + availableBottom - stackH) / 2,
+    );
     if (this._laneGradient === null || this._laneGradientHeight !== laneH) {
       const g = ctx.createLinearGradient(0, 0, 0, laneH);
       // Subtle warm wash — accent at the top (where high values live),


### PR DESCRIPTION
## Why

Two issues spotted on review of #169 after merge:

1. **Tall canvases left huge dead space** above and below a fixed 10-lane stack while "+18 more" hid most of the activity.
2. **Long LoRA names overflowed the 168 px gutter** — "LORA STR DEEP HOUSE-V1" bled past the gutter divider into the envelope area.

## What

**Adaptive lane count.** `MAX_LANES` is now the HARD CEILING (10 → 20) used only to pre-allocate the scratch buffers. Per draw, `_drawLanes` computes:

```ts
const computedMax = Math.floor((h - pads + LANE_INTER_PAD) /
  (LANE_TARGET_H + LANE_INTER_PAD));
const effectiveMaxLanes = clamp(LANE_HARD_MIN_COUNT /* 8 */,
                                MAX_LANES /* 20 */,
                                computedMax);
```

On a 700–800 px canvas this shows up to 20 lanes; short canvases keep a usable 8-lane minimum. The eviction loop now bounds its scan at `effectiveMaxLanes` (not `MAX_LANES`), so unused buffer slots don't trip oldest-eviction.

**LoRA label cleanup.** The colored track tag inside the gutter already conveys "this is a LoRA, this specific one" via the deterministic hash-based color. The `LORA STR` prefix on the label is redundant. New `laneDisplayFor()` helper in `GraphLaneLabels` strips `lora_str_` for graph-only display:

- `lora_str_deep_house-v1` → `DEEP HOUSE V1`
- `lora_str_ambient-v1` → `AMBIENT V1`

`defaultLabelFor` is untouched — mixer sliders elsewhere have more horizontal room and keep the full label.

**CSS safety net.** Added `max-width: 144px` + `text-overflow: ellipsis` scoped to `.graph-lane-labels--lanes .graph-lane-label`. Any label that still overflows (future params, custom names) clips gracefully instead of bleeding past the gutter divider.

## Test plan

- [ ] On a tall viewport (1080p+ display, drawer closed), the lane stack should fill more of the available vertical space — up to ~20 lanes visible.
- [ ] On a short viewport / mobile, lane stack still shows at least 8 lanes (not collapsing to a tiny rack).
- [ ] LoRA lanes show as `DEEP HOUSE V1` / `AMBIENT V1` in the gutter, no overflow past the divider.
- [ ] Any future label > 144 px text-width clips with ellipsis instead of bleeding into the envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)