### PR TITLE
streaming: accept optional zstd/float16-compressed source frames

### DIFF
--- a/acestep/streaming/source.py
+++ b/acestep/streaming/source.py
@@ -65,15 +65,48 @@ def _try_load_sidecar(
     return sc
 
 
+# Compact-frame sentinel: a leading 0xFFFFFFFF (never a valid channel count,
+# which is always 1 or 2) marks an optional compressed / low-precision source
+# frame. Legacy frames begin with the channel count, so the two are unambiguous.
+_COMPACT_SENTINEL = 0xFFFFFFFF
+_COMPACT_FLAG_ZSTD = 0x1
+_COMPACT_FLAG_F16 = 0x2
+
+
 def _decode_audio_msg(audio_msg: bytes) -> torch.Tensor:
     """Parse a binary audio frame into a [≤2, N] float32 tensor.
 
     Wire format (shared by the init handshake, ``swap_source``,
-    ``set_timbre_source``, ``set_structure_source``): little-endian
-    ``<II`` header carrying (channels, samples), followed by interleaved
-    float32 PCM. Returns the waveform clipped to stereo (the model only
-    consumes 2 channels).
+    ``set_timbre_source``, ``set_structure_source``):
+
+    * **Legacy** — little-endian ``<II`` header (channels, samples) followed
+      by interleaved float32 PCM.
+    * **Compact** (optional, backward-compatible) — ``<I`` sentinel
+      ``0xFFFFFFFF`` + ``<B`` flags + ``<II`` (channels, samples) + payload.
+      ``flags`` bit0 = zstd-compressed, bit1 = float16 samples. The source is
+      only a conditioning reference (it is encoded to a latent), so float16 +
+      zstd shrink the upload substantially with no audible cost — particularly
+      for repetitive/looped material that zstd compresses heavily.
+
+    Returns the waveform clipped to stereo (the model only consumes 2 channels).
     """
+    (lead,) = struct.unpack_from("<I", audio_msg, 0)
+    if lead == _COMPACT_SENTINEL:
+        flags = audio_msg[4]
+        ch, n = struct.unpack_from("<II", audio_msg, 5)
+        payload = audio_msg[13:]
+        f16 = bool(flags & _COMPACT_FLAG_F16)
+        itemsize = 2 if f16 else 4
+        if flags & _COMPACT_FLAG_ZSTD:
+            import zstandard as zstd
+
+            payload = zstd.ZstdDecompressor().decompress(
+                payload, max_output_size=n * ch * itemsize
+            )
+        dtype = np.float16 if f16 else np.float32
+        arr = np.frombuffer(payload, dtype=dtype).astype(np.float32).reshape(n, ch)
+        return torch.from_numpy(arr.T.copy())[:2]
+
     ch, n = struct.unpack("<II", audio_msg[:8])
     arr = np.frombuffer(audio_msg[8:], dtype=np.float32).reshape(n, ch)
     return torch.from_numpy(arr.T.copy())[:2]

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -603,6 +603,10 @@ def _handle_client_body(
         "pipeline_depth": state.current_depth,
         "max_pipeline_depth": streaming.max_pipeline_depth,
         "session_id": session_id,
+        # Compact source-frame encodings this server accepts (see
+        # _decode_audio_msg). Clients may compress uploads with these; absent =
+        # legacy float32 only. Always safe to ignore.
+        "src_encodings": ["zstd", "f16"],
     }))
     ws.send(src_np.astype(np.float16).tobytes())
     if streaming.initial_upload_stems is not None:


### PR DESCRIPTION
## What
Make the streaming binary source decoder (`_decode_audio_msg`) accept an
optional, backward-compatible **compact frame** alongside the existing
raw-float32 frame.

Compact frame layout:
```
<I sentinel=0xFFFFFFFF><B flags><II channels,samples> + payload
flags bit0 = zstd-compressed, bit1 = float16 samples
```
The legacy frame (`<II channels,samples>` + float32) is unchanged — the
channel count is always 1/2, so it can never collide with the sentinel.

## Why
The uploaded source is only a conditioning reference (it's encoded straight
to a latent), so its sample precision is irrelevant. float16 halves it; zstd
then crushes repetitive/looped material. Net: much smaller source uploads,
no audible change, faster connect.

## Compatibility
- Fully backward-compatible: existing clients keep sending float32 → legacy path.
- Accepted encodings are advertised in `ready.src_encodings` so clients can
  feature-gate (and fall back to float32 against older servers).
- Shared decoder, so init / `swap_source` / timbre / structure all benefit.

Draft — opening for review of the wire format.
