### PR TITLE
fix(rtmg/web): bulk sends freeze all reads — chunked sends + write_audio recv hardening

### DIFF
--- a/demos/realtime_motion_graph_web/audio_codec.py
+++ b/demos/realtime_motion_graph_web/audio_codec.py
@@ -105,7 +105,7 @@ class SliceCodec:
         return hdr + compressed
 
 
-def chunked_ws_send(ws, data, _chunk=262144) -> None:
+def chunked_ws_send(ws, data: bytes, chunk_size: int = 262144) -> None:
     """Send a binary payload as a FRAGMENTED message in ~256 KiB pieces.
 
     websockets-sync holds ``protocol_mutex`` across the whole ``send()``
@@ -120,11 +120,11 @@ def chunked_ws_send(ws, data, _chunk=262144) -> None:
     deadlock cannot form. Fragmentation is invisible at the message layer
     (clients reassemble; payload bytes are identical).
     """
-    if len(data) <= _chunk:
+    if len(data) <= chunk_size:
         ws.send(data)
         return
     mv = memoryview(data)
-    ws.send(mv[i:i + _chunk] for i in range(0, len(data), _chunk))
+    ws.send(mv[i:i + chunk_size] for i in range(0, len(data), chunk_size))
 
 
 def send_stem_payload(

--- a/demos/realtime_motion_graph_web/audio_codec.py
+++ b/demos/realtime_motion_graph_web/audio_codec.py
@@ -105,6 +105,28 @@ class SliceCodec:
         return hdr + compressed
 
 
+def chunked_ws_send(ws, data, _chunk=262144) -> None:
+    """Send a binary payload as a FRAGMENTED message in ~256 KiB pieces.
+
+    websockets-sync holds ``protocol_mutex`` across the whole ``send()``
+    (``send_data`` → ``socket.sendall``), and ``recv_events`` — the thread
+    that reads EVERY inbound frame — needs that same mutex. A single
+    multi-MB sendall therefore freezes all reads until the peer drains it,
+    which deadlocks against a peer that is itself backpressured waiting
+    for us to read (observed live: an 11 MB stem send vs a VST mid
+    ``write_audio`` upload — both sides wedged until keepalive killed the
+    session). An *iterable* payload sends as one fragmented message with
+    the mutex released between fragments, so reads interleave and the
+    deadlock cannot form. Fragmentation is invisible at the message layer
+    (clients reassemble; payload bytes are identical).
+    """
+    if len(data) <= _chunk:
+        ws.send(data)
+        return
+    mv = memoryview(data)
+    ws.send(mv[i:i + _chunk] for i in range(0, len(data), _chunk))
+
+
 def send_stem_payload(
     ws,
     *,
@@ -134,4 +156,4 @@ def send_stem_payload(
     }))
     for name in order:
         arr = stems[name].detach().cpu().numpy().T.astype(np.float16)
-        ws.send(arr.tobytes())
+        chunked_ws_send(ws, arr.tobytes())

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -540,7 +540,7 @@ def _handle_client_body(
                     "fixture_name": event.fixture_name,
                     "source_epoch": event.source_epoch,
                 }))
-                ws.send(new_src_np.astype(np.float16).tobytes())
+                chunked_ws_send(ws, new_src_np.astype(np.float16).tobytes())
                 codec.replace_mirror(new_src_np)
                 if event.stems is not None:
                     send_stem_payload(
@@ -751,6 +751,46 @@ def _handle_client_body(
                     "command_payload_coerced origin={} mtype={} errors={}",
                     source, mtype, coerce_errors,
                 )
+
+        def _recv_binary_payload(fail_type: str):
+            """Read the binary frame that must follow ``mtype``.
+
+            Bounded (10 s timeout) and type-checked, so an orphan
+            header can neither block the recv loop forever (wedging
+            the whole session) nor consume the next JSON command as
+            its payload. Both failure modes answer ``fail_type`` and
+            keep the session alive. Returns ``None`` on failure (the
+            caller must bail out); flips ``state.running`` if the
+            connection closed.
+            """
+            try:
+                audio_msg = recv_audio(timeout=10)
+            except TimeoutError:
+                logger.error(
+                    "{}_payload_timeout origin={}", mtype, origin,
+                )
+                _send_json({
+                    "type": fail_type,
+                    "error": "binary payload not received within 10s",
+                })
+                return None
+            except ConnectionClosed:
+                state.running = False
+                return None
+            if not isinstance(audio_msg, (bytes, bytearray)):
+                # Log what got eaten: if it was the next JSON command,
+                # the preview names it so the drop is traceable.
+                logger.error(
+                    "{}_payload_not_binary origin={} got={}",
+                    mtype, origin, repr(audio_msg)[:120],
+                )
+                _send_json({
+                    "type": fail_type,
+                    "error": f"expected binary payload after {mtype}",
+                })
+                return None
+            return audio_msg
+
         try:
             if mtype == "params":
                 try:
@@ -818,10 +858,8 @@ def _handle_client_body(
                 streaming.set_timbre_strength(v, origin=origin)
             elif mtype == "set_timbre_source":
                 name = data.get("name") or "timbre"
-                try:
-                    audio_msg = recv_audio()
-                except ConnectionClosed:
-                    state.running = False
+                audio_msg = _recv_binary_payload("timbre_failed")
+                if audio_msg is None:
                     return
                 logger.debug(
                     "set_timbre_source_bytes_received name={} bytes={}",
@@ -853,10 +891,8 @@ def _handle_client_body(
                 streaming.clear_timbre_source(origin=origin)
             elif mtype == "set_structure_source":
                 name = data.get("name") or "structure"
-                try:
-                    audio_msg = recv_audio()
-                except ConnectionClosed:
-                    state.running = False
+                audio_msg = _recv_binary_payload("structure_failed")
+                if audio_msg is None:
                     return
                 logger.debug(
                     "set_structure_source_bytes_received name={} bytes={}",
@@ -906,10 +942,8 @@ def _handle_client_body(
                         })
                         return
                 else:
-                    try:
-                        audio_msg = recv_audio()
-                    except ConnectionClosed:
-                        state.running = False
+                    audio_msg = _recv_binary_payload("swap_failed")
+                    if audio_msg is None:
                         return
                     try:
                         wf = _decode_audio_msg(audio_msg)
@@ -932,35 +966,8 @@ def _handle_client_body(
             elif mtype == "write_audio":
                 # "Play into the model": a binary PCM frame (only the
                 # audio being written) always follows. No song restart.
-                try:
-                    try:
-                        audio_msg = recv_audio(timeout=10)
-                    except TypeError:
-                        # recv callables without a timeout kwarg (tests).
-                        audio_msg = recv_audio()
-                except TimeoutError:
-                    logger.error(
-                        "write_audio_payload_timeout origin={}", origin,
-                    )
-                    _send_json({
-                        "type": "audio_write_failed",
-                        "error": "binary payload not received within 10s",
-                    })
-                    return
-                except ConnectionClosed:
-                    state.running = False
-                    return
-                if not isinstance(audio_msg, (bytes, bytearray)):
-                    # An orphan write_audio header must fail the write, not
-                    # consume the next JSON command as its payload (or block
-                    # the recv loop forever, wedging the whole session).
-                    logger.error(
-                        "write_audio_payload_not_binary origin={}", origin,
-                    )
-                    _send_json({
-                        "type": "audio_write_failed",
-                        "error": "expected binary payload after write_audio",
-                    })
+                audio_msg = _recv_binary_payload("audio_write_failed")
+                if audio_msg is None:
                     return
                 try:
                     wf = _decode_audio_msg(audio_msg)
@@ -1022,9 +1029,12 @@ def _handle_client_body(
                     break
                 _audio_buf = caudio if caudio is not None else b""
                 try:
+                    # The thunk accepts ``timeout`` (and ignores it) so it
+                    # matches the ``ws.recv`` signature _recv_binary_payload
+                    # calls with.
                     _dispatch_message(
                         cdata,
-                        lambda _b=_audio_buf: _b,
+                        lambda timeout=None, _b=_audio_buf: _b,
                         "control",
                     )
                 except Exception as exc:

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -96,7 +96,7 @@ from acestep.user_uploads import (
     unique_user_upload_name,
 )
 
-from .audio_codec import SliceCodec, send_stem_payload
+from .audio_codec import SliceCodec, chunked_ws_send, send_stem_payload
 from .protocol import COMMAND_NAMES, SAMPLE_RATE, coerce_command_payload
 
 
@@ -515,7 +515,7 @@ def _handle_client_body(
             _ms("first_generated_slice")
         try:
             with send_lock:
-                ws.send(frame)
+                chunked_ws_send(ws, frame)
                 ws.send(json.dumps({
                     "type": "params_update",
                     "params": dict(event.params),
@@ -657,7 +657,7 @@ def _handle_client_body(
         # manual_slot_cap / steering_available).
         **streaming.steering_payload(),
     }))
-    ws.send(src_np.astype(np.float16).tobytes())
+    chunked_ws_send(ws, src_np.astype(np.float16).tobytes())
     if streaming.initial_upload_stems is not None:
         send_stem_payload(
             ws,
@@ -933,9 +933,34 @@ def _handle_client_body(
                 # "Play into the model": a binary PCM frame (only the
                 # audio being written) always follows. No song restart.
                 try:
-                    audio_msg = recv_audio()
+                    try:
+                        audio_msg = recv_audio(timeout=10)
+                    except TypeError:
+                        # recv callables without a timeout kwarg (tests).
+                        audio_msg = recv_audio()
+                except TimeoutError:
+                    logger.error(
+                        "write_audio_payload_timeout origin={}", origin,
+                    )
+                    _send_json({
+                        "type": "audio_write_failed",
+                        "error": "binary payload not received within 10s",
+                    })
+                    return
                 except ConnectionClosed:
                     state.running = False
+                    return
+                if not isinstance(audio_msg, (bytes, bytearray)):
+                    # An orphan write_audio header must fail the write, not
+                    # consume the next JSON command as its payload (or block
+                    # the recv loop forever, wedging the whole session).
+                    logger.error(
+                        "write_audio_payload_not_binary origin={}", origin,
+                    )
+                    _send_json({
+                        "type": "audio_write_failed",
+                        "error": "expected binary payload after write_audio",
+                    })
                     return
                 try:
                     wf = _decode_audio_msg(audio_msg)


### PR DESCRIPTION
Stacked on the rt-input branch (#235). Server half of the deadlock that made live sequencer splices dead end-to-end — client half is rtmg-vst#33. Both were running as hot-patches on the :dev pod (40431735) during today's debugging with @gioelecerati and validated live (paint → splice → `write_audio_applied` → ack → audible, ~1.5 s + emergence); this PR makes them durable before the next bake wipes them.

## 1. Chunked (fragmented) bulk sends
websockets-sync holds `protocol_mutex` across `socket.sendall`, and `recv_events` — the thread that reads **every** inbound frame — needs that same mutex. One 11 MB stem send froze all reads until the peer drained it; against a VST mid `write_audio` upload (whose own reads were gated behind its sends — ixwebsocket bug, fixed in rtmg-vst#33) the two sides deadlocked permanently: params dead, splices never received, keepalive killed the session (`1011` via the CF tunnel).

Thread dump of the live wedge:
- `conn_handler`: `send_stem_payload` → `socket.sendall` **holding `protocol_mutex`**
- `recv_events`: blocked acquiring `protocol_mutex`
- `keepalive`: blocked acquiring `protocol_mutex`

Fix: stems, the post-swap source mirror, and slice frames go out as fragmented messages in ~256 KiB pieces (`chunked_ws_send` in `audio_codec.py`) — the mutex releases between fragments so reads always interleave. Fragmentation is invisible at the message layer; payload bytes are identical (verified with the web SDK and the VST's ixwebsocket).

**Note:** this half also applies to `main` — stem delivery freezes reads there too (e.g. against a swap upload in flight) — and is worth cherry-picking independently of rt-input.

## 2. `write_audio` payload read hardening
The binary payload was read with a bare blocking `recv()` and no type check:
- an orphan `write_audio` header consumed the **next JSON command** as its payload (probe-reproduced: `audio_write_failed: a bytes-like object is required, not 'str'`),
- a payload that never arrived blocked the recv loop **forever**, wedging the whole session.

The read now has a 10 s timeout and a bytes type check; both failure modes answer `audio_write_failed` and keep the session alive.

## Remaining latency levers (not in this PR)
Working end-to-end latency is ~1.5 s transport + 2–5 s emergence. The bar ships as f32 (1.49 MB) — f16/s16/zstd would cut upload 2–10×; #240's near-playhead repatch attacks the emergence delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)