### PR TITLE
feat: add websocket startup telemetry

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/engine/protocol.ts
@@ -21,6 +21,7 @@ import {
   SLICE_FLAG_DELTA,
   SLICE_HDR_SIZE,
   type AudioSlice,
+  type InitAckMessage,
   type LoraCatalogEntry,
   type SessionConfig,
   type StemAssetsMessage,
@@ -84,6 +85,52 @@ interface PendingPayload {
   config: SessionConfig;
 }
 
+export type WsTracePhase =
+  | "idle"
+  | "connecting"
+  | "open"
+  | "config_sent"
+  | "init_ack"
+  | "ready"
+  | "streaming"
+  | "error"
+  | "closed";
+
+export interface WsTrace {
+  attemptId: string;
+  urlHost: string;
+  connectStartAt: number | null;
+  openAt: number | null;
+  configSentAt: number | null;
+  initAckAt: number | null;
+  readyAt: number | null;
+  closeAt: number | null;
+  errorAt: number | null;
+  phase: WsTracePhase;
+  ready: boolean;
+  closedByUser: boolean;
+  wsReadyState: number | null;
+  closeCode: number | null;
+  closeReason: string;
+}
+
+function makeAttemptId(): string {
+  try {
+    if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+      return crypto.randomUUID();
+    }
+  } catch {}
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function hostFromWsUrl(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return "";
+  }
+}
+
 export class RemoteBackend extends EventTarget {
   readonly url: string;
   ws: WebSocket | null = null;
@@ -118,6 +165,12 @@ export class RemoteBackend extends EventTarget {
    *  report their hidden_states batch_max; eager / compile pin to 4.
    *  Null until ready. */
   maxPipelineDepth: number | null = null;
+  /** Browser-observed WS lifecycle for this concrete connection attempt. */
+  wsTrace: WsTrace;
+  /** Pod-side session id from the optional init_ack telemetry message. */
+  backendSessionId: string | null = null;
+  /** Client id echoed in init_ack; mirrors the config client_id. */
+  backendClientId: string | null = null;
 
   private _pending: PendingPayload | null;
   private _pendingSwap: SwapReadyMessage | null = null;
@@ -146,7 +199,48 @@ export class RemoteBackend extends EventTarget {
     super();
     this.url = url;
     this._pending = { interleaved, channels, config };
+    this.wsTrace = {
+      attemptId: makeAttemptId(),
+      urlHost: hostFromWsUrl(url),
+      connectStartAt: null,
+      openAt: null,
+      configSentAt: null,
+      initAckAt: null,
+      readyAt: null,
+      closeAt: null,
+      errorAt: null,
+      phase: "idle",
+      ready: false,
+      closedByUser: false,
+      wsReadyState: null,
+      closeCode: null,
+      closeReason: "",
+    };
     this._initDecoderWorker();
+  }
+
+  private _snapshotTrace(): WsTrace {
+    return { ...this.wsTrace };
+  }
+
+  private _updateTrace(patch: Partial<WsTrace>): WsTrace {
+    this.wsTrace = {
+      ...this.wsTrace,
+      ...patch,
+      ready: this.ready,
+      closedByUser: this.closedByUser,
+      wsReadyState: this.ws?.readyState ?? null,
+    };
+    const snapshot = this._snapshotTrace();
+    try {
+      useSessionStore.getState().setLastWsTrace(snapshot);
+    } catch {}
+    this.dispatchEvent(new CustomEvent("ws_trace_update", { detail: snapshot }));
+    return snapshot;
+  }
+
+  getWsTrace(): WsTrace {
+    return this._snapshotTrace();
   }
 
   private _initDecoderWorker(): void {
@@ -197,11 +291,24 @@ export class RemoteBackend extends EventTarget {
       const ws = new WebSocket(this.url);
       ws.binaryType = "arraybuffer";
       this.ws = ws;
+      this._updateTrace({
+        connectStartAt: Date.now(),
+        openAt: null,
+        configSentAt: null,
+        initAckAt: null,
+        readyAt: null,
+        closeAt: null,
+        errorAt: null,
+        phase: "connecting",
+        closeCode: null,
+        closeReason: "",
+      });
 
       let phase: Phase = "config";
 
       ws.onopen = () => {
         if (!this._pending) return;
+        this._updateTrace({ openAt: Date.now(), phase: "open" });
         // Phase 1: JSON config, then (unless server-side fixture) the
         // binary audio upload. For known fixtures the pod loads the
         // waveform from its own cache, so re-uploading ~20 MB of PCM
@@ -225,6 +332,7 @@ export class RemoteBackend extends EventTarget {
           combined.set(pcm, hdr.byteLength);
           ws.send(combined);
         }
+        this._updateTrace({ configSentAt: Date.now(), phase: "config_sent" });
         phase = "ready";
       };
 
@@ -232,7 +340,23 @@ export class RemoteBackend extends EventTarget {
         if (phase === "ready") {
           try {
             const msg = JSON.parse(ev.data as string);
+            if (msg.type === "init_ack") {
+              const ack = msg as InitAckMessage;
+              this.backendSessionId =
+                typeof ack.session_id === "string" ? ack.session_id : null;
+              this.backendClientId =
+                typeof ack.client_id === "string" ? ack.client_id : null;
+              {
+                const s = useSessionStore.getState();
+                s.setLastBackendSessionId(this.backendSessionId);
+                s.setLastBackendClientId(this.backendClientId);
+              }
+              this._updateTrace({ initAckAt: Date.now(), phase: "init_ack" });
+              this.dispatchEvent(new CustomEvent("ws_init_ack", { detail: ack }));
+              return;
+            }
             if (msg.type === "error") {
+              this._updateTrace({ errorAt: Date.now(), phase: "error" });
               reject(
                 new Error(
                   msg.message || `Server error: ${msg.code || "unknown"}`,
@@ -241,6 +365,7 @@ export class RemoteBackend extends EventTarget {
               return;
             }
             if (msg.type !== "ready") {
+              this._updateTrace({ errorAt: Date.now(), phase: "error" });
               reject(new Error(`Unexpected init message: ${ev.data}`));
               return;
             }
@@ -273,6 +398,7 @@ export class RemoteBackend extends EventTarget {
             }
             phase = "initial-buffer";
           } catch (e) {
+            this._updateTrace({ errorAt: Date.now(), phase: "error" });
             reject(e);
           }
           return;
@@ -282,10 +408,12 @@ export class RemoteBackend extends EventTarget {
           const u16 = new Uint16Array(ev.data as ArrayBuffer);
           this.initialBuffer = float16ArrayToFloat32(u16);
           this.ready = true;
+          this._updateTrace({ readyAt: Date.now(), phase: "ready" });
           phase = "streaming";
           this._pending = null;
           resolve(this);
           this.dispatchEvent(new CustomEvent("ready"));
+          this._updateTrace({ phase: "streaming" });
           return;
         }
 
@@ -457,6 +585,10 @@ export class RemoteBackend extends EventTarget {
 
       ws.onerror = (e) => {
         console.error("[protocol] ws error", e);
+        const trace = this._updateTrace({
+          errorAt: Date.now(),
+          phase: this.ready ? this.wsTrace.phase : "error",
+        });
         if (!this.ready) {
           reject(
             new Error(
@@ -464,6 +596,7 @@ export class RemoteBackend extends EventTarget {
             ),
           );
         }
+        this.dispatchEvent(new CustomEvent("ws_connect_error", { detail: trace }));
         this.dispatchEvent(new CustomEvent("error", { detail: e }));
       };
 
@@ -489,6 +622,13 @@ export class RemoteBackend extends EventTarget {
           }
           reject(new Error(msg));
         }
+        const trace = this._updateTrace({
+          closeAt: Date.now(),
+          phase: "closed",
+          closeCode: e.code,
+          closeReason: e.reason || "",
+        });
+        this.dispatchEvent(new CustomEvent("ws_close", { detail: trace }));
         this.dispatchEvent(new CustomEvent("close", { detail: e }));
       };
     });
@@ -935,6 +1075,7 @@ export class RemoteBackend extends EventTarget {
 
   close(): void {
     this.closedByUser = true;
+    this._updateTrace({ closedByUser: true });
     try {
       this.ws?.close();
     } catch {}
@@ -986,6 +1127,13 @@ export class RemoteBackend extends EventTarget {
       } catch {}
     }
     this.ws = null;
+    const trace = this._updateTrace({
+      closeAt: Date.now(),
+      phase: "closed",
+      closeCode: code,
+      closeReason: reason,
+    });
+    this.dispatchEvent(new CustomEvent("ws_close", { detail: trace }));
     // Build a CloseEvent shaped like the real thing. CloseEvent isn't
     // always constructible in older environments, so fall back to a
     // plain Event with the relevant fields glued on.

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -118,6 +118,7 @@ function buildConfig(
   // omitted; demon-public-demo wires PostHog's distinct_id).
   const clientId = getClientId();
   return {
+    telemetry_version: 1,
     sde: cfg.sde,
     lora: cfg.lora,
     depth: cfg.depth,

--- a/demos/realtime_motion_graph_web/web/store/useSessionStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useSessionStore.ts
@@ -4,7 +4,7 @@ import { create } from "zustand";
 
 import type { AudioPlayer } from "@/engine/audio/AudioPlayer";
 import type { NetworkMonitor } from "@/engine/networkMonitor";
-import type { RemoteBackend } from "@/engine/protocol";
+import type { RemoteBackend, WsTrace } from "@/engine/protocol";
 import type { WsReconnector } from "@/engine/wsReconnect";
 
 // Live-session lifecycle state. The non-serializable RemoteBackend +
@@ -49,6 +49,13 @@ interface SessionState {
   /** Server-imposed ceiling on ``pipelineDepth`` — TRT engine batch_max
    *  for TRT decoders, 4 for eager / compile. Null until ready. */
   maxPipelineDepth: number | null;
+  /** Latest browser-observed WS trace, including orphan remotes that
+   *  failed before setSession() could publish them. */
+  lastWsTrace: WsTrace | null;
+  /** Pod-side session id from optional init_ack telemetry. */
+  lastBackendSessionId: string | null;
+  /** Client id echoed by init_ack. */
+  lastBackendClientId: string | null;
 
   setStatus: (status: SessionStatus, message?: string) => void;
   setSession: (remote: RemoteBackend | null, player: AudioPlayer | null) => void;
@@ -58,6 +65,9 @@ interface SessionState {
   setCheckpointScale: (scale: string | null) => void;
   setPipelineDepth: (depth: number | null) => void;
   setMaxPipelineDepth: (max: number | null) => void;
+  setLastWsTrace: (trace: WsTrace | null) => void;
+  setLastBackendSessionId: (id: string | null) => void;
+  setLastBackendClientId: (id: string | null) => void;
   reset: () => void;
 }
 
@@ -72,6 +82,9 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   checkpointScale: null,
   pipelineDepth: null,
   maxPipelineDepth: null,
+  lastWsTrace: null,
+  lastBackendSessionId: null,
+  lastBackendClientId: null,
 
   setStatus: (status, message = "") => set({ status, message }),
   setSession: (remote, player) => set({ remote, player }),
@@ -81,6 +94,9 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   setCheckpointScale: (scale) => set({ checkpointScale: scale }),
   setPipelineDepth: (depth) => set({ pipelineDepth: depth }),
   setMaxPipelineDepth: (max) => set({ maxPipelineDepth: max }),
+  setLastWsTrace: (trace) => set({ lastWsTrace: trace }),
+  setLastBackendSessionId: (id) => set({ lastBackendSessionId: id }),
+  setLastBackendClientId: (id) => set({ lastBackendClientId: id }),
   reset: () => {
     try {
       get().monitor?.stop();
@@ -97,6 +113,9 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       reconnector: null,
       pipelineDepth: null,
       maxPipelineDepth: null,
+      lastWsTrace: null,
+      lastBackendSessionId: null,
+      lastBackendClientId: null,
       // checkpointScale survives reset on purpose: the server's
       // checkpoint doesn't change across sessions, and pre-fetching
       // it from /api/loras lets the library filter render correctly

--- a/demos/realtime_motion_graph_web/web/types/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/types/protocol.ts
@@ -55,7 +55,9 @@ export interface LoraCatalogEntry {
 export interface SessionConfig {
   /** Opt-in version for optional browser/backend telemetry messages.
    *  Servers only emit telemetry-only messages such as ``init_ack`` when
-   *  this is present, keeping old clients compatible with new pods. */
+   *  this is present, keeping old clients compatible with new pods.
+   *  In the standalone DEMON app this trace stays browser-local; hosts
+   *  that embed the UI may choose to consume/report it downstream. */
   telemetry_version?: number;
   sde?: boolean;
   lora?: boolean;

--- a/demos/realtime_motion_graph_web/web/types/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/types/protocol.ts
@@ -53,6 +53,10 @@ export interface LoraCatalogEntry {
 
 /** Sent by the client at session start (config phase). */
 export interface SessionConfig {
+  /** Opt-in version for optional browser/backend telemetry messages.
+   *  Servers only emit telemetry-only messages such as ``init_ack`` when
+   *  this is present, keeping old clients compatible with new pods. */
+  telemetry_version?: number;
   sde?: boolean;
   lora?: boolean;
   depth?: number;
@@ -89,6 +93,14 @@ export interface SessionConfig {
   client_id?: string;
   // Allow extras — pyproject's config object is permissive.
   [k: string]: unknown;
+}
+
+/** Optional server acknowledgement emitted after config parse and log
+ *  context binding, before expensive audio/model init work starts. */
+export interface InitAckMessage {
+  type: "init_ack";
+  session_id?: string;
+  client_id?: string | null;
 }
 
 /** First JSON the server returns once the audio upload is in. */

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -333,6 +333,12 @@ def _handle_client_body(
         "session_init config_keys={} client_id={}",
         sorted(config_dict.keys()), _client_id,
     )
+    if config_dict.get("telemetry_version"):
+        ws.send(json.dumps({
+            "type": "init_ack",
+            "session_id": session_id,
+            "client_id": _client_id,
+        }))
 
     _t0 = time.monotonic()
     _first_slice = [False]


### PR DESCRIPTION
Add browser-side WebSocket lifecycle tracing and an optional init_ack from the backend so client startup failures can be correlated with pod logs.

The client now records connect/open/config/ack/ready/error/close timing per attempt, stores orphan pre-ready traces in session state, and opts into telemetry with telemetry_version=1. The backend replies with init_ack only for opted-in clients after it binds session_id/client_id context, preserving old-client compatibility.