### PR TITLE
fix(rtmg): reserve config tooltip space on mobile

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -2543,6 +2543,9 @@ body.drawer-open .hud-help-readout {
   gap: 8px;
   align-items: center;
 }
+.operator-config-readout {
+  display: none;
+}
 .install-section-operator .ws-url-input { width: 220px; }
 /* Density toggle anchors the right cluster — its margin-left: auto pushes
    itself plus the trailing pause button to the far right of the row. */
@@ -5937,6 +5940,36 @@ body.curve-open #install-video-area #graph {
   gap: 10px;
 }
 .mobile-sheet-section .install-section-operator > * { width: 100%; }
+@media (max-width: 768px), (max-height: 500px) and (orientation: landscape) {
+  .mobile-sheet-section .operator-config-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: stretch;
+  }
+  .mobile-sheet-section .operator-config-actions .pause-btn {
+    width: 100%;
+  }
+  .mobile-sheet-section .operator-config-actions [data-dd-tooltip]::after {
+    display: none !important;
+  }
+  .mobile-sheet-section .operator-config-readout {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-height: 56px;
+    margin: 2px 0 0;
+    padding: 9px 10px;
+    border: 1px solid var(--frame-line);
+    border-radius: var(--radius-sm);
+    background: rgba(8, 8, 14, 0.55);
+    color: var(--text-dim);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+  .mobile-sheet-section .operator-config-readout-item {
+    display: block;
+  }
+}
 /* Stack prompts vertically on mobile — the desktop layout is a single
    row (Prompt A | blend | Prompt B | Send) that crushes textareas to
    ~30px wide at 414px viewport. */

--- a/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
@@ -37,6 +37,10 @@ import { MidiBadge } from "./MidiBadge";
 // to the legacy format.
 type DemonExport = RtmgConfig & { inputs?: SerializedInputs };
 
+const IMPORT_CONFIG_TOOLTIP = "Import config from JSON";
+const EXPORT_CONFIG_TOOLTIP =
+  "Download current config as JSON (optionally with input audio)";
+
 // Show a transient status message that clears itself after 2s — unless a
 // newer message replaced it meanwhile. Used for the import/export toasts,
 // which otherwise stuck on screen indefinitely.
@@ -393,11 +397,12 @@ export function OperatorStrip() {
 
       <section className="operator-section">
         <h3 className="operator-section-label">Config</h3>
-        <div className="operator-row">
+        <div className="operator-row operator-config-actions">
           <button
             type="button"
             className="pause-btn"
-            data-dd-tooltip="Import config from JSON"
+            data-dd-tooltip={IMPORT_CONFIG_TOOLTIP}
+            aria-describedby="operator-config-import-readout"
             aria-label="Import config"
             onClick={() => configFileInputRef.current?.click()}
           >
@@ -406,7 +411,8 @@ export function OperatorStrip() {
           <button
             type="button"
             className="pause-btn"
-            data-dd-tooltip="Download current config as JSON (optionally with input audio)"
+            data-dd-tooltip={EXPORT_CONFIG_TOOLTIP}
+            aria-describedby="operator-config-export-readout"
             aria-label="Export config"
             onClick={openExportDialog}
           >
@@ -423,6 +429,20 @@ export function OperatorStrip() {
               if (file) void onConfigFilePicked(file);
             }}
           />
+        </div>
+        <div className="operator-config-readout">
+          <span
+            id="operator-config-import-readout"
+            className="operator-config-readout-item"
+          >
+            {IMPORT_CONFIG_TOOLTIP}
+          </span>
+          <span
+            id="operator-config-export-readout"
+            className="operator-config-readout-item"
+          >
+            {EXPORT_CONFIG_TOOLTIP}
+          </span>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Fixes #192 by giving the full-screen mobile Config controls a reserved tooltip/readout area instead of relying on hover/focus pseudo-tooltips that get cramped in the sheet layout.

The Import and Export buttons now share named tooltip strings with the readout text, so the visible mobile copy stays in sync with the existing desktop tooltip content. The readout is hidden by default and only shown inside `.mobile-sheet-section` at the same responsive breakpoint used for the mobile sheet, preserving the desktop drawer layout.

I also make the two Config buttons fill a simple two-column row in the mobile sheet and suppress their pseudo-tooltip there, avoiding the obfuscated overlay while keeping the button labels and accessible descriptions intact.

Verification:
- `npm ci`
- `npm run typecheck`
- `git diff --check`
