### PR TITLE
fix(rtmg/web): show encoding progress + errors in the Almost-Ready upload modal

### DIFF
--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -8507,6 +8507,47 @@ body.curve-open #install-video-area #graph {
   margin-right: auto;
 }
 .almost-ready-btn--ghost:hover { color: var(--text); }
+.almost-ready-btn:disabled {
+  cursor: default;
+  opacity: 0.6;
+  filter: none;
+}
+
+/* In-modal busy / error banner shown between body and footer once Start
+   is pressed. Without it the "Encoding…" status lands in the status bar
+   behind the modal, so the dialog reads as frozen. */
+.almost-ready-uploading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 18px;
+  padding: 10px 12px;
+  border: 1px solid var(--frame-line);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+  color: var(--text);
+  font-size: 0.84em;
+  line-height: 1.4;
+}
+.almost-ready-uploading.is-error {
+  border-color: color-mix(in srgb, #ff5b5b 55%, var(--frame-line));
+  background: color-mix(in srgb, #ff5b5b 10%, transparent);
+  color: color-mix(in srgb, #ff9b9b 70%, var(--text));
+}
+.almost-ready-spinner {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-top-color: var(--accent);
+  animation: almost-ready-spin 0.7s linear infinite;
+}
+@keyframes almost-ready-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 
 /* ─────────────────────────────────────────────────────────────────────
    WaveformTrimDialog — interactive trim that runs between

--- a/demos/realtime_motion_graph_web/web/components/Performance/AlmostReadyDialog.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AlmostReadyDialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { type StemSourceMode } from "@/engine/audio/loadFixture";
+import { type UploadOutcome } from "@/lib/audio/commitUploadedTrack";
 import { defaultSwapSourceMode } from "@/lib/config";
 import {
   TIME_SIGNATURE_LABELS,
@@ -61,7 +62,7 @@ export interface AlmostReadyDialogProps {
     keyOverride: string | null;
     timeSignatureOverride: TimeSignature | null;
     sourceMode: StemSourceMode;
-  }) => void;
+  }) => void | Promise<UploadOutcome | void>;
   /** Only invoked when wasTrimmed is true; parent re-opens the file
    *  picker so the user can swap to a shorter source. */
   onPickAnother: () => void;
@@ -82,17 +83,44 @@ export function AlmostReadyDialog({
   );
   const [keyChoice, setKeyChoice] = useState<string>(AUTO);
   const [tsChoice, setTsChoice] = useState<string>(AUTO);
+  // Encoding happens on the server (GPU stem-rip + source prep) and can
+  // take many seconds. Without an in-modal busy state the user clicks
+  // Start and sees nothing change — the dialog looks frozen — because the
+  // "Encoding…" status and any error land in the status bar *behind* the
+  // modal. Track it here so Start shows progress and surfaces failures.
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const primaryRef = useRef<HTMLButtonElement | null>(null);
+  // Guards the post-await state writes: a successful upload (or the user
+  // hitting ×) unmounts this dialog, so we must not setState afterwards.
+  const aliveRef = useRef(true);
 
   useEffect(() => setMounted(true), []);
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
 
-  function finish() {
-    onContinue({
+  async function finish() {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    const outcome = await onContinue({
       keyOverride: keyChoice === AUTO ? null : keyChoice,
       timeSignatureOverride:
         tsChoice !== AUTO && isTimeSignature(tsChoice) ? tsChoice : null,
       sourceMode,
     });
+    // Success/abort unmounts us (parent cleared `pending`); only a failure
+    // leaves the dialog mounted, in which case show the reason and re-arm
+    // Start so the user can retry without re-picking the file.
+    if (!aliveRef.current) return;
+    setSubmitting(false);
+    if (outcome && outcome.ok === false && !outcome.aborted) {
+      setError(outcome.error || "Upload failed. Please try again.");
+    }
   }
 
   // Esc closes; Enter advances (step 1 → next, step 2 → start) unless
@@ -127,7 +155,13 @@ export function AlmostReadyDialog({
   if (!mounted) return null;
 
   return createPortal(
-    <div className="almost-ready-backdrop" onClick={onClose} role="presentation">
+    // Backdrop click closes — but not mid-encode, so a stray click can't
+    // silently abort a running upload. The × stays live as the explicit out.
+    <div
+      className="almost-ready-backdrop"
+      onClick={submitting ? undefined : onClose}
+      role="presentation"
+    >
       <div
         className="almost-ready-modal"
         role="dialog"
@@ -145,7 +179,7 @@ export function AlmostReadyDialog({
             type="button"
             className="config-modal-close"
             onClick={onClose}
-            aria-label="Cancel upload"
+            aria-label={submitting ? "Cancel encoding" : "Cancel upload"}
           >
             ×
           </button>
@@ -266,6 +300,28 @@ export function AlmostReadyDialog({
           )}
         </div>
 
+        {(submitting || error) && (
+          <div
+            className={`almost-ready-uploading${error ? " is-error" : ""}`}
+            role="status"
+            aria-live="polite"
+          >
+            {submitting ? (
+              <>
+                <span
+                  className="almost-ready-spinner"
+                  aria-hidden="true"
+                />
+                <span>
+                  Encoding on the server — this can take up to a minute.
+                </span>
+              </>
+            ) : (
+              <span>{error}</span>
+            )}
+          </div>
+        )}
+
         <div className="almost-ready-footer">
           {step === 1 ? (
             <>
@@ -300,6 +356,7 @@ export function AlmostReadyDialog({
                 type="button"
                 className="almost-ready-btn almost-ready-btn--secondary"
                 onClick={() => setStep(1)}
+                disabled={submitting}
               >
                 ← Back
               </button>
@@ -308,8 +365,10 @@ export function AlmostReadyDialog({
                 type="button"
                 className="almost-ready-btn almost-ready-btn--primary"
                 onClick={finish}
+                disabled={submitting}
+                aria-busy={submitting}
               >
-                Start
+                {submitting ? "Encoding…" : error ? "Retry" : "Start"}
               </button>
             </>
           )}

--- a/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AudioSourceCrate.tsx
@@ -259,7 +259,7 @@ export function AudioSourceCrate() {
     if (!pending) return;
     const controller = new AbortController();
     uploadAbortRef.current = controller;
-    await commitUploadedTrack({
+    return commitUploadedTrack({
       pending,
       keyOverride,
       timeSignatureOverride,

--- a/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/LiteTrackCarousel.tsx
@@ -143,7 +143,7 @@ export function LiteTrackCarousel() {
     if (!pending) return;
     const controller = new AbortController();
     uploadAbortRef.current = controller;
-    await commitUploadedTrack({
+    return commitUploadedTrack({
       pending,
       keyOverride,
       timeSignatureOverride,

--- a/demos/realtime_motion_graph_web/web/components/Performance/TrackPicker.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/TrackPicker.tsx
@@ -129,7 +129,7 @@ export function TrackPicker() {
     if (!pending) return;
     const controller = new AbortController();
     uploadAbortRef.current = controller;
-    await commitUploadedTrack({
+    return commitUploadedTrack({
       pending,
       keyOverride,
       timeSignatureOverride,

--- a/demos/realtime_motion_graph_web/web/lib/audio/commitUploadedTrack.ts
+++ b/demos/realtime_motion_graph_web/web/lib/audio/commitUploadedTrack.ts
@@ -34,6 +34,15 @@ interface CommitUploadedTrackArgs {
   signal?: AbortSignal;
 }
 
+/** What the AlmostReadyDialog needs to know after the await resolves:
+ *  success unmounts the dialog (parent cleared `pending`); an error
+ *  leaves it mounted so the dialog can show the message inline and let
+ *  the user retry; an abort means the user already closed it. */
+export type UploadOutcome =
+  | { ok: true }
+  | { ok: false; aborted: true }
+  | { ok: false; aborted?: false; error: string };
+
 export async function commitUploadedTrack({
   pending,
   keyOverride,
@@ -44,7 +53,7 @@ export async function commitUploadedTrack({
   setPending,
   setUploading,
   signal,
-}: CommitUploadedTrackArgs): Promise<void> {
+}: CommitUploadedTrackArgs): Promise<UploadOutcome> {
   const { decoded, fileName, originalFile } = pending;
   // Keep `pending` set until the upload actually succeeds: encoding can
   // fail (bad audio, server/network), and clearing it up front would throw
@@ -73,15 +82,19 @@ export async function commitUploadedTrack({
     setFixture(uploaded.name);
     setPending(null);
     setStatus(useSessionStore.getState().status, "");
+    return { ok: true };
   } catch (e) {
     // User closed the dialog mid-encode → just clear the status, no error.
     if (signal?.aborted || (e instanceof DOMException && e.name === "AbortError")) {
       setStatus(useSessionStore.getState().status, "");
-    } else {
-      const msg = e instanceof Error ? e.message : String(e);
-      setStatus(useSessionStore.getState().status, `Upload failed: ${msg}`);
-      // `pending` is intentionally left in place so the user can retry.
+      return { ok: false, aborted: true };
     }
+    const msg = e instanceof Error ? e.message : String(e);
+    setStatus(useSessionStore.getState().status, `Upload failed: ${msg}`);
+    // `pending` is intentionally left in place so the user can retry, and
+    // the dialog surfaces `error` inline (the status bar is hidden behind
+    // the modal, so returning it is the only way the user sees it).
+    return { ok: false, error: msg };
   } finally {
     setUploading(false);
   }


### PR DESCRIPTION
## Problem
After the recoverable-timeout fix (#226), the custom-song upload **still looks stuck**: clicking **START** in the Almost-Ready modal does nothing visible. The upload runs (server GPU stem-rip + source prep takes many seconds), but the modal has no in-flight state — the `Encoding…` status and even the 120 s timeout / connection errors are written to the status bar *behind* the modal, so they're invisible. On failure `pending` is intentionally preserved, so the modal stays open looking frozen. User experience: click START → nothing happens → stuck.

## Fix
Give the dialog ownership of the in-flight state:
- `commitUploadedTrack` now returns an `UploadOutcome` (`ok` / `aborted` / `error`).
- `AlmostReadyDialog` awaits `onContinue`, shows a spinner + "Encoding on the server — this can take up to a minute." banner, disables **Back**, and turns **START** into a disabled **Encoding…** while in flight.
- On failure the error is surfaced **inside** the modal and START becomes **Retry** (`pending` preserved → no re-pick). Success/abort unmount the dialog as before.
- The **×** stays live as the explicit cancel (aborts the in-flight upload); backdrop-click is suppressed mid-encode so a stray click can't silently abort.

Complements #226: that stops the hang, this makes the outcome **visible**.

## Notes
- `npm run typecheck` passes.
- Touches the three upload call sites (TrackPicker / AudioSourceCrate / LiteTrackCarousel) so `commitPending` forwards the outcome.
- If uploads still fail after this, the inline error will now name the cause (timeout vs connection vs server) — which tells us whether the deployed `:warm` pods actually carry the `upload_track` handler (added in #181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)