### PR TITLE
Preserve app path in server-info probe

### DIFF
--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -56,7 +56,8 @@ async function probeServerSideFixtures(wsUrl: string): Promise<string[]> {
   try {
     const u = new URL(wsUrl);
     u.protocol = u.protocol === "wss:" ? "https:" : "http:";
-    u.pathname = "/api/server-info";
+    const basePath = u.pathname.replace(/\/+$/, "");
+    u.pathname = `${basePath}/api/server-info`;
     u.search = "";
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), 4000);


### PR DESCRIPTION
Keep the WebSocket URL pathname when probing /api/server-info. Helps with Livepeer orchestrator integration where the base URLs look like the following:

https://<orchestrator-uri>/apps/demon/app/