### PR TITLE
make sessions fully transactional with cleanup

### DIFF
--- a/acestep/engine/model_context.py
+++ b/acestep/engine/model_context.py
@@ -80,18 +80,26 @@ class ModelContext:
         self._offload_text_encoder = False
         self._diffusion_engine = None
 
-        self._load_models(
-            project_root=project_root,
-            config_path=config_path,
-            device=device,
-            compile_decoder=compile_decoder,
-            compile_vae=compile_vae,
-            use_flash_attention=use_flash_attention,
-            offload_text_encoder=offload_text_encoder,
-            prefer_source=prefer_source,
-            skip_decoder=skip_decoder,
-            skip_vae=skip_vae,
-        )
+        try:
+            self._load_models(
+                project_root=project_root,
+                config_path=config_path,
+                device=device,
+                compile_decoder=compile_decoder,
+                compile_vae=compile_vae,
+                use_flash_attention=use_flash_attention,
+                offload_text_encoder=offload_text_encoder,
+                prefer_source=prefer_source,
+                skip_decoder=skip_decoder,
+                skip_vae=skip_vae,
+            )
+        except Exception:
+            logger.warning(
+                "model_context_load_failed_cleanup checkpoint={} device={}",
+                config_path, device,
+            )
+            self._cleanup_after_failed_load()
+            raise
 
     def close(self) -> None:
         """Release model weights + diffusion engine.
@@ -127,6 +135,17 @@ class ModelContext:
                      "text_tokenizer", "silence_latent", "config",
                      "_pending_decoder"):
             setattr(self, attr, None)
+
+    def _cleanup_after_failed_load(self) -> None:
+        """Release partially constructed model state after __init__ fails."""
+        import gc
+
+        try:
+            self.close()
+        finally:
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
 
     # ------------------------------------------------------------------
     # Initialization

--- a/acestep/engine/session.py
+++ b/acestep/engine/session.py
@@ -192,6 +192,11 @@ class Session:
             validate_backends,
         )
 
+        self.model = None  # type: ignore[assignment]
+        self.clip = None  # type: ignore[assignment]
+        self.vae = None  # type: ignore[assignment]
+        self._trt_vae_engine_paths = ()
+
         trt_engines = validate_backends(
             decoder_backend=decoder_backend,
             vae_backend=vae_backend,
@@ -237,86 +242,94 @@ class Session:
             decoder_backend=decoder_backend, vae_backend=vae_backend
         )
 
-        ctx = ModelContext(
-            project_root=project_root,
-            config_path=config_path,
-            device=device,
-            use_flash_attention=use_flash_attention,
-            offload_to_cpu=offload_to_cpu,
-            offload_text_encoder=offload_text_encoder,
-            quantization=quantization,
-            **ctx_flags,
-        )
-
-        self.model = ModelHandle(handler=ctx)
-        self.clip = CLIPHandle(handler=ctx)
-        self.vae = VAEHandle(handler=ctx)
-
-        # Windowed VAE decode config (seconds; 0 = full decode).
-        # Hard-clamp positive windows to the engine-supported range so
-        # the auto-selected windowed engine is never asked to decode a
-        # chunk longer than its profile max. <= 0 is the disable
-        # sentinel and stays as-is.
-        if vae_window > 0:
-            from acestep.paths import WINDOWED_VAE_WINDOW_RANGE_S
-            lo, hi = WINDOWED_VAE_WINDOW_RANGE_S
-            vae_window = max(lo, min(hi, vae_window))
-        self._vae_window = vae_window
-        self._vae_overlap = vae_overlap
-
-        # Auto-select the windowed VAE decode engine when windowing is
-        # active. Saves ~7.7 GB of TRT workspace at context-creation
-        # time vs the canonical 240s engine (see
-        # scripts/benchmarks/bench_vae_decode_profiles.py). Falls back
-        # silently to whatever the caller passed in when the windowed
-        # engine isn't built yet.
-        if vae_window > 0 and vae_backend == "tensorrt" and "vae_decode" in trt_engines:
-            from acestep.paths import (
-                available_windowed_vae_decode_engine,
-                looks_like_dreamvae_engine,
-                windowed_vae_decode_engine_name,
+        try:
+            ctx = ModelContext(
+                project_root=project_root,
+                config_path=config_path,
+                device=device,
+                use_flash_attention=use_flash_attention,
+                offload_to_cpu=offload_to_cpu,
+                offload_text_encoder=offload_text_encoder,
+                quantization=quantization,
+                **ctx_flags,
             )
-            from loguru import logger as _log
 
-            current = trt_engines["vae_decode"]
-            is_dreamvae = looks_like_dreamvae_engine(current)
-            windowed = available_windowed_vae_decode_engine(dreamvae=is_dreamvae)
-            if windowed is not None and str(windowed) != current:
-                _log.info(
-                    "vae_window={:.1f}s active: swapping vae_decode engine "
-                    "{} -> {}", vae_window,
-                    Path(current).stem, windowed.stem,
+            self.model = ModelHandle(handler=ctx)
+            self.clip = CLIPHandle(handler=ctx)
+            self.vae = VAEHandle(handler=ctx)
+
+            # Windowed VAE decode config (seconds; 0 = full decode).
+            # Hard-clamp positive windows to the engine-supported range so
+            # the auto-selected windowed engine is never asked to decode a
+            # chunk longer than its profile max. <= 0 is the disable
+            # sentinel and stays as-is.
+            if vae_window > 0:
+                from acestep.paths import WINDOWED_VAE_WINDOW_RANGE_S
+                lo, hi = WINDOWED_VAE_WINDOW_RANGE_S
+                vae_window = max(lo, min(hi, vae_window))
+            self._vae_window = vae_window
+            self._vae_overlap = vae_overlap
+
+            # Auto-select the windowed VAE decode engine when windowing is
+            # active. Saves ~7.7 GB of TRT workspace at context-creation
+            # time vs the canonical 240s engine (see
+            # scripts/benchmarks/bench_vae_decode_profiles.py). Falls back
+            # silently to whatever the caller passed in when the windowed
+            # engine isn't built yet.
+            if vae_window > 0 and vae_backend == "tensorrt" and "vae_decode" in trt_engines:
+                from acestep.paths import (
+                    available_windowed_vae_decode_engine,
+                    looks_like_dreamvae_engine,
+                    windowed_vae_decode_engine_name,
                 )
-                # Don't mutate the caller's dict.
-                trt_engines = dict(trt_engines)
-                trt_engines["vae_decode"] = str(windowed)
-            elif windowed is None:
-                _log.warning(
-                    "vae_window={:.1f}s active but windowed engine not "
-                    "built ({}); using {} (will reserve more VRAM than "
-                    "necessary). Build with: python -m "
-                    "acestep.engine.trt.build --all{}",
-                    vae_window,
-                    windowed_vae_decode_engine_name(dreamvae=is_dreamvae),
-                    Path(current).stem,
-                    " --with-dreamvae" if is_dreamvae else "",
-                )
+                from loguru import logger as _log
 
-        self._trt_vae_engine_paths = tuple(
-            str(trt_engines[key])
-            for key in ("vae_encode", "vae_decode")
-            if vae_backend == "tensorrt" and key in trt_engines
-        )
+                current = trt_engines["vae_decode"]
+                is_dreamvae = looks_like_dreamvae_engine(current)
+                windowed = available_windowed_vae_decode_engine(dreamvae=is_dreamvae)
+                if windowed is not None and str(windowed) != current:
+                    _log.info(
+                        "vae_window={:.1f}s active: swapping vae_decode engine "
+                        "{} -> {}", vae_window,
+                        Path(current).stem, windowed.stem,
+                    )
+                    # Don't mutate the caller's dict.
+                    trt_engines = dict(trt_engines)
+                    trt_engines["vae_decode"] = str(windowed)
+                elif windowed is None:
+                    _log.warning(
+                        "vae_window={:.1f}s active but windowed engine not "
+                        "built ({}); using {} (will reserve more VRAM than "
+                        "necessary). Build with: python -m "
+                        "acestep.engine.trt.build --all{}",
+                        vae_window,
+                        windowed_vae_decode_engine_name(dreamvae=is_dreamvae),
+                        Path(current).stem,
+                        " --with-dreamvae" if is_dreamvae else "",
+                    )
 
-        apply_trt_backends(
-            ctx,
-            decoder_backend=decoder_backend,
-            vae_backend=vae_backend,
-            trt_engines=trt_engines,
-            device=device,
-            trt_decoder_bytes_future=trt_decoder_bytes_future,
-            lora_discovery_future=lora_discovery_future,
-        )
+            self._trt_vae_engine_paths = tuple(
+                str(trt_engines[key])
+                for key in ("vae_encode", "vae_decode")
+                if vae_backend == "tensorrt" and key in trt_engines
+            )
+
+            apply_trt_backends(
+                ctx,
+                decoder_backend=decoder_backend,
+                vae_backend=vae_backend,
+                trt_engines=trt_engines,
+                device=device,
+                trt_decoder_bytes_future=trt_decoder_bytes_future,
+                lora_discovery_future=lora_discovery_future,
+            )
+        except Exception:
+            logger.warning(
+                "session_init_failed_cleanup decoder={} vae={}",
+                decoder_backend, vae_backend,
+            )
+            self.close()
+            raise
 
     @property
     def handler(self):

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -1518,12 +1518,6 @@ class StreamingSession:
     ) -> "StreamingSession":
         """Build a ready-to-run session for one connection.
 
-        Resource ownership is transactional. Once a resource is acquired
-        below, it is immediately registered with the cleanup stack. If any
-        later startup step raises before ``StreamingSession`` exists, the
-        partial session unwinds here. On success, ownership transfers to
-        :meth:`close`.
-
         Raises:
             UnsupportedTrtCheckpointError: ``checkpoint`` isn't in any
                 registered TRT profile family.

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -518,6 +518,10 @@ class StreamingSession:
         except Exception as exc:
             logger.warning("bus_close_raised error={}", exc)
         try:
+            self.audio_eng.stop()
+        except Exception as exc:
+            logger.warning("audio_engine_stop_raised error={}", exc)
+        try:
             self.stream.close()
         except Exception as exc:
             logger.warning("stream_close_raised error={}", exc)

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -1518,6 +1518,12 @@ class StreamingSession:
     ) -> "StreamingSession":
         """Build a ready-to-run session for one connection.
 
+        Resource ownership is transactional. Once a resource is acquired
+        below, it is immediately registered with the cleanup stack. If any
+        later startup step raises before ``StreamingSession`` exists, the
+        partial session unwinds here. On success, ownership transfers to
+        :meth:`close`.
+
         Raises:
             UnsupportedTrtCheckpointError: ``checkpoint`` isn't in any
                 registered TRT profile family.

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -499,9 +499,10 @@ class StreamingSession:
             )
             self.runner_holder[0] = runner
             logger.info("pipeline_running")
-            runner.run()
-        except Exception as exc:
-            logger.opt(exception=True).error("pipeline_error error={}", exc)
+            try:
+                runner.run()
+            except Exception as exc:
+                logger.opt(exception=True).error("pipeline_error error={}", exc)
         finally:
             self.close()
 

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -464,47 +464,53 @@ class StreamingSession:
         ``state.running`` flips False, and tear down GPU state + the
         event bus.
         """
-        runner = PipelineRunner(
-            self.session, self.stream, self.audio_eng,
-            state=self.state,
-            idle_threshold_s=IDLE_PAUSE_S,
-            use_midi=True,  # always "MIDI" mode; KnobState provides values
-            use_sde=self.use_sde, use_lora=self.use_lora,
-            midi_knobs=self.virtual_knobs,
-            engine_obj=self.engine_obj,
-            vae_window=self.vae_window, crop_seconds=self.crop_seconds,
-            k1_name=self.k1_name, seed=1528, skip_threshold=5e-4,
-            on_audio_ready=self._on_audio_ready,
-            before_tick=self.apply_pending,
-            walk_window=self.walk_window,
-            walk_window_s=self.walk_window_s,
-            neg_conditioning=self.cond_negative,
-            lead_floor_s=self.config.lead_floor_s,
-            lead_ceiling_s=self.config.lead_ceiling_s,
-            lead_release_tau_s=self.config.lead_release_tau_s,
-        )
-        self.runner_holder[0] = runner
-
         try:
+            runner = PipelineRunner(
+                self.session, self.stream, self.audio_eng,
+                state=self.state,
+                idle_threshold_s=IDLE_PAUSE_S,
+                use_midi=True,  # always "MIDI" mode; KnobState provides values
+                use_sde=self.use_sde, use_lora=self.use_lora,
+                midi_knobs=self.virtual_knobs,
+                engine_obj=self.engine_obj,
+                vae_window=self.vae_window, crop_seconds=self.crop_seconds,
+                k1_name=self.k1_name, seed=1528, skip_threshold=5e-4,
+                on_audio_ready=self._on_audio_ready,
+                before_tick=self.apply_pending,
+                walk_window=self.walk_window,
+                walk_window_s=self.walk_window_s,
+                neg_conditioning=self.cond_negative,
+                lead_floor_s=self.config.lead_floor_s,
+                lead_ceiling_s=self.config.lead_ceiling_s,
+                lead_release_tau_s=self.config.lead_release_tau_s,
+            )
+            self.runner_holder[0] = runner
             logger.info("pipeline_running")
             runner.run()
         except Exception as exc:
             logger.opt(exception=True).error("pipeline_error error={}", exc)
         finally:
-            # Order matters: stream.close() drops the StreamPipeline's
-            # references into the engine before session.close()
-            # actually destroys the engine + ModelContext.
-            # session.close() ends with gc.collect() + cuda.empty_cache().
-            self.state.running = False
+            self.close()
+
+    def close(self) -> None:
+        """Tear down GPU state even when a session exits before ``run``."""
+        # Order matters: stream.close() drops the StreamPipeline's
+        # references into the engine before session.close()
+        # actually destroys the engine + ModelContext.
+        # session.close() ends with gc.collect() + cuda.empty_cache().
+        self.state.running = False
+        try:
             self.bus.close()
-            try:
-                self.stream.close()
-            except Exception as exc:
-                logger.warning("stream_close_raised error={}", exc)
-            try:
-                self.session.close()
-            except Exception as exc:
-                logger.warning("session_close_raised error={}", exc)
+        except Exception as exc:
+            logger.warning("bus_close_raised error={}", exc)
+        try:
+            self.stream.close()
+        except Exception as exc:
+            logger.warning("stream_close_raised error={}", exc)
+        try:
+            self.session.close()
+        except Exception as exc:
+            logger.warning("session_close_raised error={}", exc)
 
     def _on_audio_ready(self, wav_np, win_start=None, win_end=None):
         """Runner callback. Mutates ``audio_eng`` for full-buffer

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -36,6 +36,8 @@ serialize with ticks (``enable_lora``/``disable_lora``/``set_depth``/
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from contextlib import ExitStack
 import os
 import time
 from pathlib import Path
@@ -153,6 +155,17 @@ def _compute_max_pipeline_depth(diffusion_engine) -> int:
             exc, EAGER_MAX_PIPELINE_DEPTH,
         )
         return EAGER_MAX_PIPELINE_DEPTH
+
+
+def _cleanup_create_resource(name: str, close_fn: Callable[[], None]) -> None:
+    """Run a startup cleanup callback without masking the original failure."""
+    try:
+        close_fn()
+    except Exception as exc:
+        logger.warning(
+            "streaming_create_cleanup_raised resource={} error={}",
+            name, exc,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1631,213 +1644,231 @@ class StreamingSession:
             )
             fast_vae = False
 
-        logger.info(
-            "model_load_start decoder={} vae={} checkpoint={}",
-            decoder_backend, vae_backend, checkpoint,
-        )
-        t0 = time.time()
-        engine_session = Session(
-            project_root=str(checkpoints_dir()),
-            config_path=checkpoint,
-            decoder_backend=decoder_backend,
-            vae_backend=vae_backend,
-            offload_text_encoder=offload_text_encoder,
-            trt_engines=trt_engines,
-            vae_window=vae_window,
-        )
-        logger.info("model_loaded duration_s={:.1f}", time.time() - t0)
+        with ExitStack() as cleanup:
+            logger.info(
+                "model_load_start decoder={} vae={} checkpoint={}",
+                decoder_backend, vae_backend, checkpoint,
+            )
+            t0 = time.time()
+            engine_session = Session(
+                project_root=str(checkpoints_dir()),
+                config_path=checkpoint,
+                decoder_backend=decoder_backend,
+                vae_backend=vae_backend,
+                offload_text_encoder=offload_text_encoder,
+                trt_engines=trt_engines,
+                vae_window=vae_window,
+            )
+            cleanup.callback(
+                _cleanup_create_resource,
+                "engine_session",
+                engine_session.close,
+            )
+            logger.info("model_loaded duration_s={:.1f}", time.time() - t0)
 
-        if profile_mgr is not None:
-            profile_mgr.bind(
-                engine_session.handler._diffusion_engine,
-                trt_engines, picked_dur,
+            if profile_mgr is not None:
+                profile_mgr.bind(
+                    engine_session.handler._diffusion_engine,
+                    trt_engines, picked_dur,
+                )
+
+            engine_obj = engine_session.handler._diffusion_engine
+            lora_available = bool(engine_obj and engine_obj.lora_available)
+            if use_lora and not lora_available:
+                logger.warning(
+                    "lora_engine_unavailable decoder_backend={}",
+                    decoder_backend,
+                )
+                use_lora = False
+
+            max_pipeline_depth = _compute_max_pipeline_depth(engine_obj)
+            depth = max(MIN_PIPELINE_DEPTH, min(int(depth), max_pipeline_depth))
+            logger.info(
+                "pipeline_depth_set depth={} max={} backend={}",
+                depth, max_pipeline_depth,
+                "trt" if engine_obj._trt_engine is not None else "eager",
             )
 
-        engine_obj = engine_session.handler._diffusion_engine
-        lora_available = bool(engine_obj and engine_obj.lora_available)
-        if use_lora and not lora_available:
-            logger.warning(
-                "lora_engine_unavailable decoder_backend={}",
-                decoder_backend,
-            )
-            use_lora = False
-
-        max_pipeline_depth = _compute_max_pipeline_depth(engine_obj)
-        depth = max(MIN_PIPELINE_DEPTH, min(int(depth), max_pipeline_depth))
-        logger.info(
-            "pipeline_depth_set depth={} max={} backend={}",
-            depth, max_pipeline_depth,
-            "trt" if engine_obj._trt_engine is not None else "eager",
-        )
-
-        initial_enable_ids: list[str] = []
-        if use_lora:
-            catalog_ids = {d.id for d in engine_obj.list_loras()}
-            for lid in enabled_lora_ids:
-                if lid in catalog_ids:
-                    initial_enable_ids.append(lid)
-                else:
-                    logger.warning("lora_id_not_in_catalog id={}", lid)
-            for p in extra_lora_paths:
-                pp = Path(p)
-                if not pp.exists():
-                    logger.warning("lora_path_missing path={}", p)
-                    continue
-                try:
-                    lid = engine_obj.register_lora(str(pp))
-                    if lid not in initial_enable_ids:
+            initial_enable_ids: list[str] = []
+            if use_lora:
+                catalog_ids = {d.id for d in engine_obj.list_loras()}
+                for lid in enabled_lora_ids:
+                    if lid in catalog_ids:
                         initial_enable_ids.append(lid)
-                except Exception as e:
-                    logger.exception(
-                        "lora_register_failed path={} error={}", p, e,
-                    )
-            for lid in initial_enable_ids:
-                try:
-                    engine_obj.prewarm_lora(lid)
-                except Exception as e:
-                    logger.exception(
-                        "lora_prewarm_failed id={} error={}", lid, e,
-                    )
-            if not initial_enable_ids:
-                logger.info("lora_startup_empty reason=catalog_only")
+                    else:
+                        logger.warning("lora_id_not_in_catalog id={}", lid)
+                for p in extra_lora_paths:
+                    pp = Path(p)
+                    if not pp.exists():
+                        logger.warning("lora_path_missing path={}", p)
+                        continue
+                    try:
+                        lid = engine_obj.register_lora(str(pp))
+                        if lid not in initial_enable_ids:
+                            initial_enable_ids.append(lid)
+                    except Exception as e:
+                        logger.exception(
+                            "lora_register_failed path={} error={}", p, e,
+                        )
+                for lid in initial_enable_ids:
+                    try:
+                        engine_obj.prewarm_lora(lid)
+                    except Exception as e:
+                        logger.exception(
+                            "lora_prewarm_failed id={} error={}", lid, e,
+                        )
+                if not initial_enable_ids:
+                    logger.info("lora_startup_empty reason=catalog_only")
 
-        audio_in = Audio(waveform=waveform, sample_rate=SAMPLE_RATE)
+            audio_in = Audio(waveform=waveform, sample_rate=SAMPLE_RATE)
 
-        source, detected_bpm, detected_key, detected_time_signature = (
-            _resolve_bpm_key_source(
-                engine_session,
-                audio_in=audio_in,
-                fixture_name=fixture_name,
-                samples=int(waveform.shape[1]),
-            )
-        )
-
-        upload_stems, stem_error, source, waveform = (
-            extract_and_select_upload_stem(
-                waveform,
-                session=engine_session,
-                source=source,
-                source_mode=stem_source_mode,
-                fixture_name=fixture_name,
-            )
-        )
-        if stem_error is not None and stem_source_mode != "full":
-            logger.error(
-                "stem_extract_failed_fatal source_mode={} error={}",
-                stem_source_mode, stem_error,
-            )
-            raise StemExtractFailedError(
-                f"Stem extraction failed: {stem_error}",
+            source, detected_bpm, detected_key, detected_time_signature = (
+                _resolve_bpm_key_source(
+                    engine_session,
+                    audio_in=audio_in,
+                    fixture_name=fixture_name,
+                    samples=int(waveform.shape[1]),
+                )
             )
 
-        # Two-conditioning cache for the live timbre-strength slider.
-        logger.info("text_encode_start variant=silence_and_self")
-        cond_silence, cond_full = encode_cond_pair(
-            engine_session, prompt, source.latent,
-            detected_bpm, audio_duration_s,
-            detected_key, detected_time_signature,
-        )
-        # Encode prompt B at session start so the blend slider works
-        # immediately.
-        if prompt_b and prompt_b != prompt:
-            cond_silence_b, cond_full_b = encode_cond_pair(
-                engine_session, prompt_b, source.latent,
+            upload_stems, stem_error, source, waveform = (
+                extract_and_select_upload_stem(
+                    waveform,
+                    session=engine_session,
+                    source=source,
+                    source_mode=stem_source_mode,
+                    fixture_name=fixture_name,
+                )
+            )
+            if stem_error is not None and stem_source_mode != "full":
+                logger.error(
+                    "stem_extract_failed_fatal source_mode={} error={}",
+                    stem_source_mode, stem_error,
+                )
+                raise StemExtractFailedError(
+                    f"Stem extraction failed: {stem_error}",
+                )
+
+            # Two-conditioning cache for the live timbre-strength slider.
+            logger.info("text_encode_start variant=silence_and_self")
+            cond_silence, cond_full = encode_cond_pair(
+                engine_session, prompt, source.latent,
                 detected_bpm, audio_duration_s,
                 detected_key, detected_time_signature,
             )
-        else:
-            cond_silence_b, cond_full_b = cond_silence, cond_full
-        conditioning = cond_full  # default strength=1.0 == cond_full
-
-        # Negative conditioning for the RCFG path (Residual CFG).
-        cond_negative = engine_session.encode_text(
-            tags="",
-            instruction=TASK_INSTRUCTIONS["cover"],
-            refer_latent=None,
-            bpm=detected_bpm, duration=audio_duration_s,
-            key=detected_key,
-            time_signature=detected_time_signature,
-        )
-
-        logger.info(
-            "stream_create_start steps={} pipeline_depth={}", steps, depth,
-        )
-        stream = engine_session.stream(
-            source=source,
-            conditioning=conditioning,
-            steps=steps,
-            shift=3.0,
-            pipeline_depth=depth,
-        )
-        logger.info("stream_handle_ready")
-
-        # Initial buffer
-        src_np = waveform.numpy().T
-        if crop_seconds > 0:
-            src_np = src_np[:int(crop_seconds * SAMPLE_RATE)]
-        n_channels = src_np.shape[1] if src_np.ndim > 1 else 1
-
-        _seam_fade_samples = int(0.05 * SAMPLE_RATE)
-        _seam_fade_samples = min(_seam_fade_samples, len(src_np) // 4)
-        if _seam_fade_samples > 0:
-            if src_np.ndim == 1:
-                _fade_out = np.linspace(1.0, 0.0, _seam_fade_samples).astype(src_np.dtype)
-                _fade_in = np.linspace(0.0, 1.0, _seam_fade_samples).astype(src_np.dtype)
+            # Encode prompt B at session start so the blend slider works
+            # immediately.
+            if prompt_b and prompt_b != prompt:
+                cond_silence_b, cond_full_b = encode_cond_pair(
+                    engine_session, prompt_b, source.latent,
+                    detected_bpm, audio_duration_s,
+                    detected_key, detected_time_signature,
+                )
             else:
-                _fade_out = np.linspace(1.0, 0.0, _seam_fade_samples).reshape(-1, 1).astype(src_np.dtype)
-                _fade_in = np.linspace(0.0, 1.0, _seam_fade_samples).reshape(-1, 1).astype(src_np.dtype)
-            _tail = src_np[-_seam_fade_samples:].copy()
-            _head = src_np[:_seam_fade_samples].copy()
-            src_np[-_seam_fade_samples:] = _tail * _fade_out + _head * _fade_in
+                cond_silence_b, cond_full_b = cond_silence, cond_full
+            conditioning = cond_full  # default strength=1.0 == cond_full
 
-        audio_eng = AudioEngine(src_np, SAMPLE_RATE)
+            # Negative conditioning for the RCFG path (Residual CFG).
+            cond_negative = engine_session.encode_text(
+                tags="",
+                instruction=TASK_INSTRUCTIONS["cover"],
+                refer_latent=None,
+                bpm=detected_bpm, duration=audio_duration_s,
+                key=detected_key,
+                time_signature=detected_time_signature,
+            )
 
-        k1_name = "sde_amp" if use_sde else "denoise"
-        initial_knob_ids = list(initial_enable_ids) if use_lora else []
-        banks = build_banks(use_sde, loras=initial_knob_ids)
-        virtual_knobs = KnobState(banks)
+            logger.info(
+                "stream_create_start steps={} pipeline_depth={}", steps, depth,
+            )
+            stream = engine_session.stream(
+                source=source,
+                conditioning=conditioning,
+                steps=steps,
+                shift=3.0,
+                pipeline_depth=depth,
+            )
+            cleanup.callback(
+                _cleanup_create_resource,
+                "stream",
+                stream.close,
+            )
+            logger.info("stream_handle_ready")
 
-        state = SessionState(
-            source=source,
-            bpm=detected_bpm,
-            key=detected_key,
-            time_signature=detected_time_signature,
-            duration=audio_duration_s,
-            n_channels=n_channels,
-            playback_samples=int(waveform.shape[-1]),
-            cond_pair=(cond_silence, cond_full),
-            cond_pair_b=(cond_silence_b, cond_full_b),
-            prompt_text=prompt,
-            prompt_text_b=prompt_b,
-            current_depth=int(depth),
-        )
+            # Initial buffer
+            src_np = waveform.numpy().T
+            if crop_seconds > 0:
+                src_np = src_np[:int(crop_seconds * SAMPLE_RATE)]
+            n_channels = src_np.shape[1] if src_np.ndim > 1 else 1
 
-        return cls(
-            session_id=session_id,
-            checkpoint=checkpoint,
-            config=config,
-            engine_session=engine_session,
-            stream=stream,
-            state=state,
-            audio_eng=audio_eng,
-            virtual_knobs=virtual_knobs,
-            engine_obj=engine_obj,
-            profile_mgr=profile_mgr,
-            cond_negative=cond_negative,
-            initial_buffer=src_np,
-            initial_upload_stems=upload_stems,
-            initial_stem_error=stem_error,
-            initial_stem_source_mode=stem_source_mode,
-            initial_enable_ids=initial_enable_ids,
-            lora_strengths_init=lora_strengths_init,
-            lora_available=lora_available,
-            max_pipeline_depth=max_pipeline_depth,
-            max_seconds=max_seconds,
-            walk_window=walk_window,
-            walk_window_s=walk_window_s,
-            vae_window=vae_window,
-            crop_seconds=crop_seconds,
-            use_sde=use_sde,
-            use_lora=use_lora,
-            k1_name=k1_name,
-        )
+            _seam_fade_samples = int(0.05 * SAMPLE_RATE)
+            _seam_fade_samples = min(_seam_fade_samples, len(src_np) // 4)
+            if _seam_fade_samples > 0:
+                if src_np.ndim == 1:
+                    _fade_out = np.linspace(1.0, 0.0, _seam_fade_samples).astype(src_np.dtype)
+                    _fade_in = np.linspace(0.0, 1.0, _seam_fade_samples).astype(src_np.dtype)
+                else:
+                    _fade_out = np.linspace(1.0, 0.0, _seam_fade_samples).reshape(-1, 1).astype(src_np.dtype)
+                    _fade_in = np.linspace(0.0, 1.0, _seam_fade_samples).reshape(-1, 1).astype(src_np.dtype)
+                _tail = src_np[-_seam_fade_samples:].copy()
+                _head = src_np[:_seam_fade_samples].copy()
+                src_np[-_seam_fade_samples:] = _tail * _fade_out + _head * _fade_in
+
+            audio_eng = AudioEngine(src_np, SAMPLE_RATE)
+            cleanup.callback(
+                _cleanup_create_resource,
+                "audio_engine",
+                audio_eng.stop,
+            )
+
+            k1_name = "sde_amp" if use_sde else "denoise"
+            initial_knob_ids = list(initial_enable_ids) if use_lora else []
+            banks = build_banks(use_sde, loras=initial_knob_ids)
+            virtual_knobs = KnobState(banks)
+
+            state = SessionState(
+                source=source,
+                bpm=detected_bpm,
+                key=detected_key,
+                time_signature=detected_time_signature,
+                duration=audio_duration_s,
+                n_channels=n_channels,
+                playback_samples=int(waveform.shape[-1]),
+                cond_pair=(cond_silence, cond_full),
+                cond_pair_b=(cond_silence_b, cond_full_b),
+                prompt_text=prompt,
+                prompt_text_b=prompt_b,
+                current_depth=int(depth),
+            )
+
+            streaming = cls(
+                session_id=session_id,
+                checkpoint=checkpoint,
+                config=config,
+                engine_session=engine_session,
+                stream=stream,
+                state=state,
+                audio_eng=audio_eng,
+                virtual_knobs=virtual_knobs,
+                engine_obj=engine_obj,
+                profile_mgr=profile_mgr,
+                cond_negative=cond_negative,
+                initial_buffer=src_np,
+                initial_upload_stems=upload_stems,
+                initial_stem_error=stem_error,
+                initial_stem_source_mode=stem_source_mode,
+                initial_enable_ids=initial_enable_ids,
+                lora_strengths_init=lora_strengths_init,
+                lora_available=lora_available,
+                max_pipeline_depth=max_pipeline_depth,
+                max_seconds=max_seconds,
+                walk_window=walk_window,
+                walk_window_s=walk_window_s,
+                vae_window=vae_window,
+                crop_seconds=crop_seconds,
+                use_sde=use_sde,
+                use_lora=use_lora,
+                k1_name=k1_name,
+            )
+            cleanup.pop_all()
+            return streaming

--- a/demos/realtime_motion_graph_web/web/engine/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/engine/protocol.ts
@@ -607,13 +607,11 @@ export class RemoteBackend extends EventTarget {
         //
         // Tailor the message by close code: 1011 (server internal error)
         // and 1006 (abnormal closure) are the two shapes operators see
-        // most often, both recoverable by reloading. The previous
-        // "Check the server console" tail was useless to end users and
-        // made the error feel scarier than it is.
+        // most often, both recoverable by reloading.
         if (!this.ready) {
           let msg: string;
           if (e.code === 1011) {
-            msg = "Server restarted to clear memory — refresh the page to retry.";
+            msg = "Session failed while starting — refresh the page to retry.";
           } else if (e.code === 1006) {
             msg = "Connection lost — refresh to retry.";
           } else {

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -444,11 +444,6 @@ def _handle_client_body(
     streaming_entered_run = False
 
     def _close_streaming_if_init_fails() -> None:
-        # StreamingSession.create() cleans up failures before it returns.
-        # Once it returns, this adapter owns the pre-run handshake window
-        # (ready frame, initial audio buffer, optional stems). If any of
-        # those sends fail before run() takes over, close the returned
-        # session here.
         if not streaming_entered_run:
             streaming.close()
 

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -444,6 +444,11 @@ def _handle_client_body(
     streaming_entered_run = False
 
     def _close_streaming_if_init_fails() -> None:
+        # StreamingSession.create() cleans up failures before it returns.
+        # Once it returns, this adapter owns the pre-run handshake window
+        # (ready frame, initial audio buffer, optional stems). If any of
+        # those sends fail before run() takes over, close the returned
+        # session here.
         if not streaming_entered_run:
             streaming.close()
 

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -442,9 +442,12 @@ def _handle_client_body(
     _ms("resolve_source_done")
 
     streaming_entered_run = False
+    session_registered = False
 
     def _close_streaming_if_init_fails() -> None:
         if not streaming_entered_run:
+            if session_registered:
+                session_registry.unregister(session_id)
             streaming.close()
 
     ctx_stack.callback(_close_streaming_if_init_fails)
@@ -907,6 +910,7 @@ def _handle_client_body(
         inject=inject_control,
         snapshot=snapshot_session,
     ))
+    session_registered = True
     logger.info("session_registered")
 
     # Stage the initial enable set so they get applied on the runner

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -441,6 +441,14 @@ def _handle_client_body(
         return
     _ms("resolve_source_done")
 
+    streaming_entered_run = False
+
+    def _close_streaming_if_init_fails() -> None:
+        if not streaming_entered_run:
+            streaming.close()
+
+    ctx_stack.callback(_close_streaming_if_init_fails)
+
     state = streaming.state
 
     # ---- Per-subscriber transport state ----
@@ -912,6 +920,7 @@ def _handle_client_body(
                 )
 
     try:
+        streaming_entered_run = True
         streaming.run()
     finally:
         session_registry.unregister(session_id)

--- a/tests/unit/test_streaming_create_cleanup.py
+++ b/tests/unit/test_streaming_create_cleanup.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from acestep.nodes.types import Audio
+from acestep.streaming.config import SessionConfig
+from acestep.streaming.session import StreamingSession
+
+
+class _FakeEngine:
+    _trt_engine = None
+    lora_available = False
+
+
+class _FakeSession:
+    def __init__(self, tracker, **_kwargs):
+        self.closed = False
+        self.handler = SimpleNamespace(_diffusion_engine=_FakeEngine())
+        tracker.sessions.append(self)
+
+    def close(self):
+        self.closed = True
+
+    def encode_text(self, **_kwargs):
+        return object()
+
+    def stream(self, **_kwargs):
+        stream = _FakeStream()
+        return stream
+
+
+class _FakeStream:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def _source():
+    return SimpleNamespace(
+        latent=object(),
+        context_latent=object(),
+    )
+
+
+def _audio():
+    return Audio(
+        waveform=torch.zeros((2, 9600), dtype=torch.float32),
+        sample_rate=48_000,
+    )
+
+
+def _patch_lightweight_create(monkeypatch, tracker):
+    import acestep.streaming.session as session_mod
+
+    monkeypatch.setattr(session_mod, "max_profile_duration_s", lambda **_kwargs: 1.0)
+    monkeypatch.setattr(
+        session_mod,
+        "Session",
+        lambda **kwargs: _FakeSession(tracker, **kwargs),
+    )
+    monkeypatch.setattr(
+        session_mod,
+        "_resolve_bpm_key_source",
+        lambda *_args, **_kwargs: (_source(), 120, "C major", "4"),
+    )
+    monkeypatch.setattr(
+        session_mod,
+        "extract_and_select_upload_stem",
+        lambda waveform, **_kwargs: (None, None, _source(), waveform),
+    )
+    return session_mod
+
+
+def test_create_closes_engine_session_when_conditioning_fails(monkeypatch):
+    tracker = SimpleNamespace(sessions=[])
+    session_mod = _patch_lightweight_create(monkeypatch, tracker)
+
+    def fail_encode_cond_pair(*_args, **_kwargs):
+        raise RuntimeError("conditioning failed")
+
+    monkeypatch.setattr(session_mod, "encode_cond_pair", fail_encode_cond_pair)
+
+    with pytest.raises(RuntimeError, match="conditioning failed"):
+        StreamingSession.create(
+            audio=_audio(),
+            config=SessionConfig(),
+            checkpoint="ckpt",
+            decoder_backend="eager",
+            vae_backend="eager",
+            session_id="s1",
+        )
+
+    assert tracker.sessions
+    assert tracker.sessions[0].closed
+
+
+def test_create_closes_stream_and_engine_session_when_late_setup_fails(monkeypatch):
+    tracker = SimpleNamespace(sessions=[], streams=[])
+    session_mod = _patch_lightweight_create(monkeypatch, tracker)
+
+    def fake_stream(self, **_kwargs):
+        stream = _FakeStream()
+        tracker.streams.append(stream)
+        return stream
+
+    monkeypatch.setattr(_FakeSession, "stream", fake_stream)
+    monkeypatch.setattr(
+        session_mod,
+        "encode_cond_pair",
+        lambda *_args, **_kwargs: object(),
+    )
+
+    def fail_audio_engine(*_args, **_kwargs):
+        raise RuntimeError("audio engine failed")
+
+    monkeypatch.setattr(session_mod, "AudioEngine", fail_audio_engine)
+
+    with pytest.raises(RuntimeError, match="audio engine failed"):
+        StreamingSession.create(
+            audio=_audio(),
+            config=SessionConfig(),
+            checkpoint="ckpt",
+            decoder_backend="eager",
+            vae_backend="eager",
+            session_id="s1",
+        )
+
+    assert tracker.streams
+    assert tracker.streams[0].closed
+    assert tracker.sessions
+    assert tracker.sessions[0].closed

--- a/tests/unit/test_streaming_create_cleanup.py
+++ b/tests/unit/test_streaming_create_cleanup.py
@@ -112,7 +112,7 @@ def test_create_closes_stream_and_engine_session_when_late_setup_fails(monkeypat
     monkeypatch.setattr(
         session_mod,
         "encode_cond_pair",
-        lambda *_args, **_kwargs: object(),
+        lambda *_args, **_kwargs: (object(), object()),
     )
 
     def fail_audio_engine(*_args, **_kwargs):


### PR DESCRIPTION
## Summary

This PR makes streaming session startup and teardown transactional so failed session starts do not leave GPU/model resources alive in the pod process.

The production symptom was a session-start failure followed by retries OOMing because the previous failed start had allocated model/session resources but never reached the normal `StreamingSession.run()` teardown path.

## Problem

Before this branch, most cleanup lived in `StreamingSession.run()`. That missed several startup failure windows:

1. `ModelContext._load_models()` could fail after partially loading model state.
2. `Session.__init__` could fail after creating a `ModelContext` but before returning a usable `Session`.
3. `StreamingSession.create()` could fail after `Session(...)` succeeded but before a `StreamingSession` object existed.
4. `StreamingSession.create()` could succeed, but the WebSocket init handshake could fail before `run()` started.

In cases 3 and 4, the adapter either had nothing to close yet or had not entered the normal run finalizer. That could leave PyTorch/TRT/model allocations behind until an external watchdog killed the process.

## Changes

### 1. Clean up partial `ModelContext` loads

`ModelContext.__init__` now wraps `_load_models()`.

If loading fails, it:
- closes any partially created diffusion engine/model handles,
- drops tensor-bearing attributes,
- runs `gc.collect()`,
- empties the CUDA cache when available,
- re-raises the original error.

This covers failures such as partially loaded/meta model state during model placement.

### 2. Clean up failed `Session.__init__`

`Session.__init__` now initializes close-safe fields up front, then wraps `ModelContext` creation and backend/TRT wiring.

If anything fails after construction begins, it calls `Session.close()` and re-raises.

This covers failures after `ModelContext` exists but before `Session(...)` returns.

### 3. Make `StreamingSession.create()` transactional

`StreamingSession.create()` now uses an `ExitStack` for resources acquired before the final `StreamingSession` object exists.

As each resource is acquired, it is registered immediately:
- `engine_session.close`
- `stream.close`
- `audio_eng.stop`

Ownership transfers only after `cls(...)` succeeds via `cleanup.pop_all()`.

This covers startup failures during source resolution, stem extraction, conditioning, stream creation, audio engine setup, or late session-state construction.

### 4. Close returned sessions that fail during the WebSocket init handshake

`ws_adapter` now registers a cleanup callback immediately after `StreamingSession.create()` returns.

If the ready frame, initial audio buffer, or initial stem payload fails before `streaming.run()` starts, the adapter closes the returned session.

Once `run()` starts, the normal `StreamingSession.close()` finalizer owns teardown.

### 5. Preserve runtime contracts

`PipelineRunner` construction is inside the cleanup `finally`, but constructor failures still propagate. Only `runner.run()` failures keep the previous log-and-stop behavior.

This matters for warmup: setup failures should still be visible as warmup failures, not logged and silently treated as success.

### 6. Complete `StreamingSession.close()`

`StreamingSession.close()` now also stops the owned `AudioEngine`.

For the WebSocket backend this is normally a no-op because local playback is not started, but it keeps the ownership contract complete for warmup/future callers.

### 7. Make the frontend startup failure message generic

The pre-ready 1011 close message no longer says the server restarted. A 1011 during startup can be any server-side init failure, so the message now says:

> Session failed while starting — refresh the page to retry.

## Tests / Verification

- Added lightweight unit coverage for `StreamingSession.create()` cleanup when:
  - conditioning fails after `Session(...)` succeeds,
  - late setup fails after stream creation.
- Ran Python compile checks for changed Python files.
- Ran `git diff --check`.
- Ran web `npm run typecheck`.

Note: local pytest could not be run on this Mac because the local env lacks `pytest`/`torch`, and `uv` attempts to bootstrap TensorRT CUDA wheels for macOS arm64 before running tests.

## Deployment Note

These are DEMON server-side changes. After merge, they will not affect fleet pods until the warm pod image is rebuilt/deployed.