### PR TITLE
feat(rtmg/web): flag "unstable connection" when slices land behind the playhead

### DIFF
--- a/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
+++ b/demos/realtime_motion_graph_web/web/engine/networkMonitor.ts
@@ -1,9 +1,9 @@
 import { useNetworkStore } from "@/store/useNetworkStore";
-import type { RemoteBackend } from "@demon/client";
-import type { AudioSlice } from "@demon/client";
+import { SAMPLE_RATE } from "@demon/client";
+import type { AudioPlayer, AudioSlice, RemoteBackend } from "@demon/client";
 
 // Detect "connection is actually broken" from existing WebSocket signals.
-// One input, one verdict:
+// Two inputs, one verdict:
 //
 //   Stall watchdog — no AudioSlice received in STALL_MS. The one signal
 //   that always corresponds to a real user-audible problem: slices
@@ -11,6 +11,20 @@ import type { AudioSlice } from "@demon/client";
 //   hitches. If the WebSocket dies for any reason (transient blip the
 //   server side recovered from, hard close, network drop), slices
 //   stop flowing and this catches it.
+//
+//   Bleed watchdog — slices ARE arriving, but landing BEHIND the
+//   playhead. The client's loop buffer always holds the raw source and
+//   denoised slices patch over it just ahead of the playhead, so a
+//   slice that lands in already-played audio means the listener heard
+//   the raw INPUT there. We measure each slice's landing lead (its
+//   start position minus the live playhead, folded modulo track
+//   duration so the loop-wrap pre-write reads as a small positive lead,
+//   not -duration) and flag a sustained negative worst-lead. The stall
+//   watchdog misses this — the stream is flowing, just too late — yet
+//   it is exactly what a slow / bandwidth-starved link produces and the
+//   most direct signal that the user is hearing raw source instead of
+//   the processed output. Same hysteresis as the stall path, so only a
+//   sustained problem trips it (a brief transient dip self-heals).
 //
 // What this monitor used to do but no longer does (2026-05-13):
 //
@@ -74,17 +88,59 @@ const THRESHOLDS = {
   /** Consecutive clean ticks before hiding (8s @ 500ms). Asymmetric
    *  ~1.3× the show debounce: easy to dismiss, hard to summon. */
   RECOVERY_TICKS: 16,
+
+  /** A slice landing this many seconds (or more) BEHIND the playhead is
+   *  counted as a bleed for the interval. Negative = behind. A small
+   *  margin (not exactly 0) so sub-perceptual jitter and measurement
+   *  noise around the playhead don't register; well inside the healthy
+   *  lead (~+0.2s), so a real underrun crosses it decisively. */
+  BLEED_LEAD_S: -0.05,
 } as const;
 
-export function createNetworkMonitor(remote: RemoteBackend): NetworkMonitor {
+/** Landing lead in seconds: how far ahead of the audible playhead a
+ *  slice landed, folded modulo track duration into [-dur/2, dur/2).
+ *  Positive = ahead (good); negative = it patched already-played audio
+ *  (raw source was heard). The fold makes a loop-wrap pre-write — a
+ *  slice at the buffer head while the playhead nears the end — read as
+ *  a small positive lead instead of ~-duration. `durationSec <= 0`
+ *  (unknown duration) skips the fold. Pure; unit-tested. */
+export function landingLeadSeconds(
+  startSample: number,
+  playheadSec: number,
+  durationSec: number,
+  sampleRate: number = SAMPLE_RATE,
+): number {
+  let lead = startSample / sampleRate - playheadSec;
+  if (durationSec > 0) {
+    lead = ((((lead + durationSec / 2) % durationSec) + durationSec)
+      % durationSec) - durationSec / 2;
+  }
+  return lead;
+}
+
+export function createNetworkMonitor(
+  remote: RemoteBackend,
+  player: AudioPlayer,
+): NetworkMonitor {
   let lastSliceAt = 0;
   let pendingQuality: "healthy" | "unstable" = "healthy";
   let pendingTicks = 0;
+  // Worst (most negative) landing lead observed since the last evaluate()
+  // tick, or null when no slice arrived in the interval. Worst-of-interval
+  // (not latest) so a single late slice inside an otherwise healthy 500ms
+  // still registers. Reset each tick.
+  let worstLeadS: number | null = null;
 
   const onSlice = (e: Event) => {
     const detail = (e as CustomEvent<AudioSlice>).detail;
     if (!detail) return;
     lastSliceAt = performance.now();
+    const lead = landingLeadSeconds(
+      detail.startSample, player.positionSec, player.duration,
+    );
+    if (Number.isFinite(lead)) {
+      worstLeadS = worstLeadS === null ? lead : Math.min(worstLeadS, lead);
+    }
   };
   remote.addEventListener("slice", onSlice);
 
@@ -92,11 +148,20 @@ export function createNetworkMonitor(remote: RemoteBackend): NetworkMonitor {
     const now = performance.now();
     const staleMs = lastSliceAt > 0 ? now - lastSliceAt : 0;
 
+    // Take-and-reset the worst lead for this interval. Bleeding = slices
+    // arrived but the worst one landed behind the playhead by more than
+    // the margin (heard as raw source).
+    const intervalWorstLead = worstLeadS;
+    worstLeadS = null;
+    const bleeding =
+      intervalWorstLead !== null
+      && intervalWorstLead < THRESHOLDS.BLEED_LEAD_S;
+
     // Only meaningful once we've seen at least one slice — pre-first-
     // slice we have no baseline and shouldn't flag a "stall" against zero.
     const haveBaseline = lastSliceAt > 0;
     let candidate: "healthy" | "unstable" = "healthy";
-    if (haveBaseline && staleMs >= THRESHOLDS.STALL_MS) {
+    if (haveBaseline && (staleMs >= THRESHOLDS.STALL_MS || bleeding)) {
       candidate = "unstable";
     }
 
@@ -139,6 +204,9 @@ export function createNetworkMonitor(remote: RemoteBackend): NetworkMonitor {
         quality: pendingQuality,
         staleMs: Math.round(staleMs),
         lastSliceAt: Math.round(lastSliceAt),
+        worstLeadS: intervalWorstLead === null
+          ? null : Number(intervalWorstLead.toFixed(3)),
+        bleeding,
       });
       pendingTicks = 0;
     }

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -626,7 +626,7 @@ export function useStartSession() {
           } catch {}
           useSessionStore
             .getState()
-            .setMonitor(createNetworkMonitor(remote));
+            .setMonitor(createNetworkMonitor(remote, player));
           // Re-apply the timbre / structure references the operator
           // had active. The fresh server session boots with none and
           // refs aren't carried in buildConfig, so without this a
@@ -758,6 +758,6 @@ export function useStartSession() {
     // Start the network-quality monitor now that the WS is "ready".
     // Lives on the session store so reset() (called at next session
     // start) tears it down — no orphan intervals across hot reloads.
-    useSessionStore.getState().setMonitor(createNetworkMonitor(remote));
+    useSessionStore.getState().setMonitor(createNetworkMonitor(remote, player));
   }, []);
 }

--- a/demos/realtime_motion_graph_web/web/store/useNetworkStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useNetworkStore.ts
@@ -3,12 +3,13 @@
 import { create } from "zustand";
 
 // Connection-quality store. Driven by createNetworkMonitor()
-// (engine/networkMonitor.ts), which fuses three signals — slice
-// inter-arrival jitter, server engine tickMs, and a stall watchdog —
-// into a single `quality` field consumed by NetworkIndicator. The
-// indicator is hidden when "healthy"; "unstable" fades in a subtle
-// bottom-center pill, agnostic about which leg of the connection is
-// the source of the degradation.
+// (engine/networkMonitor.ts), which fuses two signals — a stall
+// watchdog (no slices arriving) and a bleed watchdog (slices arriving
+// but landing behind the playhead, i.e. raw source audible) — into a
+// single `quality` field consumed by NetworkIndicator. The indicator
+// is hidden when "healthy"; "unstable" fades in a subtle bottom-center
+// pill, agnostic about which leg of the connection is the source of
+// the degradation.
 
 export type NetworkQuality = "healthy" | "unstable";
 

--- a/demos/realtime_motion_graph_web/web/tests/unit/networkMonitor.test.ts
+++ b/demos/realtime_motion_graph_web/web/tests/unit/networkMonitor.test.ts
@@ -1,0 +1,132 @@
+// Connection-quality monitor: landing-lead math + the bleed→unstable
+// flip. The bleed watchdog flags "unstable" when slices keep arriving
+// but land behind the playhead (raw source audible) — the case the
+// stall watchdog (no slices at all) misses.
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { SAMPLE_RATE } from "@demon/client";
+import type { AudioPlayer, RemoteBackend } from "@demon/client";
+
+import {
+  createNetworkMonitor,
+  landingLeadSeconds,
+} from "@/engine/networkMonitor";
+import { useNetworkStore } from "@/store/useNetworkStore";
+
+describe("landingLeadSeconds", () => {
+  const DUR = 60;
+
+  it("is positive when the slice lands ahead of the playhead", () => {
+    // playhead at 10s, slice written at 10.2s → +0.2s ahead.
+    const startSample = 10.2 * SAMPLE_RATE;
+    expect(landingLeadSeconds(startSample, 10, DUR)).toBeCloseTo(0.2, 5);
+  });
+
+  it("is negative when the slice lands behind the playhead", () => {
+    // playhead at 10s, slice written at 9.8s → 0.2s behind (raw heard).
+    const startSample = 9.8 * SAMPLE_RATE;
+    expect(landingLeadSeconds(startSample, 10, DUR)).toBeCloseTo(-0.2, 5);
+  });
+
+  it("folds the loop-wrap pre-write to a small positive lead", () => {
+    // Playhead near the end (59.9s), slice pre-written at the head
+    // (0.1s). Raw diff is -59.8s, but across the loop seam the playhead
+    // wraps to 0 in 0.1s then reaches 0.1s — so the slice is really
+    // +0.2s ahead. The fold must report +0.2, not a huge negative.
+    const startSample = 0.1 * SAMPLE_RATE;
+    expect(landingLeadSeconds(startSample, 59.9, DUR)).toBeCloseTo(0.2, 5);
+  });
+
+  it("skips the fold when duration is unknown (<= 0)", () => {
+    const startSample = 0.1 * SAMPLE_RATE;
+    expect(landingLeadSeconds(startSample, 59.9, 0)).toBeCloseTo(-59.8, 4);
+  });
+});
+
+describe("createNetworkMonitor bleed watchdog", () => {
+  const EVAL_MS = 500;
+  let nowMs: number;
+  let remote: RemoteBackend;
+  let player: { positionSec: number; duration: number };
+  let monitor: { stop(): void };
+
+  // Dispatch a slice whose write position is `leadS` seconds from the
+  // playhead, then advance one evaluate tick.
+  const tick = (leadS: number) => {
+    nowMs += EVAL_MS;
+    const startSample = Math.round((player.positionSec + leadS) * SAMPLE_RATE);
+    remote.dispatchEvent(
+      new CustomEvent("slice", { detail: { startSample } }),
+    );
+    vi.advanceTimersByTime(EVAL_MS);
+  };
+
+  // Advance a tick with NO slice (stall path).
+  const tickSilent = () => {
+    nowMs += EVAL_MS;
+    vi.advanceTimersByTime(EVAL_MS);
+  };
+
+  const quality = () => useNetworkStore.getState().quality;
+
+  beforeEach(() => {
+    vi.stubGlobal("window", globalThis);
+    nowMs = 1000;
+    vi.spyOn(performance, "now").mockImplementation(() => nowMs);
+    // Fake only the interval timer; performance.now stays on our spy.
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    useNetworkStore.getState().reset();
+    remote = new EventTarget() as unknown as RemoteBackend;
+    player = { positionSec: 10, duration: 60 };
+    monitor = createNetworkMonitor(remote, player as unknown as AudioPlayer);
+  });
+
+  afterEach(() => {
+    monitor.stop();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    useNetworkStore.getState().reset();
+  });
+
+  it("stays healthy while slices land ahead of the playhead", () => {
+    for (let i = 0; i < 20; i++) tick(+0.2);
+    expect(quality()).toBe("healthy");
+  });
+
+  it("does not flip on a brief transient dip (< escalate window)", () => {
+    for (let i = 0; i < 4; i++) tick(-0.3); // ~2s of bleed, below the 6s show
+    expect(quality()).toBe("healthy");
+  });
+
+  it("flips to unstable after sustained bleed, then recovers", () => {
+    // 12 ticks (6s) of behind-the-playhead slices → show.
+    for (let i = 0; i < 12; i++) tick(-0.3);
+    expect(quality()).toBe("unstable");
+
+    // 16 ticks (8s) of healthy leads → hide again.
+    for (let i = 0; i < 16; i++) tick(+0.2);
+    expect(quality()).toBe("healthy");
+  });
+
+  it("treats a tiny sub-margin negative lead as healthy", () => {
+    // -0.02s is inside BLEED_LEAD_S (-0.05): noise, not a bleed.
+    for (let i = 0; i < 16; i++) tick(-0.02);
+    expect(quality()).toBe("healthy");
+  });
+
+  it("still flips on a total stall (no slices arriving)", () => {
+    tick(+0.2); // establish a baseline slice
+    // ~6 silent ticks to cross STALL_MS, then 12 more to escalate.
+    for (let i = 0; i < 20; i++) tickSilent();
+    expect(quality()).toBe("unstable");
+  });
+});


### PR DESCRIPTION
## What & why

The connection-quality indicator only fired on a **total stall** (no slices for ~3s). The more common — and previously **silent** — degradation is when slices keep arriving but land **behind the playhead**: the loop buffer always holds the raw source, so the listener hears the raw input instead of the processed output, with no hint anything is wrong.

This adds a **bleed watchdog** to `networkMonitor`: it measures each slice's landing lead (slice start position − live playhead, folded modulo track duration so a loop-wrap pre-write reads as a small positive lead, not −duration) and flags a sustained negative worst-lead through the **same asymmetric hysteresis** as the stall path (~6s to show, ~8s to hide). The existing "UNSTABLE CONNECTION" pill now fires both when the stream stops **and** when it can't keep up.

## Changes
- `engine/networkMonitor.ts` — `createNetworkMonitor(remote, player)`; pure exported `landingLeadSeconds()` helper; `BLEED_LEAD_S` margin (−0.05s); fold bleed into the existing candidate/hysteresis; lead added to the diagnostic trip-wire.
- `hooks/useStartSession.ts` — pass `player` to both monitor call sites.
- `store/useNetworkStore.ts` — refresh the stale signal-list doc comment.
- `tests/unit/networkMonitor.test.ts` — lead-fold math (incl. loop wrap) + bleed→unstable flip, recovery, transient no-flip, sub-margin, and stall paths (9 tests).

## Scope
- **Detection only; no wire-protocol change.** Purely client-side.
- Independent of the raw-audio-bleed server fix (#256): this tells the user **when** bleed is happening; #256 reduces **how often** it happens. They compose cleanly.

## Testing
- `npx vitest run tests/unit/networkMonitor.test.ts` → 9/9 pass.
- `npm run typecheck` clean; `npm run build` succeeds.
- Pre-existing/unrelated: some suites fail locally on `Math.f16round` (missing in the local Node 20) — untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
