### PR TITLE
fix(rtmg/web): narrow pcmFrame return type to Uint8Array<ArrayBuffer>

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
@@ -223,7 +223,13 @@ async function resolveUploadWsUrl(): Promise<string> {
   return url;
 }
 
-function pcmFrame(decoded: DecodedFixture): Uint8Array {
+// Returns Uint8Array<ArrayBuffer> (not the wider Uint8Array<ArrayBufferLike>
+// that's the default in TS 5.7+'s libdom) so ws.send accepts it without
+// a cast — BufferSource excludes SharedArrayBuffer-backed views, and
+// the `new Uint8Array(byteLength)` allocation here is always ArrayBuffer-
+// backed. Without the narrow return type, consumers compiling on TS
+// 5.7+ hit "Uint8Array<ArrayBufferLike> not assignable to BufferSource".
+function pcmFrame(decoded: DecodedFixture): Uint8Array<ArrayBuffer> {
   const hdr = new ArrayBuffer(8);
   const dv = new DataView(hdr);
   dv.setUint32(0, decoded.channels, true);


### PR DESCRIPTION
## Summary

TS 5.7+ widened `Uint8Array`'s default buffer generic to `ArrayBufferLike`, which transitively includes `SharedArrayBuffer`. `WebSocket.send`'s `BufferSource` parameter excludes shared-buffer-backed views, so consumers compiling on TS 5.7+ hit:

```
error TS2345: Argument of type 'Uint8Array<ArrayBufferLike>' is not
assignable to parameter of type 'string | Blob | BufferSource'.
```

The `Uint8Array` `pcmFrame` allocates is always ArrayBuffer-backed (`new Uint8Array(byteLength)`), so narrowing the return type to `Uint8Array<ArrayBuffer>` is accurate and unblocks `ws.send(pcmFrame(decoded))` without an `as` cast at the call site.

## How we found it

While syncing this DEMON tree into [daydreamlive/demon-public-demo#303](https://github.com/daydreamlive/demon-public-demo/pull/303). That repo's tsc passes on the previous vendor SHA but fails on this one; Vercel build fails the type-check pass and blocks the deploy.

## Test plan

- [ ] `tsc --noEmit` passes from `demos/realtime_motion_graph_web/web/`
- [ ] Runtime behaviour unchanged — the Uint8Array allocation is byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)