### PR TITLE
fix: tooltip box resizing

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -2389,8 +2389,11 @@ body.drawer-open {
 .drawer-help-bar {
   flex: 0 0 auto;
   margin-top: auto;
-  min-height: 88px;
-  max-height: 28vh;
+  /* Fixed height, NOT content-driven. A band that grew/shrank with the
+     hovered control's description length would resize the control grid
+     above it on every hover — a constant stutter. Keep it constant and
+     let a rare long description scroll inside (overflow-y below). */
+  height: 92px;
   padding: 10px 12px 11px;
   border-top: 1px solid var(--frame-line);
   background: rgba(8, 8, 14, 0.55);
@@ -2399,6 +2402,13 @@ body.drawer-open {
   flex-direction: column;
   gap: 4px;
   overflow-y: auto;
+}
+/* Spread (all-controls) layout is far wider, so descriptions wrap to
+   one or two lines instead of the three-plus the narrow tabbed panel
+   needs. Reserve a shorter fixed band there so the help strip doesn't
+   eat grid height it no longer needs. */
+.install-sheet--spread .drawer-help-bar {
+  height: 58px;
 }
 .drawer-help-bar--active {
   background: rgba(12, 12, 20, 0.7);
@@ -2423,30 +2433,6 @@ body.drawer-open {
   color: var(--text-dim);
   font-style: italic;
   margin: 0;
-}
-/* Overlay variant — used by the drawer's spread (all-controls) layout
-   so the bar floats over the bottom of the panel without stealing
-   grid height. Only mounted while the user is actively hovering a
-   tooltipped control (see DrawerHelpBar's `spread` prop), so there's
-   no idle chrome over the section grid. The right edge stops before
-   the 32px edge-handle column so the handle and the spread-toggle
-   pinned inside it stay clickable. */
-.drawer-help-bar--overlay {
-  position: absolute;
-  left: 0;
-  right: 32px;
-  bottom: 0;
-  margin-top: 0;
-  flex: none;
-  min-height: 0;
-  max-height: 25%;
-  background: rgba(8, 8, 14, 0.78);
-  -webkit-backdrop-filter: blur(6px);
-          backdrop-filter: blur(6px);
-  border-radius: 0 0 0 var(--radius-md);
-  /* Above the section grid (no explicit z-index → auto) but below the
-     edge handle and the spread toggle, both of which sit at z-index 3. */
-  z-index: 2;
 }
 @media (max-width: 768px) {
   /* No drawer on mobile — the help bar lives in the desktop install

--- a/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
@@ -246,7 +246,7 @@ export function AdvancedDrawer({ savedTab, unsavedDot }: Props = {}) {
         >
           {spread ? renderAllSections(savedTab) : renderTabBody(activeTab, savedTab)}
         </div>
-        <DrawerHelpBar spread={spread} />
+        <DrawerHelpBar />
       </div>
     </aside>
   );

--- a/demos/realtime_motion_graph_web/web/components/Performance/DrawerHelpBar.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/DrawerHelpBar.tsx
@@ -12,30 +12,22 @@ import { useTooltipHover } from "@/hooks/useTooltipHover";
 // tooltip to appear. Acts as the panel's "info strip" — same role as
 // the readout band on the bottom of a Sound Particles plugin.
 //
-// In spread (all-controls) mode the static info strip would eat the
-// grid height the layout exists to maximise. So in that mode the bar
-// renders only while actively hovering something, with overlay
-// positioning (see .drawer-help-bar--overlay) so it floats over the
-// bottom of the panel instead of pushing the grid up.
+// Reserves a fixed band at the bottom in BOTH the tabbed and spread
+// (all-controls) layouts, so it never overlays the lowest controls —
+// the Config section's CONFIG / IMPORT / EXPORT buttons sit at the
+// bottom in spread mode and an overlay variant used to cover them. The
+// band always renders (showing the idle hint when nothing is hovered)
+// so toggling hover never reflows the grid.
 
-interface DrawerHelpBarProps {
-  /** When true, render as a floating overlay that only appears while
-   *  the user is actively hovering a tooltipped control. Used by the
-   *  drawer's spread/all-controls layout. */
-  spread?: boolean;
-}
-
-export function DrawerHelpBar({ spread = false }: DrawerHelpBarProps) {
+export function DrawerHelpBar() {
   const barRef = useRef<HTMLDivElement | null>(null);
   const getRoot = useCallback(() => document.getElementById("install-sheet"), []);
   const { title, text } = useTooltipHover({ getRoot, selfRef: barRef });
 
-  if (spread && !text) return null;
-
   return (
     <div
       ref={barRef}
-      className={`drawer-help-bar${text ? " drawer-help-bar--active" : ""}${spread ? " drawer-help-bar--overlay" : ""}`}
+      className={`drawer-help-bar${text ? " drawer-help-bar--active" : ""}`}
       role="status"
       aria-live="polite"
     >


### PR DESCRIPTION
this fixes the tooltip boxes so that the content in them scrolls, as opposed to forcing a resize of all the other controls in the view