### PR TITLE
Reduce VRAM

### DIFF
--- a/acestep/engine/diffusion.py
+++ b/acestep/engine/diffusion.py
@@ -184,6 +184,21 @@ class DiffusionEngine:
         # freed; engine_from_bytes has consumed it.
         del engine_bytes
         self._trt_ctx = self._trt_engine.create_execution_context()
+        if self._trt_ctx is None:
+            # TensorRT signals workspace-alloc failure (CUDA OOM) by
+            # returning None rather than raising. Drop the deserialized
+            # engine so its weight memory is freed before we raise —
+            # callers (profile manager) retry after empty_cache(), and
+            # holding the dead engine would double-book VRAM during
+            # that retry. Without this raise, the load would "succeed"
+            # and the next decode tick would crash on a bare NoneType
+            # attribute error.
+            self._trt_engine = None
+            torch.cuda.empty_cache()
+            raise RuntimeError(
+                f"TRT decoder engine.create_execution_context() returned "
+                f"None (likely CUDA OOM on workspace alloc): {engine_path}"
+            )
         self._trt_stream = _get_trt_stream()
         self._trt_buf_cache = {}
 

--- a/acestep/engine/lora.py
+++ b/acestep/engine/lora.py
@@ -313,12 +313,30 @@ class LoRAManagerBase(abc.ABC):
             if param_name not in self._param_dtype:
                 skipped += 1
                 continue
-            A = ab["A"].to(device=device, dtype=torch.float32)
-            B = ab["B"].to(device=device, dtype=torch.float32)
             target_dt = self._param_dtype[param_name]
-            d = (B @ A).to(dtype=target_dt).to(
-                device=self._delta_storage_device(),
-            ).contiguous()
+            try:
+                A = ab["A"].to(device=device, dtype=torch.float32)
+                B = ab["B"].to(device=device, dtype=torch.float32)
+                d = (B @ A).to(dtype=target_dt)
+            except torch.OutOfMemoryError:
+                # The GPU matmul is a speed nicety; on a VRAM-pressured
+                # pod (TRT workspaces + stems + engine swaps) it can OOM
+                # even though the deltas themselves live on CPU. Fall
+                # back to CPU compute for the rest of this LoRA instead
+                # of failing the enable.
+                if device.type == "cpu":
+                    raise
+                logger.warning(
+                    "_compute_deltas({}): GPU OOM during delta matmul; "
+                    "falling back to CPU compute",
+                    Path(lora_path).name,
+                )
+                device = torch.device("cpu")
+                torch.cuda.empty_cache()
+                A = ab["A"].to(device=device, dtype=torch.float32)
+                B = ab["B"].to(device=device, dtype=torch.float32)
+                d = (B @ A).to(dtype=target_dt)
+            d = d.to(device=self._delta_storage_device()).contiguous()
             # Catch base-model mismatches (e.g. 2B LoRA on XL engine):
             # element count is invariant under transpose, so a numel
             # mismatch here is unambiguous. We don't compare full
@@ -334,6 +352,12 @@ class LoRAManagerBase(abc.ABC):
                 continue
             deltas[param_name] = d
             total_bytes += d.numel() * d.element_size()
+        # When deltas are stored on CPU (TRT path) the GPU was only a
+        # matmul scratchpad; hand its pooled temporaries back to the
+        # driver so they don't sit reserved against the next TRT
+        # workspace or stem-extraction allocation.
+        if torch.cuda.is_available() and self._delta_storage_device().type == "cpu":
+            torch.cuda.empty_cache()
         if skipped:
             logger.debug(
                 "_compute_deltas({}): {} params skipped (not in engine)",

--- a/acestep/engine/session.py
+++ b/acestep/engine/session.py
@@ -182,6 +182,13 @@ class Session:
             trt_engines: Engine paths, used iff a *_backend is "tensorrt".
                 Keys: "decoder", "vae_encode", "vae_decode". Use
                 acestep.paths.default_trt_engines() for the canonical paths.
+            offload_to_cpu: Build every model on CPU and hop weights to
+                the GPU per call. NOTE: without ``offload_dit_to_cpu``
+                the DiT becomes GPU-resident on its FIRST use and stays
+                (see ``ModelContext._load_model_context``); set both for
+                a session whose steady-state VRAM must stay ~0.
+            offload_dit_to_cpu: Move the DiT back to CPU after each use
+                instead of letting it go resident on first touch.
             offload_text_encoder: Override text encoder placement policy.
                 Defaults to ``False`` so prompt edits do not pay CPU/GPU
                 transfer cost. Set ``True`` for lower steady VRAM usage.

--- a/acestep/engine/trt/profile_manager.py
+++ b/acestep/engine/trt/profile_manager.py
@@ -208,45 +208,28 @@ class TRTProfileManager:
         walk_window_s: float,
         source_duration_s: float,
     ) -> tuple[dict[str, str], float]:
-        """Swap to walk-mode mixed engines: decoder + vae_decode pinned
-        to ``walk_window_s``, vae_encode sized to ``source_duration_s``.
+        """Ensure walk-mode engines: decoder + vae_decode pinned to
+        ``walk_window_s``.
 
-        Mirrors the initial walk-mode wiring in
-        ``acestep/streaming/session.py`` (the runner only sees
-        walk_window_s of latent at a time, but VAE-encode still needs
-        to ingest the full song once at load). When a long-track swap
-        happens mid-session this is the right swap shape: keeping the
-        60s decoder on the line, only resizing vae_encode.
+        Historically this also resized ``vae_encode`` to
+        ``source_duration_s`` (the runner only sees walk_window_s of
+        latent at a time, but VAE-encode still ingests the full song
+        once at load). The encode path now chunks inputs longer than
+        the engine's max profile shape (see ``acestep/nodes/vae_nodes``)
+        and :func:`acestep.paths.available_trt_engines` pins vae_encode
+        to the smallest built engine for every duration — so the walk
+        profile's own engine set already serves any source length, and
+        resolving a larger profile here would wrongly require a bigger
+        *decoder* to exist on disk for long sources.
 
-        Falls through to :meth:`ensure_profile` semantics if the request
-        doesn't actually need a mix (source fits the walk profile).
+        ``source_duration_s`` is kept for API stability; it no longer
+        affects engine choice.
 
         Returns ``(paths, picked_dur)`` where ``picked_dur`` reflects
         the decoder/vae_decode profile (i.e. ``walk_window_s``).
         """
-        walk_paths, walk_dur = self.resolve(walk_window_s)
-        if source_duration_s <= walk_dur + 0.1:
-            return self.ensure_profile(source_duration_s)
-
-        enc_paths, _enc_dur = self.resolve(source_duration_s)
-        target_paths = {
-            "decoder": walk_paths["decoder"],
-            "vae_encode": enc_paths["vae_encode"],
-            "vae_decode": walk_paths["vae_decode"],
-        }
-
-        if self._loaded_paths == target_paths:
-            return dict(self._loaded_paths), walk_dur
-
-        prior_paths = dict(self._loaded_paths)
-        logger.info(
-            "TRT walk-profile swap: decoder={}s, vae_encode for {:.0f}s source",
-            int(walk_dur), source_duration_s,
-        )
-        self._swap(prior_paths=prior_paths, target_paths=target_paths)
-        self._loaded_dur = float(walk_dur)
-        self._loaded_paths = dict(target_paths)
-        return dict(target_paths), walk_dur
+        del source_duration_s  # encode is duration-independent now
+        return self.ensure_profile(walk_window_s)
 
     def ensure_profile(
         self, duration_s: float,
@@ -361,20 +344,37 @@ class TRTProfileManager:
             # a clean swap_failed to the client instead of letting the
             # session crash on the next decode tick with a bare
             # NoneType / "engine not bound" attribute error.
+            #
+            # Same single-retry policy as the vae_encode load below: a
+            # workspace-alloc OOM right after the eviction is often
+            # just PyTorch's cache still holding the freed blocks, and
+            # one empty_cache() + retry reliably recovers.
             try:
                 engine.load_trt_engine(new_decoder)
-            except BaseException as e:
-                self._loaded_dur = None
-                self._loaded_paths = {}
-                logger.error(
-                    "trt_profile_swap_decoder_load_failed engine={} error={}",
-                    new_decoder, e,
+            except BaseException as e_first:
+                logger.warning(
+                    "trt_profile_swap_decoder_load_retry engine={} "
+                    "first_error={}",
+                    new_decoder, e_first,
                 )
-                raise TRTProfileLoadError(
-                    component="decoder",
-                    engine_path=new_decoder,
-                    cause=e,
-                ) from e
+                try:
+                    torch.cuda.empty_cache()
+                except Exception:
+                    pass
+                try:
+                    engine.load_trt_engine(new_decoder)
+                except BaseException as e:
+                    self._loaded_dur = None
+                    self._loaded_paths = {}
+                    logger.error(
+                        "trt_profile_swap_decoder_load_failed engine={} error={}",
+                        new_decoder, e,
+                    )
+                    raise TRTProfileLoadError(
+                        component="decoder",
+                        engine_path=new_decoder,
+                        cause=e,
+                    ) from e
 
         if self._vae_tensorrt:
             from acestep.nodes.vae_nodes import _get_trt_vae

--- a/acestep/nodes/vae_nodes.py
+++ b/acestep/nodes/vae_nodes.py
@@ -496,6 +496,53 @@ def _trt_vae_profile_fits(
         return None
 
 
+def _trt_vae_encode_fits_or_chunkable(engine_path: str, shape) -> Optional[bool]:
+    """Whether the cached encode engine can serve ``shape``, directly or chunked.
+
+    Chunk-aware variant of :func:`_trt_vae_profile_fits` for the encode
+    path. A samples dim above the profile max is NOT a mismatch here:
+    :func:`_trt_vae_encode` serves it via overlapping chunks, which is
+    the whole point of pinning the small encode engine. Only
+    non-chunkable mismatches reject — rank, batch/channel out of range,
+    or samples below the profile min. Same ``None`` semantics as
+    ``_trt_vae_profile_fits`` (engine not cached, API error → "behave
+    as before", i.e. use TRT).
+    """
+    try:
+        entry = _trt_vae_cache.get(os.path.abspath(engine_path))
+        if entry is None or entry.get("engine") is None:
+            return None
+        engine = entry["engine"]
+        num_profiles = int(getattr(engine, "num_optimization_profiles", 1) or 1)
+        for profile in range(num_profiles):
+            mn, _opt, mx = engine.get_tensor_profile_shape("audio", profile)
+            if len(mn) != len(shape):
+                continue
+            if not all(
+                int(mn[i]) <= int(shape[i]) <= int(mx[i])
+                for i in range(len(shape) - 1)
+            ):
+                continue
+            n_samples = int(shape[-1])
+            if n_samples < int(mn[-1]):
+                continue
+            if n_samples <= int(mx[-1]):
+                return True
+            # Above the profile max: chunkable iff the max window leaves
+            # room for core frames beyond the two per-side margins (the
+            # same bound _plan_encode_chunks enforces).
+            max_frames = int(mx[-1]) // _VAE_SAMPLES_PER_FRAME
+            if max_frames > 2 * _VAE_ENCODE_CHUNK_MARGIN_FRAMES:
+                return True
+        return False
+    except Exception as exc:
+        logger.warning(
+            "trt_vae_encode_fit_check_failed engine={} error={}",
+            engine_path, exc,
+        )
+        return None
+
+
 def _find_best_vae_engine(component: str) -> Optional[str]:
     """Return a TRT VAE engine path for *component* if one was preloaded.
 
@@ -567,12 +614,15 @@ class VAEEncodeAudio(BaseNode):
         if (
             trt_path
             and handler.vae is not None
-            and _trt_vae_profile_fits(trt_path, "audio", tuple(waveform.shape)) is False
+            and _trt_vae_encode_fits_or_chunkable(trt_path, tuple(waveform.shape))
+            is False
         ):
-            # The cached engine belongs to another session and its
-            # profile can't take this input (e.g. a >60 s upload vs the
-            # live session's 60 s engine). This handler carries an eager
-            # VAE — use it instead of letting TRT reject the shape.
+            # The cached engine can't take this input directly OR via
+            # the chunked encode path (rank/batch/channel mismatch, or
+            # input below the profile min). This handler carries an
+            # eager VAE — use it instead of letting TRT reject the
+            # shape. Inputs that merely exceed the profile max stay on
+            # TRT: _trt_vae_encode chunks them.
             logger.info(
                 "vae_encode_trt_profile_mismatch input_shape={} engine={} "
                 "fallback=eager",

--- a/acestep/nodes/vae_nodes.py
+++ b/acestep/nodes/vae_nodes.py
@@ -189,24 +189,70 @@ def _trt_vae_decode(
     return audio_buf.clone().to(torch.float32)
 
 
-def _trt_vae_encode(
-    audio_bct: torch.Tensor, engine_path: str, device: torch.device
-) -> torch.Tensor:
-    """Encode audio [B, 2, samples] -> latents [B, D, T] via TRT.
+# Latent frame geometry shared by every ACE-Step VAE engine: 48 kHz
+# audio, 25 latent frames per second -> 1920 samples per latent frame.
+_VAE_SAMPLES_PER_FRAME = 1920
 
-    The ONNX export produces moments [B, 128, T] (mean+logvar concatenated).
-    We split and sample: latent = mean + exp(0.5 * logvar) * noise,
-    matching the VAE's latent_dist.sample() behavior.
+# Per-side context margin (in latent frames) for chunked VAE encode.
+# Empirically the Oobleck encoder's receptive field is under 8 frames:
+# with an 8-frame margin a chunked encode is bit-exact (fp16) against
+# the full-engine encode — see
+# scripts/benchmarks/validate_chunked_vae_encode.py. 64 frames (2.56 s)
+# keeps a comfortable safety factor at negligible cost.
+_VAE_ENCODE_CHUNK_MARGIN_FRAMES = 64
+
+
+def _plan_encode_chunks(
+    n_samples: int, max_samples: int, min_samples: int,
+) -> list[tuple[int, int, int, int]]:
+    """Chunk plan for an encode input longer than the engine max.
+
+    Returns ``(ctx_start, ctx_end, core_start, core_end)`` tuples in
+    latent frames. ``ctx_*`` is the audio span fed to the engine
+    (core plus receptive-field margin); ``core_*`` is the span whose
+    moments are kept. Cores tile ``[0, total_frames)`` exactly. Every
+    context span fits the engine profile: at most ``max_samples`` and
+    at least ``min_samples`` long (the tail chunk's left context is
+    extended when needed — extra frames are trimmed with the margin).
     """
-    entry = _get_trt_vae(engine_path, device)
+    spf = _VAE_SAMPLES_PER_FRAME
+    margin = _VAE_ENCODE_CHUNK_MARGIN_FRAMES
+    total_frames = (n_samples + spf - 1) // spf
+    core_frames = max_samples // spf - 2 * margin
+    if core_frames <= 0:
+        raise RuntimeError(
+            f"TRT VAE encode engine max profile ({max_samples} samples) "
+            f"is too small for chunked encode"
+        )
+    min_ctx_frames = (min_samples + spf - 1) // spf
+    plan: list[tuple[int, int, int, int]] = []
+    core_start = 0
+    while core_start < total_frames:
+        core_end = min(core_start + core_frames, total_frames)
+        ctx_start = max(0, core_start - margin)
+        ctx_end = min(total_frames, core_end + margin)
+        # The tail chunk can fall below the engine's min profile shape;
+        # extend the left context (trimmed away by the caller) to stay
+        # within range. n_samples > max_samples >= min_samples
+        # guarantees enough audio exists to the left.
+        if ctx_end - ctx_start < min_ctx_frames:
+            ctx_start = max(0, ctx_end - min_ctx_frames)
+        plan.append((ctx_start, ctx_end, core_start, core_end))
+        core_start = core_end
+    return plan
+
+
+def _trt_vae_encode_moments(
+    inp: torch.Tensor, entry: dict, engine_path: str
+) -> torch.Tensor:
+    """Single-shot TRT encode of audio [B, 2, samples] -> moments [B, 128, T].
+
+    ``inp`` must already be on-device, contiguous, and within the
+    engine's profile range.
+    """
     ctx = entry["context"]
     stream = _get_trt_stream()
-
     dtypes = entry["tensor_dtypes"]
-    inp = audio_bct.to(device=device, dtype=dtypes.get("audio", torch.float32)).contiguous()
-
-    # Release PyTorch's unused reserved VRAM before TRT encode.
-    torch.cuda.empty_cache()
 
     # Log structured TRT-VAE-encode failures from the deepest call site so
     # the JSON record carries input_shape + engine_path. The surrounding
@@ -238,7 +284,7 @@ def _trt_vae_encode(
 
     out_shape = tuple(ctx.get_tensor_shape("moments"))
     moments_dtype = dtypes.get("moments", torch.float32)
-    moments_buf = torch.empty(out_shape, dtype=moments_dtype, device=device)
+    moments_buf = torch.empty(out_shape, dtype=moments_dtype, device=inp.device)
     if not ctx.set_tensor_address("moments", moments_buf.data_ptr()):
         logger.error(
             "trt_vae_encode_rejected_output_address engine={}", engine_path,
@@ -252,9 +298,65 @@ def _trt_vae_encode(
         )
         raise RuntimeError("TRT VAE encode failed")
     stream.synchronize()
+    return moments_buf
+
+
+def _trt_vae_encode(
+    audio_bct: torch.Tensor, engine_path: str, device: torch.device
+) -> torch.Tensor:
+    """Encode audio [B, 2, samples] -> latents [B, D, T] via TRT.
+
+    The ONNX export produces moments [B, 128, T] (mean+logvar concatenated).
+    We split and sample: latent = mean + exp(0.5 * logvar) * noise,
+    matching the VAE's latent_dist.sample() behavior.
+
+    Inputs longer than the engine's max profile shape are encoded in
+    overlapping chunks and stitched at latent-frame granularity: each
+    chunk carries ``_VAE_ENCODE_CHUNK_MARGIN_FRAMES`` of audio context
+    per side, and only the interior core frames are kept. This lets a
+    small (e.g. 60 s) encode engine serve arbitrarily long sources, so
+    the profile manager never has to swap in the 120/240 s encode
+    engines and their multi-GB workspace reservations.
+    """
+    entry = _get_trt_vae(engine_path, device)
+
+    dtypes = entry["tensor_dtypes"]
+    inp = audio_bct.to(device=device, dtype=dtypes.get("audio", torch.float32)).contiguous()
+
+    # Release PyTorch's unused reserved VRAM before TRT encode.
+    torch.cuda.empty_cache()
+
+    min_dims, _, max_dims = entry["engine"].get_tensor_profile_shape("audio", 0)
+    max_samples = int(max_dims[-1])
+    min_samples = int(min_dims[-1])
+    n_samples = inp.shape[-1]
+
+    if n_samples <= max_samples:
+        moments = _trt_vae_encode_moments(inp, entry, engine_path)
+    else:
+        spf = _VAE_SAMPLES_PER_FRAME
+        plan = _plan_encode_chunks(n_samples, max_samples, min_samples)
+        total_frames = (n_samples + spf - 1) // spf
+        logger.info(
+            "trt_vae_encode_chunked samples={} engine_max={} chunks={}",
+            n_samples, max_samples, len(plan),
+        )
+        pieces: list[torch.Tensor] = []
+        for ctx_start, ctx_end, core_start, core_end in plan:
+            seg = inp[..., ctx_start * spf : min(ctx_end * spf, n_samples)]
+            m = _trt_vae_encode_moments(seg.contiguous(), entry, engine_path)
+            keep_from = core_start - ctx_start
+            if core_end >= total_frames:
+                # Tail chunk: keep whatever the engine produced past the
+                # margin so a partial trailing frame follows the engine's
+                # own rounding rather than our ceil().
+                pieces.append(m[..., keep_from:])
+            else:
+                pieces.append(m[..., keep_from : keep_from + (core_end - core_start)])
+        moments = torch.cat(pieces, dim=-1)
 
     # Split moments into mean and logvar, sample
-    mean, logvar = moments_buf.float().chunk(2, dim=1)  # [B, 64, T] each
+    mean, logvar = moments.float().chunk(2, dim=1)  # [B, 64, T] each
     std = torch.exp(0.5 * logvar)
     latent = mean + std * torch.randn_like(mean)
     return latent

--- a/acestep/paths.py
+++ b/acestep/paths.py
@@ -616,12 +616,32 @@ def available_trt_engines(
         checkpoint if "decoder" in needs else _DEFAULT_TRT_CHECKPOINT
     )
     profiles = trt_engine_profiles(profile_checkpoint)
+
+    # vae_encode is duration-independent: the TRT encode path chunks
+    # inputs longer than the engine's max profile shape (see
+    # acestep/nodes/vae_nodes.py), so the smallest BUILT encode engine
+    # serves every source duration. Larger encode engines exist only
+    # for pods that never built the small one; preferring the smallest
+    # saves multi-GB of context-creation workspace (the 240 s engine
+    # reserves ~6.4 GB more than the 60 s one — see
+    # scripts/benchmarks/vram_60s_vs_240s_results.md) and means profile
+    # swaps never reload vae_encode, removing the highest-pressure
+    # engine load from the swap path entirely.
+    smallest_built_enc: str | None = None
+    for max_dur in sorted(profiles.keys()):
+        enc_path = trt_engine_path(profiles[max_dur]["vae_encode"])
+        if enc_path.exists():
+            smallest_built_enc = str(enc_path)
+            break
+
     missing: dict[float, list[str]] = {}
     for max_dur in sorted(profiles.keys()):
         if max_dur < duration_s:
             continue
         profile = profiles[max_dur]
         paths = default_trt_engines(**profile)
+        if smallest_built_enc is not None:
+            paths["vae_encode"] = smallest_built_enc
         absent = [paths[k] for k in needs if not Path(paths[k]).exists()]
         if not absent:
             return paths, max_dur

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -2112,24 +2112,23 @@ class StreamingSession:
                 vae_backend=vae_backend,
                 checkpoint=trt_profile_checkpoint,
             )
-            trt_engines, picked_dur = profile_mgr.resolve(audio_duration_s)
             # Walk-window override: pin decoder + vae_decode at
-            # walk_window_s while keeping vae_encode sized to the full
-            # song so the source can be encoded once at load.
+            # walk_window_s. vae_encode is duration-independent (the
+            # encode path chunks long inputs and ``resolve`` always
+            # pins the smallest built encode engine), so the walk
+            # profile's own engine set serves any source length —
+            # resolving the full-source profile here would wrongly
+            # require a bigger decoder to exist on disk.
             if walk_window and use_trt and audio_duration_s > walk_window_s + 0.1:
-                walk_engines, walk_dur = profile_mgr.resolve(walk_window_s)
+                trt_engines, picked_dur = profile_mgr.resolve(walk_window_s)
                 logger.info(
                     "walk_window_active window_s={:.0f} decoder={} vae_encode={}",
                     walk_window_s,
-                    Path(walk_engines["decoder"]).stem,
+                    Path(trt_engines["decoder"]).stem,
                     Path(trt_engines["vae_encode"]).stem,
                 )
-                trt_engines = {
-                    "decoder": walk_engines["decoder"],
-                    "vae_encode": trt_engines["vae_encode"],
-                    "vae_decode": walk_engines["vae_decode"],
-                }
-                picked_dur = walk_dur
+            else:
+                trt_engines, picked_dur = profile_mgr.resolve(audio_duration_s)
 
             ideal_dur = smallest_fitting_profile_duration_s(
                 audio_duration_s,

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -25,6 +25,22 @@ import time
 import urllib.parse
 from pathlib import Path
 
+# Opt the CUDA caching allocator into expandable segments before torch
+# initializes it (first CUDA allocation). On long-uptime pods the torch
+# pool fragments across LoRA enable/disable rotations, stem-extraction
+# loads, and source swaps; classic segments then OOM on a ~100 MiB
+# request while hundreds of MiB sit "reserved but unallocated" (the
+# fleet's swap-time stem-extraction OOM signature). Expandable segments
+# grow/shrink in place via the CUDA VMM API, eliminating that
+# fragmentation class. PYTORCH_ALLOC_CONF is the torch>=2.8 name and
+# takes precedence over the deprecated PYTORCH_CUDA_ALLOC_CONF, so only
+# default it when the operator set neither.
+if not (
+    os.environ.get("PYTORCH_ALLOC_CONF")
+    or os.environ.get("PYTORCH_CUDA_ALLOC_CONF")
+):
+    os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+
 from websockets.http11 import Response
 from websockets.datastructures import Headers
 from websockets.sync.server import serve as ws_serve

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -725,7 +725,13 @@ def main():
         # Defer the heavy import until we know we need it. Pulling this in
         # loads torch + acestep + TRT machinery; in --no-backend we never
         # touch any of it.
-        from .ws_adapter import handle_client
+        from .ws_adapter import handle_client, start_idle_vram_janitor
+
+        # Session teardown frees its last GPU tensors asynchronously;
+        # the janitor returns the caching allocator's freed pool to the
+        # driver whenever the pod sits idle (see its docstring for the
+        # measured numbers).
+        start_idle_vram_janitor()
 
         def ws_handler(ws):
             handle_client(

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -112,6 +112,77 @@ from .protocol import COMMAND_NAMES, SAMPLE_RATE, coerce_command_payload
 
 
 # ---------------------------------------------------------------------------
+# Idle VRAM janitor
+# ---------------------------------------------------------------------------
+
+_JANITOR_STARTED = False
+_JANITOR_LOCK = threading.Lock()
+
+
+def start_idle_vram_janitor(
+    *,
+    interval_s: float = 5.0,
+    min_trim_bytes: int = 512 * 2**20,
+) -> None:
+    """Trim the CUDA caching allocator while no session is live.
+
+    Session teardown frees its last tensors asynchronously: the recv
+    thread is joined with a timeout, and polygraphy/TRT finalizer
+    chains can release buffers seconds after the connection handler
+    returned — after every in-band ``empty_cache()`` call has already
+    run. Those late frees land in PyTorch's caching pool and stay
+    reserved against the driver for as long as the pod idles
+    (measured: ~3 GB after a plain 60 s session, ~5 GB after one that
+    swapped to the 240 s decoder profile). That reserved-but-unused
+    pool is invisible to TensorRT, whose workspace comes from
+    cudaMalloc, so it directly eats the headroom the next session's
+    engine loads and stem extraction need.
+
+    A point-in-time trim can't win that race, so this janitor owns it:
+    every ``interval_s`` it checks that no session is registered and,
+    when the pool holds more than ``min_trim_bytes`` of freed blocks,
+    runs ``gc.collect()`` + ``torch.cuda.empty_cache()``. Idle-only by
+    construction — it never competes with a live session's allocator.
+    """
+    global _JANITOR_STARTED
+    with _JANITOR_LOCK:
+        if _JANITOR_STARTED:
+            return
+        _JANITOR_STARTED = True
+
+    def _loop() -> None:
+        import gc
+
+        while True:
+            time.sleep(interval_s)
+            try:
+                if session_registry.list_handles():
+                    continue
+                if not torch.cuda.is_available():
+                    continue
+                reserved = torch.cuda.memory_reserved()
+                allocated = torch.cuda.memory_allocated()
+                if reserved - allocated < min_trim_bytes:
+                    continue
+                gc.collect()
+                torch.cuda.empty_cache()
+                freed = reserved - torch.cuda.memory_reserved()
+                logger.info(
+                    "idle_vram_trim freed_mib={:.0f} reserved_mib={:.0f} "
+                    "allocated_mib={:.0f}",
+                    freed / 2**20,
+                    torch.cuda.memory_reserved() / 2**20,
+                    torch.cuda.memory_allocated() / 2**20,
+                )
+            except Exception as exc:  # never kill the janitor
+                logger.warning("idle_vram_trim_failed error={}", exc)
+
+    threading.Thread(
+        target=_loop, name="idle-vram-janitor", daemon=True,
+    ).start()
+
+
+# ---------------------------------------------------------------------------
 # Canonical user-upload packet processing
 # ---------------------------------------------------------------------------
 
@@ -724,14 +795,33 @@ def handle_client(
     this wrapper exists only to own a single ``ExitStack`` so the
     contextvar tokens bound for session / track unwind in reverse
     order on every exit path."""
-    with contextlib.ExitStack() as ctx_stack:
-        _handle_client_body(
-            ws, ctx_stack,
-            decoder_backend=decoder_backend,
-            vae_backend=vae_backend,
-            checkpoint=checkpoint,
-            offload_text_encoder=offload_text_encoder,
-        )
+    try:
+        with contextlib.ExitStack() as ctx_stack:
+            _handle_client_body(
+                ws, ctx_stack,
+                decoder_backend=decoder_backend,
+                vae_backend=vae_backend,
+                checkpoint=checkpoint,
+                offload_text_encoder=offload_text_encoder,
+            )
+    finally:
+        # Final allocator trim, AFTER the body frame (the last holder of
+        # the session, its state, codec, and recv-thread closures) is
+        # gone. ``Session.close()`` runs its own gc + empty_cache, but at
+        # that point this connection still references those objects, so
+        # their pool blocks are live and the trim can't return them.
+        # Once the body returns they are garbage — without this trim the
+        # caching allocator keeps the session's transient peak reserved
+        # (~3 GB after a 60s session, ~6 GB after a 240s-profile one,
+        # measured driver-level) for as long as the pod idles, which is
+        # exactly the headroom the next session's engine loads and stem
+        # extraction need. Reserved-but-unallocated VRAM also can't be
+        # used by TensorRT, whose workspace comes from cudaMalloc.
+        import gc
+
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
 
 def _handle_client_body(

--- a/scripts/benchmarks/validate_chunked_vae_encode.py
+++ b/scripts/benchmarks/validate_chunked_vae_encode.py
@@ -1,0 +1,114 @@
+"""Empirical fidelity check: chunked TRT VAE encode vs full encode.
+
+Encodes a 60 s fixture with the 60 s engine in one shot, then re-encodes
+it in overlapping chunks (as the chunked-encode path would for sources
+longer than the engine max) and compares the *moments* (mean + logvar)
+frame-by-frame. Sampling noise is excluded by comparing moments, not
+sampled latents.
+
+The interesting number is how many frames from a chunk boundary the
+means stay materially different — that bounds the receptive-field
+margin the chunked path must trim.
+
+Run: .venv/bin/python scripts/benchmarks/validate_chunked_vae_encode.py
+"""
+import sys
+from pathlib import Path
+
+repo_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(repo_root))
+
+import soundfile as sf
+import torch
+
+SAMPLES_PER_FRAME = 1920
+SR = 48_000
+
+
+def encode_moments(audio_bct: torch.Tensor, entry, device) -> torch.Tensor:
+    """Single-shot TRT encode returning moments [B, 128, T]."""
+    from acestep.nodes.vae_nodes import _get_trt_stream
+
+    ctx = entry["context"]
+    stream = _get_trt_stream()
+    dtypes = entry["tensor_dtypes"]
+    inp = audio_bct.to(device=device, dtype=dtypes.get("audio", torch.float32)).contiguous()
+    assert ctx.set_input_shape("audio", tuple(inp.shape))
+    assert ctx.set_tensor_address("audio", inp.data_ptr())
+    assert not ctx.infer_shapes()
+    out_shape = tuple(ctx.get_tensor_shape("moments"))
+    buf = torch.empty(out_shape, dtype=dtypes.get("moments", torch.float32), device=device)
+    assert ctx.set_tensor_address("moments", buf.data_ptr())
+    assert ctx.execute_async_v3(stream.ptr)
+    stream.synchronize()
+    return buf.clone().float()
+
+
+def main():
+    from acestep.nodes.vae_nodes import _get_trt_vae
+    from acestep.paths import trt_engine_path
+
+    device = torch.device("cuda")
+    engine_path = str(trt_engine_path("vae_encode_fp16_60s"))
+    entry = _get_trt_vae(engine_path, device)
+
+    eng = entry["engine"]
+    mn, opt, mx = eng.get_tensor_profile_shape("audio", 0)
+    print(f"engine profile audio: min={mn} opt={opt} max={mx}")
+
+    data, sr = sf.read(
+        str(Path.home() / ".daydream-scope/models/demon/fixtures/prog_rock_loop_60s_enm/source.wav"),
+        dtype="float32", always_2d=True,
+    )
+    assert sr == SR, f"fixture is {sr} Hz, expected {SR}"
+    wav = torch.from_numpy(data.T)  # [C, N]
+    if wav.shape[0] == 1:
+        wav = wav.repeat(2, 1)
+    n = (wav.shape[-1] // SAMPLES_PER_FRAME) * SAMPLES_PER_FRAME
+    wav = wav[:, :n].unsqueeze(0)  # [1, 2, N]
+    total_frames = n // SAMPLES_PER_FRAME
+    print(f"audio: {n} samples = {total_frames} frames = {n / SR:.1f}s")
+
+    full = encode_moments(wav, entry, device)  # [1, 128, T]
+    print(f"full moments: {tuple(full.shape)}")
+    mean_full, logvar_full = full.chunk(2, dim=1)
+    std_scale = torch.exp(0.5 * logvar_full).mean().item()
+    mean_mag = mean_full.abs().mean().item()
+    print(f"mean |mean|={mean_mag:.4f}  avg sampling std={std_scale:.4f}")
+
+    # Re-run full encode to measure TRT nondeterminism noise floor.
+    full2 = encode_moments(wav, entry, device)
+    rerun_diff = (full - full2).abs().max().item()
+    print(f"rerun max abs diff (noise floor): {rerun_diff:.6f}")
+
+    # Chunked encode: core 20s, sweep margin.
+    core_frames = 500  # 20 s
+    for margin_frames in (0, 1, 2, 4, 8, 16, 32, 48, 96):
+        chunks = []
+        t = 0
+        while t < total_frames:
+            core_end = min(t + core_frames, total_frames)
+            ctx_start = max(0, t - margin_frames)
+            ctx_end = min(total_frames, core_end + margin_frames)
+            seg = wav[:, :, ctx_start * SAMPLES_PER_FRAME : ctx_end * SAMPLES_PER_FRAME]
+            m = encode_moments(seg, entry, device)
+            chunks.append(m[:, :, t - ctx_start : t - ctx_start + (core_end - t)])
+            t = core_end
+        chunked = torch.cat(chunks, dim=2)
+        assert chunked.shape == full.shape, (chunked.shape, full.shape)
+        mean_c, _ = chunked.chunk(2, dim=1)
+        d = (mean_c - mean_full).abs()
+        # Per-frame max over channels
+        per_frame = d.amax(dim=(0, 1))
+        worst = per_frame.max().item()
+        worst_frame = per_frame.argmax().item()
+        print(
+            f"margin={margin_frames:3d} frames ({margin_frames / 25:.2f}s): "
+            f"max|Δmean|={worst:.5f} (frame {worst_frame}), "
+            f"p99={per_frame.quantile(0.99).item():.5f}, "
+            f"ratio to sampling std={worst / std_scale:.3f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_engine_profiles.py
+++ b/tests/unit/test_engine_profiles.py
@@ -202,6 +202,107 @@ class TestAvailableTrtEnginesNeedsParameter:
 
 
 # -----------------------------------------------------------------------
+# vae_encode pinning: smallest built encode engine serves every duration
+# (the TRT encode path chunks longer inputs — see vae_nodes)
+# -----------------------------------------------------------------------
+
+class TestVaeEncodePinnedToSmallestBuilt:
+    def test_long_audio_keeps_smallest_built_vae_encode(self, tmp_models_dir):
+        for d in (60.0, 120.0, 240.0):
+            _create_engine_files(tmp_models_dir, d, keys=("decoder", "vae_encode", "vae_decode"))
+        paths, picked = available_trt_engines(duration_s=200.0)
+        assert picked == 240.0
+        assert "_240s" in paths["decoder"]
+        assert "_240s" in paths["vae_decode"]
+        assert "vae_encode_fp16_60s" in paths["vae_encode"]
+
+    def test_swap_between_profiles_shares_vae_encode(self, tmp_models_dir):
+        for d in (60.0, 240.0):
+            _create_engine_files(tmp_models_dir, d, keys=("decoder", "vae_encode", "vae_decode"))
+        short, _ = available_trt_engines(duration_s=30.0)
+        long, _ = available_trt_engines(duration_s=200.0)
+        assert short["vae_encode"] == long["vae_encode"]
+
+    def test_falls_back_to_larger_encode_when_small_not_built(self, tmp_models_dir):
+        # A pod that only built the 240s profile keeps using it.
+        _create_engine_files(tmp_models_dir, 240.0, keys=("decoder", "vae_encode", "vae_decode"))
+        paths, picked = available_trt_engines(duration_s=200.0)
+        assert picked == 240.0
+        assert "vae_encode_fp16_240s" in paths["vae_encode"]
+
+    def test_no_encode_built_still_raises_when_needed(self, tmp_models_dir):
+        _create_engine_files(tmp_models_dir, 60.0, keys=("decoder", "vae_decode"))
+        with pytest.raises(EngineNotBuiltError):
+            available_trt_engines(duration_s=30.0)
+
+    def test_decoder_only_needs_ignores_vae_encode_state(self, tmp_models_dir):
+        _create_engine_files(tmp_models_dir, 60.0, keys=("decoder",))
+        paths, picked = available_trt_engines(duration_s=30.0, needs=("decoder",))
+        assert picked == 60.0
+
+
+# -----------------------------------------------------------------------
+# Chunked VAE encode planning (pure; mirrors vae_nodes chunk geometry)
+# -----------------------------------------------------------------------
+
+class TestPlanEncodeChunks:
+    SPF = 1920  # samples per latent frame
+
+    def _check_plan(self, n_samples, max_samples, min_samples):
+        from acestep.nodes.vae_nodes import (
+            _VAE_ENCODE_CHUNK_MARGIN_FRAMES,
+            _plan_encode_chunks,
+        )
+
+        plan = _plan_encode_chunks(n_samples, max_samples, min_samples)
+        total_frames = (n_samples + self.SPF - 1) // self.SPF
+        # Cores tile [0, total_frames) exactly, in order.
+        assert plan[0][2] == 0
+        assert plan[-1][3] == total_frames
+        for (a, b), (c, d) in zip(
+            [(p[2], p[3]) for p in plan], [(p[2], p[3]) for p in plan[1:]],
+        ):
+            assert b == c
+        for ctx_start, ctx_end, core_start, core_end in plan:
+            # Context spans fit the engine profile.
+            ctx_samples = (ctx_end - ctx_start) * self.SPF
+            assert ctx_samples <= max_samples
+            assert ctx_samples >= min(min_samples, n_samples)
+            # Core sits inside the context with the required margin
+            # (or extends to the input edge).
+            assert ctx_start <= core_start <= core_end <= ctx_end
+            if core_start > 0:
+                assert core_start - ctx_start >= _VAE_ENCODE_CHUNK_MARGIN_FRAMES
+            if core_end < total_frames:
+                assert ctx_end - core_end >= _VAE_ENCODE_CHUNK_MARGIN_FRAMES
+        return plan
+
+    def test_240s_input_through_60s_engine(self):
+        plan = self._check_plan(240 * 48000, 2_880_000, 240_000)
+        assert len(plan) > 1
+
+    def test_61s_input_through_60s_engine(self):
+        self._check_plan(61 * 48000, 2_880_000, 240_000)
+
+    def test_tail_chunk_extends_left_context_to_engine_min(self):
+        # Craft a tail chunk shorter than the engine min: the plan must
+        # widen its context to min_samples rather than emit an
+        # out-of-profile shape.
+        plan = self._check_plan(2_880_000 + 5 * self.SPF, 2_880_000, 240_000)
+        ctx_start, ctx_end, _, core_end = plan[-1]
+        assert (ctx_end - ctx_start) * self.SPF >= 240_000
+
+    def test_non_frame_aligned_input(self):
+        self._check_plan(240 * 48000 + 777, 2_880_000, 240_000)
+
+    def test_engine_smaller_than_margins_raises(self):
+        from acestep.nodes.vae_nodes import _plan_encode_chunks
+
+        with pytest.raises(RuntimeError, match="too small"):
+            _plan_encode_chunks(10_000_000, 100 * self.SPF, 1)
+
+
+# -----------------------------------------------------------------------
 # EngineNotBuiltError: actionable build command
 # -----------------------------------------------------------------------
 

--- a/tests/unit/test_trt_vae_profile_fit.py
+++ b/tests/unit/test_trt_vae_profile_fit.py
@@ -110,6 +110,69 @@ def test_unknown_on_trt_api_error(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Chunk-aware encode guard
+# ---------------------------------------------------------------------------
+#
+# ``_trt_vae_encode_fits_or_chunkable`` is the encode node's variant of
+# the fit guard: a samples dim above the profile max must NOT trigger
+# the eager fallback, because _trt_vae_encode serves it via overlapping
+# chunks — that is the very case the chunked encode was built for
+# (>60 s upload vs the pinned 60 s engine). Only non-chunkable
+# mismatches (rank, batch/channel, below the profile min) reject.
+
+
+def test_chunkable_above_profile_max_uses_trt(monkeypatch):
+    # 60 s engine (2_880_000 samples = 1500 frames), 120 s upload.
+    _install(monkeypatch, _FakeEngine(
+        mn=(1, 2, 48_000), opt=(1, 2, 1_440_000), mx=(1, 2, 2_880_000),
+    ))
+    assert vn._trt_vae_encode_fits_or_chunkable(_PATH, (1, 2, 5_760_000)) is True
+
+
+def test_chunk_guard_still_accepts_in_profile_shapes(monkeypatch):
+    _install(monkeypatch, _FakeEngine(
+        mn=(1, 2, 48_000), opt=(1, 2, 1_440_000), mx=(1, 2, 2_880_000),
+    ))
+    assert vn._trt_vae_encode_fits_or_chunkable(_PATH, (1, 2, 1_000_000)) is True
+    assert vn._trt_vae_encode_fits_or_chunkable(_PATH, (1, 2, 2_880_000)) is True
+
+
+def test_chunk_guard_rejects_non_chunkable_mismatches(monkeypatch):
+    _install(monkeypatch, _FakeEngine(
+        mn=(1, 2, 48_000), opt=(1, 2, 1_440_000), mx=(1, 2, 2_880_000),
+    ))
+    # Below the profile min: chunking can't help a too-short input.
+    assert vn._trt_vae_encode_fits_or_chunkable(_PATH, (1, 2, 1_000)) is False
+    # Batch out of range.
+    assert vn._trt_vae_encode_fits_or_chunkable(_PATH, (2, 2, 5_760_000)) is False
+    # Rank mismatch.
+    assert vn._trt_vae_encode_fits_or_chunkable(_PATH, (2, 48_000)) is False
+
+
+def test_chunk_guard_rejects_engine_too_small_to_chunk(monkeypatch):
+    # Max window of 128 frames leaves no core beyond the 2 x 64-frame
+    # margins — _plan_encode_chunks would raise, so reject up front.
+    too_small = 2 * vn._VAE_ENCODE_CHUNK_MARGIN_FRAMES * vn._VAE_SAMPLES_PER_FRAME
+    _install(monkeypatch, _FakeEngine(
+        mn=(1, 2, 48_000), opt=(1, 2, too_small), mx=(1, 2, too_small),
+    ))
+    assert vn._trt_vae_encode_fits_or_chunkable(_PATH, (1, 2, too_small + 1)) is False
+
+
+def test_chunk_guard_unknown_when_engine_not_cached(monkeypatch):
+    monkeypatch.setattr(vn, "_trt_vae_cache", {})
+    assert vn._trt_vae_encode_fits_or_chunkable(_PATH, (1, 2, 5_760_000)) is None
+
+
+def test_chunk_guard_unknown_on_trt_api_error(monkeypatch):
+    _install(monkeypatch, _FakeEngine(
+        mn=(1, 2, 48_000), opt=(1, 2, 1_440_000), mx=(1, 2, 2_880_000),
+        error=RuntimeError("TRT API exploded"),
+    ))
+    assert vn._trt_vae_encode_fits_or_chunkable(_PATH, (1, 2, 5_760_000)) is None
+
+
+# ---------------------------------------------------------------------------
 # Cold-cache shape rejection → eager fallback (encode node)
 # ---------------------------------------------------------------------------
 #
@@ -183,3 +246,29 @@ def test_non_shape_trt_errors_still_raise(monkeypatch):
             _eager_handler(with_vae=True),
             RuntimeError("TRT VAE encode failed"),
         )
+
+
+def test_warm_cache_long_upload_stays_on_trt_chunked_path(monkeypatch):
+    # The PR-242 review case: cached 60 s engine, eager-VAE handler
+    # (upload encoder session), >60 s upload. The guard must keep the
+    # TRT path so _trt_vae_encode chunks it, instead of pulling the
+    # eager VAE onto the GPU.
+    monkeypatch.setattr(vn, "_trt_available", lambda: True)
+    monkeypatch.setattr(vn, "_find_best_vae_engine", lambda c: _PATH)
+    _install(monkeypatch, _FakeEngine(
+        mn=(1, 2, 48_000), opt=(1, 2, 1_440_000), mx=(1, 2, 2_880_000),
+    ))
+
+    trt_called = []
+
+    def _fake_trt_encode(waveform, path, device):
+        trt_called.append(tuple(waveform.shape))
+        return torch.zeros((1, 64, 3000), dtype=torch.float32)
+
+    monkeypatch.setattr(vn, "_trt_vae_encode", _fake_trt_encode)
+    result = vn.VAEEncodeAudio().execute(
+        vae=SimpleNamespace(handler=_eager_handler(with_vae=True)),
+        audio=SimpleNamespace(waveform=torch.zeros((2, 5_760_000))),
+    )
+    assert trt_called == [(1, 2, 5_760_000)]  # TRT ran, eager did not
+    assert result["latent"].tensor.shape == (1, 3000, 64)

--- a/tests/unit/test_ws_preemption.py
+++ b/tests/unit/test_ws_preemption.py
@@ -23,6 +23,8 @@ import demos.realtime_motion_graph_web.ws_adapter as wa
 from acestep.streaming.events import StemAssets, StemFailed
 
 _DEMO = Path(wa.__file__).resolve().parent
+_REPO = _DEMO.parent.parent
+_SDK = _REPO / "packages" / "demon-client"
 
 
 # ---------------------------------------------------------------------------
@@ -31,13 +33,13 @@ _DEMO = Path(wa.__file__).resolve().parent
 
 
 def test_preempted_close_code_matches_web_sdk():
-    ts_src = (_DEMO / "web" / "sdk" / "types" / "protocol.ts").read_text(
+    ts_src = (_SDK / "types" / "protocol.ts").read_text(
         encoding="utf-8",
     )
     match = re.search(
         r"export const PREEMPTED_CLOSE_CODE\s*=\s*(\d+)", ts_src,
     )
-    assert match, "PREEMPTED_CLOSE_CODE missing from web/sdk/types/protocol.ts"
+    assert match, "PREEMPTED_CLOSE_CODE missing from packages/demon-client/types/protocol.ts"
     assert int(match.group(1)) == wa.PREEMPTED_CLOSE_CODE
 
 
@@ -50,9 +52,13 @@ def test_preempted_close_code_is_an_application_code():
 def test_web_client_handles_preempted_close():
     # Both client surfaces must reference the shared constant: the
     # reconnect loop (useStartSession) and the pre-ready error mapper
-    # (sdk/protocol.ts).
-    for rel in ("web/hooks/useStartSession.ts", "web/sdk/protocol.ts"):
-        src = (_DEMO / rel).read_text(encoding="utf-8")
+    # (packages/demon-client/protocol.ts).
+    for path in (
+        _DEMO / "web" / "hooks" / "useStartSession.ts",
+        _SDK / "protocol.ts",
+    ):
+        src = path.read_text(encoding="utf-8")
+        rel = path.relative_to(_REPO)
         assert "PREEMPTED_CLOSE_CODE" in src, f"{rel} ignores preemption"
 
 


### PR DESCRIPTION
# fix(vram): eliminate swap-time OOM and reclaim idle VRAM on long-uptime pods

**Branch:** `rafal/reduce-vram` → `main`
**Commits:** `1200019` (chunked VAE encode + engine pinning), `54a9141` (idle pool reclaim + upload encoder offload)

## Problem

Fleet pods (32 GB RTX 5090) intermittently restart with:

```
swap_failed: GPU memory pressure prevented loading the vae_encode engine for this source duration.
stem_extract_failed context=swap error=CUDA out of memory. Tried to allocate 94.00 MiB ...
```

The pods sit at ~31.3/31.4 GiB and any swap-time allocation tips them over.
Three compounding causes were identified and fixed.

## 1. Swap-time vae_encode engine load (`1200019`)

The 240 s `vae_encode` TRT engine requests **~11.8 GB of activation workspace at
context creation** (reproduced exactly; the 60 s engine needs ~4 GB), and it is
loaded *mid-swap*, after the old engine was already evicted — the unrecoverable
`TRTProfileLoadError` path that restarts the pod. VAE encode runs once per
source swap, not per realtime tick, so the capacity is wasted.

- `_trt_vae_encode` now chunks inputs longer than the engine's max profile
  shape (overlapping chunks, moments stitched at latent-frame granularity,
  single sampling pass). **Bit-exact (fp16) against single-shot encode at
  ≥8-frame margins**; shipped with a 64-frame (2.56 s) margin. Validation
  script: `scripts/benchmarks/validate_chunked_vae_encode.py`.
- `available_trt_engines` pins `vae_encode` to the **smallest built** encode
  engine for every duration; decoder/vae_decode still resolve by duration.
  Profile swaps therefore never reload vae_encode — the highest-pressure
  engine load is gone from the swap path entirely.
- Walk mode no longer resolves the full-source profile (which wrongly required
  a big *decoder* on disk for long sources).
- Decoder TRT load: raise immediately when `create_execution_context()`
  returns `None` (TRT's silent OOM signal — previously crashed on the next
  tick), with one `empty_cache()` + retry, matching the vae_encode policy.
- LoRA delta materialization falls back to CPU on GPU OOM and returns the
  GPU matmul scratch to the driver when deltas store on CPU.
- Server defaults `PYTORCH_ALLOC_CONF=expandable_segments:True` (kills the
  "94 MiB failed with hundreds of MiB reserved-but-unallocated" fragmentation
  class; operator overrides respected).

## 2. Idle pool never reclaimed after session teardown (`54a9141`)

Session start/close cycles left pods sitting on the session's transient
allocation peak: **measured ~3.6–4.7 GB idle after a plain 60 s session and
~6 GB after one that swapped to the 240 s profile**, vs a true idle floor of
~1 GB. No objects leak — a live-server census showed 14 MiB of live tensors
but 3–5 GB *reserved* in PyTorch's caching allocator. Teardown frees its last
tensors asynchronously (recv-thread join timeout, TRT finalizer chains),
after every in-band `empty_cache()` has already run, and nothing trims
afterwards. The reserved pool is invisible to TensorRT's cudaMalloc
workspaces, so it consumed exactly the headroom the next swap needed — the
slow "OOM over time" pattern.

- **Idle VRAM janitor** (`ws_adapter.start_idle_vram_janitor`): when no
  session is registered and the pool holds >512 MiB of freed blocks, run
  `gc.collect()` + `torch.cuda.empty_cache()`. Idle-only by construction —
  it never competes with the realtime loop.
- Final allocator trim at WS-handler exit, after the body frame (the last
  holder of session refs) is gone.

Verified over 9 session start/close cycles (plain and swap):
idle returns to **982–1008 MiB every time** (previously 3.6–6 GB).

## 3. Permanent second model copy for uploads (`54a9141`)

The `upload_track` path lazily built a full **eager** `Session` and cached it
for the process lifetime — pinning a second DiT+VAE+text-encoder copy
(**~6 GB**) on the GPU from the first upload onward, next to the streaming
TRT engines. It only ever runs VAE encode + semantic extract, both of which
hop weights to the GPU per call via `_load_model_context`.

- The upload encoder now builds with `offload_to_cpu=True` +
  `offload_dit_to_cpu=True`: weights live in system RAM, uploads measured at
  14–22 s, process settles at ~1.4 GB instead of ~7 GB.
- `Session` now exposes `offload_dit_to_cpu` (passthrough to `ModelContext`);
  without it, `offload_to_cpu` lets the DiT go GPU-resident on first use.

## Validation

- **Unit:** 159 passed (incl. new chunk-plan invariants and engine-selection
  tests in `tests/unit/test_engine_profiles.py`).
- **Golden:** same pass/fail profile as `main` — the only failure
  (`swap_fixture`) fails identically on `main` (uncalibrated thresholds +
  stochastic VAE-encode sampling; branch metrics were *closer* to reference
  than main's run).
- **Full-stack integration** (live server, WS protocol): 60s→240s→60s→240s
  profile swaps, vocal/instrument stem rips, and a realistic 1.2 GB-delta
  LoRA enabled across swaps — all passed, including one run under genuine
  pressure (GPU at 31/32.6 GB total).
- **A/B pressure repro** at identical 5.9 GiB free: the old swap behavior
  fails exactly like prod (240 s encode context requests 11.8 GB → context
  creation fails); the new path chunk-encodes the same 200 s source through
  the 60 s engine *and* completes a full stem extraction on top.
- **Leak cycles:** 5 plain + 4 swap session cycles, idle VRAM back to ~1 GB
  after every close.

## Deploy notes

- Pods need `vae_encode_fp16_60s` built to get the encode saving (~30 s
  build). Pods with only 240 s engines keep working unchanged.
  `scripts/deploy/stage2_models_engines.sh` currently builds only
  `--duration 240` — worth adding the 60 s encode engine to provisioning.
- Combined recoverable VRAM on a 32 GB pod: roughly **10–15 GB** (≈6.4 GB
  resident from encode-engine pinning at the 240 s profile, 3.6–6 GB idle
  pool, ~6 GB upload encoder), which is the difference between
  "31.31/31.36 GiB used, 94 MiB allocation fails" and comfortable headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
