### PR TITLE
fix(rtmg): custom-song upload can hang forever (stuck dialog + Encoding…)

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -145,6 +145,8 @@ export function AudioSourceCrate() {
   const uploadHint = useUploadOnboardingHint();
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // Aborts an in-flight upload when the Almost-Ready dialog is closed.
+  const uploadAbortRef = useRef<AbortController | null>(null);
   const placardRef = useRef<HTMLButtonElement | null>(null);
   const uploadBtnRef = useRef<HTMLButtonElement | null>(null);
   const fanRef = useRef<HTMLDivElement | null>(null);
@@ -255,6 +257,8 @@ export function AudioSourceCrate() {
     sourceMode: StemSourceMode,
   ) {
     if (!pending) return;
+    const controller = new AbortController();
+    uploadAbortRef.current = controller;
     await commitUploadedTrack({
       pending,
       keyOverride,
@@ -264,6 +268,7 @@ export function AudioSourceCrate() {
       setFixture,
       setPending,
       setUploading,
+      signal: controller.signal,
     });
   }
 
@@ -479,12 +484,16 @@ export function AudioSourceCrate() {
             commitPending(keyOverride, timeSignatureOverride, sourceMode)
           }
           onPickAnother={() => {
+            uploadAbortRef.current?.abort();
             setPending(null);
             // Re-open the picker on the next tick so the file input
             // change handler isn't racing the close.
             setTimeout(() => fileInputRef.current?.click(), 0);
           }}
-          onClose={() => setPending(null)}
+          onClose={() => {
+            uploadAbortRef.current?.abort();
+            setPending(null);
+          }}
         />
       )}
 

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
@@ -74,6 +74,8 @@ export function LiteTrackCarousel() {
   const trimCapS =
     useConfig().engine.max_source_duration_s ?? DEFAULT_TRIM_CAP_S;
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // Aborts an in-flight upload when the Almost-Ready dialog is closed.
+  const uploadAbortRef = useRef<AbortController | null>(null);
   useSeedUserUploads();
   // Host-supplied gate for track-change + upload (see useActionGate).
   // Default is allow-all; demon-public-demo overrides to require sign-up.
@@ -139,6 +141,8 @@ export function LiteTrackCarousel() {
     sourceMode: StemSourceMode,
   ) {
     if (!pending) return;
+    const controller = new AbortController();
+    uploadAbortRef.current = controller;
     await commitUploadedTrack({
       pending,
       keyOverride,
@@ -148,6 +152,7 @@ export function LiteTrackCarousel() {
       setFixture,
       setPending,
       setUploading,
+      signal: controller.signal,
     });
   }
 
@@ -261,10 +266,14 @@ export function LiteTrackCarousel() {
             commitPending(keyOverride, timeSignatureOverride, sourceMode)
           }
           onPickAnother={() => {
+            uploadAbortRef.current?.abort();
             setPending(null);
             setTimeout(() => fileInputRef.current?.click(), 0);
           }}
-          onClose={() => setPending(null)}
+          onClose={() => {
+            uploadAbortRef.current?.abort();
+            setPending(null);
+          }}
         />
       )}
 

--- a/demos/realtime_motion_graph_web/web/components/Performance/TrackPicker.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/TrackPicker.tsx
@@ -64,6 +64,8 @@ export function TrackPicker() {
     useConfig().engine.max_source_duration_s ?? DEFAULT_TRIM_CAP_S;
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // Aborts an in-flight upload when the Almost-Ready dialog is closed.
+  const uploadAbortRef = useRef<AbortController | null>(null);
   useSeedUserUploads();
   // Host-supplied gate for track-change + upload (see useActionGate).
   // Default is allow-all; demon-public-demo overrides to require sign-up.
@@ -125,6 +127,8 @@ export function TrackPicker() {
     sourceMode: StemSourceMode,
   ) {
     if (!pending) return;
+    const controller = new AbortController();
+    uploadAbortRef.current = controller;
     await commitUploadedTrack({
       pending,
       keyOverride,
@@ -134,6 +138,7 @@ export function TrackPicker() {
       setFixture,
       setPending,
       setUploading,
+      signal: controller.signal,
     });
   }
 
@@ -198,10 +203,14 @@ export function TrackPicker() {
             commitPending(keyOverride, timeSignatureOverride, sourceMode)
           }
           onPickAnother={() => {
+            uploadAbortRef.current?.abort();
             setPending(null);
             setTimeout(() => fileInputRef.current?.click(), 0);
           }}
-          onClose={() => setPending(null)}
+          onClose={() => {
+            uploadAbortRef.current?.abort();
+            setPending(null);
+          }}
         />
       )}
     </>

--- a/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
+++ b/demos/realtime_motion_graph_web/web/engine/audio/loadFixture.ts
@@ -208,6 +208,11 @@ export interface UploadTrackResult {
 export interface UploadTrackOptions {
   key?: string | null;
   timeSignature?: string | null;
+  /** Aborts the in-flight upload (e.g. the user closed the dialog). */
+  signal?: AbortSignal;
+  /** Overall deadline; the server can accept the socket but never reply
+   *  (encode hang / unsupported duration), which would hang the caller. */
+  timeoutMs?: number;
 }
 
 async function resolveUploadWsUrl(): Promise<string> {
@@ -251,7 +256,12 @@ export async function uploadTrackToServer(
   options: UploadTrackOptions = {},
 ): Promise<UploadTrackResult> {
   const wsUrl = await resolveUploadWsUrl();
+  const timeoutMs = options.timeoutMs ?? 120_000;
   return new Promise((resolve, reject) => {
+    if (options.signal?.aborted) {
+      reject(new DOMException("upload aborted", "AbortError"));
+      return;
+    }
     let settled = false;
     const ws = new WebSocket(wsUrl);
     ws.binaryType = "arraybuffer";
@@ -259,11 +269,26 @@ export async function uploadTrackToServer(
     const finish = (fn: () => void) => {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
+      options.signal?.removeEventListener("abort", onAbort);
       try {
         ws.close();
       } catch {}
       fn();
     };
+
+    // A pod can accept the upload socket but never reply (encode hang,
+    // missing/old handler) and never close it — without a deadline the caller
+    // hangs forever (the "Encoding…" / stuck-dialog bug). Fail recoverably.
+    const timer = setTimeout(() => {
+      finish(() =>
+        reject(new Error("Upload timed out — the server didn't respond.")),
+      );
+    }, timeoutMs);
+
+    const onAbort = () =>
+      finish(() => reject(new DOMException("upload aborted", "AbortError")));
+    options.signal?.addEventListener("abort", onAbort);
 
     ws.onopen = () => {
       try {

--- a/demos/realtime_motion_graph_web/web/lib/audio/commitUploadedTrack.ts
+++ b/demos/realtime_motion_graph_web/web/lib/audio/commitUploadedTrack.ts
@@ -30,6 +30,8 @@ interface CommitUploadedTrackArgs {
   setFixture: (name: string) => void;
   setPending: (pending: PendingTrackUpload | null) => void;
   setUploading: (uploading: boolean) => void;
+  /** Aborts the upload when the dialog is closed mid-encode. */
+  signal?: AbortSignal;
 }
 
 export async function commitUploadedTrack({
@@ -41,6 +43,7 @@ export async function commitUploadedTrack({
   setFixture,
   setPending,
   setUploading,
+  signal,
 }: CommitUploadedTrackArgs): Promise<void> {
   const { decoded, fileName, originalFile } = pending;
   // Keep `pending` set until the upload actually succeeds: encoding can
@@ -53,6 +56,7 @@ export async function commitUploadedTrack({
     const uploaded = await uploadTrackToServer(fileName, decoded, {
       key: keyOverride,
       timeSignature: timeSignatureOverride,
+      signal,
     });
     // The server persisted audio + sidecars + stems to disk before
     // replying upload_ok, so swaps to this track can load by name.
@@ -70,9 +74,14 @@ export async function commitUploadedTrack({
     setPending(null);
     setStatus(useSessionStore.getState().status, "");
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    setStatus(useSessionStore.getState().status, `Upload failed: ${msg}`);
-    // `pending` is intentionally left in place so the user can retry.
+    // User closed the dialog mid-encode → just clear the status, no error.
+    if (signal?.aborted || (e instanceof DOMException && e.name === "AbortError")) {
+      setStatus(useSessionStore.getState().status, "");
+    } else {
+      const msg = e instanceof Error ? e.message : String(e);
+      setStatus(useSessionStore.getState().status, `Upload failed: ${msg}`);
+      // `pending` is intentionally left in place so the user can retry.
+    }
   } finally {
     setUploading(false);
   }


### PR DESCRIPTION
## The bug
Uploading a custom song and clicking **START** on the key/tempo dialog can leave the dialog stuck, and closing it with **×** leaves an infinite "Encoding…".

## Root cause
`uploadTrackToServer` (`engine/audio/loadFixture.ts`) opens an upload WebSocket and awaits `upload_ok`/`upload_failed` **with no timeout**. If the pod accepts the socket but never replies (encode hang, missing/old handler, unsupported duration) and never closes it, the Promise never settles → `commitUploadedTrack` hangs on `await` → the dialog never closes (`setPending(null)` unreached) and `Encoding…` never clears. The dialog's close only hid it without aborting the upload.

Introduced with the persist-user-upload feature (**#181**, `a50be38`, 2026-05-30).

## Fix
- **Timeout + abort** in `uploadTrackToServer` (default 120s; `AbortSignal` support).
- `commitUploadedTrack` forwards a `signal`; on abort it clears the status (the user cancelled on purpose) rather than showing "Upload failed".
- The three dialog hosts (`TrackPicker`, `AudioSourceCrate`, `LiteTrackCarousel`) create an `AbortController` per upload and abort it on close (×/Cancel/Pick another).

A non-responsive pod now fails recoverably (retry/cancel) instead of hanging. `tsc --noEmit` clean.

> Note: the *trigger* (pod not replying to `upload_track`) is worth a separate look server-side — but this makes the client recover gracefully regardless.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>