### PR TITLE
feat(rtmg): spectral steering (on models/backend)

### DIFF
--- a/acestep/streaming/ace_backend.py
+++ b/acestep/streaming/ace_backend.py
@@ -38,10 +38,13 @@ from acestep.streaming.generator_backend import (
     Capabilities,
     TickContext,
 )
+from acestep.steering import SteeringController
 from acestep.streaming.knobs import (
     CHANNEL_GROUPS,
     KEYSTONE_CHANNELS,
     knob_specs as registry_knob_specs,
+    manual_slot_specs,
+    steering_axis_spec,
 )
 
 # Audio sample rate the ACE-Step v1.5 family is trained on, and the
@@ -121,6 +124,41 @@ def _curve_from_spec(spec, T):
     return None
 
 
+def steering_knob_specs(steering: "SteeringController") -> list:
+    """Project a SteeringController's live surface into registry specs.
+
+    Empty when no vector bundle is reachable (the knobs would be dead).
+    The spec SHAPES come from the registry factories in
+    ``acestep.streaming.knobs``; only the axis/catalog metadata is
+    filled in here, where the steering policy lives.
+    """
+    if not steering.is_loaded:
+        return []
+    specs: list = []
+    for ax in steering.auto_axes:
+        inject_layer = max(
+            0, min(steering.MANUAL_MAX_LAYER, ax.probe_layer + ax.layer_offset),
+        )
+        specs.append(steering_axis_spec(
+            ax.name,
+            axis=ax.axis,
+            inject_layer=inject_layer,
+            probe_step=ax.probe_step,
+            probe_n=steering._probe_n,
+            blurb=ax.blurb,
+        ))
+    src_max = max(0, len(steering.catalog) - 1)
+    for slot in steering.active_slots():
+        specs.extend(manual_slot_specs(
+            slot,
+            src_max=src_max,
+            catalog_len=len(steering.catalog),
+            layer_max=steering.MANUAL_MAX_LAYER,
+            step_max=steering.MANUAL_MAX_STEP,
+        ))
+    return specs
+
+
 class ACEStepBackend(DiffusionBackend):
     """ACE-Step v1.5 diffusion generation behind the GeneratorBackend seam.
 
@@ -141,6 +179,7 @@ class ACEStepBackend(DiffusionBackend):
         walk_window=False,
         walk_window_s=60.0,
         neg_conditioning=None,
+        steering: SteeringController | None = None,
     ):
         # The family codec is the engine Session: its windowed VAE
         # decode is what render_window()/render_full() drive. The
@@ -204,6 +243,19 @@ class ACEStepBackend(DiffusionBackend):
         # Rebuild-signature change detection (steps / LoRA enablement).
         # ``None`` on the first tick just seeds the baseline.
         self._last_rebuild_keys = None
+
+        # Activation steering. The controller is the source of truth for
+        # the slot count and vector catalog; the session mirrors its
+        # slot ops into KnobState / the knob manifest. ``None`` (e.g. a
+        # bare-construction test fixture) degrades to an unloaded
+        # controller so every consumer can read it unconditionally.
+        self.steering = (
+            steering if steering is not None else SteeringController(None)
+        )
+        # (pipeline, snapshot) change-detection key for _sync_steering;
+        # None forces a push on the first tick and after a
+        # steps_override-driven pipeline rebuild.
+        self._last_steering = None
 
         # ----- per-tick translation state (the old run() locals) -----
         self._last_latent = None
@@ -275,6 +327,7 @@ class ACEStepBackend(DiffusionBackend):
             depth=True,
             curves=True,
             notes_conditioning=False,
+            steering=self.steering.is_loaded,
         )
 
     def geometry(self) -> AudioGeometry:
@@ -291,11 +344,13 @@ class ACEStepBackend(DiffusionBackend):
     def knob_specs(self, lora_ids=()) -> list:
         """The ACE-family manifest: the shared registry's spec list,
         parameterized by this session's SDE mode and the enabled-LoRA
-        set the session passes in (see the protocol docstring)."""
+        set the session passes in (see the protocol docstring), plus
+        the activation-steering surface (auto axes + the live manual
+        slots) when this session's checkpoint has a vector bundle."""
         return registry_knob_specs(
             self.use_sde,
             loras=list(lora_ids) if self.use_lora else [],
-        )
+        ) + steering_knob_specs(self.steering)
 
     # ---- public hooks reachable from session ops ---------------------------
 
@@ -376,6 +431,28 @@ class ACEStepBackend(DiffusionBackend):
                 ))
         self.stream.model.handler._channel_guidance = configs
         return ch_gains[:]
+
+    def _sync_steering(self, raw: dict, last):
+        """Push activation-steering configs when the snapshot changes.
+
+        ``last`` is ``(pipeline, snapshot_tuple)`` or ``None``. Pipeline
+        identity is part of the key because ``steps_override`` rebuilds
+        the StreamPipeline (fresh, empty steering state) without
+        changing ``raw`` — without the identity check the new pipeline
+        would never receive ``set_steering``.
+        """
+        if not self.steering.is_loaded:
+            return last
+        pipe = self.stream.pipeline
+        if pipe is None:
+            return last
+        n = max(1, int(raw.get("steps_override", 8)))
+        snapshot = self.steering.snapshot_key(raw, n)
+        last_pipe, last_snapshot = last if last is not None else (None, None)
+        if pipe is last_pipe and snapshot == last_snapshot:
+            return last
+        pipe.set_steering(self.steering.build_configs(raw, n))
+        return (pipe, snapshot)
 
     # ---- GeneratorBackend hot loop -----------------------------------------
 
@@ -711,6 +788,9 @@ class ACEStepBackend(DiffusionBackend):
         if self.use_midi:
             self._last_channel_gains = self._sync_channel_guidance(
                 raw, self._last_channel_gains,
+            )
+            self._last_steering = self._sync_steering(
+                raw, self._last_steering,
             )
 
         # Route every curve-capable parameter through the shared

--- a/acestep/streaming/events.py
+++ b/acestep/streaming/events.py
@@ -167,6 +167,15 @@ class DepthApplied:
 
 
 @dataclass(frozen=True)
+class ManualSlotCount:
+    """Manual steering slot count after a manual_slot_add / manual_slot_pop
+    (published on success AND refusal so the client's +/- UI resyncs
+    either way). ``count`` is the controller's live slot count."""
+
+    count: int
+
+
+@dataclass(frozen=True)
 class SwapReady:
     """Source swap completed. Carries enough state for the transport to
     crossfade into the new buffer and update its detected-metadata UI.

--- a/acestep/streaming/families.py
+++ b/acestep/streaming/families.py
@@ -20,7 +20,15 @@ from acestep.engine.obs import logger
 
 
 def _make_acestep(ss):
+    from acestep.steering import SteeringController, ensure_steering_vectors
     from acestep.streaming.ace_backend import ACEStepBackend
+
+    # SteeringController is the source of truth for slot_count and the
+    # vector catalog; ensure_steering_vectors fetches/caches the
+    # checkpoint's probe bundle (None for checkpoints without one — XL,
+    # fetch failures — which degrades the controller to is_loaded=False
+    # and drops the steering capability/knobs for the session).
+    steering = SteeringController(ensure_steering_vectors(ss.checkpoint))
 
     return ACEStepBackend(
         ss.session, ss.stream,
@@ -34,6 +42,7 @@ def _make_acestep(ss):
         walk_window=ss.walk_window,
         walk_window_s=ss.walk_window_s,
         neg_conditioning=ss.cond_negative,
+        steering=steering,
     )
 
 
@@ -43,14 +52,48 @@ FAMILIES = {
 
 
 def _acestep_knob_universe():
-    from acestep.streaming.knobs import knob_specs
+    from acestep.steering.policy import (
+        AUTO_AXES,
+        MANUAL_MAX_LAYER,
+        MANUAL_MAX_STEP,
+        PROBE_N,
+    )
+    from acestep.streaming.knobs import (
+        knob_specs,
+        manual_slot_specs,
+        steering_axis_spec,
+    )
 
     # Every spec the family can ever expose: both SDE-mode variants plus
     # a representative LoRA-strength knob (the per-id specs all come from
-    # lora_strength_spec, so one placeholder id covers the pattern).
+    # lora_strength_spec, so one placeholder id covers the pattern), plus
+    # the steering surface — the four auto axes and one representative
+    # manual slot (per-slot specs all come from manual_slot_specs).
+    # Catalog geometry uses the canonical v15-turbo bundle's 144 cells;
+    # no network fetch happens here (policy tables only).
+    steering = [
+        steering_axis_spec(
+            ax.name,
+            axis=ax.axis,
+            inject_layer=max(
+                0, min(MANUAL_MAX_LAYER, ax.probe_layer + ax.layer_offset),
+            ),
+            probe_step=ax.probe_step,
+            probe_n=PROBE_N,
+            blurb=ax.blurb,
+        )
+        for ax in AUTO_AXES
+    ] + manual_slot_specs(
+        1,
+        src_max=143,
+        catalog_len=144,
+        layer_max=MANUAL_MAX_LAYER,
+        step_max=MANUAL_MAX_STEP,
+    )
     return (
         knob_specs(False, loras=["<lora_id>"])
         + knob_specs(True, loras=["<lora_id>"])
+        + steering
     )
 
 

--- a/acestep/streaming/generator_backend.py
+++ b/acestep/streaming/generator_backend.py
@@ -152,6 +152,11 @@ class Capabilities:
     depth: bool = False
     curves: bool = False
     notes_conditioning: bool = False
+    # Activation steering (per-layer residual shifts driven by the
+    # steer_* / man_*_<N> knobs and the manual_slot_add/pop commands).
+    # True only when the backend has a steering controller with a
+    # reachable vector bundle for its checkpoint.
+    steering: bool = False
 
 
 @dataclass(frozen=True)

--- a/acestep/streaming/knobs.py
+++ b/acestep/streaming/knobs.py
@@ -218,6 +218,101 @@ def lora_strength_spec(lora_id: str) -> KnobSpec:
     )
 
 
+# Activation-steering alpha range. Bipolar so the operator can invert an
+# axis without leaving the surface; useful magnitude is roughly 2..15 by
+# ear, breakage above that.
+STEERING_ALPHA_MAX = 30.0
+
+
+def steering_axis_spec(
+    name: str,
+    *,
+    axis: str = "",
+    inject_layer: int = 0,
+    probe_step: int = 0,
+    probe_n: int = 8,
+    blurb: str = "",
+) -> KnobSpec:
+    """The registry spec for one auto-path activation-steering knob.
+
+    Shaped here (range, group, bank) so every transport projects the
+    same contract; the axis metadata (where the vector injects, what it
+    does) arrives as plain values from the backend that owns the
+    steering policy — this module stays torch-free / acestep-free.
+    """
+    return KnobSpec(
+        name, default=0.0,
+        min_val=-STEERING_ALPHA_MAX, max_val=STEERING_ALPHA_MAX,
+        group="steering",
+        description=(
+            f"Activation-steering ({axis}) injected at DiT layer "
+            f"{inject_layer}, step round({probe_step}/{probe_n} * inject_n) "
+            f"of the current schedule. 0 = off, negative inverts the axis "
+            f"direction. {blurb}."
+            " Useful magnitude roughly 2..15 by ear; breakage above that."
+        ),
+    )
+
+
+def manual_slot_specs(
+    slot_id: int,
+    *,
+    src_max: int,
+    catalog_len: int,
+    layer_max: int,
+    step_max: int,
+) -> list:
+    """The four registry specs for one manual steering slot.
+
+    Like :func:`lora_strength_spec`, factored so the runtime slot
+    add path and the session-start manifest both shape the knobs from
+    the registry. Manual slots bypass the auto path's fractional step
+    mapping, layer offset, and sign correction — the vector lands at
+    the operator's chosen cell with the operator's chosen sign.
+    """
+    return [
+        KnobSpec(
+            f"man_src_{slot_id}", default=0.0, min_val=0.0,
+            max_val=float(src_max), type="int", group="manual",
+            description=(
+                f"Manual slot {slot_id}: vector catalog index. Resolves to "
+                f"a (axis, build_layer, build_step) cell on disk; call "
+                f"list_manual_steering_vectors for the table. Index "
+                f"0..{src_max} ({catalog_len} cells)."
+            ),
+        ),
+        KnobSpec(
+            f"man_layer_{slot_id}", default=9.0, min_val=0.0,
+            max_val=float(layer_max), type="int", group="manual",
+            description=(
+                f"Manual slot {slot_id}: DiT inject layer (0..{layer_max}). "
+                "Passed verbatim to the engine; no automatic offset."
+            ),
+        ),
+        KnobSpec(
+            f"man_step_{slot_id}", default=0.0, min_val=0.0,
+            max_val=float(step_max), type="int", group="manual",
+            description=(
+                f"Manual slot {slot_id}: diffusion inject step "
+                f"(0..{step_max}). No fractional mapping. Values past the "
+                "current steps_override - 1 silently no-op (the engine only "
+                "fires when step equals the active diffusion step)."
+            ),
+        ),
+        KnobSpec(
+            f"man_alpha_{slot_id}", default=0.0,
+            min_val=-STEERING_ALPHA_MAX, max_val=STEERING_ALPHA_MAX,
+            group="manual",
+            description=(
+                f"Manual slot {slot_id}: injection strength. 0 = slot off. "
+                "Bipolar: negative alpha inverts the chosen vector's "
+                "direction at injection (no sign correction is applied). "
+                "Useful magnitude roughly 2..15 by ear; breakage above that."
+            ),
+        ),
+    ]
+
+
 def knob_catalog(sde: bool, loras=None) -> dict:
     """Project the full registry into a transport-agnostic catalog:
     ``name -> {type, default, min?, max, group, options?, description?,

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -73,12 +73,14 @@ from acestep.streaming.audio_engine import AudioEngine
 from acestep.streaming.commands import CommandOrigin
 from acestep.streaming.config import SessionConfig
 from acestep.streaming.encode import blend_for_strength, encode_cond_pair
+from acestep.steering import CapacityError, EmptyError
 from acestep.streaming.events import (
     AudioReady,
     CommandFailed,
     DepthApplied,
     EventBus,
     LoraCatalogUpdate,
+    ManualSlotCount,
     ParamsEcho,
     PromptApplied,
     PromptBlendEcho,
@@ -462,10 +464,19 @@ class StreamingSession:
 
         # Cached {name: KnobSpec} map for hot-path validation in set_knobs.
         # knob_specs() rebuilds 34 dataclasses, so we never call it per tick;
-        # rebuilt only when the LoRA set changes (see _apply_lora_pending).
+        # rebuilt only when the LoRA set changes (see _apply_lora_pending)
+        # or a manual steering slot is added/popped.
         # Reassigned wholesale (atomic ref swap), so set_knobs can read it
         # without a lock from the dispatch thread.
         self._rebuild_knob_specs(self.initial_enable_ids)
+
+        # The backend's manifest can extend the shared registry set the
+        # KnobState was seeded from (today: the activation-steering
+        # knobs, present only when the checkpoint has a vector bundle).
+        # Seed any such knob so snapshot ``knob_values`` stays complete
+        # from t=0 — add_knob is a no-op for already-seeded names.
+        for spec in self._knob_specs_by_name.values():
+            self.virtual_knobs.add_knob(spec)
 
     def _rebuild_knob_specs(self, lora_ids: list) -> None:
         # Backend-owned manifest: which specs the LoRA set expands to is
@@ -522,6 +533,24 @@ class StreamingSession:
         return {
             "version": KNOB_SCHEMA_VERSION,
             "knobs": catalog_from_specs(self._knob_specs_by_name.values()),
+        }
+
+    def steering_payload(self) -> dict:
+        """Wire-shaped activation-steering block, shared by the ``ready``
+        frame and the snapshot. ``steering_available`` mirrors the
+        backend's ``steering`` capability bit; the count/cap fields drive
+        the client's manual-slot row rendering and +/- enablement."""
+        ctl = getattr(self.backend, "steering", None)
+        if ctl is None:
+            return {
+                "manual_slot_count": 0,
+                "manual_slot_cap": 0,
+                "steering_available": False,
+            }
+        return {
+            "manual_slot_count": ctl.slot_count,
+            "manual_slot_cap": ctl.slot_cap,
+            "steering_available": bool(ctl.is_loaded),
         }
 
     def lora_catalog_payload(self) -> list:
@@ -589,6 +618,9 @@ class StreamingSession:
             "geometry": self.geometry_payload(),
             "capabilities": self.capabilities_payload(),
             "knob_manifest": self.knob_manifest_payload(),
+            # Activation-steering surface (count drives manual-slot row
+            # rendering; available=False hides the steering tiles).
+            **self.steering_payload(),
         }
 
     # ---- Runner lifecycle ----------------------------------------------
@@ -1497,6 +1529,67 @@ class StreamingSession:
             "disable_lora_requested origin={} id={}",
             origin.value, lora_id,
         )
+
+    @requires_capability("steering", "manual_slot_add")
+    def manual_slot_add(
+        self,
+        *,
+        origin: CommandOrigin = CommandOrigin.PRIMARY,
+    ) -> None:
+        """Allocate the next manual steering slot (LIFO).
+
+        The controller is the primary write; KnobState and the cached
+        spec map mirror it so the four ``man_*_<N>`` knobs validate and
+        snapshot from the moment the slot exists. No GPU work, so it
+        applies inline (no pending queue). Publishes
+        :class:`ManualSlotCount` on success AND refusal — the client's
+        +/- UI resyncs from the echo either way.
+        """
+        self.state.last_activity_ts = time.monotonic()
+        ctl = self.backend.steering
+        try:
+            new_slot = ctl.add_slot()
+        except CapacityError:
+            logger.info(
+                "manual_slot_add_refused origin={} cap={}",
+                origin.value, ctl.slot_cap,
+            )
+        else:
+            self._rebuild_knob_specs(self._enabled_lora_ids())
+            names = ctl.knob_names(new_slot)
+            for name in (names.src, names.layer, names.step, names.alpha):
+                spec = self._knob_specs_by_name.get(name)
+                if spec is not None:
+                    self.virtual_knobs.add_knob(spec)
+            logger.info(
+                "manual_slot_added origin={} slot={}", origin.value, new_slot,
+            )
+        self.bus.publish(ManualSlotCount(count=ctl.slot_count))
+
+    @requires_capability("steering", "manual_slot_pop")
+    def manual_slot_pop(
+        self,
+        *,
+        origin: CommandOrigin = CommandOrigin.PRIMARY,
+    ) -> None:
+        """Remove the highest-numbered manual steering slot (LIFO;
+        interior deletion is not supported). Refusal on an empty
+        registry still publishes :class:`ManualSlotCount`."""
+        self.state.last_activity_ts = time.monotonic()
+        ctl = self.backend.steering
+        try:
+            popped = ctl.pop_slot()
+        except EmptyError:
+            logger.info("manual_slot_pop_refused origin={}", origin.value)
+        else:
+            names = ctl.knob_names(popped)
+            for name in (names.src, names.layer, names.step, names.alpha):
+                self.virtual_knobs.remove_knob(name)
+            self._rebuild_knob_specs(self._enabled_lora_ids())
+            logger.info(
+                "manual_slot_popped origin={} slot={}", origin.value, popped,
+            )
+        self.bus.publish(ManualSlotCount(count=ctl.slot_count))
 
     @requires_capability("timbre", "set_timbre_strength")
     def set_timbre_strength(

--- a/demos/realtime_motion_graph_web/mcp_server.py
+++ b/demos/realtime_motion_graph_web/mcp_server.py
@@ -47,13 +47,24 @@ import soundfile as sf
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
 
+from acestep.steering import (
+    MANUAL_SLOT_CAP,
+    ensure_steering_vectors,
+    enumerate_catalog,
+)
 from acestep.streaming.knobs import (
     KNOB_SCHEMA_VERSION,
+    KnobSpec,
     coerce_knob_values,
     knob_catalog,
     knob_specs,
 )
 from .protocol import coerce_command_payload, wire_contract
+
+# MCP runs as a single global process, so we pre-fetch the canonical
+# 2B turbo bundle at module init. Fetch failures leave the cache empty;
+# the next streaming session retries.
+_MANUAL_VECTOR_DIR = ensure_steering_vectors("acestep-v15-turbo")
 
 
 # MCP wire protocol owns stdout — every log MUST go to stderr. Lazy
@@ -240,6 +251,27 @@ def _waveform_to_audio_bytes(waveform: np.ndarray) -> bytes:
 
 
 # ---------------------------------------------------------------------------
+# Manual steering vector catalog (local view of the prefetched bundle)
+# ---------------------------------------------------------------------------
+
+
+def _enumerate_manual_catalog() -> list[dict]:
+    """Manual steering catalog flattened to wire-stable dicts."""
+    if _MANUAL_VECTOR_DIR is None:
+        return []
+    return [
+        {
+            "index": entry.index,
+            "axis": entry.axis,
+            "build_layer": entry.build_layer,
+            "build_step": entry.build_step,
+            "filename": entry.filename,
+        }
+        for entry in enumerate_catalog(_MANUAL_VECTOR_DIR)
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Tools — discovery
 # ---------------------------------------------------------------------------
 
@@ -339,6 +371,19 @@ async def list_knobs(session_id: Optional[str] = None) -> dict:
     which LoRAs are currently enabled — pulled from the live snapshot.
     """
     snap = await session_state(session_id)
+    # Prefer the snapshot's backend-owned manifest (Phase 2): it is the
+    # session's LIVE knob universe, including the backend-specific knobs
+    # the static registry projection can't reproduce (the steering
+    # steer_* axes and the per-slot man_*_<N> quadruples).
+    manifest = snap.get("knob_manifest") or {}
+    if isinstance(manifest, dict) and manifest.get("knobs"):
+        return {
+            "version": manifest.get("version", KNOB_SCHEMA_VERSION),
+            "knobs": manifest["knobs"],
+            "current": snap.get("knob_values") or {},
+        }
+    # Older server snapshot without a manifest: re-derive from the
+    # shared registry (no steering surface on those servers anyway).
     sde, enabled = _session_knob_shape(snap)
     return {
         "version": KNOB_SCHEMA_VERSION,
@@ -362,6 +407,33 @@ def _session_knob_shape(snap: dict) -> tuple[bool, list]:
     return sde, enabled
 
 
+def _specs_from_snapshot(snap: dict) -> dict:
+    """``{name: KnobSpec}`` for a session snapshot.
+
+    Reconstructed from the snapshot's backend-owned ``knob_manifest``
+    when present (so validation covers backend-specific knobs like the
+    steering surface); falls back to the shared registry for older
+    servers. The manifest is itself a registry projection
+    (``catalog_from_specs``), so this stays single-source."""
+    manifest = (snap.get("knob_manifest") or {}).get("knobs")
+    if isinstance(manifest, dict) and manifest:
+        return {
+            name: KnobSpec(
+                name=name,
+                default=e.get("default", 0.0),
+                min_val=e.get("min"),
+                max_val=e.get("max", 1.0),
+                type=e.get("type", "float"),
+                options=tuple(e.get("options") or ()),
+                group=e.get("group", "core"),
+                bank=bool(e.get("bank", True)),
+            )
+            for name, e in manifest.items()
+        }
+    sde, enabled = _session_knob_shape(snap)
+    return {s.name: s for s in knob_specs(sde=sde, loras=enabled)}
+
+
 async def _validate_against_session(
     raw: dict, session_id: Optional[str]
 ) -> dict:
@@ -370,12 +442,51 @@ async def _validate_against_session(
     any value is out of range or not an allowed enum/bool option. Reuses
     the same coerce_knob_values the server enforces, so MCP can't drift."""
     snap = await session_state(session_id)
-    sde, enabled = _session_knob_shape(snap)
-    specs = {s.name: s for s in knob_specs(sde=sde, loras=enabled)}
-    clean, errors = coerce_knob_values(raw, specs)
+    clean, errors = coerce_knob_values(raw, _specs_from_snapshot(snap))
     if errors:
         raise ValueError("; ".join(errors))
     return clean
+
+
+@mcp.tool()
+async def add_manual_slot(session_id: Optional[str] = None) -> dict:
+    """Spawn the next manual steering slot (LIFO; alpha defaults to 0).
+
+    Refused (no-op echo) at MANUAL_SLOT_CAP.
+    """
+    _send_cmd(session_id, {"type": "manual_slot_add"})
+    snap = await session_state(session_id)
+    return {
+        "count": int(snap.get("manual_slot_count") or 0),
+        "cap": MANUAL_SLOT_CAP,
+    }
+
+
+@mcp.tool()
+async def pop_manual_slot(session_id: Optional[str] = None) -> dict:
+    """Remove the highest-numbered manual steering slot.
+
+    LIFO; interior deletion is not supported. Refused (no-op echo) on
+    an empty registry.
+    """
+    _send_cmd(session_id, {"type": "manual_slot_pop"})
+    snap = await session_state(session_id)
+    return {
+        "count": int(snap.get("manual_slot_count") or 0),
+        "cap": MANUAL_SLOT_CAP,
+    }
+
+
+@mcp.tool()
+async def list_manual_steering_vectors() -> dict:
+    """Catalog of pre-built steering vectors for the manual slots.
+
+    Returns ``{"count": N, "vectors": [...]}``. Each entry's ``index``
+    is the value to set on ``man_src_<slot>``. Order is stable across
+    sessions (axis-major, then build_layer asc, then build_step asc).
+    """
+    cat = _enumerate_manual_catalog()
+    return {"count": len(cat), "vectors": cat}
 
 
 # ---------------------------------------------------------------------------

--- a/demos/realtime_motion_graph_web/protocol.py
+++ b/demos/realtime_motion_graph_web/protocol.py
@@ -293,6 +293,22 @@ COMMANDS: tuple = (
         description="Disable a LoRA and drop its lora_str_<id> knob.",
     ),
     CommandSpec(
+        "manual_slot_add",
+        requires="steering",
+        description="Allocate the next manual steering slot (LIFO); "
+                    "allocates its four man_*_<N> knobs. Echoed back as "
+                    "manual_slot_count on success AND refusal (at "
+                    "manual_slot_cap).",
+    ),
+    CommandSpec(
+        "manual_slot_pop",
+        requires="steering",
+        description="Remove the highest-numbered manual steering slot and "
+                    "drop its man_*_<N> knobs (LIFO; interior deletion is "
+                    "not supported). Echoed back as manual_slot_count on "
+                    "success AND refusal (empty registry).",
+    ),
+    CommandSpec(
         "set_timbre_strength",
         fields=(FieldSpec("value", "float", required=True, default=1.0,
                           description="1.0 = full reference, 0.0 = silence "
@@ -439,6 +455,25 @@ EVENTS: tuple = (
                                   "resolved (SDE mode, enabled lora_str_<id> "
                                   "knobs). /api/knobs remains the static "
                                   "pre-session probe."),
+            # Activation-steering surface. Wire-optional like the
+            # Phase-2 fields above: absent on backends without the
+            # steering capability, and the client hides the steering
+            # tiles when steering_available isn't explicitly true.
+            FieldSpec("manual_slot_count", "int",
+                      description="Active manual steering slot count; "
+                                  "drives the client's man_*_<N> row "
+                                  "rendering. Updated live via the "
+                                  "manual_slot_count event."),
+            FieldSpec("manual_slot_cap", "int",
+                      description="Server-imposed ceiling on manual "
+                                  "steering slots; gates the client's "
+                                  "+ button."),
+            FieldSpec("steering_available", "bool",
+                      description="True when the session's checkpoint has "
+                                  "a reachable steering-vector bundle; "
+                                  "false hides the steering surface (the "
+                                  "steer_*/man_* knobs are absent from "
+                                  "the manifest too)."),
         ),
         binary_follow=True,
         description="First JSON after the upload handshake, followed by the "
@@ -538,6 +573,15 @@ EVENTS: tuple = (
         fields=(FieldSpec("value", "int", required=True,
                           description="The clamped applied depth."),),
         description="Ack for set_depth.",
+    ),
+    EventSpec(
+        "manual_slot_count",
+        fields=(FieldSpec("count", "int", required=True,
+                          description="The live manual steering slot "
+                                      "count after the command."),),
+        description="Ack for manual_slot_add / manual_slot_pop — emitted on "
+                    "success and refusal alike so the client's +/- UI "
+                    "resyncs either way.",
     ),
     EventSpec(
         "timbre_set",

--- a/demos/realtime_motion_graph_web/web/app/globals.css
+++ b/demos/realtime_motion_graph_web/web/app/globals.css
@@ -4193,15 +4193,15 @@ body.curve-open #install-video-area #graph {
   margin: 0;
   max-width: 70ch;
 }
-/* Side-by-side columns for the two voice banks. Internal voices on the
-   left (8 wide), tuned morph on the right (6 wide), thin vertical
-   divider between them — the inShaper "shaper-1 / shaper-2" two-pane
-   layout in miniature. */
+/* Two-column grid shared by every row inside the voice tile (channels
+   on row 1, steering on row 2 when present). Grid (not flex) so the
+   columns auto-size to the widest content across rows — that's what
+   makes "manual steering" line up with "channel groups" above. */
 .voice-sections-row {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: 14px;
+  display: grid;
+  grid-template-columns: auto 1px auto;
+  row-gap: 14px;
+  column-gap: 14px;
   align-items: stretch;
 }
 .voice-section {
@@ -4214,8 +4214,7 @@ body.curve-open #install-video-area #graph {
   width: 1px;
   align-self: stretch;
   background: var(--frame-line);
-  margin: 4px 4px;
-  flex: 0 0 auto;
+  margin: 4px 0;
 }
 .voice-section-label {
   font-family: var(--font-mono);
@@ -4224,6 +4223,7 @@ body.curve-open #install-video-area #graph {
   text-transform: uppercase;
   color: var(--text-dim);
 }
+
 
 /* A tile is a labeled card that groups related controls. Tiles are sized
    to their content (no fixed widths beyond what their inner channels and

--- a/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/AdvancedDrawer.tsx
@@ -265,7 +265,7 @@ const SPREAD_SECTIONS: Array<{ id: DrawerTab; label: string }> = [
   { id: "core", label: "Core" },
   { id: "styles", label: "Styles" },
   { id: "mod", label: "Mod" },
-  { id: "voice", label: "Channels" },
+  { id: "voice", label: "Experimental" },
   { id: "config", label: "Config" },
 ];
 

--- a/demos/realtime_motion_graph_web/web/components/Performance/DrawerTabs.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/DrawerTabs.tsx
@@ -27,7 +27,7 @@ export type DrawerTab = (typeof DRAWER_TABS)[number];
 const TAB_LABELS: Record<DrawerTab, string> = {
   core: "Core",
   mod: "Mod",
-  voice: "Channels",
+  voice: "Experimental",
   styles: "Styles",
   // Auto-generated control surface, rendered straight from the backend
   // /api/knobs manifest. Reference template for a re-skinned UI.

--- a/demos/realtime_motion_graph_web/web/components/Performance/MobileFullSheet.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/MobileFullSheet.tsx
@@ -29,7 +29,7 @@ const TABS: { id: Tab; label: string }[] = [
   { id: "core", label: "Core" },
   { id: "styles", label: "Styles" },
   { id: "mod", label: "Mod" },
-  { id: "voice", label: "Channels" },
+  { id: "voice", label: "Experimental" },
   { id: "saved", label: "Saved" },
   { id: "config", label: "Config" },
 ];

--- a/demos/realtime_motion_graph_web/web/components/Performance/ModTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/ModTile.tsx
@@ -2,7 +2,12 @@
 
 import { usePerformanceStore } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
-import { DCW_MODES, DCW_WAVELETS, RCFG_MODES, type RcfgMode } from "@/types/engine";
+import {
+  DCW_MODES,
+  DCW_WAVELETS,
+  RCFG_MODES,
+  type RcfgMode,
+} from "@/types/engine";
 
 import { Knob } from "./Knob";
 import { defaultLabelFor, kbdHintFor } from "./SliderTile";

--- a/demos/realtime_motion_graph_web/web/components/Performance/SliderTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/SliderTile.tsx
@@ -63,6 +63,18 @@ const PARAM_TOOLTIPS: Record<string, string> = {
   cfg_rescale:
     "After CFG, mix the guided velocity's magnitude back toward what the positive forward produced. 0 keeps raw CFG; 1 fully snaps the magnitude. Pair with high guidance_scale to keep the prompt-push without the harshness that high CFG causes on its own.",
 
+  // ── Activation steering (auto path) ──
+  // Each tooltip names the underlying probe cell so the operator can
+  // recreate the effect on a manual slot.
+  steer_bright:
+    "Activation-steering: positive alpha shifts spectral centroid up (brighter, more highs). 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector brightness_l09_t3 at layer = 9, step = round(3/8 x steps_count).",
+  steer_warm:
+    "Activation-steering: positive alpha tilts the spectrum toward bass (warmer). The raw vector points the wrong way for this axis, so this knob folds in a -1 sign. 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector warmth_l15_t0 at layer = 15, step = 0, then INVERT alpha sign (manual mode is sign-agnostic).",
+  steer_rough:
+    "Activation-steering: positive alpha increases spectral flatness (grittier, noisier). Vector magnitude at this probe cell is small, so effect builds slowly. 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector roughness_l09_t3 at layer = 9, step = round(3/8 x steps_count).",
+  steer_density:
+    "Activation-steering: positive alpha thins the texture toward sparse/minimal. Inject layer is shifted 3 shallower than the probe layer (Phase-3 transfer finding). 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector density_l18_t3 at layer = 15 (probe 18 minus 3), step = round(3/8 x steps_count).",
+
   // ── DCW ──
   dcw_scaler:
     "Experimental — adjusts the low-band strength of an internal correction the model applies to itself during generation (DCW). This scaler is active in the early part of the run. The exact audio mapping is still being explored — sweep it to discover what it does for your source. Extreme values can be unpredictable but cool.",
@@ -96,6 +108,19 @@ export function tooltipFor(param: string): string | undefined {
   }
   if (param === "lora_blend") {
     return "Crossfade between LoRA A and LoRA B. 0 = A only, 1 = B only, 0.5 = both at half strength. Use this to morph between two styles smoothly.";
+  }
+  // Manual steering tooltips share copy across all slots.
+  if (param.startsWith("man_src_")) {
+    return "Catalog index of the steering vector this slot fires. The catalog enumerates every pre-built (axis, build_layer, build_step) cell on disk in stable axis-major order. Double-click the readout to type an exact index; query the MCP list_manual_steering_vectors tool for the full table. Has no effect until α is non-zero.";
+  }
+  if (param.startsWith("man_layer_")) {
+    return "DiT inject layer (0-23). The vector is added to this layer's post-block residual. Bypasses the auto path's density layer offset — the value lands exactly where you point it.";
+  }
+  if (param.startsWith("man_step_")) {
+    return "Diffusion inject step (0-15). Bypasses the auto path's fractional step mapping; the engine fires the injection only on the step that matches this value. If you pick a step past the current steps count - 1, the slot stays silent until you raise the step count.";
+  }
+  if (param.startsWith("man_alpha_")) {
+    return "Strength of this manual slot's injection. 0 disables the slot. Negative α inverts the vector's direction at injection time (no sign correction is applied; what you set is what the engine receives). Sweep range and breakage point mirror the perceptual steering knobs.";
   }
   return PARAM_TOOLTIPS[param];
 }

--- a/demos/realtime_motion_graph_web/web/components/Performance/VoiceTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/VoiceTile.tsx
@@ -71,7 +71,7 @@ export function VoiceTile() {
       )}
       <div className="voice-sections-row">
         <div className="voice-section">
-          <div className="voice-section-label">Highlights</div>
+          <div className="voice-section-label">channel highlights</div>
           <div className="mixer-channels">
             {MORPH.map((p) => {
               const r = ranges[p];
@@ -92,7 +92,7 @@ export function VoiceTile() {
         </div>
         <div className="voice-section-divider" aria-hidden="true" />
         <div className="voice-section">
-          <div className="voice-section-label">Groups</div>
+          <div className="voice-section-label">channel groups</div>
           <div className="mixer-channels">
             {VOICES.map((p) => {
               const r = ranges[p];

--- a/demos/realtime_motion_graph_web/web/components/Performance/VoiceTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/VoiceTile.tsx
@@ -3,7 +3,9 @@
 import { useEffect, useState } from "react";
 
 import { useConfig } from "@/lib/config";
+import { useSessionStore } from "@/store/useSessionStore";
 
+import { Knob } from "./Knob";
 import { SliderGroup } from "./SliderGroup";
 import { defaultLabelFor, kbdHintFor } from "./SliderTile";
 
@@ -31,6 +33,15 @@ const MORPH = ["ch13", "ch14", "ch19", "ch23", "ch29", "ch56"];
 
 export function VoiceTile() {
   const ranges = useConfig().channel_ranges;
+  const manualSlotCount = useSessionStore((s) => s.manualSlotCount);
+  const manualSlotCap = useSessionStore((s) => s.manualSlotCap);
+  const steeringAvailable = useSessionStore((s) => s.steeringAvailable);
+  const remote = useSessionStore((s) => s.remote);
+  const slotCount = manualSlotCount ?? 0;
+  const slotCap = manualSlotCap ?? 0;
+  const canAddSlot = remote !== null && slotCap > 0 && slotCount < slotCap;
+  const canPopSlot = remote !== null && slotCount > 0;
+  const showSteering = steeringAvailable === true;
   // Experimental-feature notice — dismissable, and the dismissal sticks
   // across reloads. Read after mount (not in the useState initializer)
   // so a localStorage read can't break SSR hydration.
@@ -69,6 +80,9 @@ export function VoiceTile() {
           </p>
         </div>
       )}
+      {/* Two-column grid shared by the channel rows and the steering
+          rows so column 1 (highlights / steering) and column 2 (groups
+          / manual steering) line up across rows. */}
       <div className="voice-sections-row">
         <div className="voice-section">
           <div className="voice-section-label">channel highlights</div>
@@ -111,6 +125,115 @@ export function VoiceTile() {
             })}
           </div>
         </div>
+
+        {showSteering && (
+          <>
+            <div className="voice-section">
+              <div className="voice-section-label">steering</div>
+              <div className="knob-rack">
+                <Knob
+                  param="steer_bright"
+                  label="bright"
+                  kbd={kbdHintFor("steer_bright")}
+                />
+                <Knob
+                  param="steer_warm"
+                  label="warm"
+                  kbd={kbdHintFor("steer_warm")}
+                />
+                <Knob
+                  param="steer_rough"
+                  label="rough"
+                  kbd={kbdHintFor("steer_rough")}
+                />
+                <Knob
+                  param="steer_density"
+                  label="density"
+                  kbd={kbdHintFor("steer_density")}
+                />
+              </div>
+            </div>
+            <div className="voice-section-divider" aria-hidden="true" />
+            <div className="voice-section">
+              <div className="voice-section-label">manual steering</div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "12px",
+                  flexWrap: "wrap",
+                }}
+              >
+                <div
+                  className="knob-rack"
+                  style={{ display: "flex", flexDirection: "column", gap: "8px" }}
+                >
+                  {Array.from({ length: slotCount }, (_, i) => i + 1).map((slot) => (
+                    <div key={slot} className="knob-rack" style={{ gap: "8px" }}>
+                      <Knob
+                        param={`man_src_${slot}`}
+                        label="src"
+                        kbd={kbdHintFor(`man_src_${slot}`)}
+                      />
+                      <Knob
+                        param={`man_layer_${slot}`}
+                        label="layer"
+                        kbd={kbdHintFor(`man_layer_${slot}`)}
+                      />
+                      <Knob
+                        param={`man_step_${slot}`}
+                        label="step"
+                        kbd={kbdHintFor(`man_step_${slot}`)}
+                      />
+                      <Knob
+                        param={`man_alpha_${slot}`}
+                        label="Strength"
+                        kbd={kbdHintFor(`man_alpha_${slot}`)}
+                      />
+                    </div>
+                  ))}
+                </div>
+                <div
+                  data-role="manual-slot-controls"
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "4px",
+                  }}
+                >
+                  <button
+                    type="button"
+                    className="dcw-toggle"
+                    disabled={!canAddSlot}
+                    data-dd-tooltip={
+                      canAddSlot
+                        ? "Add manual steering slot"
+                        : `Manual slot cap (${slotCap}) reached`
+                    }
+                    onClick={() => remote?.sendManualSlotAdd()}
+                    style={{ minWidth: "28px", padding: "2px 6px" }}
+                  >
+                    +
+                  </button>
+                  <button
+                    type="button"
+                    className="dcw-toggle"
+                    disabled={!canPopSlot}
+                    data-dd-tooltip={
+                      canPopSlot
+                        ? "Remove last manual steering slot"
+                        : "No manual slots to remove"
+                    }
+                    onClick={() => remote?.sendManualSlotPop()}
+                    style={{ minWidth: "28px", padding: "2px 6px" }}
+                  >
+                    −
+                  </button>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -193,11 +193,21 @@ function wireRemoteListeners(
     // ungated). The hand-coded swap/timbre/structure/LoRA panels read
     // it via useCapability.
     s.setCapabilities(remote.capabilities);
+    // Activation-steering surface (null on servers without it = tiles
+    // hidden). VoiceTile reads these to render the steering racks.
+    s.setManualSlotCount(remote.manualSlotCount);
+    s.setManualSlotCap(remote.manualSlotCap);
+    s.setSteeringAvailable(remote.steeringAvailable);
   });
   remote.addEventListener("depth_applied", (e) => {
     useSessionStore
       .getState()
       .setPipelineDepth((e as CustomEvent<number>).detail);
+  });
+  remote.addEventListener("manual_slot_count", (e) => {
+    useSessionStore
+      .getState()
+      .setManualSlotCount((e as CustomEvent<number | null>).detail);
   });
   // WS startup telemetry. The SDK only observes its own connection
   // (wsTrace + the optional init_ack echo); persisting the latest trace

--- a/demos/realtime_motion_graph_web/web/sdk/protocol.ts
+++ b/demos/realtime_motion_graph_web/web/sdk/protocol.ts
@@ -38,6 +38,8 @@ import type {
   DisableLoraCommand,
   EnableLoraCommand,
   LoopBandCommand,
+  ManualSlotAddCommand,
+  ManualSlotPopCommand,
   ParamsCommand,
   PromptCommand,
   SetDepthCommand,
@@ -221,6 +223,15 @@ export class RemoteBackend extends EventTarget {
    *  on older servers / replays; `/api/knobs` remains the static
    *  pre-session probe. */
   knobManifest: KnobManifestResponse | null = null;
+  /** Active manual steering slot count, mirrored from the server
+   *  (`ready` + `manual_slot_count` echoes). Null until ready / on
+   *  servers without the steering surface. */
+  manualSlotCount: number | null = null;
+  /** Server-imposed cap on manual steering slots. Null until ready. */
+  manualSlotCap: number | null = null;
+  /** Whether the session's checkpoint has steering vectors. The host
+   *  hides the steering tiles when false. Null until ready. */
+  steeringAvailable: boolean | null = null;
   /** Browser-observed WS lifecycle for this concrete connection attempt. */
   wsTrace: WsTrace;
   /** Pod-side session id from the optional init_ack telemetry message. */
@@ -448,6 +459,20 @@ export class RemoteBackend extends EventTarget {
               (msg.capabilities as CapabilityMask | undefined) ?? null;
             this.knobManifest =
               (msg.knob_manifest as KnobManifestResponse | undefined) ?? null;
+            // Activation-steering surface. Wire-optional like the
+            // Phase-2 fields: null hides the steering tiles host-side.
+            this.manualSlotCount =
+              typeof msg.manual_slot_count === "number"
+                ? msg.manual_slot_count
+                : null;
+            this.manualSlotCap =
+              typeof msg.manual_slot_cap === "number"
+                ? msg.manual_slot_cap
+                : null;
+            this.steeringAvailable =
+              typeof msg.steering_available === "boolean"
+                ? msg.steering_available
+                : null;
             // Scale + depth bounds are exposed as instance fields; the host
             // app mirrors them into its own state from the "ready" event
             // listener (the SDK never writes app stores).
@@ -632,6 +657,16 @@ export class RemoteBackend extends EventTarget {
                   new CustomEvent("depth_applied", { detail: v }),
                 );
               }
+              break;
+            }
+            case "manual_slot_count": {
+              // Echoed after manual_slot_add / manual_slot_pop (success
+              // or refusal). The host mirrors it into its own state.
+              const v = typeof msg.count === "number" ? msg.count : null;
+              this.manualSlotCount = v;
+              this.dispatchEvent(
+                new CustomEvent("manual_slot_count", { detail: v }),
+              );
               break;
             }
             default:
@@ -909,6 +944,25 @@ export class RemoteBackend extends EventTarget {
     if (this.ws?.readyState !== WebSocket.OPEN) return;
     try {
       const msg: DisableLoraCommand = { type: "disable_lora", id };
+      this.ws.send(JSON.stringify(msg));
+    } catch {}
+  }
+
+  /** Add the next manual steering slot (LIFO). Server echoes
+   *  ``manual_slot_count`` on success or refusal. */
+  sendManualSlotAdd(): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    try {
+      const msg: ManualSlotAddCommand = { type: "manual_slot_add" };
+      this.ws.send(JSON.stringify(msg));
+    } catch {}
+  }
+
+  /** Pop the highest-numbered manual steering slot. */
+  sendManualSlotPop(): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    try {
+      const msg: ManualSlotPopCommand = { type: "manual_slot_pop" };
       this.ws.send(JSON.stringify(msg));
     } catch {}
   }

--- a/demos/realtime_motion_graph_web/web/sdk/types/wireContract.gen.ts
+++ b/demos/realtime_motion_graph_web/web/sdk/types/wireContract.gen.ts
@@ -29,6 +29,8 @@ export type CommandName =
   | "set_depth"
   | "enable_lora"
   | "disable_lora"
+  | "manual_slot_add"
+  | "manual_slot_pop"
   | "set_timbre_strength"
   | "set_timbre_source"
   | "set_timbre_fixture"
@@ -47,6 +49,8 @@ export const COMMAND_NAMES: readonly CommandName[] = [
   "set_depth",
   "enable_lora",
   "disable_lora",
+  "manual_slot_add",
+  "manual_slot_pop",
   "set_timbre_strength",
   "set_timbre_source",
   "set_timbre_fixture",
@@ -71,6 +75,7 @@ export type EventName =
   | "stem_assets"
   | "stem_failed"
   | "depth_applied"
+  | "manual_slot_count"
   | "timbre_set"
   | "timbre_cleared"
   | "timbre_failed"
@@ -93,6 +98,7 @@ export const EVENT_NAMES: readonly EventName[] = [
   "stem_assets",
   "stem_failed",
   "depth_applied",
+  "manual_slot_count",
   "timbre_set",
   "timbre_cleared",
   "timbre_failed",
@@ -170,6 +176,14 @@ export interface EnableLoraCommand {
 export interface DisableLoraCommand {
   type: "disable_lora";
   id: string;
+}
+
+export interface ManualSlotAddCommand {
+  type: "manual_slot_add";
+}
+
+export interface ManualSlotPopCommand {
+  type: "manual_slot_pop";
 }
 
 export interface SetTimbreStrengthCommand {
@@ -258,6 +272,12 @@ export interface ReadyEvent {
   capabilities?: Record<string, unknown>;
   /** Per-session knob manifest: the same {version, knobs} envelope GET /api/knobs serves, but backend-owned and session-resolved (SDE mode, enabled lora_str_<id> knobs). /api/knobs remains the static pre-session probe. */
   knob_manifest?: Record<string, unknown>;
+  /** Active manual steering slot count; drives the client's man_*_<N> row rendering. Updated live via the manual_slot_count event. */
+  manual_slot_count?: number;
+  /** Server-imposed ceiling on manual steering slots; gates the client's + button. */
+  manual_slot_cap?: number;
+  /** True when the session's checkpoint has a reachable steering-vector bundle; false hides the steering surface (the steer_*\/man_* knobs are absent from the manifest too). */
+  steering_available?: boolean;
 }
 
 export interface ErrorEvent {
@@ -334,6 +354,12 @@ export interface DepthAppliedEvent {
   type: "depth_applied";
   /** The clamped applied depth. */
   value: number;
+}
+
+export interface ManualSlotCountEvent {
+  type: "manual_slot_count";
+  /** The live manual steering slot count after the command. */
+  count: number;
 }
 
 export interface TimbreSetEvent {
@@ -444,6 +470,8 @@ export type WireCommand =
   | SetDepthCommand
   | EnableLoraCommand
   | DisableLoraCommand
+  | ManualSlotAddCommand
+  | ManualSlotPopCommand
   | SetTimbreStrengthCommand
   | SetTimbreSourceCommand
   | SetTimbreFixtureCommand
@@ -467,6 +495,7 @@ export type WireEvent =
   | StemAssetsEvent
   | StemFailedEvent
   | DepthAppliedEvent
+  | ManualSlotCountEvent
   | TimbreSetEvent
   | TimbreClearedEvent
   | TimbreFailedEvent

--- a/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/usePerformanceStore.ts
@@ -17,6 +17,11 @@ import {
   type TimeSignature,
 } from "@/types/engine";
 
+// Pre-seed defaults for every potential manual steering slot so reset /
+// snapback / curve hooks never miss a key when the server allocates a
+// new slot at runtime. Must match the prereg ceiling in engine.ts.
+const MANUAL_SLOT_PREREG = 16;
+
 // Top-level performance state. Mirrors app.js's module-level vars
 // (sliderValues, seedValue, blendValue, activeKey, prompts, fixture, mode,
 // kiosk). LoRA strength sliders live in useLoraStore.
@@ -259,6 +264,11 @@ const DEFAULT_SLIDER_VALUES: Record<string, number> = {
   ch23: 1.0,
   ch29: 1.0,
   ch56: 1.0,
+  steer_bright: 0.0,
+  steer_warm: 0.0,
+  steer_rough: 0.0,
+  steer_density: 0.0,
+  // Manual steering slot defaults are filled in below the object literal.
   dcw_scaler: 0.05,
   dcw_high_scaler: 0.02,
   dcw_mult_blend: 0.0,
@@ -271,6 +281,13 @@ const DEFAULT_SLIDER_VALUES: Record<string, number> = {
   cfg_rescale: 0.0,
   steps_override: 8,
 };
+
+for (let slot = 1; slot <= MANUAL_SLOT_PREREG; slot++) {
+  DEFAULT_SLIDER_VALUES[`man_src_${slot}`] = 0;
+  DEFAULT_SLIDER_VALUES[`man_layer_${slot}`] = 9;
+  DEFAULT_SLIDER_VALUES[`man_step_${slot}`] = 0;
+  DEFAULT_SLIDER_VALUES[`man_alpha_${slot}`] = 0.0;
+}
 
 /** A re-applyable record of an active timbre / structure reference.
  *  `timbreName` / `structName` are the server-acked DISPLAY name

--- a/demos/realtime_motion_graph_web/web/store/useSessionStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useSessionStore.ts
@@ -63,6 +63,15 @@ interface SessionState {
   lastBackendSessionId: string | null;
   /** Client id echoed by init_ack. */
   lastBackendClientId: string | null;
+  /** Active manual steering slot count, mirrored from the server.
+   *  Null until ready. */
+  manualSlotCount: number | null;
+  /** Server-imposed cap on manual steering slots. Drives the +/- enable
+   *  state in ModTile. Null until ready. */
+  manualSlotCap: number | null;
+  /** Whether the session's checkpoint has steering vectors. When false,
+   *  ModTile hides both steering tiles. Null until ready. */
+  steeringAvailable: boolean | null;
 
   setStatus: (status: SessionStatus, message?: string) => void;
   setSession: (remote: RemoteBackend | null, player: AudioPlayer | null) => void;
@@ -76,6 +85,9 @@ interface SessionState {
   setLastWsTrace: (trace: WsTrace | null) => void;
   setLastBackendSessionId: (id: string | null) => void;
   setLastBackendClientId: (id: string | null) => void;
+  setManualSlotCount: (count: number | null) => void;
+  setManualSlotCap: (cap: number | null) => void;
+  setSteeringAvailable: (available: boolean | null) => void;
   reset: () => void;
 }
 
@@ -94,6 +106,9 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   lastWsTrace: null,
   lastBackendSessionId: null,
   lastBackendClientId: null,
+  manualSlotCount: null,
+  manualSlotCap: null,
+  steeringAvailable: null,
 
   setStatus: (status, message = "") => set({ status, message }),
   setSession: (remote, player) => set({ remote, player }),
@@ -107,6 +122,9 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   setLastWsTrace: (trace) => set({ lastWsTrace: trace }),
   setLastBackendSessionId: (id) => set({ lastBackendSessionId: id }),
   setLastBackendClientId: (id) => set({ lastBackendClientId: id }),
+  setManualSlotCount: (count) => set({ manualSlotCount: count }),
+  setManualSlotCap: (cap) => set({ manualSlotCap: cap }),
+  setSteeringAvailable: (available) => set({ steeringAvailable: available }),
   reset: () => {
     try {
       get().monitor?.stop();
@@ -129,6 +147,9 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       lastWsTrace: null,
       lastBackendSessionId: null,
       lastBackendClientId: null,
+      manualSlotCount: null,
+      manualSlotCap: null,
+      steeringAvailable: null,
       // checkpointScale survives reset on purpose: the server's
       // checkpoint doesn't change across sessions, and pre-fetching
       // it from /api/loras lets the library filter render correctly

--- a/demos/realtime_motion_graph_web/web/types/engine.ts
+++ b/demos/realtime_motion_graph_web/web/types/engine.ts
@@ -74,6 +74,16 @@ export const SLIDER_META: Record<string, SliderMeta> = {
   ch29: { max: 3.0, step: 0.15, pro: true },
   ch56: { max: 3.0, step: 0.15, pro: true },
 
+  // Activation-steering. ±30 range so the operator can invert the axis
+  // without leaving the surface. Useful magnitude ~5..15 by ear.
+  steer_bright:   { min: -30.0, max: 30.0, step: 0.5, pro: true },
+  steer_warm:     { min: -30.0, max: 30.0, step: 0.5, pro: true },
+  steer_rough:    { min: -30.0, max: 30.0, step: 0.5, pro: true },
+  steer_density:  { min: -30.0, max: 30.0, step: 0.5, pro: true },
+
+  // Manual steering slots (man_*_<N>) are pre-registered in the loop
+  // below so a runtime slot add doesn't have to mutate SLIDER_META.
+
   // DCW (wavelet-domain post-step correction). Numeric knobs only; the
   // boolean ON/OFF + mode + wavelet choices live in their own panel state.
   //
@@ -91,6 +101,19 @@ export const SLIDER_META: Record<string, SliderMeta> = {
   dcw_mag_phase: { max: 1.0, step: 0.05, pro: true },
   dcw_soft_thresh: { max: 0.3, step: 0.01, pro: true },
 };
+
+// SLIDER_META pre-reg ceiling. Authoritative cap is the server's
+// ``manual_slot_cap``; raising the server cap above this means bumping
+// this number too.
+const MANUAL_SLOT_PREREG = 16;
+for (let slot = 1; slot <= MANUAL_SLOT_PREREG; slot++) {
+  SLIDER_META[`man_src_${slot}`]   = { min: 0, max: 143, step: 1, pro: true };
+  SLIDER_META[`man_layer_${slot}`] = { min: 0, max: 23,  step: 1, pro: true };
+  SLIDER_META[`man_step_${slot}`]  = { min: 0, max: 15,  step: 1, pro: true };
+  SLIDER_META[`man_alpha_${slot}`] = {
+    min: -30.0, max: 30.0, step: 0.5, pro: true,
+  };
+}
 
 export const DCW_MODES = ["low", "high", "double", "pix"] as const;
 export const DCW_WAVELETS = ["haar", "db4", "sym8", "db8"] as const;

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -60,6 +60,7 @@ from acestep.streaming.events import (
     CommandFailed,
     DepthApplied,
     LoraCatalogUpdate,
+    ManualSlotCount,
     ParamsEcho,
     PromptApplied,
     PromptBlendEcho,
@@ -554,6 +555,8 @@ def _handle_client_body(
             _send_json({"type": "lora_catalog", "catalog": event.catalog})
         elif isinstance(event, DepthApplied):
             _send_json({"type": "depth_applied", "value": event.value})
+        elif isinstance(event, ManualSlotCount):
+            _send_json({"type": "manual_slot_count", "count": event.count})
         elif isinstance(event, CommandFailed):
             _send_json({
                 "type": "command_failed",
@@ -618,6 +621,9 @@ def _handle_client_body(
         "geometry": streaming.geometry_payload(),
         "capabilities": streaming.capabilities_payload(),
         "knob_manifest": streaming.knob_manifest_payload(),
+        # Activation-steering surface (manual_slot_count /
+        # manual_slot_cap / steering_available).
+        **streaming.steering_payload(),
     }))
     ws.send(src_np.astype(np.float16).tobytes())
     if streaming.initial_upload_stems is not None:
@@ -768,6 +774,10 @@ def _handle_client_body(
                 lid = data.get("id")
                 if lid:
                     streaming.disable_lora(str(lid), origin=origin)
+            elif mtype == "manual_slot_add":
+                streaming.manual_slot_add(origin=origin)
+            elif mtype == "manual_slot_pop":
+                streaming.manual_slot_pop(origin=origin)
             elif mtype == "set_timbre_strength":
                 try:
                     v = float(data.get("value", 1.0))


### PR DESCRIPTION
# feat(rtmg): spectral steering, re-expressed in the registry-driven control surface

> ## Merge order
> **Stacked: opened against `ryanontheinside/feat/models/spectral/spectral-control`. Merge #224 -> #220 -> #229 -> spectral-control before this.**
> Stack: `main` <- #224 <- #220 <- #229 (models/backend) <- spectral-control <- **this**.
> **Supersedes #163** (same feature, ported from the pre-seam `ryanontheinside/feat/spectral/demo-on-spectral-control`; close that one in favor of this).
> Heads-up for whoever merges this after the mrt2 (#230) / sa3 (#231) leaves (or vice versa): `acestep/streaming/families.py` will conflict — this PR extends the ACE factory + knob universe, those add their families to the same registries. Resolution is mechanical (keep both).

The demo/control surface for the spectral-control backend underneath: four perceptual steering knobs (bright / warm / rough / density) plus runtime-allocatable manual slots that fire any vector in the probe catalog at an operator-chosen (layer, step, alpha).

## What's here (two commits)

**`4c3eff1` tab rename.** "Channels" tab -> "Experimental"; section labels become "channel highlights" / "channel groups".

**`dd556b8` spectral steering.** The original feature, re-expressed in the post-refactor architecture instead of the old hand-rolled knob banks:

- **Knob registry** (`acestep/streaming/knobs.py`): pure `steering_axis_spec()` / `manual_slot_specs()` factories (same pattern as `lora_strength_spec`). `ACEStepBackend.knob_specs()` appends them when the session's checkpoint has a vector bundle, so `/api/knobs`-shaped manifests, the wire `ready` frame, MCP `list_knobs`, and `DynamicKnobPanel` all pick them up with zero per-transport code.
- **Backend** (`ace_backend.py`): owns the `SteeringController` (constructed in `families._make_acestep` via `ensure_steering_vectors(checkpoint)`); `_sync_steering()` pushes configs on snapshot change (pipeline identity is part of the key so a `steps_override` rebuild re-arms), sitting next to `_sync_channel_guidance` in `_prepare_tick`. New `Capabilities.steering` bit, true only when vectors loaded.
- **Session** (`session.py`): `manual_slot_add` / `manual_slot_pop` ops gated by `@requires_capability("steering", ...)`; KnobState + the cached spec map mirror the controller's LIFO slots; `ManualSlotCount` bus event published on success AND refusal; `steering_payload()` (count / cap / available) shared by snapshot and the `ready` frame.
- **Wire contract** (`protocol.py`): `manual_slot_add` / `manual_slot_pop` commands (`requires="steering"`), `manual_slot_count` event, three wire-optional `ready` fields. `wireContract.gen.ts` regenerated; all drift guards green.
- **MCP** (`mcp_server.py`): `add_manual_slot` / `pop_manual_slot` / `list_manual_steering_vectors` tools; `list_knobs` and knob validation now prefer the session snapshot's backend-owned `knob_manifest` (the only projection that can carry backend-specific knobs), falling back to the static registry for older servers.
- **Client**: SDK stays store-free per #220's convention — `manualSlotCount` / `manualSlotCap` / `steeringAvailable` are `RemoteBackend` instance fields + a typed `manual_slot_count` switch case; the host mirrors them in `useStartSession`. Senders typed against the generated command types. `VoiceTile` grows the steering knob rack + manual-slot rows with +/- controls; tooltips in `SliderTile`; `SLIDER_META` pre-registers `man_*_{1..16}`.

Deliberately dropped from the original commit: the unrelated `config.json` default LoRA/prompt swaps (`funkv1` / `Phonk`, prompt A) — debugging defaults that rode into #163.

## Validation

- 149/149 unit tests (incl. wire-contract drift guards over the new commands/event/capability and the knob-homonym guard over the extended universe).
- Web: `tsc` clean, `next build` clean, vitest unit 35/35, replay tier 6/6 (bit-exact).
- Offline smoke against the real cached v15-turbo bundle: 144-cell catalog loads, auto-axis + manual configs build correctly (sign/layer-offset/fractional-step semantics intact).
- Golden harness: pending a free GPU window; will be run at this tip and reported here.
