### PR TITLE
fix(stream): silence latent off-by-one crashes source swap to short/o…

### DIFF
--- a/acestep/nodes/vae_nodes.py
+++ b/acestep/nodes/vae_nodes.py
@@ -708,6 +708,15 @@ class EmptyLatent(BaseNode):
                     description="Duration (s)",
                     min=1.0, max=600.0, step=1.0,
                 ),
+                NodeParam(
+                    name="frames", type="number", default=0,
+                    description=(
+                        "Exact latent frame count (0 = derive from duration). "
+                        "Set by the streaming runner to avoid the "
+                        "duration round-trip dropping a frame."
+                    ),
+                    hidden=True,
+                ),
             ),
         )
 
@@ -719,7 +728,18 @@ class EmptyLatent(BaseNode):
         handler._ensure_silence_latent_on_device()
         silence = handler.silence_latent  # [1, T_full, D]
 
-        T = int(duration * 25)  # 25 fps latent rate
+        # Frame count: prefer an explicit integer ``frames`` (exact — used by
+        # the streaming runner so the silence latent matches the source
+        # latent's T exactly). Fall back to deriving it from ``duration``,
+        # using round() rather than truncation: int(duration * 25) drops a
+        # frame for durations whose frame count round-trips just under an
+        # integer (e.g. 410 frames -> 16.4s -> int(409.9999...) == 409),
+        # which then can't blend against a real 410-frame context latent.
+        frames = kwargs.get("frames") or 0
+        if frames:
+            T = int(frames)
+        else:
+            T = int(round(duration * 25))  # 25 fps latent rate
         # Take first T frames from the silence latent (tiled if needed)
         if silence.dim() == 3:
             latent = silence[:, :T, :].clone()

--- a/acestep/streaming/pipeline_runner.py
+++ b/acestep/streaming/pipeline_runner.py
@@ -309,7 +309,7 @@ class PipelineRunner:
         walk_active = self.walk_window and full_src_T > self.walk_window_T
         T_frames = self.walk_window_T if walk_active else full_src_T
         self._silence_latent = EmptyLatent().execute(
-            model=self.stream.model, duration=T_frames / 25.0,
+            model=self.stream.model, frames=T_frames,
         )["latent"]
 
     def _decode_advance_s(self) -> float:


### PR DESCRIPTION
…dd-length clips

Swapping the streaming source mid-session to a clip whose latent frame count T satisfies int(T/25.0 * 25) != T crashed the pipeline with:

  The size of tensor a (409) must match the size of tensor b (410)
  at non-singleton dimension 1

in LatentBlend, when hint-strength blending mixes the silence latent with the source's context latent. This hits ~5% of clip lengths (e.g. a 16.4s / 410-frame mic recording -> int(16.4*25) == 409), so arbitrary user recordings and loops trip it.

Root cause: PipelineRunner._rebuild_silence_latent sized the silence latent by round-tripping the source frame count through seconds (T_frames / 25.0) into EmptyLatent, which converted back with T = int(duration * 25). Float truncation drops one frame for many durations, leaving silence at T-1 while the context latent is T.

Fix:
- EmptyLatent accepts an exact integer `frames` (hidden NodeParam); the duration fallback now uses round() instead of truncation.
- _rebuild_silence_latent passes the source's exact frame count.

Verified by reproducing the exact error on the old path and confirming the blend succeeds for every 1..2000-frame source on the new path.