### PR TITLE
Magenta RT 2 backend family (sidecar-hosted, append-only)

### DIFF
--- a/acestep/streaming/families.py
+++ b/acestep/streaming/families.py
@@ -37,8 +37,19 @@ def _make_acestep(ss):
     )
 
 
+def _make_mrt2(ss):
+    from acestep.streaming.mrt2.backend import MRT2Backend
+
+    return MRT2Backend(
+        config=ss.config,
+        state=ss.state,
+        midi_knobs=ss.virtual_knobs,
+    )
+
+
 FAMILIES = {
     "acestep": _make_acestep,
+    "mrt2": _make_mrt2,
 }
 
 
@@ -62,8 +73,31 @@ def _acestep_knob_universe():
 # must be renamed (prefix / group), so the first lazily-reused name
 # can't become a silent semantic fork. Keyed identically to FAMILIES;
 # the guard enforces the keys stay in sync.
+def _mrt2_knob_universe():
+    from acestep.streaming.mrt2.backend import mrt2_knob_specs
+
+    return mrt2_knob_specs()
+
+
 FAMILY_KNOB_UNIVERSES = {
     "acestep": _acestep_knob_universe,
+    "mrt2": _mrt2_knob_universe,
+}
+
+
+def _create_mrt2_session(cls, **kwargs):
+    from acestep.streaming.mrt2.backend import create_mrt2_session
+
+    return create_mrt2_session(cls, **kwargs)
+
+
+# Families whose per-connect setup doesn't fit the ACE create path
+# (TRT profiles, model load, demucs, conditioning encode). Keyed like
+# FAMILIES; absent = the family rides StreamingSession.create's default
+# body. Contract: ``creator(cls, *, audio, config, checkpoint,
+# session_id, **rest) -> StreamingSession``.
+SESSION_CREATORS = {
+    "mrt2": _create_mrt2_session,
 }
 
 

--- a/acestep/streaming/mrt2/__init__.py
+++ b/acestep/streaming/mrt2/__init__.py
@@ -1,0 +1,10 @@
+"""Magenta RealTime 2 backend family.
+
+A :class:`~acestep.streaming.generator_backend.GeneratorBackend`
+implementor for Google's Magenta RT 2 (recurrentgemma backbone,
+SpectroStream codec) — the first token/AR family behind the seam and
+the first sidecar-hosted one. See ``backend.py`` for the in-process
+client and ``scripts/mrt2_sidecar.py`` for the generation loop that
+runs next to the JAX model (WSL venv or Linux pod; JAX has no CUDA on
+native Windows).
+"""

--- a/acestep/streaming/mrt2/backend.py
+++ b/acestep/streaming/mrt2/backend.py
@@ -1,0 +1,657 @@
+"""MRT2Backend: Magenta RT 2 behind the GeneratorBackend seam.
+
+The model is autoregressive (recurrentgemma over SpectroStream codec
+tokens): it emits final 40 ms frames from a recurrent state and can
+never revise them. That inverts most of the diffusion backend's
+contract, and this class is the reference for how an append-only
+family sits behind the seam:
+
+* ``render_window`` IGNORES the runner's position hint and returns the
+  next frontier chunk (the seam documents this for append-only
+  backends). Committed audio is never re-rendered.
+* Song shape is the rolling window (plan §3.6 v1): a synthetic
+  ``WINDOW_S`` duration; the frontier writes advance modulo the window
+  and the player loops it like any fixed song. The "song" is a tape
+  loop continuously overwritten just behind the playhead.
+* Each emitted chunk re-emits the previous chunk's final ``XFADE``
+  samples at its head (overlap), so the runner's unconditional
+  leading-edge crossfade blends new audio against identical samples —
+  a no-op — instead of smearing every chunk start with last lap's
+  stale audio.
+* Generation runs out-of-process (JAX has no CUDA on native Windows):
+  this class is a thin TCP client to ``scripts/mrt2_sidecar.py``
+  (protocol: :mod:`acestep.streaming.mrt2.protocol`), pacing the
+  sidecar with credit so the frontier stays ``mrt2_lead`` seconds
+  ahead of the playhead. For an append-only model that buffered lead
+  IS the knob-to-ear latency, so it is an operator knob, not a
+  constant.
+
+Conditioning: ``set_prompt`` / ``set_prompt_blend`` route here from
+the session (backend control hooks); the sidecar embeds tags via
+MusicCoCa and lerps A↔B embeddings for the blend. Sampling knobs
+(temperature / top_k / three CFG scales) ride the ordinary params
+channel as ``mrt2_``-prefixed bank knobs (group ``"mrt2"``) and are
+forwarded to the sidecar when they move; they apply at 40 ms frame
+granularity on the generation frontier.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import threading
+import time
+from collections import deque
+
+import numpy as np
+
+from acestep.engine.obs import logger
+from acestep.streaming.generator_backend import (
+    AudioChunk,
+    AudioGeometry,
+    Capabilities,
+    LeadProfile,
+    ProduceMode,
+    TickContext,
+)
+from acestep.streaming.knobs import KnobSpec
+from acestep.streaming.mrt2 import protocol as mp
+
+# Rolling-window song shape (plan §3.6 v1): the synthetic duration the
+# session declares and the player loops.
+WINDOW_S = 60.0
+WINDOW_SAMPLES = int(WINDOW_S * mp.SAMPLE_RATE)
+
+# Overlap re-emitted at each chunk head so the runner's leading-edge
+# crossfade blends against identical samples. Matches the runner's
+# fade length (min(1200, len // 4) at 48 kHz = 25 ms).
+XFADE = 1200
+
+# Cap on one render's emission. Keeps a post-stall burst from writing
+# a multi-second slab in one tick (and from out-running the wire).
+MAX_EMIT_S = 1.5
+
+# Heartbeat cadence / liveness deadline for the sidecar link.
+PING_EVERY_S = 2.0
+LOST_AFTER_S = 8.0
+
+# Largest credit grant per tick. The sidecar holds at most ~this much
+# un-asked-for work, so a stale grant can't run far past a knob change.
+MAX_GRANT_FRAMES = 50
+
+
+def mrt2_knob_specs() -> list:
+    """The MRT2 family knob universe (also the homonym-guard manifest;
+    see families.FAMILY_KNOB_UNIVERSES). All names carry the family
+    prefix per plan §3.3 — none of these mean anything to another
+    family. CFG bounds mirror the model's documented [-1, 7] range."""
+    return [
+        KnobSpec(
+            "mrt2_temperature", default=1.3, min_val=0.0, max_val=4.0,
+            group="mrt2",
+            description="Sampling temperature for the token sampler.",
+        ),
+        KnobSpec(
+            "mrt2_top_k", default=40, min_val=1.0, max_val=1024.0,
+            type="int", group="mrt2",
+            description="Top-k sampling threshold.",
+        ),
+        KnobSpec(
+            "mrt2_cfg_musiccoca", default=3.0, min_val=-1.0, max_val=7.0,
+            group="mrt2",
+            description="MusicCoCa (style/prompt) CFG scale.",
+        ),
+        KnobSpec(
+            "mrt2_cfg_notes", default=1.0, min_val=-1.0, max_val=7.0,
+            group="mrt2",
+            description="Notes-conditioning CFG scale.",
+        ),
+        KnobSpec(
+            "mrt2_cfg_drums", default=1.0, min_val=-1.0, max_val=7.0,
+            group="mrt2",
+            description="Drums-conditioning CFG scale.",
+        ),
+        KnobSpec(
+            "mrt2_lead", default=0.75, min_val=0.3, max_val=3.0,
+            group="mrt2",
+            description="Target generation lead over the playhead in "
+                        "seconds. Append-only audio cannot be revised, "
+                        "so this IS the knob-to-ear latency floor; "
+                        "raise it for underrun safety, lower it for "
+                        "responsiveness.",
+        ),
+    ]
+
+
+# Knob name -> sidecar control field. (mrt2_lead is backend-local.)
+_SIDECAR_KNOBS = {
+    "mrt2_temperature": "temperature",
+    "mrt2_top_k": "top_k",
+    "mrt2_cfg_musiccoca": "cfg_musiccoca",
+    "mrt2_cfg_notes": "cfg_notes",
+    "mrt2_cfg_drums": "cfg_drums",
+}
+
+
+def sidecar_address() -> tuple:
+    """Resolve the sidecar address from ``DEMON_MRT2_SIDECAR``
+    (``host:port``), defaulting to the protocol module's localhost
+    port. WSL2 forwards localhost, so the default reaches a sidecar
+    inside WSL from the Windows-side server."""
+    raw = os.environ.get("DEMON_MRT2_SIDECAR", "")
+    if raw:
+        host, _, port = raw.rpartition(":")
+        return host or mp.DEFAULT_HOST, int(port)
+    return mp.DEFAULT_HOST, mp.DEFAULT_PORT
+
+
+class SidecarClient:
+    """Blocking-socket client to the MRT2 sidecar with a reader thread.
+
+    Audio chunks land in an internal queue the backend drains on the
+    runner thread; control sends happen from whatever thread the
+    session op runs on, serialized by a lock. All link failures
+    degrade to ``lost = True`` (logged once) rather than raising into
+    the runner loop — the session keeps serving its rolling buffer.
+    """
+
+    def __init__(self, host: str, port: int, connect_timeout_s: float = 5.0):
+        self._addr = (host, port)
+        self._sock = socket.create_connection((host, port), timeout=connect_timeout_s)
+        self._send_lock = threading.Lock()
+        self._audio: deque = deque()
+        self._audio_lock = threading.Lock()
+        self.frames_received = 0
+        self.last_rx_ts = time.monotonic()
+        self.lost = False
+        self.meta: dict = {}
+
+        # Handshake: hello -> meta, still on the connect timeout.
+        self._sock.sendall(mp.pack_json({"type": "hello"}))
+        kind, payload = mp.recv_msg(self._sock)
+        if kind != mp.MSG_JSON:
+            raise ConnectionError("mrt2 sidecar: expected meta, got audio")
+        meta = mp.unpack_json(payload)
+        if meta.get("type") != "meta":
+            raise ConnectionError(f"mrt2 sidecar: expected meta, got {meta.get('type')!r}")
+        if (
+            meta.get("sample_rate") != mp.SAMPLE_RATE
+            or meta.get("channels") != mp.CHANNELS
+            or meta.get("frame_samples") != mp.FRAME_SAMPLES
+        ):
+            raise ConnectionError(f"mrt2 sidecar: geometry mismatch: {meta}")
+        self.meta = meta
+
+        self._sock.settimeout(None)
+        self._reader = threading.Thread(
+            target=self._read_loop, name="mrt2-sidecar-reader", daemon=True,
+        )
+        self._reader.start()
+
+    # ---- reader thread ----------------------------------------------------
+
+    def _read_loop(self) -> None:
+        try:
+            while True:
+                kind, payload = mp.recv_msg(self._sock)
+                self.last_rx_ts = time.monotonic()
+                if kind == mp.MSG_AUDIO:
+                    _idx, num_frames, pcm = mp.unpack_audio(payload)
+                    arr = np.frombuffer(pcm, dtype=np.float32).reshape(
+                        -1, mp.CHANNELS,
+                    )
+                    with self._audio_lock:
+                        self._audio.append(arr)
+                        self.frames_received += num_frames
+                else:
+                    msg = mp.unpack_json(payload)
+                    if msg.get("type") == "err":
+                        logger.error("mrt2_sidecar_err message={}", msg.get("message"))
+                    # pong and anything else: last_rx_ts update is enough.
+        except (ConnectionError, OSError) as exc:
+            if not self.lost:
+                self.lost = True
+                logger.error("mrt2_sidecar_lost reader error={}", exc)
+
+    # ---- senders (any thread) ----------------------------------------------
+
+    def send_json(self, obj: dict) -> None:
+        if self.lost:
+            return
+        try:
+            with self._send_lock:
+                self._sock.sendall(mp.pack_json(obj))
+        except (ConnectionError, OSError) as exc:
+            if not self.lost:
+                self.lost = True
+                logger.error("mrt2_sidecar_lost send error={}", exc)
+
+    # ---- runner-thread drains ----------------------------------------------
+
+    def pop_audio(self) -> list:
+        with self._audio_lock:
+            out = list(self._audio)
+            self._audio.clear()
+        return out
+
+    def close(self) -> None:
+        self.lost = True
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+
+
+class MRT2Backend:
+    """Magenta RT 2 generation behind the GeneratorBackend seam.
+
+    Append-only, sidecar-hosted, rolling-window song shape. See module
+    docstring; the seam-contract notes live on each method.
+    """
+
+    name = "mrt2"
+
+    def __init__(self, *, config, state, midi_knobs, client: SidecarClient | None = None):
+        self.config = config
+        self.state = state
+        self.midi_knobs = midi_knobs
+
+        # Runner slice-width bookkeeping (PipelineRunner reads this for
+        # its stall/shortfall math and the windowed-mode switch). The
+        # emission itself is frontier-driven and variable-length.
+        self.vae_window = 1.0
+        self.decode_span_s = 0.0
+        self.last_tick_ms = 0.0
+        self.last_dec_ms = 0.0
+
+        owns_client = client is None
+        if client is None:
+            host, port = sidecar_address()
+            try:
+                client = SidecarClient(host, port)
+            except (ConnectionError, OSError, ValueError) as exc:
+                # Loud at session create (plan: config-time failure, the
+                # client asked for a generator this deployment isn't
+                # running).
+                raise RuntimeError(
+                    f"mrt2 sidecar unreachable at {host}:{port} "
+                    f"(start scripts/mrt2_sidecar.py in the MRT2 venv, "
+                    f"or set DEMON_MRT2_SIDECAR): {exc}"
+                ) from exc
+        self.client = client
+        logger.info("mrt2_sidecar_connected meta={}", client.meta)
+
+        # The TCP link is a real acquired resource: from here on, any
+        # failure before __init__ returns (e.g. the initial prompt seed
+        # below hitting a sidecar protocol error) must not strand it —
+        # the caller can't close a backend it never received. Mirrors
+        # ModelContext/Session's transactional constructors. Injected
+        # clients stay caller-owned and are left alone.
+        try:
+
+            # ---- frontier / rolling-window state (runner thread only) ----
+            # Absolute samples handed to the runner (exclusive); the wire
+            # position is this modulo WINDOW_SAMPLES.
+            self._abs_written = 0
+            # Pending PCM drained from the client but not yet emitted.
+            self._pending: deque = deque()
+            self._pending_samples = 0
+            # Last XFADE emitted samples, re-emitted at the next chunk head.
+            self._tail: np.ndarray | None = None
+
+            # Unwrapped playhead estimate (laps over the rolling window).
+            self._playhead_wrapped_prev = 0.0
+            self._playhead_laps = 0
+
+            # Credit accounting (frames granted vs received).
+            self._granted = 0
+
+            # Last knob values forwarded to the sidecar.
+            self._sent_knobs: dict = {}
+
+            self._last_ping_ts = 0.0
+            self._lost_logged = False
+
+            # Stashed for the params echo.
+            self._echo: dict = {}
+
+            # Initial conditioning: the session seeds prompts into state
+            # before the backend is constructed.
+            self.handle_set_prompt(
+                getattr(state, "prompt_text", "") or "",
+                tags_b=getattr(state, "prompt_text_b", None),
+            )
+        except BaseException:
+            if owns_client:
+                try:
+                    client.close()
+                except Exception:
+                    pass
+            raise
+
+    # ---- contract ----------------------------------------------------------
+
+    def capabilities(self) -> Capabilities:
+        # Everything defaults False: no refinement (append-only), no
+        # swap/timbre/structure/stems (no positional source), no LoRA,
+        # no depth, no curves. notes_conditioning is real in the model
+        # but not wired yet (plan Phase 3.5).
+        return Capabilities()
+
+    def geometry(self) -> AudioGeometry:
+        return AudioGeometry(
+            sample_rate=mp.SAMPLE_RATE,
+            channels=mp.CHANNELS,
+            chunk_rate_hz=1.0 / mp.FRAME_SECONDS,
+            duration_s=WINDOW_S,
+        )
+
+    def lead_profile(self) -> LeadProfile:
+        # The runner's adaptive lead positions diffusion re-renders;
+        # append-only emission ignores the position hint, so the
+        # runner defaults are fine. The lead that matters here is the
+        # mrt2_lead knob (credit pacing).
+        return LeadProfile()
+
+    def knob_specs(self, lora_ids=()) -> list:
+        return mrt2_knob_specs()
+
+    # ---- session control hooks ----------------------------------------------
+
+    def handle_set_prompt(self, tags: str, *, tags_b: str | None = None) -> None:
+        """Backend route for the universal ``set_prompt`` op: forward
+        the raw tags; the sidecar owns MusicCoCa embedding (and caches
+        per-tags embeddings, so blend moves don't re-embed)."""
+        self.client.send_json({
+            "type": "prompt", "tags": tags or "", "tags_b": tags_b,
+        })
+
+    def handle_set_prompt_blend(self, value: float) -> None:
+        """Backend route for ``set_prompt_blend``: the sidecar lerps
+        the cached A/B style embeddings."""
+        self.client.send_json({"type": "blend", "value": float(value)})
+
+    def close(self) -> None:
+        self.client.close()
+
+    # ---- hot loop -------------------------------------------------------------
+
+    def sync_source(self, ctx: TickContext) -> None:
+        # No positional source: nothing to reconcile. Unwrap the
+        # playhead here (once per tick, before produce) so credit
+        # pacing sees a monotonic clock across window laps.
+        pos = ctx.playhead_s
+        if pos < self._playhead_wrapped_prev - WINDOW_S * 0.5:
+            self._playhead_laps += 1
+        self._playhead_wrapped_prev = pos
+
+    def read_knobs(self) -> dict:
+        return self.midi_knobs.get_all_values()
+
+    def has_pending_refit(self) -> bool:
+        return False
+
+    def rebuild_imminent(self, knobs: dict) -> bool:
+        return False
+
+    def has_renderable_state(self) -> bool:
+        return self._abs_written > 0 or self._pending_samples > 0
+
+    def playable_duration_s(self):
+        return WINDOW_S
+
+    def _playhead_abs_samples(self) -> int:
+        return int(
+            (self._playhead_laps * WINDOW_S + self._playhead_wrapped_prev)
+            * mp.SAMPLE_RATE
+        )
+
+    def _forward_knobs(self, raw: dict) -> None:
+        update = {}
+        for knob, field in _SIDECAR_KNOBS.items():
+            val = raw.get(knob)
+            if val is None:
+                continue
+            val = int(val) if field == "top_k" else round(float(val), 4)
+            if self._sent_knobs.get(field) != val:
+                update[field] = val
+        if update:
+            self._sent_knobs.update(update)
+            self.client.send_json({"type": "knobs", **update})
+
+    def produce(self, knobs: dict, ctx: TickContext, mode: ProduceMode) -> bool:
+        """One tick: forward control changes, pace the sidecar with
+        credit, drain arrived audio. Modes are a no-op distinction
+        here — there is no expensive local generate step to skip, and
+        music must keep flowing through DiT-pause idle ("reuse"), so
+        every mode runs the same pull path."""
+        t0 = time.perf_counter()
+        now = time.monotonic()
+
+        client = self.client
+        if not client.lost:
+            # Heartbeat + liveness.
+            if now - self._last_ping_ts >= PING_EVERY_S:
+                self._last_ping_ts = now
+                client.send_json({"type": "ping", "t": now})
+            if now - client.last_rx_ts > LOST_AFTER_S:
+                client.lost = True
+                logger.error(
+                    "mrt2_sidecar_lost reason=liveness deadline_s={}",
+                    LOST_AFTER_S,
+                )
+
+            self._forward_knobs(knobs)
+
+            # Credit pacing: keep (emitted + pending + outstanding)
+            # ``mrt2_lead`` seconds ahead of the unwrapped playhead.
+            lead_s = float(knobs.get("mrt2_lead", 0.75))
+            outstanding = self._granted - client.frames_received
+            covered = (
+                self._abs_written
+                + self._pending_samples
+                + max(0, outstanding) * mp.FRAME_SAMPLES
+            )
+            target = self._playhead_abs_samples() + int(lead_s * mp.SAMPLE_RATE)
+            deficit = target - covered
+            if deficit > 0:
+                grant = min(
+                    MAX_GRANT_FRAMES,
+                    -(-deficit // mp.FRAME_SAMPLES),  # ceil div
+                )
+                self._granted += grant
+                client.send_json({"type": "credit", "frames": int(grant)})
+
+        for arr in client.pop_audio():
+            self._pending.append(arr)
+            self._pending_samples += arr.shape[0]
+
+        self._echo = {k: knobs.get(k) for k in _SIDECAR_KNOBS}
+        self._echo["mrt2_lead"] = knobs.get("mrt2_lead")
+        self.last_tick_ms = (time.perf_counter() - t0) * 1000
+
+        if self._pending_samples == 0:
+            # Nothing landed this tick. The ACE backend's GPU step paces
+            # the loop; here the socket does, so nap briefly instead of
+            # spinning the runner at CPU speed.
+            time.sleep(0.01)
+            return False
+        return True
+
+    def render_window(self, t_start_s: float):
+        """Emit the next frontier chunk. The position hint is ignored
+        (append-only: there is exactly one place new audio can go).
+        Returns None when no new frames are pending — the runner's
+        gap-fill tick then writes nothing, which is correct: committed
+        audio is already in the buffer and never changes."""
+        if self._pending_samples == 0:
+            return None
+        t0 = time.perf_counter()
+
+        # Gather up to MAX_EMIT_S, clamped at the rolling-window edge
+        # so a chunk never spans the wrap seam (the remainder stays
+        # pending for the next tick, ~one loop iteration later).
+        wrapped_start = self._abs_written % WINDOW_SAMPLES
+        room = WINDOW_SAMPLES - wrapped_start
+        budget = min(int(MAX_EMIT_S * mp.SAMPLE_RATE), room)
+
+        parts = []
+        taken = 0
+        while self._pending and taken < budget:
+            arr = self._pending.popleft()
+            if taken + arr.shape[0] > budget:
+                cut = budget - taken
+                parts.append(arr[:cut])
+                self._pending.appendleft(arr[cut:])
+                taken = budget
+            else:
+                parts.append(arr)
+                taken += arr.shape[0]
+        self._pending_samples -= taken
+        new_pcm = parts[0] if len(parts) == 1 else np.concatenate(parts)
+
+        # Overlap head: re-emit the tail of the previous emission so
+        # the runner's leading-edge crossfade blends identical samples.
+        # Skipped when it would cross the wrap seam backwards (once per
+        # lap) and on the very first chunk.
+        head = None
+        if self._tail is not None and 0 < XFADE <= wrapped_start:
+            head = self._tail[-XFADE:]
+
+        if head is not None:
+            pcm = np.concatenate([head, new_pcm])
+            start_sample = wrapped_start - head.shape[0]
+        else:
+            pcm = np.array(new_pcm, copy=True)  # runner mutates in place
+            start_sample = wrapped_start
+
+        # Update the tail from pristine data BEFORE handing the chunk
+        # out (the runner crossfades win_np in place).
+        if self._tail is None:
+            self._tail = np.array(new_pcm[-XFADE:], copy=True)
+        else:
+            self._tail = np.concatenate([self._tail, new_pcm])[-XFADE:].copy()
+
+        self._abs_written += taken
+        self.last_dec_ms = (time.perf_counter() - t0) * 1000
+        return AudioChunk(pcm=pcm, start_sample=int(start_sample))
+
+    def render_full(self):
+        # Legacy full-buffer mode (vae_window <= 0) never applies: this
+        # backend always declares a positive window.
+        return None
+
+    # ---- bookkeeping ------------------------------------------------------
+
+    def on_fresh_generation(self, knobs: dict) -> None:
+        params = self.state.params
+        params["num_gens"] = params.get("num_gens", 0) + 1
+        params["tick_ms"] = self.last_tick_ms
+        params["dec_ms"] = self.last_dec_ms
+        for name, val in self._echo.items():
+            if val is None:
+                continue
+            params[name] = round(float(val), 3)
+        params["_prompt"] = self.state.prompt_text
+
+
+# ---------------------------------------------------------------------------
+# Session creation (families.SESSION_CREATORS["mrt2"])
+# ---------------------------------------------------------------------------
+
+
+def create_mrt2_session(cls, *, audio, config, checkpoint, session_id, **_unused):
+    """Build a StreamingSession for the MRT2 family.
+
+    The ACE create path (TRT profiles, model load, demucs, conditioning
+    encode) doesn't apply: the model lives in the sidecar. What a
+    session needs here is the rolling-window buffer, the family knob
+    bank, and a SessionState whose source-derived metadata is honestly
+    absent — geometry/capabilities in ``ready`` are the declared truth
+    (plan §3.6: nullable metadata rides the capability mask).
+
+    ``audio`` (the handshake upload/fixture) is intentionally ignored:
+    there is no source to swap in, and starting from silence is honest
+    — the frontier overwrites the window from t=0. ``checkpoint`` is
+    recorded but unused; the sidecar picks the model variant at ITS
+    launch (``--model``).
+    """
+    from contextlib import ExitStack
+
+    from acestep.streaming.audio_engine import AudioEngine
+    from acestep.streaming.knobs import KnobState
+    from acestep.streaming.session import _cleanup_create_resource
+    from acestep.streaming.state import SessionState
+
+    if audio is not None and getattr(audio, "waveform", None) is not None:
+        logger.info(
+            "mrt2_create_ignoring_source duration_s={:.1f} reason=append_only_family",
+            audio.waveform.shape[-1] / mp.SAMPLE_RATE,
+        )
+
+    buf = np.zeros((WINDOW_SAMPLES, mp.CHANNELS), dtype=np.float32)
+    prompt = config.prompt or ""
+    prompt_b = config.prompt_b if config.prompt_b is not None else prompt
+
+    state = SessionState(
+        source=None,
+        bpm=0,
+        key="",
+        time_signature="4/4",
+        duration=WINDOW_S,
+        n_channels=mp.CHANNELS,
+        playback_samples=WINDOW_SAMPLES,
+        cond_pair=None,
+        cond_pair_b=None,
+        prompt_text=prompt,
+        prompt_text_b=prompt_b,
+        current_depth=1,
+    )
+
+    # Same transactional create shape as StreamingSession.create's ACE
+    # body: resources acquired before ``cls(...)`` succeeds register on
+    # the stack the moment they exist; ownership transfers via
+    # ``pop_all()`` only on success. The sidecar TCP link itself is
+    # acquired inside ``cls(...)`` (MRT2Backend.__init__, via
+    # make_backend) — its no-leak guarantee lives in the transactional
+    # constructors (MRT2Backend.__init__ closes a self-acquired client
+    # on failure; StreamingSession.__init__ closes the backend if init
+    # fails after make_backend).
+    with ExitStack() as cleanup:
+        audio_eng = AudioEngine(buf, mp.SAMPLE_RATE)
+        cleanup.callback(
+            _cleanup_create_resource,
+            "audio_engine",
+            audio_eng.stop,
+        )
+        streaming = cls(
+            session_id=session_id,
+            checkpoint=checkpoint,
+            config=config,
+            engine_session=None,
+            stream=None,
+            state=state,
+            audio_eng=audio_eng,
+            virtual_knobs=KnobState(mrt2_knob_specs()),
+            engine_obj=None,
+            profile_mgr=None,
+            cond_negative=None,
+            initial_buffer=buf,
+            initial_upload_stems=None,
+            initial_stem_error=None,
+            initial_stem_source_mode=None,
+            initial_enable_ids=[],
+            lora_strengths_init={},
+            lora_available=False,
+            max_pipeline_depth=1,
+            max_seconds=WINDOW_S,
+            walk_window=False,
+            walk_window_s=WINDOW_S,
+            vae_window=1.0,
+            crop_seconds=0.0,
+            use_sde=False,
+            use_lora=False,
+            k1_name="mrt2_temperature",
+        )
+        cleanup.pop_all()
+        return streaming

--- a/acestep/streaming/mrt2/protocol.py
+++ b/acestep/streaming/mrt2/protocol.py
@@ -1,0 +1,128 @@
+"""MRT2 sidecar frame protocol — the single source of truth.
+
+The Magenta RT 2 model runs out-of-process (JAX has no CUDA on native
+Windows; the generation loop lives in a WSL venv or on a pod) behind a
+deliberately tiny TCP protocol. This module defines it once; both ends
+import it:
+
+* the in-process :class:`~acestep.streaming.mrt2.backend.MRT2Backend`
+  imports it normally, and
+* ``scripts/mrt2_sidecar.py`` loads THIS FILE via
+  ``importlib.util.spec_from_file_location`` — never ``import acestep``
+  — because the sidecar venv has magenta_rt + JAX but no torch, and the
+  ``acestep`` package import would pull the GPU stack.
+
+So: stdlib only. No numpy, no acestep imports.
+
+Framing (both directions, little-endian):
+
+    u32 payload_length | u8 kind | payload
+
+``kind == MSG_JSON``: payload is a UTF-8 JSON object with a ``"type"``
+field. Control plane:
+
+    backend -> sidecar: {"type": "hello"}
+                        {"type": "prompt", "tags": str, "tags_b": str|null}
+                        {"type": "blend", "value": float}          # A<->B style blend in [0,1]
+                        {"type": "knobs", "temperature"?: float, "top_k"?: int,
+                         "cfg_musiccoca"?: float, "cfg_notes"?: float,
+                         "cfg_drums"?: float}
+                        {"type": "credit", "frames": int}          # grant N more 40ms frames
+                        {"type": "ping", "t": float}
+    sidecar -> backend: {"type": "meta", "sample_rate": int, "channels": int,
+                         "frame_samples": int, "model": str}
+                        {"type": "pong", "t": float}
+                        {"type": "err", "message": str}
+
+``kind == MSG_AUDIO`` (sidecar -> backend only): payload is
+
+    u64 frame_index | u16 num_frames | f32 PCM interleaved
+                                       [num_frames * FRAME_SAMPLES * CHANNELS]
+
+``frame_index`` is the index of the FIRST frame in the chunk, counting
+every frame the sidecar has emitted since its process started (it does
+NOT reset per connection — the backend anchors on the first chunk it
+sees). Audio is final on first emit: the model is autoregressive and
+never refines, so frames are append-only by construction.
+
+Flow control is credit-based: the sidecar generates only while it holds
+credit, the backend grants credit to keep the frontier a configured
+lead ahead of the playhead. The model outruns real time (mrt2_small =
+~1.7x RT on the dev 5090), so credit, not throughput, paces generation
+— and the buffered lead stays small because for an append-only model
+the buffered lead IS the knob-to-ear latency.
+"""
+
+import json
+import struct
+
+# Audio shape (matches Magenta RT 2's SpectroStream output and,
+# fortuitously, DEMON's engine rate — no resample needed).
+SAMPLE_RATE = 48000
+CHANNELS = 2
+FRAME_SAMPLES = 1920          # one model frame = 40 ms at 48 kHz
+FRAME_SECONDS = FRAME_SAMPLES / SAMPLE_RATE
+
+# Message kinds.
+MSG_JSON = 1
+MSG_AUDIO = 2
+
+_LEN = struct.Struct("<I")
+_KIND = struct.Struct("<B")
+AUDIO_HDR = struct.Struct("<QH")  # frame_index, num_frames
+
+# Default sidecar address. WSL2 forwards localhost, so the Windows-side
+# server reaches a sidecar bound inside WSL at the same address.
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 7531
+
+# Hard ceiling on one message's payload (1 MiB covers ~34 frames of
+# f32 stereo; chunks are a handful of frames). Protects both ends from
+# a corrupt length prefix.
+MAX_PAYLOAD = 1 << 20
+
+
+def pack_msg(kind: int, payload: bytes) -> bytes:
+    """One wire message: length prefix + kind byte + payload."""
+    return _LEN.pack(len(payload) + 1) + _KIND.pack(kind) + payload
+
+
+def pack_json(obj: dict) -> bytes:
+    return pack_msg(MSG_JSON, json.dumps(obj).encode("utf-8"))
+
+
+def pack_audio(frame_index: int, num_frames: int, pcm_bytes: bytes) -> bytes:
+    return pack_msg(
+        MSG_AUDIO, AUDIO_HDR.pack(frame_index, num_frames) + pcm_bytes,
+    )
+
+
+def recv_exact(sock, n: int) -> bytes:
+    """Read exactly ``n`` bytes from a blocking socket, or raise
+    ``ConnectionError`` on EOF."""
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("sidecar connection closed")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def recv_msg(sock) -> tuple:
+    """Read one framed message. Returns ``(kind, payload_bytes)``."""
+    (length,) = _LEN.unpack(recv_exact(sock, _LEN.size))
+    if not 1 <= length <= MAX_PAYLOAD + 1:
+        raise ConnectionError(f"bad frame length {length}")
+    body = recv_exact(sock, length)
+    return body[0], body[1:]
+
+
+def unpack_json(payload: bytes) -> dict:
+    return json.loads(payload.decode("utf-8"))
+
+
+def unpack_audio(payload: bytes) -> tuple:
+    """Returns ``(frame_index, num_frames, pcm_bytes)``."""
+    frame_index, num_frames = AUDIO_HDR.unpack_from(payload, 0)
+    return frame_index, num_frames, payload[AUDIO_HDR.size:]

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -99,7 +99,7 @@ from acestep.streaming.knobs import (
     knob_specs,
     lora_strength_spec,
 )
-from acestep.streaming.families import make_backend
+from acestep.streaming.families import SESSION_CREATORS, make_backend
 from acestep.streaming.generator_backend import UnsupportedOperation
 from acestep.streaming.pipeline_runner import PipelineRunner
 from acestep.streaming.source import (
@@ -373,7 +373,9 @@ class StreamingSession:
         session_id: str,
         checkpoint: str,
         config: SessionConfig,
-        engine_session: Session,
+        # None for families whose generation lives behind the backend
+        # seam without the ACE engine stack (e.g. mrt2's sidecar).
+        engine_session: Session | None,
         stream,
         state: SessionState,
         audio_eng: AudioEngine,
@@ -460,12 +462,26 @@ class StreamingSession:
             getattr(config, "backend", "acestep") or "acestep", self,
         )
 
-        # Cached {name: KnobSpec} map for hot-path validation in set_knobs.
-        # knob_specs() rebuilds 34 dataclasses, so we never call it per tick;
-        # rebuilt only when the LoRA set changes (see _apply_lora_pending).
-        # Reassigned wholesale (atomic ref swap), so set_knobs can read it
-        # without a lock from the dispatch thread.
-        self._rebuild_knob_specs(self.initial_enable_ids)
+        try:
+            # Cached {name: KnobSpec} map for hot-path validation in set_knobs.
+            # knob_specs() rebuilds 34 dataclasses, so we never call it per tick;
+            # rebuilt only when the LoRA set changes (see _apply_lora_pending).
+            # Reassigned wholesale (atomic ref swap), so set_knobs can read it
+            # without a lock from the dispatch thread.
+            self._rebuild_knob_specs(self.initial_enable_ids)
+        except BaseException:
+            # The backend may own real acquired resources (the MRT2
+            # sidecar socket); if __init__ fails after make_backend, the
+            # caller never receives the object and can't close them.
+            # Same transactional-constructor contract as ModelContext /
+            # Session.__init__.
+            close = getattr(self.backend, "close", None)
+            if close is not None:
+                try:
+                    close()
+                except Exception as exc:
+                    logger.warning("backend_close_raised error={}", exc)
+            raise
 
     def _rebuild_knob_specs(self, lora_ids: list) -> None:
         # Backend-owned manifest: which specs the LoRA set expands to is
@@ -664,14 +680,24 @@ class StreamingSession:
             self.audio_eng.stop()
         except Exception as exc:
             logger.warning("audio_engine_stop_raised error={}", exc)
-        try:
-            self.stream.close()
-        except Exception as exc:
-            logger.warning("stream_close_raised error={}", exc)
-        try:
-            self.session.close()
-        except Exception as exc:
-            logger.warning("session_close_raised error={}", exc)
+        # Backend-owned resources first (e.g. the MRT2 sidecar
+        # socket); families without a close() have nothing to do.
+        close = getattr(self.backend, "close", None)
+        if close is not None:
+            try:
+                close()
+            except Exception as exc:
+                logger.warning("backend_close_raised error={}", exc)
+        if self.stream is not None:
+            try:
+                self.stream.close()
+            except Exception as exc:
+                logger.warning("stream_close_raised error={}", exc)
+        if self.session is not None:
+            try:
+                self.session.close()
+            except Exception as exc:
+                logger.warning("session_close_raised error={}", exc)
 
     def _on_audio_ready(self, wav_np, win_start=None, win_end=None):
         """Runner callback. Mutates ``audio_eng`` for full-buffer
@@ -1034,6 +1060,11 @@ class StreamingSession:
         """Recompose ``stream.conditioning`` from the cached A/B pairs,
         current timbre strength, and current prompt blend."""
         state = self.state
+        if state.cond_pair is None:
+            # Families that own their conditioning (backend control
+            # hooks) carry no cached pairs; interp-method flips and
+            # other incidental callers are no-ops here.
+            return
         cs_a, cf_a = state.cond_pair
         ca = blend_for_strength(
             cs_a, cf_a, state.timbre_strength, method=state.interp_timbre,
@@ -1361,6 +1392,25 @@ class StreamingSession:
         :class:`PromptApplied`."""
         state = self.state
         state.last_activity_ts = time.monotonic()
+
+        # Backend control hook (universal op, family-specific
+        # implementation): a backend that owns its own conditioning
+        # (MRT2 forwards tags to its sidecar's MusicCoCa) defines
+        # ``handle_set_prompt`` and the ACE encode path below never
+        # runs. The ACE backend defines no hook — byte-identical path.
+        handle = getattr(self.backend, "handle_set_prompt", None)
+        if handle is not None:
+            with state._lock:
+                state.prompt_text = tags
+                state.prompt_text_b = tags_b if tags_b else tags
+            logger.info(
+                "prompt_set origin={} tags={!r} tags_b={!r} backend={}",
+                origin.value, tags, tags_b, self.backend.name,
+            )
+            handle(tags, tags_b=tags_b)
+            self.bus.publish(PromptApplied(tags=tags))
+            return
+
         with state._lock:
             ts_override = _normalize_time_signature(time_signature)
             if ts_override is not None:
@@ -1401,6 +1451,19 @@ class StreamingSession:
         v = max(0.0, min(1.0, float(value)))
         if origin is CommandOrigin.EXTERNAL:
             self.bus.publish(PromptBlendEcho(value=v))
+            return
+        # Backend control hook — same pattern as set_prompt: MRT2 lerps
+        # cached style embeddings in its sidecar; ACE recomposes the
+        # cached conditioning pairs below.
+        handle = getattr(self.backend, "handle_set_prompt_blend", None)
+        if handle is not None:
+            with self.state._lock:
+                self.state.prompt_blend = v
+            handle(v)
+            logger.debug(
+                "prompt_blend_set origin={} value={:.3f} backend={}",
+                origin.value, v, self.backend.name,
+            )
             return
         with self.state._lock:
             self.state.prompt_blend = v
@@ -1696,6 +1759,26 @@ class StreamingSession:
             StemExtractFailedError: stem extraction failed for an
                 upload whose ``stem_source_mode`` selected a stem.
         """
+        # Family dispatch BEFORE any ACE-shaped setup (TRT profiles,
+        # model load, conditioning encode): a family with its own
+        # creator builds the session itself. The default body below IS
+        # the acestep creator. Families without a creator entry that
+        # aren't acestep still fail loudly later in __init__ via
+        # families.make_backend.
+        family = getattr(config, "backend", "acestep") or "acestep"
+        creator = SESSION_CREATORS.get(family)
+        if creator is not None:
+            return creator(
+                cls,
+                audio=audio,
+                config=config,
+                checkpoint=checkpoint,
+                session_id=session_id,
+                decoder_backend=decoder_backend,
+                vae_backend=vae_backend,
+                offload_text_encoder=offload_text_encoder,
+            )
+
         waveform = audio.waveform
 
         use_trt = decoder_backend == "tensorrt" or vae_backend == "tensorrt"

--- a/demos/realtime_motion_graph_web/web/app/magenta/MagentaPanel.tsx
+++ b/demos/realtime_motion_graph_web/web/app/magenta/MagentaPanel.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState } from "react";
+
+import type { KnobManifestEntry } from "@demon/client";
+import styles from "./magenta.module.css";
+
+import { useMagentaSession } from "./useMagentaSession";
+
+// Magenta RT 2 frontend — the hardware-pedal chassis from the
+// ambient-oneknob POC (daydream-ambien-oneknob branch), but instead of
+// one macro knob it lays out every control the mrt2 family actually
+// declares: the knob bank straight from ready.knob_manifest, Tags A/B,
+// and the A↔B blend. Nothing acestep-shaped exists here — no fixtures,
+// no LoRAs, no timbre/structure.
+
+const DEFAULT_TAGS_A = "warm analog synthwave, steady beat";
+const DEFAULT_TAGS_B = "";
+
+function knobLabel(name: string): string {
+  return name.replace(/^mrt2_/, "").replace(/_/g, " ");
+}
+
+function formatValue(entry: KnobManifestEntry, value: number): string {
+  return entry.type === "int" ? String(Math.round(value)) : value.toFixed(2);
+}
+
+interface RotorKnobProps {
+  name: string;
+  entry: KnobManifestEntry;
+  value: number;
+  onChange: (value: number) => void;
+}
+
+// Small rotary control — the POC's rotor pattern (invisible range input
+// over a CSS pointer disc) at satellite size. Range/step come from the
+// manifest entry; the -135°..+135° sweep matches the POC's big knob.
+function RotorKnob({ name, entry, value, onChange }: RotorKnobProps) {
+  const min = entry.min ?? 0;
+  const max = entry.max ?? 1;
+  const span = max - min || 1;
+  const norm = Math.max(0, Math.min(1, (value - min) / span));
+  const angle = -135 + norm * 270;
+  const step = entry.type === "int" ? 1 : span / 200;
+
+  return (
+    <div className={styles.knobCell} title={entry.description}>
+      <div className={styles.knobWrap}>
+        <input
+          className={styles.knobInput}
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          onChange={(event) => onChange(Number(event.target.value))}
+          aria-label={knobLabel(name)}
+        />
+        <div className={styles.knob}>
+          <div
+            className={styles.pointerRotor}
+            style={{ transform: `rotate(${angle}deg)` }}
+          >
+            <div className={styles.knobPointer} />
+          </div>
+        </div>
+      </div>
+      <div className={styles.knobValue}>{formatValue(entry, value)}</div>
+      <div className={styles.knobLabel}>{knobLabel(name)}</div>
+    </div>
+  );
+}
+
+export function MagentaPanel() {
+  const session = useMagentaSession();
+  const [tagsA, setTagsA] = useState(DEFAULT_TAGS_A);
+  const [tagsB, setTagsB] = useState(DEFAULT_TAGS_B);
+  const [blend, setBlendState] = useState(0);
+
+  const running = session.status === "ready" || session.status === "connecting";
+
+  function onToggle() {
+    if (running) {
+      void session.stop();
+    } else {
+      void session.start(tagsA, tagsB, blend);
+    }
+  }
+
+  function onBlend(value: number) {
+    setBlendState(value);
+    session.setBlend(value);
+  }
+
+  return (
+    <main className={styles.shell}>
+      <section className={styles.plugin} aria-label="Daydream Magenta">
+        <div className={styles.brandRow}>
+          <div className={styles.brand}>Daydream</div>
+        </div>
+
+        <div className={styles.knobGrid}>
+          {session.knobs.length > 0 ? (
+            session.knobs.map(({ name, entry }) => (
+              <RotorKnob
+                key={name}
+                name={name}
+                entry={entry}
+                value={session.values[name] ?? 0}
+                onChange={(v) => session.setKnob(name, v)}
+              />
+            ))
+          ) : (
+            <div className={styles.knobPlaceholder}>
+              {session.status === "connecting"
+                ? "loading knob bank…"
+                : "knobs appear when the session starts"}
+            </div>
+          )}
+        </div>
+
+        <div className={styles.tags}>
+          <label className={styles.tagSlot}>
+            <span>Tags A</span>
+            <textarea
+              rows={2}
+              value={tagsA}
+              onChange={(event) => setTagsA(event.target.value)}
+            />
+          </label>
+          <div className={styles.blendRow}>
+            <span>A</span>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={blend}
+              onChange={(event) => onBlend(Number(event.target.value))}
+              aria-label="Prompt blend"
+            />
+            <span>B</span>
+          </div>
+          <label className={styles.tagSlot}>
+            <span>Tags B</span>
+            <textarea
+              rows={2}
+              value={tagsB}
+              onChange={(event) => setTagsB(event.target.value)}
+            />
+          </label>
+          <button
+            type="button"
+            className={styles.sendBtn}
+            disabled={session.status !== "ready"}
+            onClick={() => session.sendTags(tagsA, tagsB)}
+          >
+            Send Tags
+          </button>
+        </div>
+
+        <div className={styles.title}>magenta</div>
+
+        <div className={styles.transport}>
+          <button
+            type="button"
+            className={`${styles.powerBtn}${running ? ` ${styles.powerOn}` : ""}`}
+            onClick={onToggle}
+          >
+            {running ? "Stop" : "Start"}
+          </button>
+          <span
+            className={`${styles.statusDot} ${styles[`status_${session.status}`]}`}
+            aria-hidden="true"
+          />
+          <span className={styles.statusText}>
+            {session.message || session.status}
+          </span>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/demos/realtime_motion_graph_web/web/app/magenta/magenta.module.css
+++ b/demos/realtime_motion_graph_web/web/app/magenta/magenta.module.css
@@ -1,0 +1,348 @@
+/* Magenta RT 2 panel — the hardware-pedal chassis lifted from the
+   ambient-oneknob POC (daydream-ambien-oneknob branch): same shell
+   gradient, same wood side rails, same brand/title typography. The big
+   single rotor is replaced by a satellite grid of the mrt2 knob bank
+   plus the Tags A/B + blend surface. */
+
+.shell {
+  align-items: center;
+  background:
+    radial-gradient(circle at 50% 18%, rgb(255 255 255 / 10%), transparent 26%),
+    radial-gradient(circle at 50% 86%, rgb(205 107 187 / 12%), transparent 32%),
+    linear-gradient(145deg, #14171b, #050607 72%);
+  color: #f1f1ed;
+  display: flex;
+  justify-content: center;
+  min-height: 100svh;
+  overflow: auto;
+  padding: 24px;
+}
+
+.plugin {
+  background:
+    radial-gradient(circle at 50% 16%, rgb(255 255 255 / 8%), transparent 34%),
+    linear-gradient(180deg, #30343a, #15181d 52%, #08090b);
+  border: 1px solid #565d66;
+  border-radius: 8px;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 18%),
+    inset 0 -14px 30px rgb(0 0 0 / 46%),
+    0 28px 80px rgb(0 0 0 / 52%);
+  display: grid;
+  gap: 16px;
+  grid-template-rows: auto auto auto auto auto;
+  max-width: 560px;
+  padding: 26px 32px 24px;
+  position: relative;
+  width: min(92vw, 560px);
+}
+
+.plugin::before,
+.plugin::after {
+  background:
+    radial-gradient(ellipse at 42% 8%, rgb(255 226 164 / 34%), transparent 22%),
+    radial-gradient(ellipse at 70% 62%, rgb(58 26 9 / 45%), transparent 28%),
+    repeating-radial-gradient(ellipse at 18% 24%, rgb(66 31 11 / 32%) 0 3px, transparent 4px 15px),
+    repeating-linear-gradient(91deg, rgb(255 226 164 / 18%) 0 2px, transparent 2px 8px),
+    linear-gradient(100deg, #693216 0%, #a7602a 22%, #cf8d45 48%, #793d1a 76%, #3c1a0c 100%);
+  border: 1px solid rgb(16 8 3 / 80%);
+  border-radius: 6px;
+  box-shadow:
+    inset 6px 0 12px rgb(255 226 165 / 20%),
+    inset -8px 0 18px rgb(28 11 3 / 64%),
+    0 0 0 1px rgb(255 255 255 / 8%);
+  content: "";
+  height: calc(100% - 58px);
+  position: absolute;
+  top: 29px;
+  width: 44px;
+}
+
+.plugin::before {
+  left: -17px;
+}
+
+.plugin::after {
+  right: -17px;
+}
+
+.brandRow {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  min-height: 44px;
+  position: relative;
+}
+
+.brand {
+  color: #ffffff;
+  font-family: "Product Sans", "Google Sans", "Arial Rounded MT Bold", "Trebuchet MS", system-ui, sans-serif;
+  font-size: 38px;
+  font-weight: 800;
+  letter-spacing: -0.065em;
+  line-height: 1;
+  text-shadow: 0 2px 0 rgb(0 0 0 / 55%), 0 0 18px rgb(255 255 255 / 14%);
+}
+
+/* ── knob bank ─────────────────────────────────────────────────────── */
+
+.knobGrid {
+  display: grid;
+  gap: 14px 10px;
+  grid-template-columns: repeat(3, 1fr);
+  justify-items: center;
+  min-height: 132px;
+}
+
+.knobPlaceholder {
+  align-self: center;
+  color: #8b8f93;
+  font-size: 12px;
+  grid-column: 1 / -1;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.knobCell {
+  display: grid;
+  gap: 4px;
+  justify-items: center;
+}
+
+.knobWrap {
+  display: grid;
+  height: 84px;
+  place-items: center;
+  position: relative;
+  width: 84px;
+}
+
+.knobInput {
+  cursor: pointer;
+  height: 84px;
+  opacity: 0;
+  position: absolute;
+  width: 84px;
+  z-index: 4;
+}
+
+.knob {
+  align-items: center;
+  background:
+    radial-gradient(circle at 38% 32%, #5c626b, transparent 22%),
+    radial-gradient(circle at 62% 72%, #050607, transparent 34%),
+    linear-gradient(135deg, #30353d, #070809);
+  border: 2px solid #0d0e0f;
+  border-radius: 50%;
+  box-shadow:
+    inset 0 5px 9px rgb(255 255 255 / 7%),
+    inset 0 -9px 15px rgb(0 0 0 / 62%),
+    0 8px 14px rgb(0 0 0 / 62%);
+  display: flex;
+  height: 76px;
+  justify-content: center;
+  position: relative;
+  width: 76px;
+}
+
+.knob::before {
+  border: 2px solid rgb(255 255 255 / 74%);
+  border-radius: 50%;
+  content: "";
+  height: 34px;
+  position: absolute;
+  width: 34px;
+}
+
+.pointerRotor {
+  inset: 0;
+  position: absolute;
+  transition: transform 90ms linear;
+}
+
+.knobPointer {
+  background: linear-gradient(180deg, #ffffff, #eec9e6);
+  border-radius: 999px;
+  box-shadow: 0 0 6px rgb(255 255 255 / 34%);
+  height: 20px;
+  left: calc(50% - 2px);
+  position: absolute;
+  top: 6px;
+  width: 4px;
+}
+
+.knobValue {
+  color: #f6f7f7;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 800;
+}
+
+.knobLabel {
+  color: #d3d3cc;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+/* ── tags + blend ──────────────────────────────────────────────────── */
+
+.tags {
+  display: grid;
+  gap: 10px;
+}
+
+.tagSlot {
+  display: grid;
+  gap: 5px;
+}
+
+.tagSlot span {
+  color: #d3d3cc;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tagSlot textarea {
+  background: #101112;
+  border: 1px solid rgb(255 255 255 / 16%);
+  border-radius: 4px;
+  color: #eeeeea;
+  font: inherit;
+  font-size: 13px;
+  padding: 7px 9px;
+  resize: vertical;
+}
+
+.blendRow {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+}
+
+.blendRow span {
+  color: #d3d3cc;
+  font-size: 11px;
+  font-weight: 900;
+}
+
+.blendRow input {
+  accent-color: #cd6bbb;
+  flex: 1;
+}
+
+.sendBtn {
+  background: linear-gradient(180deg, #2c3037, #14171b);
+  border: 1px solid rgb(255 255 255 / 22%);
+  border-radius: 5px;
+  color: #f1f1ed;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 900;
+  justify-self: end;
+  letter-spacing: 0.08em;
+  min-height: 32px;
+  padding: 0 16px;
+  text-transform: uppercase;
+}
+
+.sendBtn:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+/* ── title + transport ─────────────────────────────────────────────── */
+
+.title {
+  color: #ffffff;
+  font-size: 30px;
+  font-weight: 900;
+  justify-self: center;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  text-shadow: 0 2px 0 rgb(0 0 0 / 50%);
+}
+
+.transport {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  min-height: 36px;
+}
+
+.powerBtn {
+  background: linear-gradient(180deg, #2c3037, #14171b);
+  border: 1px solid rgb(255 255 255 / 22%);
+  border-radius: 5px;
+  color: #f1f1ed;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  min-height: 32px;
+  min-width: 88px;
+  text-transform: uppercase;
+}
+
+.powerOn {
+  border-color: rgb(205 107 187 / 70%);
+  box-shadow: 0 0 12px rgb(205 107 187 / 30%);
+}
+
+.statusDot {
+  border-radius: 50%;
+  height: 9px;
+  width: 9px;
+}
+
+.status_idle {
+  background: #5a5f66;
+}
+
+.status_connecting {
+  animation: magenta-pulse 1.1s ease-in-out infinite;
+  background: #d9b54a;
+}
+
+.status_ready {
+  background: #5fd97e;
+  box-shadow: 0 0 8px rgb(95 217 126 / 55%);
+}
+
+.status_error {
+  background: #e0524d;
+  box-shadow: 0 0 8px rgb(224 82 77 / 55%);
+}
+
+.statusText {
+  color: #c9cbc6;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+
+@keyframes magenta-pulse {
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (max-width: 620px) {
+  .shell {
+    padding: 10px;
+  }
+
+  .plugin {
+    padding: 18px 22px;
+    width: min(94vw, 430px);
+  }
+
+  .plugin::before,
+  .plugin::after {
+    width: 28px;
+  }
+}

--- a/demos/realtime_motion_graph_web/web/app/magenta/page.tsx
+++ b/demos/realtime_motion_graph_web/web/app/magenta/page.tsx
@@ -1,0 +1,10 @@
+import { MagentaPanel } from "./MagentaPanel";
+
+export const metadata = {
+  title: "DEMON · magenta",
+  description: "Magenta RT 2 live frontend.",
+};
+
+export default function MagentaPage() {
+  return <MagentaPanel />;
+}

--- a/demos/realtime_motion_graph_web/web/app/magenta/useMagentaSession.ts
+++ b/demos/realtime_motion_graph_web/web/app/magenta/useMagentaSession.ts
@@ -1,0 +1,213 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { AudioPlayer, RemoteBackend, SLICE_FLAG_DELTA } from "@demon/client";
+import type {
+  AudioSlice,
+  KnobManifest,
+  KnobManifestEntry,
+  SessionConfig,
+} from "@demon/client";
+import { defaultWsUrl } from "@/engine/podUrl";
+
+// Magenta-only session hook. Deliberately standalone: no app stores, no
+// fixture decode, no LoRA catalog, no prompt transform — the mrt2 family
+// has none of those surfaces, so this is just SDK + the four things a
+// magenta session actually speaks: config, params, set_prompt,
+// set_prompt_blend.
+//
+// The knob bank comes from the session's own `ready.knob_manifest`
+// (backend-owned, session-resolved), NOT the static /api/knobs probe —
+// so the panel renders whatever knobs the mrt2 backend declares, and
+// future additions (notes/drums conditioning) appear without UI edits.
+
+export type MagentaStatus = "idle" | "connecting" | "ready" | "error";
+
+export interface MagentaKnob {
+  name: string;
+  entry: KnobManifestEntry;
+}
+
+// The mrt2 session creator ignores the handshake audio entirely (no
+// positional source — the frontier starts from silence), but the WS
+// adapter still reads one binary frame when no server-side fixture is
+// named. Send the smallest honest stub: 0.2 s of stereo zeros, one
+// server latent-pool (9600 samples) so every downstream length
+// computation stays aligned.
+const STUB_FRAMES = 9600;
+const STUB_CHANNELS = 2;
+
+const PARAMS_TICK_MS = 80;
+
+function knobList(manifest: KnobManifest): MagentaKnob[] {
+  // Insertion order is the registry's declaration order — keep it.
+  return Object.entries(manifest)
+    .filter(([, entry]) => entry.type === "float" || entry.type === "int")
+    .map(([name, entry]) => ({ name, entry }));
+}
+
+function defaultValues(knobs: MagentaKnob[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const { name, entry } of knobs) {
+    if (typeof entry.default === "number") out[name] = entry.default;
+  }
+  return out;
+}
+
+export function useMagentaSession() {
+  const remoteRef = useRef<RemoteBackend | null>(null);
+  const playerRef = useRef<AudioPlayer | null>(null);
+  const tickRef = useRef<number | null>(null);
+  const valuesRef = useRef<Record<string, number>>({});
+
+  const [status, setStatus] = useState<MagentaStatus>("idle");
+  const [message, setMessage] = useState("");
+  const [knobs, setKnobs] = useState<MagentaKnob[]>([]);
+  const [values, setValues] = useState<Record<string, number>>({});
+
+  const stop = useCallback(async () => {
+    if (tickRef.current != null) {
+      window.clearInterval(tickRef.current);
+      tickRef.current = null;
+    }
+    try {
+      await playerRef.current?.close();
+    } catch {}
+    try {
+      remoteRef.current?.close();
+    } catch {}
+    playerRef.current = null;
+    remoteRef.current = null;
+    setStatus("idle");
+    setMessage("");
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      void stop();
+    };
+  }, [stop]);
+
+  const start = useCallback(
+    async (tagsA: string, tagsB: string, blend: number) => {
+      await stop();
+      setStatus("connecting");
+      setMessage("Connecting…");
+      try {
+        const config: SessionConfig = {
+          telemetry_version: 1,
+          backend: "mrt2",
+          prompt: tagsA,
+          prompt_b: tagsB || tagsA,
+        };
+        const remote = new RemoteBackend(
+          defaultWsUrl(),
+          new Float32Array(STUB_FRAMES * STUB_CHANNELS),
+          STUB_CHANNELS,
+          config,
+        );
+        remoteRef.current = remote;
+
+        remote.addEventListener("slice", (event) => {
+          const detail = (event as CustomEvent<AudioSlice>).detail;
+          const player = playerRef.current;
+          if (!player || detail.epoch !== player.swapCount) return;
+          const startFrame = Math.floor(detail.startSample);
+          if (detail.flags === SLICE_FLAG_DELTA) {
+            player.addDelta(startFrame, detail.audio);
+          } else {
+            player.patch(startFrame, detail.audio);
+          }
+        });
+        remote.addEventListener("close", () => {
+          if (remote.closedByUser) return;
+          setStatus("error");
+          setMessage("Connection lost.");
+        });
+
+        await remote.connect();
+        if (!remote.initialBuffer) {
+          throw new Error("server sent no initial buffer");
+        }
+
+        // Per-session knob bank from ready.knob_manifest. A server old
+        // enough to omit it can't run mrt2 sessions anyway, so an empty
+        // panel here would mean a contract break — surface it.
+        const manifest = remote.knobManifest?.knobs ?? {};
+        const list = knobList(manifest);
+        const defaults = defaultValues(list);
+        setKnobs(list);
+        setValues(defaults);
+        valuesRef.current = defaults;
+
+        const player = new AudioPlayer();
+        playerRef.current = player;
+        await player.init(remote.initialBuffer, remote.channels);
+        await player.resume();
+
+        if (blend > 0) remote.sendSetPromptBlend(blend);
+
+        // Continuous params flow, same cadence the one-knob POC used:
+        // the runner samples knob values at each tick, so keep them
+        // streaming rather than edge-triggered.
+        tickRef.current = window.setInterval(() => {
+          const liveRemote = remoteRef.current;
+          const livePlayer = playerRef.current;
+          if (!liveRemote || !livePlayer) return;
+          liveRemote.sendParams(valuesRef.current, livePlayer.positionSec);
+        }, PARAMS_TICK_MS);
+
+        setStatus("ready");
+        setMessage("");
+      } catch (err) {
+        await stop();
+        setStatus("error");
+        setMessage(err instanceof Error ? err.message : "Start failed");
+      }
+    },
+    [stop],
+  );
+
+  const setKnob = useCallback((name: string, value: number) => {
+    setValues((prev) => {
+      const next = { ...prev, [name]: value };
+      valuesRef.current = next;
+      return next;
+    });
+    // Snappy path: ship immediately too; the tick is the steady-state.
+    const remote = remoteRef.current;
+    const player = playerRef.current;
+    if (remote && player) {
+      remote.sendParams(
+        { ...valuesRef.current, [name]: value },
+        player.positionSec,
+      );
+    }
+  }, []);
+
+  const sendTags = useCallback((tagsA: string, tagsB: string) => {
+    remoteRef.current?.sendPrompt(
+      tagsA,
+      undefined,
+      undefined,
+      tagsB || undefined,
+    );
+  }, []);
+
+  const setBlend = useCallback((value: number) => {
+    remoteRef.current?.sendSetPromptBlend(Math.max(0, Math.min(1, value)));
+  }, []);
+
+  return {
+    knobs,
+    message,
+    sendTags,
+    setBlend,
+    setKnob,
+    start,
+    status,
+    stop,
+    values,
+  };
+}

--- a/scripts/mrt2_live_check.py
+++ b/scripts/mrt2_live_check.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+"""Live smoke test for the MRT2 backend against a running sidecar.
+
+Drives MRT2Backend exactly the way PipelineRunner does (sync_source →
+read_knobs → produce → render_window), with a simulated real-time
+playhead, for ~12 seconds of audio: prompt A for the first stretch, a
+prompt change mid-stream, and a temperature move near the end. Writes
+the assembled rolling-window audio to ``out/mrt2_live_check.wav`` and
+prints frontier/latency stats.
+
+Run on the Windows side (repo venv) with the sidecar already up in the
+MRT2 venv:
+
+    (WSL)  source ~/.venvs/mrt2/bin/activate && \
+           python /mnt/c/_dev/projects/DEMON/scripts/mrt2_sidecar.py
+    (Win)  .venv/Scripts/python.exe scripts/mrt2_live_check.py
+"""
+
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from acestep.streaming.generator_backend import TickContext  # noqa: E402
+from acestep.streaming.knobs import KnobState  # noqa: E402
+from acestep.streaming.mrt2 import protocol as mp  # noqa: E402
+from acestep.streaming.mrt2.backend import (  # noqa: E402
+    WINDOW_S,
+    WINDOW_SAMPLES,
+    MRT2Backend,
+    mrt2_knob_specs,
+)
+
+
+class _State:
+    prompt_text = "warm analog synthwave, steady beat"
+    prompt_text_b = ""
+
+    def __init__(self):
+        self.params = {}
+
+
+def main() -> int:
+    run_s = 12.0
+    knobs = KnobState(mrt2_knob_specs())
+    backend = MRT2Backend(config=None, state=_State(), midi_knobs=knobs)
+
+    buf = np.zeros((WINDOW_SAMPLES, mp.CHANNELS), dtype=np.float32)
+    t_start = time.monotonic()
+    first_audio_s = None
+    writes = 0
+    emitted = 0
+    prompt_changed = temp_changed = False
+
+    while True:
+        wall = time.monotonic() - t_start
+        if wall >= run_s:
+            break
+        playhead_s = wall % WINDOW_S  # simulated real-time playback
+        ctx = TickContext(playhead_s=playhead_s, buffer_duration_s=WINDOW_S)
+
+        if wall > 6.0 and not prompt_changed:
+            prompt_changed = True
+            print(f"[{wall:5.2f}s] prompt -> 'aggressive drum and bass'")
+            backend.handle_set_prompt("aggressive drum and bass, fast breaks")
+        if wall > 9.5 and not temp_changed:
+            temp_changed = True
+            print(f"[{wall:5.2f}s] mrt2_temperature -> 2.2")
+            knobs.update({"mrt2_temperature": 2.2})
+
+        backend.sync_source(ctx)
+        raw = backend.read_knobs()
+        fresh = backend.produce(raw, ctx, "generate")
+        if not fresh:
+            continue
+        chunk = backend.render_window(playhead_s)
+        while chunk is not None:
+            s, e = chunk.start_sample, chunk.start_sample + chunk.pcm.shape[0]
+            buf[s:e] = chunk.pcm
+            writes += 1
+            emitted = max(emitted, backend._abs_written)
+            if first_audio_s is None and np.abs(chunk.pcm).max() > 1e-4:
+                first_audio_s = wall
+                print(f"[{wall:5.2f}s] first non-silent audio "
+                      f"(frontier {emitted / mp.SAMPLE_RATE:.2f}s)")
+            chunk = backend.render_window(playhead_s)
+        backend.on_fresh_generation(raw)
+
+    frontier_s = backend._abs_written / mp.SAMPLE_RATE
+    lead_s = frontier_s - (time.monotonic() - t_start)
+    print(f"done: wall={run_s:.1f}s frontier={frontier_s:.2f}s "
+          f"lead={lead_s:+.2f}s writes={writes} "
+          f"sidecar_lost={backend.client.lost}")
+    print(f"params echo: {backend.state.params}")
+
+    out = Path(__file__).resolve().parent.parent / "out"
+    out.mkdir(exist_ok=True)
+    path = out / "mrt2_live_check.wav"
+    try:
+        import soundfile as sf
+
+        sf.write(str(path), buf[: int(frontier_s * mp.SAMPLE_RATE)], mp.SAMPLE_RATE)
+        print(f"wrote {path}")
+    except ImportError:
+        from scipy.io import wavfile
+
+        wavfile.write(
+            str(path), mp.SAMPLE_RATE,
+            (buf[: int(frontier_s * mp.SAMPLE_RATE)] * 32767).astype(np.int16),
+        )
+        print(f"wrote {path}")
+
+    # Evaluate BEFORE close() — close marks the client lost by design.
+    ok = (
+        backend.client.lost is False
+        and first_audio_s is not None
+        and abs(lead_s) < 2.0
+    )
+    backend.close()
+    print("PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mrt2_sidecar.py
+++ b/scripts/mrt2_sidecar.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python
+"""Magenta RT 2 generation sidecar for the DEMON ``mrt2`` backend family.
+
+Runs NEXT TO the JAX model, not inside the DEMON server process: JAX has
+no CUDA on native Windows, so this script lives in the MRT2 venv (WSL:
+``~/.venvs/mrt2``, see notes/magenta-realtime) or on a Linux pod, and
+serves frames to :class:`acestep.streaming.mrt2.backend.MRT2Backend`
+over the tiny TCP protocol in ``acestep/streaming/mrt2/protocol.py``.
+
+That protocol module is loaded BY FILE PATH (spec_from_file_location),
+never via ``import acestep`` — the acestep package import would pull
+torch, which this venv deliberately does not have.
+
+Usage (from the repo root, inside the MRT2 venv):
+
+    python scripts/mrt2_sidecar.py --model mrt2_small
+
+The model is loaded and JIT-warmed once at startup (~30s); connections
+are then served one at a time. Generation is credit-paced: the loop
+only runs ``mrt.generate`` while the connected backend has granted
+frames, so the (faster-than-real-time) model never runs ahead of the
+backend's configured lead — for an append-only model, audio generated
+ahead of need is latency, not safety.
+
+The recurrent state persists across prompt/knob changes (that is the
+whole point: one evolving stream of music, conditioned live) and is
+reset only when a new connection arrives.
+"""
+
+import argparse
+import importlib.util
+import queue
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Protocol module, loaded by file path (NOT ``import acestep`` — no torch
+# in this venv; see module docstring).
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PROTO_PATH = _REPO_ROOT / "acestep" / "streaming" / "mrt2" / "protocol.py"
+_spec = importlib.util.spec_from_file_location("mrt2_protocol", _PROTO_PATH)
+mp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mp)
+
+
+def log(msg: str) -> None:
+    print(f"[mrt2-sidecar +{time.monotonic() - _T0:9.2f}s] {msg}", flush=True)
+
+
+_T0 = time.monotonic()
+
+
+class Conditioning:
+    """Live conditioning shared between the socket reader and the
+    generation loop. The reader thread writes; the generation loop
+    snapshots before each chunk, so changes land at chunk granularity
+    (a handful of 40 ms frames)."""
+
+    def __init__(self, style_model, defaults: dict):
+        self._style_model = style_model
+        self._lock = threading.Lock()
+        self._embed_cache: dict = {}
+        self.tags = ""
+        self.tags_b = None
+        self.blend = 0.0
+        self.knobs = dict(defaults)
+        self._style = None
+        self._style_dirty = True
+
+    def _embed(self, tags: str):
+        emb = self._embed_cache.get(tags)
+        if emb is None:
+            emb = self._style_model.embed_batch_text([tags])[0]
+            # Unbounded growth is fine in practice (an operator types
+            # dozens of prompts, not millions), but cap it anyway.
+            if len(self._embed_cache) > 256:
+                self._embed_cache.clear()
+            self._embed_cache[tags] = emb
+        return emb
+
+    def set_prompt(self, tags: str, tags_b) -> None:
+        with self._lock:
+            self.tags = tags or ""
+            self.tags_b = tags_b if tags_b else None
+            self._style_dirty = True
+
+    def set_blend(self, value: float) -> None:
+        with self._lock:
+            self.blend = max(0.0, min(1.0, float(value)))
+            self._style_dirty = True
+
+    def set_knobs(self, update: dict) -> None:
+        with self._lock:
+            self.knobs.update(update)
+
+    def snapshot(self):
+        """(style_embedding | None, knobs dict) for the next chunk.
+        The style embedding is recomputed only when tags/blend moved;
+        embeddings are cached per tags string so blend sweeps cost a
+        lerp, not a MusicCoCa forward."""
+        with self._lock:
+            tags, tags_b, blend = self.tags, self.tags_b, self.blend
+            knobs = dict(self.knobs)
+            dirty = self._style_dirty
+            self._style_dirty = False
+        if dirty:
+            emb_a = self._embed(tags) if tags else None
+            if tags_b and blend > 0.0 and emb_a is not None:
+                emb_b = self._embed(tags_b)
+                style = (1.0 - blend) * emb_a + blend * emb_b
+            elif tags_b and blend > 0.0:
+                style = self._embed(tags_b) if blend >= 0.999 else None
+            else:
+                style = emb_a
+            self._style = style
+        return self._style, knobs
+
+
+def serve_one(conn, mrt, cond_defaults: dict, chunk_frames: int) -> None:
+    """Serve one backend connection until it drops."""
+    conn.settimeout(None)
+    ctrl: "queue.Queue" = queue.Queue()
+    alive = [True]
+
+    def _reader():
+        try:
+            while True:
+                kind, payload = mp.recv_msg(conn)
+                if kind == mp.MSG_JSON:
+                    ctrl.put(mp.unpack_json(payload))
+        except (ConnectionError, OSError):
+            alive[0] = False
+            ctrl.put(None)  # wake the main loop
+
+    cond = Conditioning(mrt._style_model, cond_defaults)
+    credit = 0
+    frame_index = 0
+    state = None  # fresh recurrent state per connection
+    send_lock = threading.Lock()
+
+    def _send(data: bytes) -> bool:
+        try:
+            with send_lock:
+                conn.sendall(data)
+            return True
+        except (ConnectionError, OSError):
+            alive[0] = False
+            return False
+
+    threading.Thread(target=_reader, daemon=True).start()
+
+    while alive[0]:
+        # Drain control messages. Out of credit -> block briefly (the
+        # next message is the only thing that can change that); credit
+        # in hand -> drain whatever is queued and get on with generating.
+        try:
+            msg = ctrl.get(timeout=0.05) if credit <= 0 else ctrl.get_nowait()
+        except queue.Empty:
+            msg = "none"
+        while msg != "none":
+            if msg is None:
+                return
+            mtype = msg.get("type")
+            if mtype == "hello":
+                _send(mp.pack_json({
+                    "type": "meta",
+                    "sample_rate": mp.SAMPLE_RATE,
+                    "channels": mp.CHANNELS,
+                    "frame_samples": mp.FRAME_SAMPLES,
+                    "model": MODEL_NAME,
+                }))
+            elif mtype == "prompt":
+                cond.set_prompt(msg.get("tags", ""), msg.get("tags_b"))
+                log(f"prompt tags={msg.get('tags')!r} tags_b={msg.get('tags_b')!r}")
+            elif mtype == "blend":
+                cond.set_blend(msg.get("value", 0.0))
+            elif mtype == "knobs":
+                update = {
+                    k: v for k, v in msg.items()
+                    if k in ("temperature", "top_k", "cfg_musiccoca",
+                             "cfg_notes", "cfg_drums")
+                }
+                cond.set_knobs(update)
+                log(f"knobs {update}")
+            elif mtype == "credit":
+                credit += int(msg.get("frames", 0))
+            elif mtype == "ping":
+                _send(mp.pack_json({"type": "pong", "t": msg.get("t")}))
+            try:
+                msg = ctrl.get_nowait()
+            except queue.Empty:
+                msg = "none"
+
+        if credit <= 0 or not alive[0]:
+            continue
+
+        n = min(credit, chunk_frames)
+        style, knobs = cond.snapshot()
+        t0 = time.monotonic()
+        try:
+            wav, state = mrt.generate(
+                style=style,
+                frames=n,
+                state=state,
+                temperature=float(knobs["temperature"]),
+                top_k=int(knobs["top_k"]),
+                cfg_musiccoca=float(knobs["cfg_musiccoca"]),
+                cfg_notes=float(knobs["cfg_notes"]),
+                cfg_drums=float(knobs["cfg_drums"]),
+            )
+        except Exception as exc:  # surface, don't die mid-connection
+            log(f"generate failed: {exc!r}")
+            _send(mp.pack_json({"type": "err", "message": str(exc)}))
+            credit = 0
+            continue
+        gen_s = time.monotonic() - t0
+
+        pcm = np.asarray(wav.samples, dtype=np.float32)
+        if pcm.ndim == 1:
+            pcm = pcm.reshape(-1, 1).repeat(mp.CHANNELS, axis=1)
+        pcm = np.ascontiguousarray(pcm[:, : mp.CHANNELS], dtype=np.float32)
+        # Pin the header invariant exactly: num_frames * FRAME_SAMPLES
+        # samples on the wire (the backend's credit accounting and the
+        # runner's rolling-window math both lean on it).
+        want = n * mp.FRAME_SAMPLES
+        if pcm.shape[0] != want:
+            log(f"unexpected chunk length {pcm.shape[0]} != {want}; pinning")
+            if pcm.shape[0] > want:
+                pcm = pcm[:want]
+            else:
+                pcm = np.vstack(
+                    [pcm, np.zeros((want - pcm.shape[0], mp.CHANNELS), np.float32)],
+                )
+        if not _send(mp.pack_audio(frame_index, n, pcm.tobytes())):
+            return
+        frame_index += n
+        credit -= n
+        if frame_index % 250 < n:  # ~every 10 s of audio
+            log(
+                f"frontier={frame_index * mp.FRAME_SECONDS:.1f}s "
+                f"chunk={n}f gen={gen_s * 1000:.0f}ms "
+                f"rt_x={n * mp.FRAME_SECONDS / max(gen_s, 1e-9):.2f}"
+            )
+
+
+MODEL_NAME = ""
+
+
+def main() -> int:
+    global MODEL_NAME
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--host", default=mp.DEFAULT_HOST)
+    ap.add_argument("--port", type=int, default=mp.DEFAULT_PORT)
+    ap.add_argument("--model", default="mrt2_small",
+                    help="Model variant (mrt2_small fits real-time on a "
+                         "5090; mrt2_base is ~0.93x RT as shipped).")
+    ap.add_argument("--chunk-frames", type=int, default=2,
+                    help="Frames per generate call (2 = 80 ms; smaller = "
+                         "lower control latency, more per-call overhead).")
+    args = ap.parse_args()
+    MODEL_NAME = args.model
+
+    log(f"loading {args.model} (JAX) …")
+    from magenta_rt import MagentaRT2Jax
+
+    mrt = MagentaRT2Jax(size=args.model)
+    cond_defaults = {
+        "temperature": 1.3, "top_k": 40,
+        "cfg_musiccoca": 3.0, "cfg_notes": 1.0, "cfg_drums": 1.0,
+    }
+    log("warmup generate (JIT compile) …")
+    t0 = time.monotonic()
+    _wav, _state = mrt.generate(frames=args.chunk_frames, state=None)
+    log(f"warm in {time.monotonic() - t0:.1f}s; "
+        f"serving on {args.host}:{args.port}")
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind((args.host, args.port))
+    srv.listen(1)
+    while True:
+        conn, addr = srv.accept()
+        conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        log(f"backend connected from {addr}")
+        try:
+            serve_one(conn, mrt, cond_defaults, args.chunk_frames)
+        except Exception as exc:
+            log(f"connection error: {exc!r}")
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+            log("backend disconnected")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_mrt2_backend.py
+++ b/tests/unit/test_mrt2_backend.py
@@ -1,0 +1,282 @@
+"""MRT2 backend family: frame protocol + append-only frontier semantics.
+
+Covers the pieces that don't need the sidecar (or a GPU):
+
+* protocol framing round-trips over a real socketpair,
+* the rolling-window emission contract (overlap head, wrap-seam clamp,
+  start_sample placement) with an injected fake sidecar client,
+* credit pacing and knob forwarding,
+* the family's declared contract surface (capabilities / geometry /
+  knob universe registration — the homonym guard in
+  test_knob_homonyms.py picks the universe up automatically).
+
+The live path (real sidecar in the MRT2 venv, WS session end-to-end)
+is exercised manually; see scripts/mrt2_sidecar.py.
+"""
+
+import socket
+import time
+
+import numpy as np
+import pytest
+
+from acestep.streaming.generator_backend import Capabilities, TickContext
+from acestep.streaming.knobs import KnobState
+from acestep.streaming.mrt2 import protocol as mp
+from acestep.streaming.mrt2.backend import (
+    WINDOW_S,
+    WINDOW_SAMPLES,
+    XFADE,
+    MRT2Backend,
+    mrt2_knob_specs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Protocol framing
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_json_roundtrip():
+    a, b = socket.socketpair()
+    try:
+        msg = {"type": "knobs", "temperature": 1.7, "top_k": 64}
+        a.sendall(mp.pack_json(msg))
+        kind, payload = mp.recv_msg(b)
+        assert kind == mp.MSG_JSON
+        assert mp.unpack_json(payload) == msg
+    finally:
+        a.close()
+        b.close()
+
+
+def test_protocol_audio_roundtrip():
+    a, b = socket.socketpair()
+    try:
+        pcm = np.arange(2 * mp.FRAME_SAMPLES * mp.CHANNELS, dtype=np.float32)
+        a.sendall(mp.pack_audio(123, 2, pcm.tobytes()))
+        kind, payload = mp.recv_msg(b)
+        assert kind == mp.MSG_AUDIO
+        idx, n, raw = mp.unpack_audio(payload)
+        assert (idx, n) == (123, 2)
+        out = np.frombuffer(raw, dtype=np.float32)
+        np.testing.assert_array_equal(out, pcm)
+    finally:
+        a.close()
+        b.close()
+
+
+def test_protocol_rejects_corrupt_length():
+    a, b = socket.socketpair()
+    try:
+        a.sendall(b"\xff\xff\xff\xff")
+        with pytest.raises(ConnectionError):
+            mp.recv_msg(b)
+    finally:
+        a.close()
+        b.close()
+
+
+# ---------------------------------------------------------------------------
+# Backend with a fake sidecar client
+# ---------------------------------------------------------------------------
+
+
+class FakeClient:
+    """Stands in for SidecarClient: records control sends, lets tests
+    feed audio frames directly."""
+
+    def __init__(self):
+        self.sent: list = []
+        self.lost = False
+        self.last_rx_ts = time.monotonic()
+        self.frames_received = 0
+        self.meta = {"type": "meta", "model": "fake"}
+        self.closed = False
+        self._audio: list = []
+
+    def send_json(self, obj):
+        self.sent.append(obj)
+
+    def pop_audio(self):
+        out, self._audio = self._audio, []
+        return out
+
+    def close(self):
+        self.closed = True
+
+    # test helper
+    def feed_frames(self, num_frames: int, value: float = 0.5):
+        arr = np.full(
+            (num_frames * mp.FRAME_SAMPLES, mp.CHANNELS), value, np.float32,
+        )
+        self._audio.append(arr)
+        self.frames_received += num_frames
+        self.last_rx_ts = time.monotonic()
+
+
+class _State:
+    prompt_text = "test prompt"
+    prompt_text_b = "test prompt b"
+
+    def __init__(self):
+        self.params = {}
+
+
+def make_backend():
+    client = FakeClient()
+    backend = MRT2Backend(
+        config=None,
+        state=_State(),
+        midi_knobs=KnobState(mrt2_knob_specs()),
+        client=client,
+    )
+    return backend, client
+
+
+def _ctx(playhead_s=0.0):
+    return TickContext(playhead_s=playhead_s, buffer_duration_s=WINDOW_S)
+
+
+def test_constructor_sends_initial_prompt():
+    backend, client = make_backend()
+    prompts = [m for m in client.sent if m["type"] == "prompt"]
+    assert prompts and prompts[0]["tags"] == "test prompt"
+    assert prompts[0]["tags_b"] == "test prompt b"
+
+
+def test_contract_surface():
+    backend, _ = make_backend()
+    assert backend.capabilities() == Capabilities()  # everything False
+    g = backend.geometry()
+    assert (g.sample_rate, g.channels) == (mp.SAMPLE_RATE, mp.CHANNELS)
+    assert g.chunk_rate_hz == pytest.approx(25.0)
+    assert g.duration_s == WINDOW_S
+    assert backend.playable_duration_s() == WINDOW_S
+    assert backend.vae_window > 0
+    assert not backend.has_renderable_state()
+    assert backend.render_full() is None
+    names = {s.name for s in backend.knob_specs()}
+    assert all(n.startswith("mrt2_") for n in names)
+
+
+def test_produce_grants_credit_for_the_lead():
+    backend, client = make_backend()
+    knobs = backend.read_knobs()
+    backend.sync_source(_ctx(0.0))
+    fresh = backend.produce(knobs, _ctx(0.0), "generate")
+    assert fresh is False  # nothing fed yet
+    credits = [m for m in client.sent if m["type"] == "credit"]
+    assert len(credits) == 1
+    # default mrt2_lead = 0.75 s -> ceil(0.75 * 48000 / 1920) = 19 frames
+    assert credits[0]["frames"] == 19
+    # No double-grant while the first is outstanding.
+    backend.produce(knobs, _ctx(0.0), "generate")
+    assert len([m for m in client.sent if m["type"] == "credit"]) == 1
+
+
+def test_emission_overlap_and_placement():
+    backend, client = make_backend()
+    knobs = backend.read_knobs()
+
+    client.feed_frames(5, value=0.25)
+    backend.sync_source(_ctx(0.0))
+    assert backend.produce(knobs, _ctx(0.0), "generate") is True
+
+    chunk1 = backend.render_window(0.0)
+    assert chunk1 is not None
+    assert chunk1.start_sample == 0  # first chunk: no overlap head
+    assert chunk1.pcm.shape == (5 * mp.FRAME_SAMPLES, mp.CHANNELS)
+    assert backend.has_renderable_state()
+
+    # Second batch: chunk must re-emit the previous XFADE samples at
+    # its head so the runner's leading-edge crossfade blends identical
+    # audio.
+    client.feed_frames(3, value=0.75)
+    assert backend.produce(knobs, _ctx(0.0), "generate") is True
+    chunk2 = backend.render_window(0.0)
+    assert chunk2.start_sample == 5 * mp.FRAME_SAMPLES - XFADE
+    assert chunk2.pcm.shape[0] == 3 * mp.FRAME_SAMPLES + XFADE
+    np.testing.assert_array_equal(
+        chunk2.pcm[:XFADE],
+        np.full((XFADE, mp.CHANNELS), 0.25, np.float32),
+    )
+    np.testing.assert_array_equal(
+        chunk2.pcm[XFADE:],
+        np.full((3 * mp.FRAME_SAMPLES, mp.CHANNELS), 0.75, np.float32),
+    )
+
+    # Runner mutates chunks in place (crossfade); the backend's tail
+    # copy must be unaffected.
+    chunk2.pcm[:] = -1.0
+    client.feed_frames(1, value=0.5)
+    backend.produce(knobs, _ctx(0.0), "generate")
+    chunk3 = backend.render_window(0.0)
+    np.testing.assert_array_equal(
+        chunk3.pcm[:XFADE],
+        np.full((XFADE, mp.CHANNELS), 0.75, np.float32),
+    )
+
+
+def test_emission_clamps_at_window_wrap():
+    backend, client = make_backend()
+    knobs = backend.read_knobs()
+
+    # Park the frontier just shy of the window seam.
+    short = 1000
+    backend._abs_written = WINDOW_SAMPLES - short
+    backend._tail = np.full((XFADE, mp.CHANNELS), 0.1, np.float32)
+
+    client.feed_frames(2, value=0.9)  # 3840 samples > room
+    backend.sync_source(_ctx(0.0))
+    backend.produce(knobs, _ctx(0.0), "generate")
+
+    pre = backend.render_window(0.0)
+    # Clamped at the seam: overlap head + exactly `short` new samples.
+    assert pre.start_sample == WINDOW_SAMPLES - short - XFADE
+    assert pre.pcm.shape[0] == short + XFADE
+    assert pre.start_sample + pre.pcm.shape[0] == WINDOW_SAMPLES
+
+    post = backend.render_window(0.0)
+    # Remainder lands at the window start, overlap skipped across the
+    # seam (it would wrap backwards).
+    assert post.start_sample == 0
+    assert post.pcm.shape[0] == 2 * mp.FRAME_SAMPLES - short
+    assert backend.render_window(0.0) is None  # drained
+
+
+def test_knob_changes_forward_once():
+    backend, client = make_backend()
+    state = backend.midi_knobs
+    backend.sync_source(_ctx(0.0))
+    backend.produce(backend.read_knobs(), _ctx(0.0), "generate")
+    baseline = [m for m in client.sent if m["type"] == "knobs"]
+    assert len(baseline) == 1  # initial defaults forwarded once
+
+    state.update({"mrt2_temperature": 2.0})
+    backend.produce(backend.read_knobs(), _ctx(0.0), "generate")
+    backend.produce(backend.read_knobs(), _ctx(0.0), "generate")
+    updates = [m for m in client.sent if m["type"] == "knobs"][1:]
+    assert updates == [{"type": "knobs", "temperature": 2.0}]
+
+
+def test_prompt_hooks_forward_to_sidecar():
+    backend, client = make_backend()
+    backend.handle_set_prompt("acid techno", tags_b="lofi house")
+    backend.handle_set_prompt_blend(0.4)
+    assert {"type": "prompt", "tags": "acid techno", "tags_b": "lofi house"} in client.sent
+    assert {"type": "blend", "value": 0.4} in client.sent
+
+
+def test_family_is_registered():
+    from acestep.streaming.families import (
+        FAMILIES,
+        FAMILY_KNOB_UNIVERSES,
+        SESSION_CREATORS,
+    )
+
+    assert "mrt2" in FAMILIES
+    assert "mrt2" in FAMILY_KNOB_UNIVERSES
+    assert "mrt2" in SESSION_CREATORS
+    universe = FAMILY_KNOB_UNIVERSES["mrt2"]()
+    assert {s.name for s in universe} == {s.name for s in mrt2_knob_specs()}


### PR DESCRIPTION
# DRAFT: Magenta RT 2 as a backend family (sidecar-hosted, append-only)

> ## Merge order
> **Draft, stacked: opened against `ryanontheinside/feat/models/backend`. Merge #224 -> #220 -> models/backend before this.**
> Stack: `main` <- #224 <- #220 <- models/backend <- **this (draft)**. Sibling leaf: sa3 (draft, same parent).
> Heads-up for whoever merges the second leaf: `families.py` will conflict (both leaves register their family in the same dicts); `streaming/session.py` resolves clean apart from one comment line.

First non-diffusion model family behind the GeneratorBackend seam, validating that the seam absorbs a generator with a completely different shape: Google's Magenta RealTime 2, running in a WSL sidecar process, append-only (no refinement, no positional source), rolling-window song instead of fixed-length.

## What's here (two commits)

**`a9ff406` mrt2 backend.**
- `acestep/streaming/mrt2/protocol.py`: versioned, language-neutral length-prefixed frame protocol (JSON control + raw PCM audio frames) over TCP. Deliberately generic: this is the template for absorbing ANY future generator in any runtime.
- `scripts/mrt2_sidecar.py`: the model host. Owns the Magenta RT 2 checkpoint inside its own venv/runtime (WSL), streams PCM frames on credit grants. Model variant is picked at sidecar launch (`--model=X`).
- `acestep/streaming/mrt2/backend.py`: `MRT2Backend` behind the seam. Frontier-driven emission with crossfade splicing into a rolling window; credit accounting; prompt and style-blend forwarded to the sidecar's MusicCoCa conditioning (`handle_set_prompt`, `handle_set_prompt_blend`). Capability mask is all-off except generation: every ACE-shaped command (swap, timbre, structure, LoRA, depth) fails loudly via `command_failed`.
- `create_mrt2_session` registered in `families.SESSION_CREATORS`: the family bypasses the ACE create path entirely (no TRT profiles, no model load, no demucs, no conditioning encode). Honest nullable metadata (no bpm/key) per the contract surface.
- `tests/unit/test_mrt2_backend.py`: protocol framing, frontier/window math, credit flow, prompt forwarding, capability mask (13 tests, no sidecar needed).

**`dc2dc9c` magenta pedal.** `/magenta` web page: a minimal pedal-style UI (prompt, blend, temperature) built on the @demon/client SDK and gated by the served capability mask, demonstrating that a non-ACE family gets a working frontend without touching the shipped app.

## Transactional create (carried from #222's semantics)

The sidecar TCP link is a real acquired resource, so a failed session create cannot strand it: `MRT2Backend.__init__` closes a self-acquired client if construction fails after connect (injected test clients stay caller-owned), `StreamingSession.__init__` closes the backend if init fails after `make_backend`, and the factory registers the audio engine on an ExitStack with `pop_all()` ownership transfer, mirroring the ACE create path. `StreamingSession.close()` closes backend-owned resources first.

## Status / why draft

Live-verified end-to-end against the WSL sidecar (append-only frontier contract, prompt steering). Remaining before ready-for-review: sidecar deployment story for pods, and a golden-harness scenario for the family. `scripts/mrt2_live_check.py` is the manual smoke (needs the sidecar running).

## Validation (2026-06-06, restacked tip)

160 unit tests passing at this tip (mrt2 suite + all inherited guards), web typecheck clean.
