### PR TITLE
fix(ws): raise keepalive ping_timeout to 90s (stop 1011 mid-session drops)

### DIFF
--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -652,6 +652,12 @@ def main():
         # See web/engine/audio/loadFixture.ts.
         max_size=100 * 1024 * 1024,
         process_request=_process_request,
+        # A generation tick or TRT/VAE setup can hold the GIL long enough to
+        # starve the keepalive's recv_events thread past the 20s default, so a
+        # live session gets closed with `1011 keepalive ping timeout`. Widen
+        # the pong deadline to 90s. Trade-off: slower detection of genuinely
+        # dead clients — pair with an app-level idle-session reaper.
+        ping_timeout=90,
     )
     ws_thread = threading.Thread(target=srv.serve_forever, daemon=True)
     ws_thread.start()


### PR DESCRIPTION
## TL;DR ⚡
Stop kicking **live** users mid-session. One line: WebSocket keepalive `ping_timeout` **20s → 90s**.

## The bug 🐛
`websockets.sync` runs **3 threads/connection** → ① handler · ② `recv_events` · ③ keepalive.
- A heavy **native** op (TRT/VAE setup) holds the **GIL** → ② can't parse the client's pong in time → ③ closes the socket: **`1011 keepalive ping timeout`**.
- Real users dropped mid-song. **~19 across the fleet in 5.7h** — engine never crashed.

## The fix ✅
`ping_timeout=90` on `ws_serve(...)`. Gives a busy tick room to finish before the keepalive gives up.

## Trade-off ⚠️
Longer timeout = slower detection of *genuinely* dead clients → a zombie session can hold a GPU slot up to 90s.
**Follow-up (separate PR):** app-level **idle-session reaper**.

## Not this PR 🚫
Root cause (single-thread blocking) → would need the asyncio + `run_in_executor` rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)