### PR TITLE
exp(latency): minimum acceptable latent size for the loop workflow

### DIFF
--- a/scripts/experiments/latent_size/latent_size_results.md
+++ b/scripts/experiments/latent_size/latent_size_results.md
@@ -1,0 +1,106 @@
+# Minimum acceptable latent size for the loop-focused workflow
+
+**Task:** "We currently loop over one section of 60 second latent. Does
+it need to be 60 seconds?" Smaller window ⇒ less DiT compute per
+(re)diffusion ⇒ lower param-update latency (knob-to-ear), and a smaller
+activation/workspace footprint ⇒ VRAM headroom.
+
+**TL;DR:** No, 60 s is not required — but the gains have *two different
+knees* and they meet around **20–30 s**:
+
+- **Latency payoff saturates at ~20 s.** Generate (DiT) time falls 60→30 s
+  (0.58→0.45 s) then *plateaus at ~0.38 s* for any window ≤20 s, because
+  at small T the DiT is launch/overhead-bound, not compute-bound. Going
+  below 20 s buys essentially nothing more on generate.
+- **Quality degrades below ~15 s.** Dead-space (`silence_frac`) climbs
+  steadily as the window shrinks — 0.095 at 60 s → 0.20 at 10 s → 0.27 at
+  6 s. Short windows can't sustain continuous musical content.
+
+**Recommendation:** prototype the live loop window at **30 s** (safe) or
+**20 s** (aggressive). 20 s roughly halves total offline compute vs 60 s
+and shrinks the would-be TRT workspace, while the quality proxies stay at
+the 60 s baseline. Do **not** drop below ~15 s without careful listening —
+dead-space risk rises sharply and the latency curve is already flat there.
+**Confirm by ear** on the saved clips before committing a window size.
+
+## Method
+
+- Harness: [`latent_size_sweep.py`](./latent_size_sweep.py).
+- Pure text-to-music (the loop-focused generation case). Only `duration`
+  varies; prompt/seed/knobs fixed. 2 prompts (techno, lo-fi) × 8 windows
+  × 3 seeds = **48 renders**. Eager backend, 8 steps, shift 3.0, CFG 7.5,
+  seeds `[1528, 42, 9999]`.
+- Timing brackets `torch.cuda.synchronize()` so wall time reflects GPU
+  work, not async launch.
+- Proxies as in the loop-prompting study: `seam_spec_dist` (loop-seam
+  texture continuity), `silence_frac` (near-silent 50 ms frames — the
+  dead-space / degeneracy signal), plus `rms_db` / `centroid_hz` sanity.
+
+## Results (mean across prompts × seeds)
+
+| window | frames | gen_s | gen speedup | dec_s | gen+dec | seam_spec_dist | silence_frac |
+|---|---|---|---|---|---|---|---|
+| 60 s | 1500 | 0.582 | 1.00× | 0.209 | 0.791 | 0.582 | 0.095 |
+| 45 s | 1125 | 0.549 | 1.06× | 0.147 | 0.696 | 0.519 | 0.105 |
+| 30 s | 750 | 0.448 | 1.30× | 0.093 | 0.541 | 0.673 | 0.124 |
+| **20 s** | **500** | **0.391** | **1.49×** | **0.052** | **0.443** | **0.500** | **0.105** |
+| 15 s | 375 | 0.387 | 1.50× | 0.039 | 0.426 | 0.634 | 0.152 |
+| 10 s | 250 | 0.379 | 1.54× | 0.025 | 0.404 | 0.439 | 0.201 |
+| 8 s | 200 | 0.378 | 1.54× | 0.021 | 0.399 | 0.491 | 0.164 |
+| 6 s | 150 | 0.380 | 1.53× | 0.016 | 0.396 | 0.504 | 0.265 |
+
+## Interpretation
+
+- **Generate is compute-bound only 30–60 s, then launch-bound.** The
+  ~0.38 s floor is fixed per-call overhead (kernel launches, Python, fixed
+  setup) that T can't shrink. So the DiT latency win is real but *capped*
+  — ~1.5× by 20 s and flat thereafter.
+- **Decode scales ~linearly with T** (0.21→0.016 s) because VAE decode is
+  length-bound. NB: this matters for *offline* render only — the live
+  engine uses a windowed VAE (fixed ~1 s decode), so decode latency is
+  already decoupled from the loop-window size in production.
+- **The quality limiter is dead-space, not seam quality.**
+  `seam_spec_dist` is noisy with no monotonic trend (shorter ≠ obviously
+  worse seams). But `silence_frac` roughly doubles by 10 s and rises
+  sharply below 15 s: the model leaves more empty space when asked to
+  fill a very short section. 20–30 s holds near the 60 s baseline.
+- **Net:** the latency knee (~20 s) and the quality knee (~15 s) bracket a
+  comfortable operating point at **20–30 s**.
+
+## What this means for the live engine (and VRAM)
+
+The transferable result is the **DiT compute scaling**, not the absolute
+eager ms. In the live path the window is the `walk_window_s` /
+`walk_window_T` the backend feeds the DiT (`acestep/streaming/ace_backend.py`),
+and the DiT runs on TRT. Two consequences:
+
+- **Param latency:** a smaller window means proportionally less DiT work
+  per re-diffusion when a knob/prompt changes — the direct payoff for the
+  "chip away at param latency" goals. The eager launch-bound floor here is
+  pessimistic; lower-overhead TRT may keep scaling a bit past 20 s.
+- **VRAM (ties to #242):** TRT engine workspace is reserved by the
+  profile's max T. Today only **60/120/240 s** profiles ship
+  (`acestep/paths.py`). Realizing a 20–30 s window live therefore requires
+  **building a sub-60 s TRT profile** — which itself reserves less
+  workspace, a direct VRAM win on top of the latency one.
+
+## Caveats / threats to validity
+
+- Objective proxies, not perceptual truth. The decision-relevant signals
+  (`gen_s` scaling, `silence_frac`) are solid; final musical acceptability
+  is human-judged — **listen to the saved WAVs**.
+- Eager single-shot timings. Absolute ms differ on TRT/windowed; the
+  *shape* of the curve is the result.
+- Text-to-music; a source-driven cover/walk run may behave differently
+  (the source supplies content, possibly lowering the dead-space risk at
+  short windows). Natural follow-up.
+- 2 prompts / 3 seeds shows the trend, not tight error bars. Widen
+  `--seeds` / `--durations` to sharpen the knee.
+
+## Reproduce
+
+```
+.venv/bin/python scripts/experiments/latent_size/latent_size_sweep.py
+# add e.g. --durations 25 22 20 18  to zoom in on the knee
+# WAVs + metrics.json -> test_output/experiments/latent_size/ (gitignored)
+```

--- a/scripts/experiments/latent_size/latent_size_sweep.py
+++ b/scripts/experiments/latent_size/latent_size_sweep.py
@@ -1,0 +1,235 @@
+"""Minimum acceptable latent size for the loop-focused workflow.
+
+Science task: "We currently loop over one section of 60 second latent.
+Does it need to be 60 seconds?"
+
+Why it matters: the diffusion window length T (frames = seconds × 25) is
+the size of the tensor the DiT denoises every pass. A shorter window
+means proportionally less DiT compute per (re)diffusion — i.e. lower
+param-update latency (knob-to-ear) — and a smaller activation footprint
+(VRAM). The cost is quality: a too-short section may lose musical
+structure or loop too tightly. This sweeps the window and measures both
+sides so we can pick the smallest *acceptable* size.
+
+Design: pure text-to-music (the loop-focused generation case), fixed
+prompts/seeds/knobs, vary only ``duration``. Eager backend so the
+latency curve is clean compute scaling, free of torch.compile recompiles
+or TRT profile quantization. For each render we record generate +
+decode wall time and the same loop/quality proxies as the loop-prompting
+study, and save a WAV for human listening.
+
+Latency caveat: these are single-shot eager timings, NOT the live
+knob-to-ear number (that path is windowed + TRT). The transferable
+result is the *scaling with T*; realizing a sub-60 s window live also
+needs a matching TRT engine profile (today: 60/120/240 s only).
+
+Run (Linux):
+    .venv/bin/python scripts/experiments/latent_size/latent_size_sweep.py
+Run (Windows):
+    .venv/Scripts/python.exe scripts\\experiments\\latent_size\\latent_size_sweep.py
+
+Outputs WAVs + metrics.json under test_output/experiments/latent_size/
+(both gitignored) and prints a markdown summary for the results doc.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = next(
+    p for p in (_HERE, *_HERE.parents) if (p / "pyproject.toml").exists()
+)
+# Force OUR repo to the front (a sibling ACE-Step checkout shadows `acestep`).
+while str(_REPO_ROOT) in sys.path:
+    sys.path.remove(str(_REPO_ROOT))
+sys.path.insert(0, str(_REPO_ROOT))
+
+import torch  # noqa: E402
+
+torch.set_grad_enabled(False)
+
+from acestep.constants import TASK_INSTRUCTIONS  # noqa: E402
+from acestep.engine.session import Session  # noqa: E402
+from acestep.nodes.types import Curve  # noqa: E402
+
+
+# One rhythmic (seams audible, structure matters) + one melodic prompt.
+PROMPTS = [
+    {"slug": "techno", "tags": "driving techno, punchy kick, dark hypnotic groove, modular bleeps",
+     "bpm": 130, "key": "F minor"},
+    {"slug": "lofi", "tags": "lo-fi hip hop, mellow piano, vinyl crackle, boom bap drums",
+     "bpm": 80, "key": "C minor"},
+]
+
+DURATIONS = [60.0, 45.0, 30.0, 20.0, 15.0, 10.0, 8.0, 6.0]
+SEEDS = [1528, 42, 9999]
+STEPS = 8
+SHIFT = 3.0
+CFG = 7.5
+
+SR = 48000
+WIN_S = 0.5  # head/tail window for the seam proxies
+
+
+def _stats(xs):
+    xs = sorted(xs)
+    n = len(xs)
+    return {"mean": round(sum(xs) / n, 4), "min": round(xs[0], 4),
+            "p50": round(xs[n // 2], 4), "max": round(xs[-1], 4), "n": n}
+
+
+def _mono(wav: torch.Tensor) -> torch.Tensor:
+    w = wav.detach().float().cpu()
+    while w.dim() > 2:
+        w = w.squeeze(0)
+    if w.dim() == 2:
+        w = w.mean(0)
+    return w
+
+
+def _log_spec_profile(seg: torch.Tensor) -> torch.Tensor:
+    n_fft = 2048
+    if seg.numel() < n_fft:
+        seg = torch.nn.functional.pad(seg, (0, n_fft - seg.numel()))
+    spec = torch.stft(seg, n_fft=n_fft, hop_length=512,
+                      window=torch.hann_window(n_fft), return_complex=True)
+    return torch.log1p(spec.abs().mean(dim=1))
+
+
+def clip_metrics(wav: torch.Tensor) -> dict:
+    """Loop/quality proxies for one decoded clip (see loop_prompting study)."""
+    m = _mono(wav)
+    n = m.numel()
+    w = min(int(WIN_S * SR), n // 2)
+    head, tail = m[:w], m[-w:]
+
+    hp, tp = _log_spec_profile(head), _log_spec_profile(tail)
+    seam_spec_dist = float(torch.linalg.vector_norm(hp - tp) / math.sqrt(hp.numel()))
+    rms = lambda x: float(torch.sqrt(torch.clamp((x ** 2).mean(), min=1e-12)))
+    to_db = lambda r: 20.0 * math.log10(max(r, 1e-9))
+
+    fl = int(0.05 * SR)
+    frames = m[: (n // fl) * fl].reshape(-1, fl)
+    frame_rms_db = torch.tensor([to_db(rms(f)) for f in frames])
+    silence_frac = float((frame_rms_db < -45.0).float().mean())
+
+    prof = _log_spec_profile(m)
+    freqs = torch.linspace(0, SR / 2, prof.numel())
+    centroid_hz = float((freqs * prof).sum() / torch.clamp(prof.sum(), min=1e-9))
+
+    return {
+        "seam_spec_dist": round(seam_spec_dist, 5),
+        "silence_frac": round(silence_frac, 4),
+        "rms_db": round(to_db(rms(m)), 2),
+        "centroid_hz": round(centroid_hz, 1),
+    }
+
+
+def save_wav(wav: torch.Tensor, path: Path) -> None:
+    import soundfile as sf
+    w = wav.detach().float().cpu()
+    while w.dim() > 2:
+        w = w.squeeze(0)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(str(path), w.T.numpy(), SR)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--durations", type=float, nargs="+", default=DURATIONS)
+    ap.add_argument("--seeds", type=int, nargs="+", default=SEEDS)
+    ap.add_argument("--steps", type=int, default=STEPS)
+    ap.add_argument("--shift", type=float, default=SHIFT)
+    ap.add_argument("--cfg", type=float, default=CFG)
+    ap.add_argument("--out", type=Path,
+                    default=_REPO_ROOT / "test_output" / "experiments" / "latent_size")
+    args = ap.parse_args()
+
+    t0 = time.time()
+    print("[1] loading session (eager)...", flush=True)
+    session = Session()
+    print(f"    ready in {time.time() - t0:.1f}s", flush=True)
+
+    rows = []
+    for p in PROMPTS:
+        for dur in args.durations:
+            cond = session.encode_text(
+                tags=p["tags"], lyrics="[instrumental]",
+                instruction=TASK_INSTRUCTIONS["text2music"],
+                bpm=p["bpm"], duration=dur, key=p["key"],
+            )
+            neg = session.null_conditioning(cond)
+            T = int(round(dur * 25))
+            guidance = Curve(tensor=torch.full((T,), args.cfg, dtype=torch.bfloat16))
+            for seed in args.seeds:
+                torch.cuda.synchronize()
+                tg = time.time()
+                lat = session.generate(
+                    conditioning=cond, negative=neg, guidance_curve=guidance,
+                    seed=seed, duration=dur, steps=args.steps, shift=args.shift,
+                )
+                torch.cuda.synchronize()
+                gen_s = time.time() - tg
+
+                td = time.time()
+                audio = session.decode(lat)
+                torch.cuda.synchronize()
+                dec_s = time.time() - td
+
+                met = clip_metrics(audio.waveform)
+                save_wav(audio.waveform, args.out / p["slug"] / f"dur{int(dur)}s__seed{seed}.wav")
+                row = {"prompt": p["slug"], "duration_s": dur, "frames": T, "seed": seed,
+                       "gen_s": round(gen_s, 4), "dec_s": round(dec_s, 4), **met}
+                rows.append(row)
+                print(f"  {p['slug']:7s} dur={dur:5.1f}s (T={T:4d}) seed={seed:<5d} "
+                      f"gen={gen_s:.3f}s dec={dec_s:.3f}s "
+                      f"seam={met['seam_spec_dist']:.4f} sil={met['silence_frac']:.3f}",
+                      flush=True)
+
+    # Aggregate per duration across prompts+seeds.
+    agg = {}
+    base_gen = None
+    for dur in args.durations:
+        sub = [r for r in rows if r["duration_s"] == dur]
+        g = _stats([r["gen_s"] for r in sub])
+        if dur == 60.0:
+            base_gen = g["mean"]
+        agg[str(dur)] = {
+            "gen_s": g,
+            "dec_s": _stats([r["dec_s"] for r in sub]),
+            "seam_spec_dist": _stats([r["seam_spec_dist"] for r in sub]),
+            "silence_frac": _stats([r["silence_frac"] for r in sub]),
+        }
+
+    out = {
+        "generated_utc": datetime.now(timezone.utc).isoformat(),
+        "config": {"durations": args.durations, "seeds": args.seeds,
+                   "steps": args.steps, "shift": args.shift, "cfg": args.cfg,
+                   "prompts": [p["slug"] for p in PROMPTS]},
+        "rows": rows, "aggregate": agg,
+    }
+    args.out.mkdir(parents=True, exist_ok=True)
+    (args.out / "metrics.json").write_text(json.dumps(out, indent=2))
+
+    print("\n### Latency + quality vs window size (mean across prompts × seeds)\n")
+    print("| duration | frames | gen_s | gen speedup vs 60s | dec_s | seam_spec_dist | silence_frac |")
+    print("|---|---|---|---|---|---|---|")
+    for dur in args.durations:
+        a = agg[str(dur)]
+        g = a["gen_s"]["mean"]
+        sp = f"{base_gen / g:.2f}x" if base_gen and g else "—"
+        print(f"| {dur:.0f}s | {int(dur*25)} | {g:.3f} | {sp} | "
+              f"{a['dec_s']['mean']:.3f} | {a['seam_spec_dist']['mean']:.4f} | "
+              f"{a['silence_frac']['mean']:.4f} |")
+    print(f"\nWAVs + metrics.json under {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

A *science* task: **does the looped section need to be a 60 s latent?** Smaller window ⇒ less DiT compute per (re)diffusion ⇒ lower param-update latency (knob-to-ear) and smaller activation/workspace footprint ⇒ VRAM headroom. This PR adds a reproducible sweep, runs it on the model (RTX 5090), and writes up the finding.

- `scripts/experiments/latent_size/latent_size_sweep.py` — harness
- `scripts/experiments/latent_size/latent_size_results.md` — methodology + results + recommendation

No engine/runtime code changes — pure offline experiment under `scripts/experiments/`. Output WAVs + `metrics.json` land in `test_output/` (gitignored).

## Method

Pure text-to-music (the loop-focused generation case); only `duration` varies. 2 prompts × 8 windows (60→6 s) × 3 seeds = **48 renders**, eager backend, timing cuda-synced. Scored with loop-seam / dead-space proxies + saved WAVs.

## Finding — 60 s is not required; sweet spot ≈ 20–30 s

The gains have **two knees** that meet around 20–30 s:

| window | frames | gen_s | gen speedup | dec_s | gen+dec | silence_frac |
|---|---|---|---|---|---|---|
| 60 s | 1500 | 0.582 | 1.00× | 0.209 | 0.791 | 0.095 |
| 45 s | 1125 | 0.549 | 1.06× | 0.147 | 0.696 | 0.105 |
| 30 s | 750 | 0.448 | 1.30× | 0.093 | 0.541 | 0.124 |
| **20 s** | **500** | **0.391** | **1.49×** | **0.052** | **0.443** | **0.105** |
| 15 s | 375 | 0.387 | 1.50× | 0.039 | 0.426 | 0.152 |
| 10 s | 250 | 0.379 | 1.54× | 0.025 | 0.404 | 0.201 |
| 6 s | 150 | 0.380 | 1.53× | 0.016 | 0.396 | 0.265 |

- **Latency payoff saturates at ~20 s.** Generate (DiT) falls 60→30 s then *plateaus at ~0.38 s* — at small T the DiT is launch/overhead-bound, not compute-bound. ~1.5× win, capped.
- **Quality degrades below ~15 s.** Dead-space (`silence_frac`) roughly doubles by 10 s and rises sharply below 15 s; the seam proxy stays noisy/flat (no clear seam degradation). 20–30 s holds at the 60 s baseline.

**Recommendation:** prototype the live loop window at **30 s (safe)** or **20 s (aggressive)** — ~halves total offline compute vs 60 s, with quality proxies at baseline. Don't go below ~15 s without careful listening (dead-space risk + flat latency curve). **Confirm by ear** before committing a window size.

## Live-engine + VRAM implications

The transferable result is the **DiT compute scaling**, not the absolute eager ms (live path is windowed VAE + TRT). A smaller `walk_window_s` means proportionally less DiT work per re-diffusion (param-latency win). TRT workspace is reserved by the profile's max T and today only **60/120/240 s** profiles ship (`acestep/paths.py`) — so realizing a 20–30 s window live requires **building a sub-60 s TRT profile**, which itself reserves less workspace (**direct VRAM win, ties to #242**). The eager launch-bound floor is pessimistic; lower-overhead TRT may keep scaling a bit past 20 s.

## Caveats

Objective proxies (the decision-relevant `gen_s` scaling + `silence_frac` are solid; musical acceptability is human-judged — **listen**). Eager single-shot timings — the *shape* of the curve is the result, not the ms. Text-to-music; a source-driven cover/walk may lower dead-space risk at short windows (natural follow-up). Compounds with the companion **`loop-prompting-quality`** study.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
