### PR TITLE
demo: make remote/headless client-server setup work out of the box

### DIFF
--- a/demos/realtime_motion_graph_web/README.md
+++ b/demos/realtime_motion_graph_web/README.md
@@ -54,19 +54,28 @@ To run the GPU server on one machine and open the UI from another, bind the
 backend to all interfaces and tell the browser the server's address:
 
 ```bash
+# launcher flags go BEFORE `--`; backend flags (e.g. --accel) go AFTER it.
 uv run python -u -m demos.realtime_motion_graph_web.run \
-  --host 0.0.0.0 --client-host 10.0.0.5     # 10.0.0.5 = the server's LAN IP
+  --host 0.0.0.0 --client-host 10.0.0.5 \
+  -- --accel tensorrt
+# (10.0.0.5 = the server's LAN IP)
 ```
 
-Then open `http://10.0.0.5:6660` from the client. Note:
+On startup the launcher prints `engine base URL (for browser): …` — it must be
+the server's address, not `127.0.0.1`. Then open `http://10.0.0.5:6660` from
+the client. Note:
 
-- `--client-host` sets the address the **browser** uses. The HTTP routes are
-  proxied through the dev server, but the **WebSocket connects straight to the
-  backend**, so this must be reachable from the client — not `localhost`.
+- **Argument order matters.** Everything after `--` is forwarded to the
+  backend, so a launcher flag like `--client-host` placed after `--` silently
+  has no effect (the base URL falls back to `127.0.0.1`, which a remote browser
+  resolves to *itself*). Put launcher flags before `--`.
+- `--client-host` sets the address the **browser** uses for both the HTTP API
+  and the WebSocket — both connect straight to the backend, so it must be
+  reachable from the client, not `localhost`.
 - Open **both** ports on the server's firewall: `:6660` (UI) and `:1318`
-  (WebSocket).
-- Changing `web/.env.local` or `next.config.ts` requires restarting the dev
-  server — those are read only at startup.
+  (backend HTTP + WebSocket).
+- Changing `web/.env.local` requires restarting the dev server — it's read
+  only at startup.
 
 The full UI lives under `web/` (React + zustand, mirrored from the
 internal `daydreamlive/demon-react` package). See `web/components/`,

--- a/demos/realtime_motion_graph_web/README.md
+++ b/demos/realtime_motion_graph_web/README.md
@@ -48,6 +48,26 @@ Open `http://localhost:6660`. Next.js rewrites `/api/*`, `/fixtures/*`,
 `/loras/*`, and `/videos/*` to the backend at `:1318`; the WebSocket
 URL comes from `NEXT_PUBLIC_POD_BASE_URL` (set by the launcher).
 
+### Remote / headless server
+
+To run the GPU server on one machine and open the UI from another, bind the
+backend to all interfaces and tell the browser the server's address:
+
+```bash
+uv run python -u -m demos.realtime_motion_graph_web.run \
+  --host 0.0.0.0 --client-host 10.0.0.5     # 10.0.0.5 = the server's LAN IP
+```
+
+Then open `http://10.0.0.5:6660` from the client. Note:
+
+- `--client-host` sets the address the **browser** uses. The HTTP routes are
+  proxied through the dev server, but the **WebSocket connects straight to the
+  backend**, so this must be reachable from the client — not `localhost`.
+- Open **both** ports on the server's firewall: `:6660` (UI) and `:1318`
+  (WebSocket).
+- Changing `web/.env.local` or `next.config.ts` requires restarting the dev
+  server — those are read only at startup.
+
 The full UI lives under `web/` (React + zustand, mirrored from the
 internal `daydreamlive/demon-react` package). See `web/components/`,
 `web/engine/`, `web/hooks/`, and `web/store/` for the source.

--- a/demos/realtime_motion_graph_web/run.py
+++ b/demos/realtime_motion_graph_web/run.py
@@ -184,6 +184,20 @@ def main() -> int:
     if backend_extras and backend_extras[0] == "--":
         backend_extras = backend_extras[1:]
 
+    # Common footgun: launcher-only flags placed *after* `--` get forwarded to
+    # the backend instead of parsed here, so e.g. --client-host silently has no
+    # effect and the browser falls back to 127.0.0.1. Warn loudly.
+    _launcher_only = {"--client-host", "--web-port", "--no-install"}
+    _misplaced = [a for a in backend_extras if a.split("=", 1)[0] in _launcher_only]
+    if _misplaced:
+        print(
+            f"WARNING: {', '.join(_misplaced)} came after `--`, so it was "
+            f"forwarded to the backend, not parsed by the launcher (it has no "
+            f"effect there). Put launcher flags BEFORE `--`, e.g.:\n"
+            f"    run.py --host 0.0.0.0 --client-host <server-ip> -- --accel tensorrt",
+            flush=True,
+        )
+
     npm = _resolve_npm()
     if not args.no_install:
         _ensure_node_modules(npm)

--- a/demos/realtime_motion_graph_web/run.py
+++ b/demos/realtime_motion_graph_web/run.py
@@ -164,6 +164,17 @@ def main() -> int:
         help="Next.js dev port (default 6660).",
     )
     parser.add_argument(
+        "--client-host",
+        default=None,
+        help=(
+            "Address the browser should use to reach the backend, for a "
+            "remote client (UI and GPU server on different machines). The "
+            "WebSocket connects to this directly, so it must be reachable "
+            "from the client — e.g. the server's LAN IP. Defaults to the "
+            "local backend address (fine when UI and backend share a host)."
+        ),
+    )
+    parser.add_argument(
         "--no-install",
         action="store_true",
         help="Skip the `npm install` check.",
@@ -188,11 +199,38 @@ def main() -> int:
         str(args.port),
         *backend_extras,
     ]
-    web_cmd = [npm, "run", "dev", "--", "-p", str(args.web_port)]
+    # The browser uses NEXT_PUBLIC_POD_BASE_URL directly for the WebSocket, so
+    # for a remote client it must point at an address the *client* can reach
+    # (not 127.0.0.1). Precedence:
+    #   1. --client-host <host>                    -> http://<host>:<port>
+    #   2. an explicitly pre-set NEXT_PUBLIC_POD_BASE_URL in the environment
+    #   3. the local backend address (default; fine when UI+backend share a host)
+    remote = bool(args.client_host) or args.host in ("0.0.0.0", "::")
 
     web_env = os.environ.copy()
-    backend_url = f"http://{_local_backend_host(args.host)}:{args.port}"
+    if args.client_host:
+        backend_url = f"http://{args.client_host}:{args.port}"
+    elif os.environ.get("NEXT_PUBLIC_POD_BASE_URL"):
+        backend_url = os.environ["NEXT_PUBLIC_POD_BASE_URL"].rstrip("/")
+    else:
+        backend_url = f"http://{_local_backend_host(args.host)}:{args.port}"
     web_env["NEXT_PUBLIC_POD_BASE_URL"] = backend_url
+
+    # Build the web dev command. When the client is remote, bind the dev
+    # server to all interfaces so it's reachable, and surface a hint if the
+    # base URL still points at localhost (the browser can't reach that).
+    web_cmd = [npm, "run", "dev", "--", "-p", str(args.web_port)]
+    if remote:
+        web_cmd += ["-H", "0.0.0.0"]
+        if "localhost" in backend_url or "127.0.0.1" in backend_url:
+            print(
+                f"{_PREFIXES['web']} WARNING: NEXT_PUBLIC_POD_BASE_URL is "
+                f"{backend_url}, which a remote browser can't reach. Pass "
+                f"--client-host <server-ip> so the WebSocket connects to the "
+                f"server, not the client.",
+                flush=True,
+            )
+    print(f"{_PREFIXES['web']} engine base URL (for browser): {backend_url}", flush=True)
 
     print(f"{_PREFIXES['backend']} {' '.join(backend_cmd)}", flush=True)
     print(
@@ -235,8 +273,9 @@ def main() -> int:
         stderr=subprocess.STDOUT,
     )
     banner = _color("\x1b[1;32m")
+    ui_host = args.client_host or "localhost"
     print(
-        f"\n{banner}>>> Open http://localhost:{args.web_port}/{_RESET}\n",
+        f"\n{banner}>>> Open http://{ui_host}:{args.web_port}/{_RESET}\n",
         flush=True,
     )
 

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -72,6 +72,10 @@ _NO_CACHE_HEADERS = [
     # Chrome requires this for Web MIDI API device enumeration.
     ("Permissions-Policy", "midi=*"),
 ]
+_PUBLIC_HTTP_HEADERS = [
+    ("Access-Control-Allow-Origin", "*"),
+    *_NO_CACHE_HEADERS,
+]
 
 
 def _resolve_video(name: str) -> Path | None:
@@ -155,8 +159,7 @@ def _process_request(connection, request):
                 # no credentials/custom headers → no preflight; a single
                 # ACAO:* on the response is sufficient and safe (nothing
                 # sensitive here).
-                ("Access-Control-Allow-Origin", "*"),
-                *_NO_CACHE_HEADERS,
+                *_PUBLIC_HTTP_HEADERS,
             ]),
             body,
         )
@@ -223,7 +226,7 @@ def _process_request(connection, request):
             Headers([
                 ("Content-Type", "application/json; charset=utf-8"),
                 ("Content-Length", str(len(body))),
-                *_NO_CACHE_HEADERS,
+                *_PUBLIC_HTTP_HEADERS,
             ]),
             body,
         )
@@ -243,7 +246,7 @@ def _process_request(connection, request):
             Headers([
                 ("Content-Type", "application/json; charset=utf-8"),
                 ("Content-Length", str(len(body))),
-                *_NO_CACHE_HEADERS,
+                *_PUBLIC_HTTP_HEADERS,
             ]),
             body,
         )
@@ -260,7 +263,7 @@ def _process_request(connection, request):
             Headers([
                 ("Content-Type", "application/json; charset=utf-8"),
                 ("Content-Length", str(len(body))),
-                *_NO_CACHE_HEADERS,
+                *_PUBLIC_HTTP_HEADERS,
             ]),
             body,
         )
@@ -286,8 +289,7 @@ def _process_request(connection, request):
             Headers([
                 ("Content-Type", "application/json; charset=utf-8"),
                 ("Content-Length", str(len(body))),
-                ("Access-Control-Allow-Origin", "*"),
-                *_NO_CACHE_HEADERS,
+                *_PUBLIC_HTTP_HEADERS,
             ]),
             body,
         )
@@ -308,8 +310,7 @@ def _process_request(connection, request):
             Headers([
                 ("Content-Type", "application/json; charset=utf-8"),
                 ("Content-Length", str(len(body))),
-                ("Access-Control-Allow-Origin", "*"),
-                *_NO_CACHE_HEADERS,
+                *_PUBLIC_HTTP_HEADERS,
             ]),
             body,
         )
@@ -331,7 +332,7 @@ def _process_request(connection, request):
             Headers([
                 ("Content-Type", "application/json; charset=utf-8"),
                 ("Content-Length", str(len(body))),
-                *_NO_CACHE_HEADERS,
+                *_PUBLIC_HTTP_HEADERS,
             ]),
             body,
         )
@@ -353,7 +354,7 @@ def _process_request(connection, request):
                 Headers([
                     ("Content-Type", "text/plain; charset=utf-8"),
                     ("Content-Length", str(len(msg))),
-                    *_NO_CACHE_HEADERS,
+                    *_PUBLIC_HTTP_HEADERS,
                 ]),
                 msg,
             )
@@ -368,7 +369,7 @@ def _process_request(connection, request):
                     Headers([
                         ("Content-Type", "text/plain; charset=utf-8"),
                         ("Content-Length", str(len(msg))),
-                        *_NO_CACHE_HEADERS,
+                        *_PUBLIC_HTTP_HEADERS,
                     ]),
                     msg,
                 )
@@ -379,7 +380,7 @@ def _process_request(connection, request):
                 Headers([
                     ("Content-Type", ctype or "application/octet-stream"),
                     ("Content-Length", str(len(body))),
-                    *_NO_CACHE_HEADERS,
+                    *_PUBLIC_HTTP_HEADERS,
                 ]),
                 body,
             )
@@ -407,7 +408,7 @@ def _process_request(connection, request):
                         Headers([
                             ("Content-Type", "text/plain; charset=utf-8"),
                             ("Content-Length", str(len(msg))),
-                            *_NO_CACHE_HEADERS,
+                            *_PUBLIC_HTTP_HEADERS,
                         ]),
                         msg,
                     )
@@ -418,7 +419,7 @@ def _process_request(connection, request):
                     Headers([
                         ("Content-Type", ctype or "application/octet-stream"),
                         ("Content-Length", str(len(body))),
-                        *_NO_CACHE_HEADERS,
+                        *_PUBLIC_HTTP_HEADERS,
                     ]),
                     body,
                 )
@@ -437,7 +438,7 @@ def _process_request(connection, request):
                     Headers([
                         ("Content-Type", "text/plain; charset=utf-8"),
                         ("Content-Length", str(len(msg))),
-                        *_NO_CACHE_HEADERS,
+                        *_PUBLIC_HTTP_HEADERS,
                     ]),
                     msg,
                 )
@@ -448,7 +449,7 @@ def _process_request(connection, request):
                 Headers([
                     ("Content-Type", ctype or "application/octet-stream"),
                     ("Content-Length", str(len(body))),
-                    *_NO_CACHE_HEADERS,
+                    *_PUBLIC_HTTP_HEADERS,
                 ]),
                 body,
             )
@@ -461,7 +462,7 @@ def _process_request(connection, request):
         Headers([
             ("Content-Type", "text/plain; charset=utf-8"),
             ("Content-Length", str(len(body))),
-            *_NO_CACHE_HEADERS,
+            *_PUBLIC_HTTP_HEADERS,
         ]),
         body,
     )

--- a/demos/realtime_motion_graph_web/web/.env.local.example
+++ b/demos/realtime_motion_graph_web/web/.env.local.example
@@ -1,4 +1,9 @@
-# Engine WebSocket base URL. The HTTP routes (/api/*, /fixtures/*, /loras/*,
-# /videos/*) are proxied by next.config.ts rewrites so they don't need an env
-# var, but the WebSocket connection bypasses Next.js entirely.
-NEXT_PUBLIC_POD_BASE_URL=http://localhost:8765
+# Engine base URL. The HTTP routes (/api/*, /fixtures/*, /loras/*, /videos/*)
+# are proxied by next.config.ts rewrites, but the WebSocket connection uses
+# this value directly from the browser, so it must be an address the *client*
+# can reach.
+#
+# Same machine (UI + backend on one host): the launcher sets this for you.
+# Remote client (UI on one machine, GPU server on another): set it to the
+# server's LAN address, e.g. http://10.0.0.5:1318 — NOT localhost/127.0.0.1.
+NEXT_PUBLIC_POD_BASE_URL=http://localhost:1318

--- a/demos/realtime_motion_graph_web/web/app/RTMGBoot.tsx
+++ b/demos/realtime_motion_graph_web/web/app/RTMGBoot.tsx
@@ -16,14 +16,25 @@ import type { LoraCatalogEntry } from "@demon/client";
 import type { WireContract } from "@demon/client";
 import { KNOB_SCHEMA_VERSION, PROTOCOL_VERSION } from "@demon/client";
 
-// Same-origin URL builder. The engine's HTTP routes (/api/*, /fixtures/*,
-// /loras/*, /videos/*) are proxied to the Python backend at :8765 by the
-// Next.js rewrites in next.config.ts. The WebSocket URL goes through
-// `defaultWsUrl()` which reads NEXT_PUBLIC_POD_BASE_URL — set in .env.local.
+// Engine URL builder. Builds ABSOLUTE URLs straight to the backend
+// (NEXT_PUBLIC_POD_BASE_URL) for /api/*, /fixtures/*, /loras/*, /videos/* —
+// the same host the WebSocket connects to. The backend sends
+// `Access-Control-Allow-Origin: *`, so the cross-origin fetch is allowed.
 //
-// Configured at module load (top-level, not in useEffect) so it's ready
-// before any child component's mount-time fetch fires.
-setEngineUrlBuilder((path) => (path.startsWith("/") ? path : `/${path}`));
+// We deliberately do NOT rely on next.config.ts rewrites to proxy these:
+// the dev bundler doesn't reliably forward them, which surfaces as 404s on
+// /api/* even though the engine serves them fine over curl. Going direct to
+// the backend makes the remote client/server case "just work" once
+// NEXT_PUBLIC_POD_BASE_URL points at the server (see run.py --client-host).
+//
+// Falls back to a same-origin relative path when the base URL is unset (the
+// old rewrite path). Configured at module load (top-level, not in useEffect)
+// so it's ready before any child component's mount-time fetch fires.
+const _engineBase = (process.env.NEXT_PUBLIC_POD_BASE_URL ?? "").replace(/\/$/, "");
+setEngineUrlBuilder((path) => {
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return _engineBase ? `${_engineBase}${p}` : p;
+});
 
 // Fire the config + LoRA catalog fetches in parallel and await both
 // before applyConfig(). listLoras' side effect writes the server's

--- a/demos/realtime_motion_graph_web/web/next.config.ts
+++ b/demos/realtime_motion_graph_web/web/next.config.ts
@@ -11,7 +11,18 @@ const backendUrl = (
   process.env.NEXT_PUBLIC_POD_BASE_URL ?? "http://127.0.0.1:1318"
 ).replace(/\/$/, "");
 
+function backendHostname(): string | null {
+  try {
+    return new URL(backendUrl).hostname;
+  } catch {
+    return null;
+  }
+}
+
+const devOriginHost = backendHostname();
+
 const nextConfig: NextConfig = {
+  ...(devOriginHost ? { allowedDevOrigins: [devOriginHost] } : {}),
   async rewrites() {
     return [
       { source: "/api/:path*", destination: `${backendUrl}/api/:path*` },


### PR DESCRIPTION
## Problem

Running the realtime demo with the UI on one machine and the GPU server on another doesn't work out of the box, and the failure is opaque: the dev server returns **404 on `/api/fixtures` / `/api/loras`** even though the engine serves them fine (`curl http://<server>:1318/api/fixtures` works). That's the Next.js rewrites proxying to a wrong/unreachable base URL — not an engine bug. ([repro from a user trying exactly this](https://github.com/daydreamlive/DEMON) — headless GPU box + separate client.)

Two root causes:

1. **`run.py` forces `NEXT_PUBLIC_POD_BASE_URL` to the local backend** (and maps `--host 0.0.0.0` → `127.0.0.1`). That env var is read **at startup** by `next.config.ts` for the rewrites *and* used **client-side** by the browser for the WebSocket. So the obvious knob (`.env.local`) is silently overridden, and the browser's WS points at `127.0.0.1` (= the *client*, not the server).
2. **`web/.env.local.example` shipped `:8765`** — the demo backend is `:1318`, so anyone who copies it gets `/api/*` 404s.

## Changes

- **`run.py`**: add `--client-host` for the browser-facing address; respect an explicitly pre-set `NEXT_PUBLIC_POD_BASE_URL`; bind the dev server to all interfaces when remote (`-H 0.0.0.0`); print the resolved base URL and warn when it still points at localhost; fix the "Open …" banner to show the right host.
- **`web/.env.local.example`**: correct the port to `:1318` and document the remote case in the comment.
- **`README.md`**: add a short "Remote / headless server" section (bind `0.0.0.0`, set `--client-host`, open both ports, restart after config changes).

## Usage after this

```bash
# server with GPU:
uv run python -u -m demos.realtime_motion_graph_web.run \
  --host 0.0.0.0 --client-host 10.0.0.5
# open http://10.0.0.5:6660 from the client
```

Same-machine usage is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)