### PR TITLE
feat(trt): 30s decoder profile for the loop-focused workflow

### DIFF
--- a/acestep/paths.py
+++ b/acestep/paths.py
@@ -312,6 +312,19 @@ def trt_engine_path(engine_name: str) -> Path:
 # scripts/benchmarks/vram_60s_vs_240s_results.md. Pick the smallest profile
 # that fits the audio (see `select_trt_engines` and `available_trt_engines`).
 _TRT_ENGINE_PROFILES: dict[float, dict[str, str]] = {
+    # 30s decoder for the loop-focused / short-source workflow: a smaller
+    # seq_max (750 frames vs 1500) reserves less DiT activation workspace
+    # (VRAM headroom) and is opt-tuned at 750 for lower param-update
+    # latency. The VAE engines are intentionally the 60s builds — the
+    # walk-window path keeps vae_encode sized to the full song, and the
+    # 60s vae_decode already accepts ≤1500 frames, so 750-frame decodes
+    # need no dedicated engine. Build with
+    # ``python -m acestep.engine.trt.build --all --duration 30 --decoder-only``.
+    30.0: {
+        "decoder": "spectral_decoder_mixed_refit_b8_30s",
+        "vae_encode": "vae_encode_fp16_60s",
+        "vae_decode": "vae_decode_fp16_60s",
+    },
     60.0: {
         "decoder": "spectral_decoder_mixed_refit_b8_60s",
         "vae_encode": "vae_encode_fp16_60s",

--- a/docs/TRT.md
+++ b/docs/TRT.md
@@ -176,6 +176,25 @@ Build only decoder engines:
 uv run python -m acestep.engine.trt.build --all --decoder-only --duration 60
 ```
 
+Build the 30s loop-window decoder (decoder-only):
+
+```powershell
+uv run python -m acestep.engine.trt.build --all --decoder-only --duration 30
+```
+
+The `30.0` profile in `acestep/paths.py` serves the loop-focused /
+short-source workflow (`walk_window_s = 30`, or any source ≤ 30s). Its
+`seq_max` is 750 frames (vs 1500 for 60s), so the DiT context reserves
+less activation workspace and is opt-tuned at 750 for lower
+param-update latency. It is **decoder-only**: the profile reuses the
+existing 60s VAE engines, because the walk-window path keeps
+`vae_encode` sized to the full song and the 60s `vae_decode` already
+accepts ≤ 1500-frame inputs. (A dedicated sub-60s VAE engine is not
+needed and currently fails the TRT optimization-profile check on
+Blackwell — see `RTX 5090 / Blackwell VAE Builds` above.) Measured on a
+5090 vs running the same 750-frame window on the 60s engine: ~12% faster
+warm generate (0.121s vs 0.137s) and ~0.25 GB less process VRAM.
+
 Build only VAE engines:
 
 ```powershell


### PR DESCRIPTION
> **Draft** — the 30s decoder is built and validated on a 5090, but the point of this PR is to enable an **ear test** of 30s loop quality on the real engine path before we commit to a default. Promote out of draft once 30s sounds good live.

## What

Acts on the **latent-size experiment** finding (a 20–30 s loop window is viable; 60 s isn't required). Registers a **30 s TRT decoder profile** so the loop-focused / short-source path runs on a decoder opt-tuned for a 750-frame window instead of borrowing the 60 s engine.

One-line runtime change: a `30.0` entry in `_TRT_ENGINE_PROFILES` (`acestep/paths.py`) + docs.

## Why this is the whole change

- `seq_min = 126` on the existing engines, so the 60 s decoder *already* accepts a 750-frame (30 s) input — 30 s "worked" before, just on an engine opt-tuned for 1500 frames and reserving 60 s of workspace. This profile gives the window its own decoder (`seq_opt = seq_max = 750`).
- The walk-window path (`acestep/streaming/session.py`) resolves `decoder` + `vae_decode` at `walk_window_s` while keeping `vae_encode` full-song. So with this profile, `walk_window_s = 30` now picks a real 30 s decoder. Sources ≤ 30 s pick it directly too.
- **Decoder-only on purpose.** The profile reuses the existing **60 s VAE** engines: the walk path keeps `vae_encode` at full-song size, and the 60 s `vae_decode` already accepts ≤ 1500-frame inputs, so 750-frame decodes need no dedicated VAE engine. A sub-60 s VAE engine also isn't buildable today — it fails the TRT optimization-profile check on Blackwell (documented in `docs/TRT.md`).

## Build (binaries are not in the repo)

```
python -m acestep.engine.trt.build --all --decoder-only --duration 30
```

Engine lands under `~/.daydream-scope/.../trt_engines/spectral_decoder_mixed_refit_b8_30s/`, same as the 60s/120s/240s engines. Built in ~48 s here (reuses the cached decoder ONNX).

## Validation (RTX 5090)

- 30 s decoder loads via TRT, generates a `[1, 750, 64]` latent, decodes OK, LoRA refit works.
- Profile resolution: `≤30s → 30s engine`, `31–60s → 60s` (existing paths unchanged).
- 30 s window vs the **same 750-frame window on the 60 s engine**: **~12% faster** warm generate (0.121 s vs 0.137 s), **~0.25 GB** less process VRAM (15.88 vs 16.13 GB).

Honest scope: the deltas are modest — the dominant VRAM lever was always `vae_encode` (which the walk path keeps full-size), and per-pass generate at 750 frames is already fast. The real prize from the experiment is **quality at a shorter loop** (shorter sections sustain musical content down to ~15–20 s before dead-space rises), which is a listening call.

## How to ear-test 30 s

In `demos/realtime_motion_graph_web/web/public/config.json`:

```json
{ "engine": { "walk_window": true, "walk_window_s": 30 } }
```

Load a source longer than 30 s and listen to the looped 30 s sections. (Pairs naturally with the loop-phrase toggle in #264.)

## Follow-ups (not in this PR)

- XL-turbo 30 s decoder (the `_XL_TURBO_TRT_ENGINE_PROFILES` table) — resolve() falls back to 60 s for XL until built.
- If 30 s wins by ear, consider a 20 s profile and/or making `walk_window_s` a first-class UI control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
