### PR TITLE
fix(ws): filter the websockets handshake-probe traceback flood

### DIFF
--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -17,6 +17,7 @@ Usage:
 """
 
 import json
+import logging
 import mimetypes
 import os
 import sys
@@ -476,11 +477,27 @@ def _stub_handle_client(ws):
         pass
 
 
+class _DropHandshakeNoise(logging.Filter):
+    """Drop the `opening handshake failed` records websockets logs for every
+    non-WebSocket connection that hits the port — health probes, port
+    scanners, the tunnel's TCP checks. Each is a full InvalidMessage/EOFError
+    traceback (~2k per pod per session) and never actionable. Real failures
+    log a different message (`connection handler failed`) and pass through.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.getMessage() != "opening handshake failed"
+
+
 def main():
     # Wire logging FIRST so even the CLI-arg validation prints flow through
     # the configured sinks. configure() is idempotent so a duplicate call
     # in any nested entry point is a no-op.
     configure_logging()
+    # Silence the handshake-failure traceback flood from port probes. The
+    # record is logged directly on `websockets.server` (not a per-connection
+    # child), so a filter on that logger catches every one.
+    logging.getLogger("websockets.server").addFilter(_DropHandshakeNoise())
 
     host = "0.0.0.0"
     port = 1318  # single port: serves both HTTP and WebSocket


### PR DESCRIPTION
> ⚠️ **Draft.** Pairs with the `vae_nodes` logging cleanup (#249) — land both in the same `:warm` bake.

## TL;DR ⚡
Non-WebSocket connections flood the log with `opening handshake failed` tracebacks. Drop that one record.

## The noise 🔊
- Health probes / port scanners / the tunnel's TCP checks hit `:8765` without a valid WS request.
- websockets logs a full `InvalidMessage`/`EOFError` **traceback** per hit → **~2,030 per pod per session**.
- They fail **before** `_process_request`, so the HTTP short-circuit can't catch them.

## The fix ✅
A small `logging.Filter` on the `websockets.server` logger that drops records whose message is exactly `opening handshake failed`. The record is logged on that logger directly (no per-connection child), so one filter catches all — traceback included.

## Safe by design 🛡️
- Real handler errors log a **different** message (`connection handler failed`) → still surface.
- Verified with a standalone test: noise dropped, real errors kept.

## Deploy note 📦
DEMON server code → needs a `:warm` re-bake to hit the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)