### PR TITLE
Latency Improvement Experimentation

### DIFF
--- a/acestep/engine/stream.py
+++ b/acestep/engine/stream.py
@@ -219,6 +219,11 @@ class _Slot:
     # populated on step 0, reused on every subsequent step of this slot.
     initial_noise: Optional[torch.Tensor] = None
     vt_neg_cached: Optional[torch.Tensor] = None
+    # Host-side "is the slot's own x0_target_strength non-zero" flag,
+    # computed once at slot init so the per-step gate doesn't pay a
+    # normalize + .any().item() per slot per tick. Only consulted when
+    # no shared x0_target_strength override is active.
+    x0_strength_active: bool = False
 
 
 class StreamPipeline:
@@ -246,6 +251,7 @@ class StreamPipeline:
         config: DiffusionConfig,
         pipeline_depth: Optional[int] = None,
         adapter: Optional[ModelAdapter] = None,
+        queue_cap: Optional[int] = None,
     ):
         """``adapter`` selects the model family behind the Tier-2 seam
         (:mod:`acestep.engine.model_adapter`). ``None`` (every existing
@@ -273,13 +279,23 @@ class StreamPipeline:
         # Pipeline state
         self._slots: List[Optional[_Slot]] = [None] * self._depth
         self._queue: List[SlotRequest] = []
+        # Max queued requests before the oldest is dropped. ``None``
+        # keeps the historical cap (= depth). Streaming callers that
+        # re-submit every tick should pass 1: only the freshest request
+        # matters, and a deeper queue only adds parameter staleness
+        # (each queue position costs ~steps/depth ticks of latency on
+        # per-slot parameters like denoise/seed).
+        self._queue_cap: Optional[int] = queue_cap
 
         # Cached device/dtype (set on first submit)
         self._device: Optional[torch.device] = None
         self._dtype: Optional[torch.dtype] = None
 
-        # Schedule cache: denoise -> cpu tensor
-        self._schedule_cache: dict[float, torch.Tensor] = {}
+        # Schedule cache: denoise -> cpu tensor. LRU-bounded so a
+        # continuously swept denoise knob (every distinct float is a
+        # key) can't grow it without bound over a long session.
+        self._schedule_cache: "OrderedDict[float, torch.Tensor]" = OrderedDict()
+        self._schedule_cache_max = 256
 
         # TRT state (mirrors DiffusionEngine pattern). Snapshotted from
         # the engine here, refreshed on profile swaps via the
@@ -326,6 +342,17 @@ class StreamPipeline:
         # at the setter so callers can pass scalars without thinking
         # about shape.
         self._shared_curves: dict[str, torch.Tensor] = {}
+        # Last raw value passed to set_shared_curve per name, used to
+        # skip re-normalization when a caller pushes the same scalar /
+        # tensor object every tick (the streaming backend does).
+        self._shared_curves_src: dict[str, object] = {}
+        # Device/dtype-cast copies of _shared_curves entries, refreshed
+        # lazily on first hot-path use after a set. Avoids a small H2D
+        # transfer per slot per tick when shared curves live on CPU.
+        self._shared_curves_dev: dict[str, torch.Tensor] = {}
+        # Host-side "shared x0_target_strength is non-zero" flag,
+        # computed once at the setter instead of per slot per tick.
+        self._shared_x0_active: bool = False
 
         # Channel guidance: a ``[1, T, 64]`` per-channel gain applied to
         # ``xt`` before each forward pass. Lives in its own field rather
@@ -434,13 +461,19 @@ class StreamPipeline:
     def submit(self, request: SlotRequest) -> None:
         """Enqueue a generation request.
 
-        The queue is capped at ``_depth`` items.  When the caller submits
-        faster than the pipeline consumes (always the case when
-        depth < infer_steps), the oldest queued request is dropped so
-        that fresh parameters reach the ring buffer promptly instead of
-        sitting behind an ever-growing backlog of stale requests.
+        The queue is capped at ``queue_cap`` items (default: ``_depth``).
+        When the caller submits faster than the pipeline consumes
+        (always the case when depth < infer_steps), the oldest queued
+        request is dropped so that fresh parameters reach the ring
+        buffer promptly instead of sitting behind an ever-growing
+        backlog of stale requests. Streaming callers that re-submit
+        every tick should construct the pipeline with ``queue_cap=1``
+        so a retiring slot is always refilled with the freshest
+        parameters.
         """
-        if len(self._queue) >= self._depth:
+        cap = self._queue_cap if self._queue_cap is not None else self._depth
+        cap = max(1, cap)
+        while len(self._queue) >= cap:
             self._queue.pop(0)
         self._queue.append(request)
 
@@ -449,13 +482,19 @@ class StreamPipeline:
 
         Schedule construction is family knowledge (ACE flow-matching
         ``shift`` warp vs SA3 LogSNR warp), so it lives on the adapter;
-        the cache stays here.
+        the cache stays here, LRU-bounded by ``_schedule_cache_max``.
         """
-        if denoise not in self._schedule_cache:
-            self._schedule_cache[denoise] = self.adapter.build_schedule(
-                self.config, denoise, self._device, self._dtype
-            ).cpu()
-        return self._schedule_cache[denoise]
+        cached = self._schedule_cache.get(denoise)
+        if cached is not None:
+            self._schedule_cache.move_to_end(denoise)
+            return cached
+        schedule = self.adapter.build_schedule(
+            self.config, denoise, self._device, self._dtype
+        ).cpu()
+        self._schedule_cache[denoise] = schedule
+        while len(self._schedule_cache) > self._schedule_cache_max:
+            self._schedule_cache.popitem(last=False)
+        return schedule
 
     def _ensure_device(self, device: torch.device, dtype: torch.dtype):
         if self._device is None:
@@ -557,11 +596,21 @@ class StreamPipeline:
             noise.clone() if request.rcfg_mode == "self" else None
         )
 
+        # Host-side x0_target_strength activity flag (see _Slot). The
+        # field is scalar-or-curve; .any() matches the historical
+        # tensor gate, bool() matches it for scalars (non-zero = active).
+        strength = request.x0_target_strength
+        if isinstance(strength, torch.Tensor):
+            x0_active = bool(strength.abs().any().item())
+        else:
+            x0_active = bool(strength)
+
         return _Slot(
             request=request, xt=xt,
             t_schedule=t_schedule, step_idx=0,
             momentum_buffer=momentum_buffer,
             initial_noise=initial_noise,
+            x0_strength_active=x0_active,
         )
 
     # ------------------------------------------------------------------
@@ -647,23 +696,53 @@ class StreamPipeline:
         """
         ones_3d, zeros_3d = self._ensure_sentinels()
 
-        eff_vs = self._eff_shared(slot, "velocity_scale")
-        eff_sdc = self._eff_shared(slot, "sde_denoise_curve")
-        eff_onc = self._eff_shared(slot, "ode_noise_curve")
+        vs = self._shared_curve_dev(
+            slot, "velocity_scale", vt.device, vt.dtype,
+        )
+        sdc = self._shared_curve_dev(
+            slot, "sde_denoise_curve", slot.xt.device, slot.xt.dtype,
+        )
+        onc = self._shared_curve_dev(
+            slot, "ode_noise_curve", slot.xt.device, slot.xt.dtype,
+        )
 
-        vs = (
-            eff_vs.to(device=vt.device, dtype=vt.dtype)
-            if eff_vs is not None else ones_3d
-        )
-        sdc = (
-            eff_sdc.to(device=slot.xt.device, dtype=slot.xt.dtype)
-            if eff_sdc is not None else None
-        )
-        onc = (
-            eff_onc.to(device=slot.xt.device, dtype=slot.xt.dtype)
-            if eff_onc is not None else zeros_3d
-        )
+        if vs is None:
+            vs = ones_3d
+        if onc is None:
+            onc = zeros_3d
         return vs, sdc, onc
+
+    def _shared_curve_dev(
+        self,
+        slot: "_Slot",
+        name: str,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> Optional[torch.Tensor]:
+        """Device/dtype-resident effective curve for ``name``.
+
+        Same precedence as :meth:`_eff_shared` (shared override first,
+        then slot field), but the shared override's device cast is
+        cached on ``_shared_curves_dev`` so repeated ticks don't pay a
+        per-slot H2D copy for CPU-resident shared curves. The cast is
+        the identical ``.to(device, dtype)`` the hot path used to
+        perform inline, so values are byte-identical.
+        """
+        v = self._shared_curves.get(name)
+        if v is not None:
+            dev = self._shared_curves_dev.get(name)
+            if (
+                dev is None
+                or dev.device != device
+                or dev.dtype != dtype
+            ):
+                dev = v.to(device=device, dtype=dtype)
+                self._shared_curves_dev[name] = dev
+            return dev
+        v = getattr(slot.request, name, None)
+        if v is None:
+            return None
+        return ode_steps.normalize_curve(v).to(device=device, dtype=dtype)
 
     # The batched decoder forward lives on the family's ModelAdapter
     # (``self.adapter.batched_forward``) — moved there verbatim from
@@ -718,9 +797,11 @@ class StreamPipeline:
         else:
             bufs["hidden_states"].copy_(xt_io)
 
-        # timestep: one scalar per row.
-        for i, t in enumerate(timestep_list):
-            bufs["timestep"][i] = t
+        # timestep: one scalar per row, staged on CPU and shipped in a
+        # single H2D copy instead of B per-element writes.
+        bufs["timestep"].copy_(
+            torch.tensor(timestep_list, dtype=bufs["timestep"].dtype)
+        )
 
         # encoder_hidden_states: already padded to max_L + catted by
         # the caller. The engine has no ``encoder_attention_mask``
@@ -753,7 +834,14 @@ class StreamPipeline:
 
         if not ctx.execute_async_v3(self._trt_stream.ptr):
             raise RuntimeError("TRT decoder execution failed")
-        self._trt_stream.synchronize()
+        # No host sync here. The polygraphy stream is created with
+        # cudaStreamCreate (a *blocking* stream w.r.t. the legacy
+        # default stream PyTorch uses), so the ``out.to(...)`` below —
+        # and every subsequent torch op — is implicitly ordered after
+        # the TRT execution on the GPU. Dropping the explicit
+        # synchronize lets the CPU run ahead and enqueue the
+        # integration math for this tick while the engine is still
+        # executing, instead of blocking the host once per forward.
 
         out = self._trt_out_buf
         if pad:
@@ -779,10 +867,21 @@ class StreamPipeline:
         ``buf`` is ``[B, num_layers, hidden_size]``; zeroed first so
         previous-tick content doesn't leak. Rows with no matching shift
         stay zero, which the engine adds as a no-op per layer.
+
+        When no steering configs are active the zero is skipped
+        entirely unless a previous forward actually wrote into the
+        buffer (``_steering_dirty`` on the owning cache entry) — the
+        buffer is allocated zeroed, so the common no-steering case is
+        a no-op instead of a per-forward fill kernel.
         """
-        buf.zero_()
+        bufs = self._trt_bufs
         if not self._steering_by_layer:
+            if bufs is not None and bufs.get("_steering_dirty"):
+                buf.zero_()
+                bufs["_steering_dirty"] = False
             return
+        buf.zero_()
+        wrote = False
         for layer_idx, applies in self._steering_by_layer.items():
             if layer_idx < 0 or layer_idx >= self._steering_num_layers:
                 continue
@@ -792,6 +891,9 @@ class StreamPipeline:
                     continue
                 v = apply.vector.to(device=buf.device, dtype=buf.dtype)
                 buf[mask_rows, layer_idx, :] += apply.scale * v
+                wrote = True
+        if bufs is not None:
+            bufs["_steering_dirty"] = wrote
 
     # ------------------------------------------------------------------
     # TRT buffer management
@@ -941,7 +1043,11 @@ class StreamPipeline:
                 if slot is not None and slot.xt.shape[1] != target_T:
                     self._slots[i] = None
 
-        # Check for finished slot (slot at final step of its schedule)
+        # Check for a leftover finished slot. With same-tick delivery
+        # below this only fires when MORE than one slot finished on a
+        # previous tick (possible when depth >= steps) — the extras
+        # drain here, one per tick, preserving the one-result-per-tick
+        # contract.
         finished = None
         for i, slot in enumerate(self._slots):
             if slot is not None and slot.step_idx >= len(slot.t_schedule) - 1:
@@ -967,6 +1073,22 @@ class StreamPipeline:
 
         indices, slots = zip(*active)
         self._tick_pt(slots, indices)
+
+        # Same-tick delivery: a slot that just reached its final step is
+        # returned NOW rather than parked until the next tick's scan —
+        # one full tick of latency shaved off every generation. Only
+        # when no leftover was already claimed above, so at most one
+        # latent is delivered per tick.
+        if finished is None:
+            for i in indices:
+                slot = self._slots[i]
+                if (
+                    slot is not None
+                    and slot.step_idx >= len(slot.t_schedule) - 1
+                ):
+                    finished = slot.xt
+                    self._slots[i] = None
+                    break
 
         self._last_tick_ms = (time.time() - tick_start) * 1000
         self.ticks += 1
@@ -1219,15 +1341,20 @@ class StreamPipeline:
             # ``x0_target_strength`` path: blend toward a target latent
             # at scalar (or per-frame curve) strength, gated to the
             # refinement half.  Preserving the historical "strength==0
-            # falls through to the fast path" behavior — checks the
-            # effective (shared override or slot field) strength via a
-            # tensor.any() sync, which costs one host-device fence per
-            # slot per step but lets the gate stay tensor-safe.
-            eff_strength = self._eff_shared(slot, "x0_target_strength")
-            strength_active = (
-                eff_strength is not None
-                and bool(eff_strength.abs().any().item())
-            )
+            # falls through to the fast path" behavior. The activity
+            # check is a host-side flag (computed once at the shared
+            # setter / slot init) instead of a per-slot-per-step
+            # tensor.any().item() fence; the effective tensor is only
+            # materialized when the blend actually fires.
+            if "x0_target_strength" in self._shared_curves:
+                strength_active = self._shared_x0_active
+                eff_strength = self._shared_curves["x0_target_strength"]
+            else:
+                strength_active = slot.x0_strength_active
+                eff_strength = (
+                    ode_steps.normalize_curve(req.x0_target_strength)
+                    if strength_active else None
+                )
             scalar_x0_target = (
                 req.x0_target is not None
                 and strength_active
@@ -1404,11 +1531,32 @@ class StreamPipeline:
         always ``[B, T, 1]`` and downstream consumers do not need to
         type-discriminate. Pass ``None`` to revert that name to per-slot
         behavior.
+
+        Re-setting the same scalar value (or the same tensor object)
+        is a no-op — streaming backends push the full knob state every
+        tick, and skipping unchanged values avoids re-normalizing and
+        re-uploading curves whose knobs aren't moving.
         """
         if value is None:
             self._shared_curves.pop(name, None)
+            self._shared_curves_src.pop(name, None)
+            self._shared_curves_dev.pop(name, None)
             return
-        self._shared_curves[name] = ode_steps.normalize_curve(value)
+        prev = self._shared_curves_src.get(name)
+        if isinstance(value, (int, float, bool)):
+            if (
+                isinstance(prev, (int, float, bool))
+                and float(prev) == float(value)
+            ):
+                return
+        elif value is prev:
+            return
+        self._shared_curves_src[name] = value
+        norm = ode_steps.normalize_curve(value)
+        self._shared_curves[name] = norm
+        self._shared_curves_dev.pop(name, None)
+        if name == "x0_target_strength":
+            self._shared_x0_active = bool(norm.abs().any().item())
 
     def _eff_shared(self, slot: "_Slot", name: str):
         """Return shared override for ``name`` if set, else slot's field.
@@ -1625,6 +1773,8 @@ class StreamPipeline:
         self._schedule_cache.clear()
         self._compiled_cache.clear()
         self._shared_curves.clear()
+        self._shared_curves_src.clear()
+        self._shared_curves_dev.clear()
         # DCW corrector holds wavelet basis tensors on GPU; drop it.
         self._dcw_corrector = None
         # Detach references to the engine + decoder so DiffusionEngine.close

--- a/acestep/nodes/diffusion_nodes.py
+++ b/acestep/nodes/diffusion_nodes.py
@@ -669,9 +669,15 @@ class StreamDenoise(BaseNode):
             noise_on_cpu=noise_on_cpu,
             use_cache=use_cache,
         )
+        # queue_cap=1: StreamDenoise submits one request per tick, so
+        # only the freshest queued request is ever worth running. The
+        # historical cap (= depth) let up to depth-1 stale requests sit
+        # ahead of a knob change, adding ~steps/depth ticks of latency
+        # per queue position to per-slot parameters (denoise, seed).
         self._pipeline = StreamPipeline(
             self._engine, config,
             pipeline_depth=depth,
+            queue_cap=1,
         )
         self._last_handle_id = handle_id
         return self._pipeline

--- a/acestep/nodes/vae_nodes.py
+++ b/acestep/nodes/vae_nodes.py
@@ -180,8 +180,12 @@ def _trt_vae_decode(
             engine_path, tuple(lat.shape),
         )
         raise RuntimeError("TRT VAE decode failed")
-    stream.synchronize()
-
+    # No host sync: the polygraphy stream is a blocking stream w.r.t.
+    # PyTorch's legacy default stream, so the .clone() below is
+    # implicitly ordered after the TRT execution on the GPU. The
+    # caller's eventual D2H (.cpu() at emission) is the natural sync
+    # point; blocking the host here would only serialize CPU prep
+    # against GPU work.
     return audio_buf.clone().to(torch.float32)
 
 

--- a/acestep/streaming/ace_backend.py
+++ b/acestep/streaming/ace_backend.py
@@ -313,6 +313,14 @@ class ACEStepBackend(DiffusionBackend):
         # flips this flag and produce() honors it on the next pass.
         self._hint_dirty = False
 
+        # SDE-curve build cache. The knob-driven curve (amplitude /
+        # periodicity / src_T) is deterministic in its inputs, so it is
+        # only rebuilt when one of them moves. Reusing the same tensor
+        # object also lets StreamPipeline.set_shared_curve skip the
+        # per-tick re-normalize + device re-upload.
+        self._sde_curve_key: tuple | None = None
+        self._sde_curve_val: "torch.Tensor | None" = None
+
     # ---- contract ----------------------------------------------------------
 
     def capabilities(self) -> Capabilities:
@@ -754,15 +762,27 @@ class ACEStepBackend(DiffusionBackend):
             client_sde = _curve_from_spec(raw.get("sde_denoise_curve"), src_T)
             if client_sde is not None:
                 sde_curve = client_sde
+                self._sde_curve_key = None
+                self.state.sde_curve_display = sde_curve.squeeze().numpy()
             else:
                 periodicity = raw.get("periodicity", 0.0)
-                if periodicity > 0.01:
-                    cycles = periodicity * (src_T / 25.0)
-                    t = torch.linspace(0, 1, src_T).unsqueeze(0).unsqueeze(-1)
-                    sde_curve = amplitude * (0.5 + 0.5 * torch.sin(2 * 3.14159 * cycles * t))
+                # Rebuild only when an input actually moves; the curve
+                # is a pure function of (amplitude, periodicity, src_T)
+                # and steady knobs otherwise pay a [1, src_T, 1] build
+                # + display refresh + shared-curve re-upload per tick.
+                key = (amplitude, periodicity, src_T)
+                if key != self._sde_curve_key:
+                    if periodicity > 0.01:
+                        cycles = periodicity * (src_T / 25.0)
+                        t = torch.linspace(0, 1, src_T).unsqueeze(0).unsqueeze(-1)
+                        sde_curve = amplitude * (0.5 + 0.5 * torch.sin(2 * 3.14159 * cycles * t))
+                    else:
+                        sde_curve = torch.full((1, src_T, 1), amplitude, dtype=torch.float32)
+                    self._sde_curve_key = key
+                    self._sde_curve_val = sde_curve
+                    self.state.sde_curve_display = sde_curve.squeeze().numpy()
                 else:
-                    sde_curve = torch.full((1, src_T, 1), amplitude, dtype=torch.float32)
-            self.state.sde_curve_display = sde_curve.squeeze().numpy()
+                    sde_curve = self._sde_curve_val
         else:
             denoise = k1
             self.state.sde_curve_display = None


### PR DESCRIPTION
# DEMON end-to-end latency: review, measurements, changes

> This work was done in collaboration with Claude Fable Extra High

This document is the result of a full latency review of the DEMON
streaming stack — from a knob turn in the web demo (or any client) to
the audio that comes out — including the TRT inference layer. It
covers:

1. [The knob-to-ear latency path](#1-the-knob-to-ear-latency-path) and
   every contributor we control.
2. [The e2e test strategy](#2-test-strategy) (`tests/e2e_latency/`,
   runnable outside the demo app).
3. [Measured results](#3-measured-results) before/after on this
   build's hardware.
4. [The changes made](#4-changes-made), each with its latency math and
   caveats.
5. [Validation](#5-validation-bit-exactness-and-regressions) —
   bit-exactness probes and regression coverage.
6. [Further proposals not implemented](#6-further-proposals-with-caveats),
   with the risks that kept them out of this pass.

Hardware/context for all numbers: RTX 4090 (shared with other
processes, ~7 GB free VRAM), TRT decoder `decoder_mixed_refit_b8_60s`
(legacy pre-spectral build), depth 4, steps 8, 30 s source, ODE mode
unless stated.

---

## 1. The knob-to-ear latency path

A knob change traverses, in order:

| Stage | Typical cost | Owner / control |
|---|---|---|
| Client knob smoothing | 0–`smoothMs` | web UI (`useParamSync`); param send ~125 Hz |
| WS transport | ~0–2 ms (LAN) | TCP_NODELAY already set |
| `set_knobs` → next runner iteration | 0–1 tick | `PipelineRunner` loop, no inter-tick sleeps |
| **Shared-curve params** (SDE strength, velocity, x0 strength…) | **1 tick** | `set_shared_curve` overrides all in-flight slots next tick |
| **Per-slot params** (ODE denoise, seed) | queue wait + `steps` ticks | submit queue + ring buffer drain |
| Finished-latent delivery | 0 ticks (was 1) | `StreamPipeline.tick()` |
| VAE windowed decode + crossfade + emit | ~8 ms decode + render | `vae_window=0.4 s`, TRT VAE |
| Playback lead (buffer between write head and playhead) | **0.12–1.35 s adaptive** | `PipelineRunner` lead controller |
| Client AudioWorklet buffer | ~10–30 ms | web audio path |

Two structural facts dominate everything else:

* **Parameter class decides engine latency.** Shared-curve parameters
  reach the output in one tick (~36 ms on TRT). Per-slot parameters
  (`denoise` in ODE mode, `seed`) only land on *newly submitted*
  requests, which must wait in the submit queue and then run their
  full `steps` schedule. The demo's "strength" knob is per-slot in ODE
  mode and shared-curve in SDE mode — SDE mode is an order of
  magnitude more responsive by construction.
* **The playback lead is the dominant audible term.** The engine can
  converge in ~300 ms while the listener still waits for the playhead
  to reach the rewritten region. The adaptive lead controller
  (`PipelineRunner`) floors near 0.2 s on a healthy GPU; everything
  the engine gains shortens the *fresh-generation* horizon that the
  lead is measured against.

---

## 2. Test strategy

New suite: **`tests/e2e_latency/`** — engine-level and full-stack
measurements outside the demo app, black-box at public API
boundaries so the same measurements stay valid across internal
refactors.

```bash
# engine-level: knob -> finished latent (ticks + ms), determinism guard
.venv/Scripts/python.exe -m pytest tests/e2e_latency/test_knob_to_latent.py -v -s

# full stack: headless StreamingSession, simulated client heartbeat
.venv/Scripts/python.exe -m pytest tests/e2e_latency/test_streaming_session.py -v -s
```

Environment: `DEMON_E2E_ACCEL=tensorrt|eager|compile` (default:
tensorrt when engines exist), `DEMON_E2E_GPU` (default: most free
VRAM), `DEMON_E2E_DEPTH` / `DEMON_E2E_STEPS`. Reports land in
`runs/latency-reports/e2e-*.json` for build-to-build diffing —
**treat the diff, not the pass/fail, as the output**; assertions are
coarse architectural ceilings only.

Measurement design:

* **Functional change detection.** With a fixed seed and constant
  knobs the pipeline reaches a steady state where every finished
  latent is bit-identical. After a knob flip, the first differing
  finished latent marks *first change*; the first repeating new latent
  marks *converged*. No pipeline internals are inspected.
* **Full-stack timing** subscribes to `AudioReady` events from a
  headless `StreamingSession` and feeds `set_knobs` with an advancing
  `playback_pos` heartbeat, mirroring the web client. It reports
  first-write, write gaps, measured lead, tick/decode percentiles,
  generation rate, and knob→fresh-generation latency (first write
  whose window was generated entirely after the knob).
* **Determinism guard.** Two fresh streams with identical knobs must
  produce bit-identical steady-state latents
  (`test_seed_determinism_streaming`).

The conftest patches the canonical TRT profile table to the legacy
(pre-spectral) decoder engine names when the spectral builds are
missing on the machine — test-process only.

The pre-existing golden harness (`tests/golden/`) remains the wire-level
regression net; it was not run here (refs are captured on an RTX 5090
and require calibration on other cards — see its README).

---

## 3. Measured results

### Engine level (TRT, depth 4, steps 8)

| Metric | Before | After | Δ |
|---|---|---|---|
| tick p50 | 36.7 ms | 35.7 ms | −3 % |
| `denoise` knob first change | 13 ticks / 486 ms | **8 ticks / 282 ms** | **−42 %** |
| `denoise` knob converged | 14 ticks / 522 ms | 13 ticks / 459 ms | −12 % |
| shared curve first change | 2 ticks / 74 ms | **1 tick / 37 ms** | **−50 %** |
| shared curve converged | 10 ticks / 366 ms | 9 ticks / 321 ms | −12 % |

Eager backend (same machine): tick p50 130 → 115 ms (−12 %, the CPU-side
wins matter more without TRT); denoise first change 14 → 8 ticks.

### Full stack (headless StreamingSession, TRT)

| Metric | Before | After | Δ |
|---|---|---|---|
| knob → fresh generation | 406 ms | **172 ms** | **−58 %** |
| first write after start | 0.50 s | 0.20–0.33 s | −34…60 % |
| write gap p50 | 63 ms | 63 ms | — |
| measured lead p50 | 0.197 s | 0.198 s | — |
| generations/s | 7.14 | 7.29 | +2 % |

(`knob_to_next_write` is a single-sample phase measurement and jitters
between 16–47 ms; not meaningful at this resolution.)

---

## 4. Changes made

### 4.1 Submit-queue cap = 1 in streaming mode

`StreamPipeline` queued up to `depth` requests; streaming callers
submit a fresh request every tick, so a knob change sat behind up to
`depth−1` stale requests, each costing ~`steps/depth` ticks before a
retiring slot picked it up. `StreamPipeline` now takes
`queue_cap` (default: historical `depth`), and `StreamDenoise`
constructs its pipeline with `queue_cap=1` — a retiring slot is always
refilled with the *freshest* parameters.

* Latency math: removes ~`(depth−1)·steps/depth` ticks of queue wait
  from every per-slot parameter (measured: −5 ticks at d4/s8).
* Throughput: unchanged — submissions arrive every tick, so the queue
  can never starve.
* Caveats: callers that batch-submit *distinct* requests faster than
  ticks would lose intermediates — no such caller exists
  (`StreamDenoise` is the only production submit site; drain mode
  submits exactly one). Walk-window chunk selection is playhead-driven
  per submission, so latest-wins is the correct semantic there too.
  Direct `StreamPipeline` users (calibration script, parity tests)
  keep the old default.

### 4.2 Same-tick delivery of finished latents

`tick()` previously parked a slot that reached its final step until
the *next* tick's scan returned it. Newly finished slots are now
delivered at the end of the tick that finished them. One full tick
(~36 ms TRT / ~115 ms eager) shaved off **every** generation,
permanently. The one-result-per-tick contract is preserved (a pre-tick
scan still drains leftovers when several slots finish together, one
per tick, which only happens when `depth ≥ steps`).

Caveat: inter-tick observers see slightly different state
(`active_slots` drops one tick earlier; `is_warmed_up` is stats-only).
No control flow in the repo depends on the old phase.

### 4.3 Removed host syncs after TRT enqueues (decoder + VAE decode)

`_trt_forward` ended with `self._trt_stream.synchronize()`;
`_trt_vae_decode` did the same. The polygraphy stream is created with
`cudaStreamCreate` — a *blocking* stream with respect to the legacy
default stream PyTorch uses — so every subsequent torch op is already
implicitly ordered after the TRT execution on the GPU. The explicit
syncs only blocked the host. With them gone, the CPU enqueues the
integration math / emission prep while the engine is still executing.

* Caveats: `_last_tick_ms` now measures mostly enqueue time; per-loop
  wall timings in the runner stay accurate because emission's `.cpu()`
  is a natural sync point, but sub-component attribution shifts
  toward whatever op forces the sync. If PyTorch is ever moved off
  the legacy default stream (per-thread default streams, explicit
  `torch.cuda.Stream` contexts around the tick), the implicit
  ordering assumption must be revisited — the right fix then is CUDA
  events, not host syncs. One-shot paths (`diffusion.py`,
  `trt/runtime.py` TRTDecoder, VAE encode) keep their syncs — they
  are cold paths and not worth the risk surface.

### 4.4 Shared-curve hot-path caching

* `set_shared_curve` now skips re-normalization when the same scalar
  value or tensor object is pushed again (the streaming backend pushes
  the full knob state every tick).
* The device/dtype cast of shared curves is cached
  (`_shared_curves_dev`), eliminating a per-slot-per-tick H2D copy for
  CPU-resident curves (SDE denoise curve at T=750 was 4 uploads/tick).
* `ace_backend` rebuilds the knob-driven SDE curve only when
  (amplitude, periodicity, src_T) actually move, and reuses the same
  tensor object so the setter's skip fires.
* The `x0_target_strength` "is it active" gate is now a host-side flag
  computed once at the setter / slot init instead of a
  per-slot-per-step `tensor.any().item()` fence.

Caveat: in-place mutation of a tensor passed to `set_shared_curve`
followed by re-setting the same object is now a no-op; all callers
build fresh tensors when values change.

### 4.5 Micro-opts in the TRT forward

* Timestep rows staged on CPU and shipped in one H2D copy instead of
  B per-element writes.
* The steering buffer zero-fill is skipped when no steering configs
  are active and the buffer is already clean (dirty flag per cache
  entry); buffers are allocated zeroed.

### 4.6 Schedule cache LRU bound

`_schedule_cache` (denoise → CPU schedule tensor) grew unboundedly —
every distinct float from a swept knob is a key. Now an LRU capped at
256 entries. Values are *not* quantized: quantizing would change
schedules and break bit-exactness for nearby denoise values.

---

## 5. Validation (bit-exactness and regressions)

* **Cross-build bit-exactness probe** (`test_output/bitexact_probe.py`):
  steady-state finished-latent SHA256 under (a) plain ODE, (b) shared
  velocity curve, (c) shared x0_target_strength + target latent, with
  a seeded VAE encode. Identical hashes on the baseline build (changes
  stashed) and the modified build:
  `d5148851…` / `095f3d0c…` / `baccf5ce…`. The math is byte-identical;
  the changes alter only *when* parameters land and *when* latents are
  delivered.
* **Unit suite**: 149 passed (4 skipped: checkpoints not on disk;
  `test_deck_mix.py` / `test_stem_source_mode_gating.py` are stale
  uncommitted files from the deck branch and fail to import on main
  with or without these changes).
* **Adapter parity rail** (`test_ace_adapter_parity.py`): passes.
* **Streaming determinism** (`test_seed_determinism_streaming`):
  passes on TRT and eager.

What is intentionally *not* identical to the old build: wire-level
streaming audio. Slots now run fresher requests (queue cap) and
deliver a tick earlier, so the windows written at a given wall time
differ — that is the improvement, not a regression. The golden
harness's tier-2 tolerance comparison is the right tool to confirm
perceptual equivalence; its refs need one-time calibration on this
card class (see `tests/golden/README.md`).

---

## 6. Further proposals (with caveats)

Ordered by expected payoff:

1. **Prefer SDE mode (or shared-curve denoise) for the strength
   knob.** The single biggest knob-latency lever costs no engine work:
   per-slot ODE denoise is structurally `steps` ticks slower than the
   shared-curve path. An ODE-mode shared "denoise-like" control (e.g.
   mapping strength onto a velocity/noise curve) would make ODE feel
   like SDE. Caveat: changing a slot's t-schedule mid-flight is not
   mathematically equivalent to truncating it; this needs design, not
   just plumbing.
2. **Lead floor tuning.** Measured lead p50 sits at ~0.2 s; the floor
   and release time-constant are env-tunable. Lowering the floor cuts
   audible latency 1:1, at the cost of underrun margin on slow ticks
   (LoRA refit stalls, profile swaps). Worth a guarded experiment with
   the gap-fill telemetry watched.
3. **CUDA Graphs over the TRT forward + integration.** The tick is
   now enqueue-bound; capturing the steady-state tick as a graph would
   collapse launch overhead (~tens of µs × dozens of kernels). Caveats:
   shape changes (T transitions, CFG row counts), TRT `execute_async_v3`
   inside a torch graph capture is fragile, and refit invalidates
   captures — a large, risky change for maybe 10–20 % of tick time.
4. **Event-based timing.** Replace wall-clock `tick_ms`/`dec_ms` with
   CUDA event pairs so the runner's pacing logic sees true GPU cost
   without forcing syncs. Low risk; do it when timing fidelity starts
   driving decisions (e.g. for the lead controller).
5. **Pinned staging for per-tick H2D** (timesteps, CPU noise, CPU
   curves). The single-copy timestep fill landed; promoting the rest
   to pinned+async needs double-buffering against in-flight reuse.
6. **Noise caching per integer seed.** `_make_noise` reseeds the
   global RNG and generates on CPU every submission (~1 ms at T=750).
   Caching `(seed, T, D)` → noise would also stop the global RNG
   side-effects. Caveat: SDE re-noise draws from the same global RNG
   stream, so removing the per-tick `manual_seed` *changes SDE output*
   — must be gated to ODE or paired with a dedicated generator, and
   golden-verified.
7. **Spectral engine rebuild.** This machine runs legacy engines
   without the steering binding. Rebuilding (`python -m
   acestep.engine.trt.build --all`) restores steering and picks up
   current TRT kernel improvements. FP8 (`fp8_mixed`) decoder engines
   cut forward time further on Ada+; needs the calibration flow from
   `docs/TRT.md` and a listening pass.
8. **Walk-window chunk pre-encoding** and **conditioning re-encode
   avoidance** on prompt edits: both are stall (p99) reducers rather
   than steady-state wins; the prompt path already caches by text.