### PR TITLE
feat: support external demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,23 @@ uv run python -u -m demos.realtime_motion_graph_web.run -- --accel tensorrt
 uv run python -u -m demos.realtime_motion_graph_web.run -- --checkpoint xl
 ```
 
+External static demo repos can be mounted at runtime with `--demo <path>`.
+DEMON serves them as already-built static files and prints their direct
+URLs at startup:
+
+```bash
+uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\path\to\demo
+```
+
+Those repos own any browser/CDN/build dependencies; DEMON only provides
+static hosting plus the shared browser SDK at `/sdk/demon-client.js`.
+For a concrete no-build example, see the external
+`demon-summon-frontend` demo:
+
+```bash
+uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\_dev\projects\demos\demon-summon-frontend
+```
+
 Highlights:
 
 - **Prompt A ↔ B blending.** Two text fields plus a blend slider. One encoder pass per submission; the slider lerps per tick.

--- a/demos/common/static_site.py
+++ b/demos/common/static_site.py
@@ -1,24 +1,25 @@
 """Static-site serving shared by the demo backends.
 
-Standalone no-build demos (e.g. ``demos/arp``) are plain directories of
-HTML/JS/CSS served from the same port as the WebSocket backend so the
-page and the WS share one origin. This module owns that serving logic so
-the realtime-motion-graph server (or any future backend host) mounts a
-demo with one table entry instead of growing bespoke route code per demo.
+Standalone no-build demos are plain directories of HTML/JS/CSS served
+from the same port as the WebSocket backend so the page and the WS share
+one origin. This module owns that serving logic so the
+realtime-motion-graph server (or any future backend host) mounts a demo
+with one table entry instead of growing bespoke route code per demo.
 
-A demo opts in by dropping a ``demo.static.json`` manifest in its
-directory::
+A demo opts in by dropping a ``demon.demo.json`` manifest in its
+directory; the older repo-local ``demo.static.json`` name is still
+accepted::
 
-    {"route": "/arp"}
+    {"route": "/arp", "entry": "index.html"}
 
-:func:`discover_static_demos` scans ``demos/*/demo.static.json`` and
+:func:`discover_static_demos` scans ``demos/*`` for manifests and
 returns the mount table; :func:`serve_static_mounts` resolves a request
 path against it. The shared demon-client browser bundle
 (``packages/demon-client/dist``, see its ``build.mjs``) is mounted at
 :data:`SDK_ROUTE` so every static demo loads ONE copy of the SDK /
 slice-decoder worker / audio worklet instead of vendoring its own.
 
-Depends only on the ``websockets`` library — no torch, no acestep — so
+Depends only on the ``websockets`` library - no torch, no acestep - so
 ``--no-backend`` UI-only servers can import it for free.
 """
 
@@ -27,7 +28,9 @@ from __future__ import annotations
 import json
 import mimetypes
 import urllib.parse
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Mapping
 
 from websockets.datastructures import Headers
 from websockets.http11 import Response
@@ -49,7 +52,8 @@ SDK_ROUTE = "/sdk"
 # demo manifest may not claim them.
 RESERVED_ROUTES = ("/api", "/fixtures", "/user_uploads", "/videos", SDK_ROUTE)
 
-_MANIFEST_NAME = "demo.static.json"
+MANIFEST_NAMES = ("demon.demo.json", "demo.static.json")
+DEFAULT_ENTRY = "index.html"
 
 _NO_CACHE_HEADERS = [
     ("Cache-Control", "no-store, must-revalidate"),
@@ -58,31 +62,122 @@ _NO_CACHE_HEADERS = [
 ]
 
 
+@dataclass(frozen=True)
+class StaticMount:
+    """A validated static demo mount."""
+
+    route: str
+    root: Path
+    entry: str = DEFAULT_ENTRY
+
+
 def sdk_dist_dir() -> Path:
     """The committed demon-client browser bundle directory."""
     return _REPO_ROOT / "packages" / "demon-client" / "dist"
 
 
-def discover_static_demos(demos_root: Path | None = None) -> dict:
-    """Scan ``demos/*/demo.static.json`` and return ``{route: directory}``.
+def _validate_route(manifest: Path, route: object) -> str:
+    if not isinstance(route, str) or not route.startswith("/") or route == "/":
+        raise ValueError(f"{manifest}: route must be a non-root '/...' string")
+    route = route.rstrip("/")
+    if not route:
+        raise ValueError(f"{manifest}: route must be a non-root '/...' string")
+    if any(route == r or route.startswith(r + "/") for r in RESERVED_ROUTES):
+        raise ValueError(
+            f"{manifest}: route {route!r} collides with reserved routes "
+            f"{RESERVED_ROUTES}"
+        )
+    return route
+
+
+def _validate_entry(manifest: Path, root: Path, entry: object) -> str:
+    if entry is None:
+        entry = DEFAULT_ENTRY
+    if not isinstance(entry, str) or not entry:
+        raise ValueError(f"{manifest}: entry must be a relative file path string")
+    decoded = urllib.parse.unquote(entry).replace("\\", "/")
+    if decoded.startswith("/") or decoded in (".", ".."):
+        raise ValueError(f"{manifest}: entry must be relative to the demo directory")
+    candidate = (root / decoded).resolve()
+    if not candidate.is_relative_to(root):
+        raise ValueError(f"{manifest}: entry {entry!r} escapes the demo directory")
+    return decoded
+
+
+def _manifest_for_directory(path: Path) -> Path:
+    for name in MANIFEST_NAMES:
+        manifest = path / name
+        if manifest.is_file():
+            return manifest
+    raise ValueError(f"{path}: expected one of {MANIFEST_NAMES}")
+
+
+def load_static_demo(path: str | Path) -> StaticMount:
+    """Load one static demo from a manifest file or demo directory."""
+    source = Path(path).expanduser()
+    manifest = _manifest_for_directory(source) if source.is_dir() else source
+    if manifest.name not in MANIFEST_NAMES:
+        raise ValueError(f"{manifest}: expected manifest named one of {MANIFEST_NAMES}")
+    if not manifest.is_file():
+        raise ValueError(f"{manifest}: manifest file does not exist")
+
+    root = manifest.parent.resolve()
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{manifest}: invalid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{manifest}: manifest must be a JSON object")
+
+    route = _validate_route(manifest, data.get("route"))
+    entry = _validate_entry(manifest, root, data.get("entry"))
+    return StaticMount(route=route, root=root, entry=entry)
+
+
+def _add_mount(
+    mounts: dict[str, StaticMount],
+    mount: StaticMount,
+    source: Path,
+) -> None:
+    existing = mounts.get(mount.route)
+    if existing is not None:
+        raise ValueError(
+            f"{source}: route {mount.route!r} already claimed by {existing.root}"
+        )
+    mounts[mount.route] = mount
+
+
+def discover_static_demos(demos_root: Path | None = None) -> dict[str, StaticMount]:
+    """Scan ``demos/*`` for static demo manifests.
 
     Malformed manifests and reserved/duplicate routes raise immediately:
     a typo'd mount should fail the server at boot, not 404 mysteriously.
     """
     if demos_root is None:
         demos_root = _REPO_ROOT / "demos"
-    mounts: dict = {}
-    for manifest in sorted(demos_root.glob(f"*/{_MANIFEST_NAME}")):
-        data = json.loads(manifest.read_text(encoding="utf-8"))
-        route = data.get("route")
-        if not isinstance(route, str) or not route.startswith("/") or route == "/":
-            raise ValueError(f"{manifest}: route must be a non-root '/...' string")
-        route = route.rstrip("/")
-        if any(route == r or route.startswith(r + "/") for r in RESERVED_ROUTES):
-            raise ValueError(f"{manifest}: route {route!r} collides with {RESERVED_ROUTES}")
-        if route in mounts:
-            raise ValueError(f"{manifest}: route {route!r} already claimed by {mounts[route]}")
-        mounts[route] = manifest.parent.resolve()
+    mounts: dict[str, StaticMount] = {}
+    for demo_dir in sorted(p for p in demos_root.iterdir() if p.is_dir()):
+        try:
+            manifest = _manifest_for_directory(demo_dir)
+        except ValueError:
+            continue
+        mount = load_static_demo(manifest)
+        _add_mount(mounts, mount, manifest)
+    return mounts
+
+
+def build_static_mounts(
+    extra_demos: list[str | Path] | tuple[str | Path, ...] = (),
+) -> dict[str, StaticMount]:
+    """Build the full static mount table, including /sdk and external demos."""
+    mounts: dict[str, StaticMount] = {
+        SDK_ROUTE: StaticMount(route=SDK_ROUTE, root=sdk_dist_dir()),
+    }
+    for mount in discover_static_demos().values():
+        _add_mount(mounts, mount, mount.root)
+    for demo in extra_demos:
+        mount = load_static_demo(demo)
+        _add_mount(mounts, mount, Path(demo))
     return mounts
 
 
@@ -115,15 +210,21 @@ def _file_response(target: Path) -> Response:
     )
 
 
-def serve_static_site(path_only: str, route: str, root: Path) -> Response | None:
+def serve_static_site(
+    path_only: str,
+    route: str,
+    root: Path,
+    entry: str = DEFAULT_ENTRY,
+) -> Response | None:
     """Serve ``path_only`` from ``root`` mounted at ``route``.
 
     ``route`` is slash-prefixed with no trailing slash (``"/arp"``). Bare
     ``route`` 301-redirects to ``route + "/"`` (otherwise the page's
     relative asset URLs resolve against ``/`` and break); ``route + "/"``
-    maps to ``index.html``; everything else is a path-escape-guarded file
-    lookup inside ``root``. Returns ``None`` when the path doesn't match
-    the mount or names no file, so the caller can fall through to its 404.
+    maps to the manifest entry; everything else is a path-escape-guarded
+    file lookup inside ``root``. Returns ``None`` when the path doesn't
+    match the mount or names no file, so the caller can fall through to
+    its 404.
     """
     root = root.resolve()
     if path_only == route:
@@ -137,7 +238,8 @@ def serve_static_site(path_only: str, route: str, root: Path) -> Response | None
             b"",
         )
     if path_only == route + "/":
-        target = root / "index.html"
+        candidate = (root / entry).resolve()
+        target = candidate if candidate.is_relative_to(root) else None
     elif path_only.startswith(route + "/"):
         rel = urllib.parse.unquote(path_only[len(route) + 1:])
         candidate = (root / rel).resolve()
@@ -152,10 +254,19 @@ def serve_static_site(path_only: str, route: str, root: Path) -> Response | None
     return _file_response(target)
 
 
-def serve_static_mounts(path_only: str, mounts: dict) -> Response | None:
-    """Resolve ``path_only`` against a ``{route: directory}`` table."""
-    for route, root in mounts.items():
-        resp = serve_static_site(path_only, route, root)
+def serve_static_mounts(
+    path_only: str,
+    mounts: Mapping[str, StaticMount | Path],
+) -> Response | None:
+    """Resolve ``path_only`` against a static mount table."""
+    for route, mount in mounts.items():
+        if isinstance(mount, StaticMount):
+            root = mount.root
+            entry = mount.entry
+        else:
+            root = mount
+            entry = DEFAULT_ENTRY
+        resp = serve_static_site(path_only, route, root, entry)
         if resp is not None:
             return resp
     return None

--- a/demos/realtime_motion_graph_web/README.md
+++ b/demos/realtime_motion_graph_web/README.md
@@ -48,6 +48,53 @@ Open `http://localhost:6660`. Next.js rewrites `/api/*`, `/fixtures/*`,
 `/loras/*`, and `/videos/*` to the backend at `:1318`; the WebSocket
 URL comes from `NEXT_PUBLIC_POD_BASE_URL` (set by the launcher).
 
+### External static demos
+
+Static demo repos can be mounted at runtime without vendoring them into
+DEMON. Add a `demon.demo.json` manifest to the external repo:
+
+```json
+{
+  "route": "/arp",
+  "entry": "index.html"
+}
+```
+
+`entry` is optional and defaults to `index.html`. The demo is served as
+static files only; DEMON does not run build scripts or import demo code.
+Browser code should load the shared SDK from `/sdk/demon-client.js`.
+
+Run the backend directly with one or more external demos:
+
+```powershell
+uv run python -u -m demos.realtime_motion_graph_web.server --demo C:\path\to\demo
+```
+
+Or pass the demo path to the launcher:
+
+```powershell
+uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\path\to\demo
+```
+
+Example: `demon-summon-frontend` is a no-build external demo that uses the
+shared `/sdk/demon-client.js` bundle, server fixtures, live LoRA controls, and
+MediaPipe hand tracking as a control surface:
+
+```powershell
+uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\_dev\projects\demos\demon-summon-frontend
+```
+
+The backend prints each mounted static demo URL at startup, for example
+`Static demo: http://localhost:1318/arp/`. `--demo` may be repeated.
+The older forwarding form also works when you need to pass backend args
+verbatim: `uv run python -u -m demos.realtime_motion_graph_web.run -- --demo C:\path\to\demo`.
+
+DEMON treats these paths as already-built static files. It does not run
+`npm install`, `uv sync`, build scripts, or demo code. No-build demos can
+use browser-native modules, committed static assets, pinned CDN imports,
+or DEMON's shared `/sdk/` browser bundle. Demos with their own build
+tooling should build themselves before being mounted.
+
 ### Remote / headless server
 
 To run the GPU server on one machine and open the UI from another, bind the

--- a/demos/realtime_motion_graph_web/run.py
+++ b/demos/realtime_motion_graph_web/run.py
@@ -179,6 +179,16 @@ def main() -> int:
         action="store_true",
         help="Skip the `npm install` check.",
     )
+    parser.add_argument(
+        "--demo",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help=(
+            "Mount an external static demo repo. May be repeated. "
+            "Equivalent to forwarding `--demo PATH` to the backend."
+        ),
+    )
     args, backend_extras = parser.parse_known_args()
     # `--` separator is preserved by parse_known_args; strip it if present.
     if backend_extras and backend_extras[0] == "--":
@@ -211,6 +221,7 @@ def main() -> int:
         args.host,
         "--port",
         str(args.port),
+        *[item for demo in args.demo for item in ("--demo", demo)],
         *backend_extras,
     ]
     # The browser uses NEXT_PUBLIC_POD_BASE_URL directly for the WebSocket, so

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -34,9 +34,7 @@ from acestep.fixtures import KNOWN_FIXTURES, audio_fixture
 from acestep.user_uploads import enumerate_user_uploads, user_upload_audio
 
 from ..common.static_site import (
-    SDK_ROUTE,
-    discover_static_demos,
-    sdk_dist_dir,
+    build_static_mounts,
     serve_static_mounts,
 )
 
@@ -48,13 +46,12 @@ from ..common.static_site import (
 VIDEOS_DIR = Path(__file__).parent / "videos"
 _VIDEO_EXTS = {".mp4", ".webm", ".mov"}
 
-# Standalone static demos (each a self-contained page in demos/<name>/
-# with a demo.static.json manifest, e.g. the Arpeggiator -> DEMON demo at
-# /arp) plus the shared demon-client browser bundle they load from /sdk/.
-# Served from this backend so each page and the WS share one origin/port;
-# no Next.js involved. Built at import time so a malformed manifest fails
-# the server at boot instead of 404ing mysteriously.
-_STATIC_MOUNTS = {SDK_ROUTE: sdk_dist_dir(), **discover_static_demos()}
+# Standalone static demos (repo-local manifests plus any external repos
+# passed with --demo) and the shared demon-client browser bundle they load
+# from /sdk/. Served from this backend so each page and the WS share one
+# origin/port; no Next.js involved. Built in main() after CLI parsing so
+# external demo manifest errors fail clearly at startup.
+_STATIC_MOUNTS = {}
 
 # Set in main() based on --no-backend; read by _process_request when the
 # client polls /api/server-info on startup.
@@ -91,6 +88,28 @@ _PUBLIC_HTTP_HEADERS = [
     ("Access-Control-Allow-Origin", "*"),
     *_NO_CACHE_HEADERS,
 ]
+
+
+def _collect_repeated_arg(args: list[str], flag: str) -> list[str]:
+    """Collect repeated ``--flag value`` and ``--flag=value`` occurrences."""
+    values: list[str] = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == flag:
+            if i + 1 >= len(args):
+                raise SystemExit(f"[Server] {flag} requires a path")
+            values.append(args[i + 1])
+            i += 2
+            continue
+        prefix = flag + "="
+        if arg.startswith(prefix):
+            value = arg[len(prefix):]
+            if not value:
+                raise SystemExit(f"[Server] {flag} requires a path")
+            values.append(value)
+        i += 1
+    return values
 
 
 def _resolve_video(name: str) -> Path | None:
@@ -591,6 +610,7 @@ def main():
     checkpoint = "acestep-v15-turbo"  # DiT variant; overridden by --checkpoint
 
     args = sys.argv[1:]
+    static_demo_paths = _collect_repeated_arg(args, "--demo")
     no_backend = "--no-backend" in args or "--ui-only" in args
     offload_text_encoder = "--offload-text-encoder" in args
     if "--host" in args:
@@ -656,12 +676,22 @@ def main():
             f"[Server] --mode must be one of {_VALID_MODES}, got {default_mode!r}"
         )
 
-    global _NO_BACKEND, _ACCEL, _KIOSK, _DEFAULT_MODE, _CHECKPOINT
+    global _NO_BACKEND, _ACCEL, _KIOSK, _DEFAULT_MODE, _CHECKPOINT, _STATIC_MOUNTS
     _NO_BACKEND = no_backend
     _ACCEL = accel
     _KIOSK = kiosk
     _DEFAULT_MODE = default_mode
     _CHECKPOINT = checkpoint
+
+    try:
+        _STATIC_MOUNTS = build_static_mounts(static_demo_paths)
+    except ValueError as exc:
+        raise SystemExit(f"[Server] invalid static demo: {exc}") from exc
+    for route, mount in _STATIC_MOUNTS.items():
+        logger.info(
+            "static_route_mounted route={} root={} entry={}",
+            route, mount.root, mount.entry,
+        )
 
     if no_backend:
         ws_handler = _stub_handle_client
@@ -829,6 +859,9 @@ def main():
     print("=" * 60)
     print(f"  WebSocket: ws://{browsable_host}:{port}/")
     print(f"  HTTP API:  http://{browsable_host}:{port}/api/...")
+    static_routes = [route for route in _STATIC_MOUNTS if route != "/sdk"]
+    for route in static_routes:
+        print(f"  Static demo: http://{browsable_host}:{port}{route}/")
     print(f"  Fixtures:  daydreamlive/demon-fixtures-v2 (HF, {len(KNOWN_FIXTURES)} files, on-demand)")
     print("  Ctrl+C to stop")
     print("=" * 60)

--- a/tests/unit/test_static_site.py
+++ b/tests/unit/test_static_site.py
@@ -1,0 +1,105 @@
+import json
+
+import pytest
+
+from demos.common import static_site
+
+
+def _write_demo(
+    tmp_path,
+    route="/demo",
+    manifest_name="demon.demo.json",
+    dirname=None,
+    **extra,
+):
+    demo = tmp_path / (dirname or route.strip("/"))
+    demo.mkdir(parents=True)
+    (demo / "index.html").write_text("index", encoding="utf-8")
+    manifest = {"route": route, **extra}
+    (demo / manifest_name).write_text(json.dumps(manifest), encoding="utf-8")
+    return demo
+
+
+def test_loads_directory_manifest(tmp_path):
+    demo = _write_demo(tmp_path, route="/external")
+
+    mount = static_site.load_static_demo(demo)
+
+    assert mount.route == "/external"
+    assert mount.root == demo.resolve()
+    assert mount.entry == "index.html"
+
+
+def test_loads_manifest_path_with_legacy_name(tmp_path):
+    demo = _write_demo(tmp_path, route="/legacy", manifest_name="demo.static.json")
+
+    mount = static_site.load_static_demo(demo / "demo.static.json")
+
+    assert mount.route == "/legacy"
+    assert mount.root == demo.resolve()
+
+
+def test_defaults_entry_to_index_html(tmp_path):
+    demo = _write_demo(tmp_path, route="/default")
+
+    assert static_site.load_static_demo(demo).entry == "index.html"
+
+
+def test_serves_route_redirect_and_route_entry(tmp_path):
+    demo = _write_demo(tmp_path, route="/demo", entry="home.html")
+    (demo / "home.html").write_text("home", encoding="utf-8")
+    mount = static_site.load_static_demo(demo)
+    mounts = {mount.route: mount}
+
+    redirect = static_site.serve_static_mounts("/demo", mounts)
+    entry = static_site.serve_static_mounts("/demo/", mounts)
+
+    assert redirect is not None
+    assert redirect.status_code == 301
+    assert redirect.headers["Location"] == "/demo/"
+    assert entry is not None
+    assert entry.status_code == 200
+    assert entry.body == b"home"
+
+
+def test_blocks_traversal(tmp_path):
+    demo = _write_demo(tmp_path, route="/demo")
+    outside = tmp_path / "secret.txt"
+    outside.write_text("secret", encoding="utf-8")
+    mount = static_site.load_static_demo(demo)
+
+    assert static_site.serve_static_mounts("/demo/../secret.txt", {"/demo": mount}) is None
+
+    (demo / "demon.demo.json").write_text(
+        json.dumps({"route": "/bad", "entry": "../secret.txt"}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="escapes"):
+        static_site.load_static_demo(demo)
+
+
+@pytest.mark.parametrize("route", ["/api", "/api/demo", "/fixtures", "/sdk"])
+def test_rejects_reserved_routes(tmp_path, route):
+    demo = _write_demo(tmp_path, route=route)
+
+    with pytest.raises(ValueError, match="reserved routes"):
+        static_site.load_static_demo(demo)
+
+
+@pytest.mark.parametrize("route", ["/", "///", "demo"])
+def test_rejects_invalid_routes(tmp_path, route):
+    demo = _write_demo(tmp_path, route=route, dirname="invalid")
+
+    with pytest.raises(ValueError, match="non-root"):
+        static_site.load_static_demo(demo)
+
+
+def test_rejects_duplicate_routes(tmp_path, monkeypatch):
+    first = _write_demo(tmp_path, route="/dupe", dirname="first")
+    second = _write_demo(tmp_path, route="/dupe", dirname="second")
+    second_manifest = second / "demon.demo.json"
+
+    monkeypatch.setattr(static_site, "discover_static_demos", lambda: {})
+
+    with pytest.raises(ValueError, match="already claimed"):
+        static_site.build_static_mounts([first, second_manifest])


### PR DESCRIPTION
Enables external demos. Allows vibe coding and deploying front ends without polluting this repo. 

Example: https://github.com/daydreamlive/demon-summon-frontend