### PR TITLE
fix(rtmg): wipe user_uploads/ between sessions to stop cross-user leak

### DIFF
--- a/acestep/user_uploads.py
+++ b/acestep/user_uploads.py
@@ -16,6 +16,8 @@ sidecar read). The write half is :mod:`acestep.sidecars`; callers run
 
 from __future__ import annotations
 
+import shutil
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, TYPE_CHECKING
@@ -91,6 +93,43 @@ def enumerate_user_uploads() -> list[str]:
         ):
             names.add(p.name)
     return sorted(names)
+
+
+def wipe_user_uploads() -> int:
+    """Delete every entry under ``user_uploads_dir()``.
+
+    The directory is per-pod scratch space, not per-user storage —
+    uploads are durable on Tigris (see demon-public-demo's
+    ``app/api/sessions/uploads/audio/presign``); the on-disk copy
+    here is a fast-path cache for the current session only. Pods are
+    rented from a pool and reused across users, so any file we leave
+    behind would surface to the next renter via
+    :func:`enumerate_user_uploads` and the ``/api/user_uploads``
+    HTTP endpoint — that's the cross-user fixture leak the rtmg
+    backend now closes by calling this between sessions.
+
+    Returns the number of top-level entries removed. Tolerates the
+    directory being absent (returns 0). Individual delete failures
+    are logged to stdout and skipped — a stuck file on one user's
+    upload must not prevent us from cleaning up the others.
+    """
+    d = user_uploads_dir()
+    if not d.is_dir():
+        return 0
+    removed = 0
+    for entry in d.iterdir():
+        try:
+            if entry.is_dir() and not entry.is_symlink():
+                shutil.rmtree(entry)
+            else:
+                entry.unlink()
+            removed += 1
+        except OSError as exc:
+            sys.stdout.write(
+                f"[user_uploads] wipe failed for {entry.name!r}: {exc}\n"
+            )
+            sys.stdout.flush()
+    return removed
 
 
 def user_upload_audio(name: str) -> Path:

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -620,6 +620,28 @@ def main():
                 control_host, control_port, exc,
             )
 
+    # Pre-flight: clear any user uploads left behind in
+    # MODELS_DIR/user_uploads/ before we start accepting traffic. The
+    # rtmg backend is one-session-per-pod, but pods are rented from a
+    # pool and reused across users — without this, a fresh process
+    # boot on a recycled pod would expose the previous renter's
+    # uploads to the next renter via /api/user_uploads (and let them
+    # play the audio via /user_uploads/<name>). Also matters for the
+    # baked :warm image, which captures /workspace/demon_models — any
+    # uploads sitting in the bake host's user_uploads_dir at bake
+    # time would otherwise ship into every fresh pod. The per-session
+    # wipe in ws_adapter.handle_client covers consecutive sessions on
+    # a single process; this one covers cold boot. Skipped in
+    # --no-backend (no sessions ever land).
+    if not no_backend:
+        from acestep.user_uploads import wipe_user_uploads
+        try:
+            wiped = wipe_user_uploads()
+            if wiped:
+                logger.info("user_uploads_wiped_at_startup entries={}", wiped)
+        except Exception as exc:
+            logger.warning("user_uploads_wipe_at_startup_failed error={}", exc)
+
     logger.info("server_starting port={}", port)
     srv = ws_serve(
         ws_handler,

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -334,6 +334,26 @@ def _handle_client_body(
         "session_init config_keys={} client_id={}",
         sorted(config_dict.keys()), _client_id,
     )
+
+    # When this main session ends, wipe MODELS_DIR/user_uploads/ so
+    # the next renter on this pod can't list (or replay) what this
+    # user uploaded. Registered AFTER the upload_track early-return
+    # above on purpose: that branch is a separate, short-lived WS
+    # used to PUSH a file into user_uploads/ — wiping on its exit
+    # would delete the upload we just persisted. Only the main
+    # session (this point onward) registers the wipe. Process-boot
+    # also wipes once in server.main() so a crashed-process scenario
+    # is still covered.
+    def _wipe_on_session_end() -> None:
+        from acestep.user_uploads import wipe_user_uploads
+        try:
+            wiped = wipe_user_uploads()
+            if wiped:
+                logger.info("user_uploads_wiped_at_session_end entries={}", wiped)
+        except Exception as exc:
+            logger.warning("user_uploads_wipe_at_session_end_failed error={}", exc)
+
+    ctx_stack.callback(_wipe_on_session_end)
     if config_dict.get("telemetry_version"):
         ws.send(json.dumps({
             "type": "init_ack",


### PR DESCRIPTION
## Summary

Pods rented from the pool are reused across users, but `MODELS_DIR/user_uploads/` has always been **global per-pod** — no per-user or per-session namespace. Any audio the previous renter uploaded was left on disk, so when the pool reassigned the pod, the next renter's `TrackPicker` hydrated the "Your tracks" group from `/api/user_uploads` → `enumerate_user_uploads()` (which just `iterdir()`s the whole dir) and showed the prior user's filenames alongside the built-in Library fixtures. They could also play the audio via `/user_uploads/<name>` — same enumerate-based whitelist gates it. **One user could see and play tracks uploaded by another.**

This PR wipes `user_uploads_dir()` at the two points where a transition from "previous user's session" to "current user's session" happens:

1. **Process startup** — `server.main()` right before `ws_serve()` starts accepting traffic. Covers cold boot, process respawn after a crash, and any historical content captured into the `:warm` bake image (see ops note below).
2. **Main-session teardown** — `ws_adapter._handle_client_body()` via `ctx_stack.callback`, registered AFTER the `upload_track` early-return so we never wipe a file the same WS just persisted. Covers consecutive sessions on a single python process (pool reassignment without a pod replacement).

The `upload_track` WS path is separate and short-lived; it writes one file and closes, so it never registers the wipe callback. The main session WS does the wipe in its `finally`/exit, by which time the user's own uploads are already durable on Tigris (via demon-public-demo's `app/api/sessions/uploads/audio/presign` + `bucketKey` roundtrip). The on-disk copy under `user_uploads_dir()` is only a per-session fast-path cache, so wiping it costs nothing real.

## Ops note (:warm bake image audit)

The existing `:warm` Docker image captures `/workspace/demon_models` into the engines/checkpoints layers. If the bake host (Fly bake-agent or the GPU bake pod) has any audio in `/workspace/demon_models/user_uploads/` from past testing, those files have been baked into every fresh pod — visible to whoever the pool routes there first. The startup wipe in this PR clears them on first boot of any pod running this code, so the immediate user-visible bug closes when this lands on `:warm`. But the bake itself should also be verified:

```sh
# On the Fly bake-agent (or any pod running current :warm)
ls -la /workspace/demon_models/user_uploads/ 2>/dev/null
```

If non-empty, do a one-time `rm -rf` on the bake host's `/workspace/demon_models/user_uploads/*` before the next bake so the layer hash doesn't keep dragging the stale tarball forward.

## Test plan

- [ ] Local: start the rtmg backend with `--no-backend` off, no client connected — confirm the startup wipe log line fires (`user_uploads_wiped_at_startup entries=N` when N>0; absent otherwise).
- [ ] Local: upload a track, then close the WS — confirm `user_uploads_wiped_at_session_end entries=N` fires on close and `MODELS_DIR/user_uploads/` is empty.
- [ ] Local: trigger an `upload_track` WS in isolation (not the main session) — confirm it persists the file (the wipe callback is not registered on that branch).
- [ ] Cold-boot a fleet pod (`:warm`) after this lands on `:warm`, connect, query `/api/user_uploads` — confirm it returns `[]` even if the baked image had stale content.
- [ ] Two-user manual: user A uploads a track + disconnects → user B is routed to same pod → user B's `/api/user_uploads` returns `[]` (not user A's filename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)