### PR TITLE
refactor(web/config): separate shared config from web-only block + version it

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/PerformanceShell.tsx
@@ -86,7 +86,7 @@ export function PerformanceShell() {
   useRefSourceAcks("structure");
   useMcpMirror();
   const config = useConfig();
-  useIdleReset(config.reset_seconds);
+  useIdleReset(config.web.reset_seconds);
 
   const startSession = useStartSession();
   const status = useSessionStore((s) => s.status);

--- a/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useFixtureSwap.ts
@@ -118,7 +118,7 @@ export function useFixtureSwap() {
           // swap at 1:30 resumes at 1:30 of the new track unless we seek.
           // This gate is the single source of truth for restart-on-swap on
           // both paths. Operator can disable via config.
-          if (getConfig().restart_song_on_swap) {
+          if (getConfig().web.restart_song_on_swap) {
             session.player?.seek(0);
           }
           // Always update detectedBpm / detectedKey / detectedTimeSignature
@@ -260,7 +260,7 @@ export function useFixtureSwap() {
         // denoise value with a snap-to-zero. Consume-and-clear here so
         // the next legitimate swap reverts to the normal behaviour.
         const perfState = usePerformanceStore.getState();
-        const gate = getConfig().denoise_session_gate;
+        const gate = getConfig().web.denoise_session_gate;
         if (perfState.skipNextDenoiseGate) {
           perfState.setSkipNextDenoiseGate(false);
         } else if (gate.enabled) {

--- a/demos/realtime_motion_graph_web/web/hooks/useRenderLoop.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useRenderLoop.ts
@@ -116,10 +116,10 @@ export function useRenderLoop(refs: Refs) {
         // every applyConfig() so an async-arriving config or future
         // "Reload config" affordance lands without a page refresh.
         const applyFx = (c: ReturnType<typeof getConfig>) => {
-          e.setParallaxStrength(c.effects.parallax_strength);
-          e.setBloomOnKick(c.effects.bloom_on_kick);
-          e.setBloomThreshold(c.effects.bloom_threshold);
-          e.setWarpStrength(c.effects.warp_strength);
+          e.setParallaxStrength(c.web.effects.parallax_strength);
+          e.setBloomOnKick(c.web.effects.bloom_on_kick);
+          e.setBloomThreshold(c.web.effects.bloom_threshold);
+          e.setWarpStrength(c.web.effects.warp_strength);
         };
         applyFx(getConfig());
         unsubEffectsConfig = subscribeConfig(applyFx);

--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -703,7 +703,7 @@ export function useStartSession() {
     setStatus("connecting", "Starting audio…");
 
     const player = new AudioPlayer({
-      loudnessConfig: () => getConfig().audio,
+      loudnessConfig: () => getConfig().web.audio,
     });
     try {
       await player.init(remote.initialBuffer, remote.channels);
@@ -755,7 +755,7 @@ export function useStartSession() {
     // we consume-and-clear here too. Fresh sessions don't set the flag,
     // so their gate behaviour is unchanged.
     const perfState = usePerformanceStore.getState();
-    const gate = getConfig().denoise_session_gate;
+    const gate = getConfig().web.denoise_session_gate;
     if (perfState.skipNextDenoiseGate) {
       perfState.setSkipNextDenoiseGate(false);
     } else if (gate.enabled) {

--- a/demos/realtime_motion_graph_web/web/lib/config.ts
+++ b/demos/realtime_motion_graph_web/web/lib/config.ts
@@ -305,12 +305,17 @@ export interface RtmgConfigLoop {
   fullBuffer?: boolean;
 }
 
-export interface RtmgConfig {
-  engine: RtmgConfigEngine;
-  prompts: RtmgConfigPrompts;
-  controls: RtmgConfigControls;
-  channel_ranges: RtmgConfigChannelRanges;
-  seed: number;
+/** The browser demo's own presentation, playback, and interaction
+ *  settings. Deliberately separated from the shared `RtmgConfig` fields
+ *  so the config object stays portable across frontends (Ableton M4L,
+ *  the VST, MCP / headless): those consume only the shared fields and
+ *  keep their own equivalent of this block. On the wire / in config.json
+ *  this lives under the top-level `web` key.
+ *
+ *  Note `channel_ranges` is NOT here — per-channel {min,max,reverse} is
+ *  part of the shared *control surface* a native plugin's knob layout
+ *  would also honor, so it lives on `RtmgConfig` directly. */
+export interface RtmgWebConfig {
   effects: RtmgConfigEffects;
   audio: RtmgConfigAudio;
   reset_seconds: number;
@@ -321,10 +326,30 @@ export interface RtmgConfig {
    * ScriptProcessor fallback already restarts on swap; this aligns the
    * worklet path with that behavior and makes it operator-tunable. */
   restart_song_on_swap: boolean;
+}
+
+export interface RtmgConfig {
+  /** Shared-config schema version. Bump on a breaking shape change so
+   *  consumers across frontends can detect mismatches. Old config.json
+   *  files that predate the field are normalised to 1 on load. */
+  version: number;
+  engine: RtmgConfigEngine;
+  prompts: RtmgConfigPrompts;
+  controls: RtmgConfigControls;
+  /** Per-channel {min,max,reverse} for the channel-gain controls. Part
+   *  of the shared control surface (a VST / M4L knob layout would honor
+   *  the same ranges), so it sits alongside `controls` rather than in
+   *  the web-only block. */
+  channel_ranges: RtmgConfigChannelRanges;
+  seed: number;
   /** Default inference source for uploaded-track swaps. Built-in
    *  fixtures keep using their full source unless the track is present
-   *  in the custom upload store. */
+   *  in the custom upload store. Engine-facing (selects the audio sent
+   *  for inference), so it stays in the shared config rather than `web`. */
   swap_source_mode: SwapSourceMode;
+  /** The browser demo's own presentation/playback/interaction settings.
+   *  Other frontends ignore this block. */
+  web: RtmgWebConfig;
   /** Per-param schedule curves. Same shape useCurveStore persists to
    *  localStorage today, lifted into the operator-editable config so a
    *  pod's deployed sound can ship its automation alongside its
@@ -338,6 +363,7 @@ export interface RtmgConfig {
 }
 
 export const DEFAULT_CONFIG: RtmgConfig = {
+  version: 1,
   engine: {
     sde: false,
     lora: true,
@@ -410,27 +436,29 @@ export const DEFAULT_CONFIG: RtmgConfig = {
     ch56: { min: 0, max: 2.0, reverse: false },
   },
   seed: 0,
-  effects: {
-    parallax_strength: 0.4,
-    bloom_on_kick: 0.3,
-    bloom_threshold: 0.15,
-    warp_strength: 0.4,
-  },
-  audio: {
-    lufs_enabled: false,
-    lufs_window_sec: 3.0,
-    lufs_metric: "lufs",
-    lufs_peak_headroom: 4.0,
-    lufs_silence_floor_db: 30.0,
-    lufs_silence_floor_hysteresis_db: 6.0,
-  },
-  reset_seconds: 0,
-  denoise_session_gate: {
-    enabled: true,
-    glide_ms: 700,
-  },
-  restart_song_on_swap: true,
   swap_source_mode: "instruments",
+  web: {
+    effects: {
+      parallax_strength: 0.4,
+      bloom_on_kick: 0.3,
+      bloom_threshold: 0.15,
+      warp_strength: 0.4,
+    },
+    audio: {
+      lufs_enabled: false,
+      lufs_window_sec: 3.0,
+      lufs_metric: "lufs",
+      lufs_peak_headroom: 4.0,
+      lufs_silence_floor_db: 30.0,
+      lufs_silence_floor_hysteresis_db: 6.0,
+    },
+    reset_seconds: 0,
+    denoise_session_gate: {
+      enabled: true,
+      glide_ms: 700,
+    },
+    restart_song_on_swap: true,
+  },
 };
 
 let _activeConfig: RtmgConfig = DEFAULT_CONFIG;
@@ -574,12 +602,48 @@ export function useConfig(): RtmgConfig {
   return c;
 }
 
+/** Fields that lived at the top level before the `web` split and now
+ *  belong under `web`. `channel_ranges` is intentionally excluded — it
+ *  was top-level in the old flat shape and stays top-level (shared) in
+ *  the new one, so it needs no lifting. */
+const LEGACY_WEB_KEYS = [
+  "effects",
+  "audio",
+  "reset_seconds",
+  "denoise_session_gate",
+  "restart_song_on_swap",
+] as const;
+
+/** Lift a pre-`web` flat config (effects/audio/... at the top level)
+ *  into the current nested shape so older config.json files and exported
+ *  sounds keep loading. Only fills `web` sub-fields the override doesn't
+ *  already set under `web`; a config that already nests `web` is returned
+ *  untouched. Operates on a shallow copy — never mutates input. */
+export function normalizeConfigShape(
+  raw: Partial<RtmgConfig> & Record<string, unknown>,
+): Partial<RtmgConfig> {
+  const hasLegacyTopLevel = LEGACY_WEB_KEYS.some((k) => k in raw);
+  if (!hasLegacyTopLevel) return raw;
+  const liftedWeb: Record<string, unknown> = { ...(raw.web ?? {}) };
+  for (const k of LEGACY_WEB_KEYS) {
+    if (k in raw && !(k in liftedWeb)) liftedWeb[k] = (raw as Record<string, unknown>)[k];
+  }
+  const out: Record<string, unknown> = { ...raw, web: liftedWeb };
+  for (const k of LEGACY_WEB_KEYS) delete out[k];
+  return out as Partial<RtmgConfig>;
+}
+
 export function mergeConfig(
   base: RtmgConfig,
-  override: Partial<RtmgConfig> | null | undefined,
+  rawOverride: Partial<RtmgConfig> | null | undefined,
 ): RtmgConfig {
-  if (!override) return base;
+  if (!rawOverride) return base;
+  const override = normalizeConfigShape(
+    rawOverride as Partial<RtmgConfig> & Record<string, unknown>,
+  );
+  const web: Partial<RtmgWebConfig> = override.web ?? {};
   return {
+    version: typeof override.version === "number" ? override.version : base.version,
     engine: { ...base.engine, ...(override.engine ?? {}) },
     prompts: { ...base.prompts, ...(override.prompts ?? {}) },
     controls: { ...base.controls, ...(override.controls ?? {}) },
@@ -592,23 +656,25 @@ export function mergeConfig(
       ...(override.channel_ranges ?? {}),
     },
     seed: typeof override.seed === "number" ? override.seed : base.seed,
-    effects: { ...base.effects, ...(override.effects ?? {}) },
-    audio: { ...base.audio, ...(override.audio ?? {}) },
-    reset_seconds:
-      typeof override.reset_seconds === "number"
-        ? override.reset_seconds
-        : base.reset_seconds,
-    denoise_session_gate: {
-      ...base.denoise_session_gate,
-      ...(override.denoise_session_gate ?? {}),
-    },
-    restart_song_on_swap:
-      typeof override.restart_song_on_swap === "boolean"
-        ? override.restart_song_on_swap
-        : base.restart_song_on_swap,
     swap_source_mode: isSwapSourceMode(override.swap_source_mode)
       ? override.swap_source_mode
       : base.swap_source_mode,
+    web: {
+      effects: { ...base.web.effects, ...(web.effects ?? {}) },
+      audio: { ...base.web.audio, ...(web.audio ?? {}) },
+      reset_seconds:
+        typeof web.reset_seconds === "number"
+          ? web.reset_seconds
+          : base.web.reset_seconds,
+      denoise_session_gate: {
+        ...base.web.denoise_session_gate,
+        ...(web.denoise_session_gate ?? {}),
+      },
+      restart_song_on_swap:
+        typeof web.restart_song_on_swap === "boolean"
+          ? web.restart_song_on_swap
+          : base.web.restart_song_on_swap,
+    },
     // Curves are operator-authored and only meaningful as a whole bag,
     // so the override entry replaces the base entry whole when present.
     // Absent override keeps whatever the base has (DEFAULT_CONFIG leaves
@@ -724,7 +790,7 @@ export function applyConfig(c: RtmgConfig): void {
       ? resolved.controls.dcw_wavelet
       : s.dcwWavelet,
     rcfgMode: isRcfgMode(resolved.controls.rcfg_mode) ? resolved.controls.rcfg_mode : s.rcfgMode,
-    lufsOn: resolved.audio.lufs_enabled,
+    lufsOn: resolved.web.audio.lufs_enabled,
   }));
 
   // Loop region: when the config carries one, push it into the perf
@@ -841,10 +907,10 @@ export function applyConfig(c: RtmgConfig): void {
  * DEMON-shaped base of a session without rebuilding the field-mapping
  * logic.
  *
- * Fields the stores don't own (channel_ranges, effects, audio
- * defaults, denoise_session_gate, restart_song_on_swap, swap_source_mode, the
- * non-numeric engine.* config) are pulled from the active config so
- * exports round-trip cleanly through Import.
+ * Fields the stores don't own (channel_ranges, swap_source_mode, the
+ * non-numeric engine.* config, and the whole `web` block — effects,
+ * audio defaults, denoise_session_gate, restart_song_on_swap) are pulled
+ * from the active config so exports round-trip cleanly through Import.
  */
 export function captureRtmgConfig(): RtmgConfig {
   const perf = usePerformanceStore.getState();
@@ -865,6 +931,7 @@ export function captureRtmgConfig(): RtmgConfig {
   }
 
   return {
+    version: active.version,
     engine: {
       ...active.engine,
       key: perf.activeKey,
@@ -884,12 +951,14 @@ export function captureRtmgConfig(): RtmgConfig {
     controls,
     channel_ranges: active.channel_ranges,
     seed: perf.seed,
-    effects: active.effects,
-    audio: { ...active.audio, lufs_enabled: perf.lufsOn },
-    reset_seconds: active.reset_seconds,
-    denoise_session_gate: active.denoise_session_gate,
-    restart_song_on_swap: active.restart_song_on_swap,
     swap_source_mode: active.swap_source_mode,
+    web: {
+      effects: active.web.effects,
+      audio: { ...active.web.audio, lufs_enabled: perf.lufsOn },
+      reset_seconds: active.web.reset_seconds,
+      denoise_session_gate: active.web.denoise_session_gate,
+      restart_song_on_swap: active.web.restart_song_on_swap,
+    },
     loop: {
       band: perf.loopBand,
       enabled: perf.bandLoopEnabled,

--- a/demos/realtime_motion_graph_web/web/public/config.json
+++ b/demos/realtime_motion_graph_web/web/public/config.json
@@ -1,7 +1,11 @@
 {
   "_comment": "Initial settings for the DEMON installation. Edit and refresh — no rebuild needed. Slider max/step lives in types/engine.ts (SLIDER_META); only the per-control starting value is set here. Schema and defaults: web/lib/config.ts.",
 
+  "_shape_help": "Two concerns live here. Everything OUTSIDE `web` is the SHARED config — engine/generation intent and the control surface that any frontend driving DEMON consumes (web demo, Ableton M4L, the VST, MCP/headless). The `web` block is the browser demo's own presentation/playback/interaction; other frontends read the shared fields, keep their own equivalent of `web`, and ignore this one. `version` tags the shared schema; bump it on a breaking shape change.",
+
   "_variants_help": "Selected fields carry an `_xl` sibling (depth_xl, enabled_loras_xl in engine; a_xl, b_xl, blend_xl in prompts). When the active checkpoint scale is 5B (xl), the `_xl` value wins at applyConfig time. Other scales (2B / unknown) use the base value. Selection happens once at boot after /api/loras returns the checkpoint scale.",
+
+  "version": 1,
 
   "engine": {
     "sde": false,
@@ -86,7 +90,12 @@
     "dcw_wavelet": "haar"
   },
 
-  "_channel_ranges_help": "Per-channel slider range + direction. {min,max} caps the value the slider/MIDI/keyboard can drive into the engine (also applied to scheduled-curve writes via clampToMeta). `reverse: true` flips the input mapping so dragging UP (or turning the MIDI knob clockwise) sends a LOWER engine value -- use for channels that sound better when turned down so the operator's instinct to push up produces the desired result. Stored values still live in [min, max]; reverse changes only the UI/input mapping, not the wire range. Omitted params fall back to SLIDER_META in types/engine.ts (max=3.0 by default, no min).",
+  "seed": 42,
+
+  "_swap_source_mode_help": "Default inference source for uploaded-track swaps. One of full, instruments, vocals. Built-in fixtures keep using their full source unless the track is present in the upload library. Engine-facing (selects what audio is sent for inference), so it lives in the shared config.",
+  "swap_source_mode": "instruments",
+
+  "_channel_ranges_help": "Per-channel control range + direction — part of the shared control surface, so the VST and M4L knob mappings can honor it too. {min,max} caps the value a slider/MIDI/keyboard can drive into the engine (also applied to scheduled-curve writes via clampToMeta). `reverse: true` flips the input mapping so dragging UP (or turning the knob clockwise) sends a LOWER engine value -- use for channels that sound better when turned down so the operator's instinct to push up produces the desired result. Stored values still live in [min, max]; reverse changes only the input mapping, not the wire range. Omitted params fall back to SLIDER_META in types/engine.ts (max=3.0 by default, no min).",
   "channel_ranges": {
     "ch_g0": { "min": 0, "max": 2.2, "reverse": false },
     "ch_g1": { "min": 0, "max": 2.0, "reverse": false },
@@ -104,38 +113,36 @@
     "ch56": { "min": 0, "max": 2.0, "reverse": false }
   },
 
-  "seed": 42,
+  "_web_help": "The browser demo's own presentation, playback, and interaction settings. Other frontends (Ableton M4L, the VST, MCP/headless) read the shared fields above and ignore this block — each keeps its own equivalent.",
+  "web": {
+    "_audio_help": "Output audio chain (client-side playback DSP). lufs_enabled toggles the loudness matcher on at boot (operator can still flip it via the LUFS button in-session). lufs_window_sec controls the meter's sliding window. 3s is the standard. Lower = faster response but noisier and prone to high-water spikes on transients. Practical floor ~1.5s. lufs_metric picks the metric: 'lufs' (BS.1770 K-weighted, broadcast standard) or 'dba' (IEC 61672 A-weighted, closer to perceived loudness on bright/distorted content). lufs_silence_floor_db disengages the matcher when the chunk at the playhead reads more than this far below target (gain ramps to 1.0 instead of computing a boost), so silent regions of the model output don't get amplified into audible noise; 30 is well outside real musical content, lower to 20 to disengage on quiet passages too. lufs_silence_floor_hysteresis_db is the Schmitt-trigger band: once disengaged, the matcher re-engages only when the chunk reads within (floor - hysteresis) dB of target, preventing flapping at the threshold. Widen if you still hear volume swells at silence boundaries. The matcher always seeds the high-water mark with the source's loudest short-term window at session start, so the louder of {source, denoised} defines the target from t=0 -- no need to wait for the meter to discover it.",
+    "audio": {
+      "lufs_enabled": false,
+      "lufs_window_sec": 1.5,
+      "lufs_metric": "lufs",
+      "lufs_peak_headroom": 4.0,
+      "lufs_silence_floor_db": 30.0,
+      "lufs_silence_floor_hysteresis_db": 6.0
+    },
 
-  "_audio_help": "Output audio chain. lufs_enabled toggles the loudness matcher on at boot (operator can still flip it via the LUFS button in-session). lufs_window_sec controls the meter's sliding window. 3s is the standard. Lower = faster response but noisier and prone to high-water spikes on transients. Practical floor ~1.5s. lufs_metric picks the metric: 'lufs' (BS.1770 K-weighted, broadcast standard) or 'dba' (IEC 61672 A-weighted, closer to perceived loudness on bright/distorted content). lufs_silence_floor_db disengages the matcher when the chunk at the playhead reads more than this far below target (gain ramps to 1.0 instead of computing a boost), so silent regions of the model output don't get amplified into audible noise; 30 is well outside real musical content, lower to 20 to disengage on quiet passages too. lufs_silence_floor_hysteresis_db is the Schmitt-trigger band: once disengaged, the matcher re-engages only when the chunk reads within (floor - hysteresis) dB of target, preventing flapping at the threshold. Widen if you still hear volume swells at silence boundaries. The matcher always seeds the high-water mark with the source's loudest short-term window at session start, so the louder of {source, denoised} defines the target from t=0 -- no need to wait for the meter to discover it.",
-  "audio": {
-    "lufs_enabled": false,
-    "lufs_window_sec": 1.5,
-    "lufs_metric": "lufs",
-    "lufs_peak_headroom": 4.0,
-    "lufs_silence_floor_db": 30.0,
-    "lufs_silence_floor_hysteresis_db": 6.0
-  },
+    "_effects_help": "Audio-reactive video shader pipeline (parallax + bloom-on-kick). Both effects pulse with the kick envelope; the perimeter ribbons + DEMON wordmark also pulse with kick via a CSS variable.",
+    "effects": {
+      "parallax_strength": 0.4,
+      "bloom_on_kick": 0.3,
+      "bloom_threshold": 0.15,
+      "warp_strength": 0.4
+    },
 
-  "_effects_help": "Audio-reactive video shader pipeline (parallax + bloom-on-kick). Both effects pulse with the kick envelope; the perimeter ribbons + DEMON wordmark also pulse with kick via a CSS variable.",
-  "effects": {
-    "parallax_strength": 0.4,
-    "bloom_on_kick": 0.3,
-    "bloom_threshold": 0.15,
-    "warp_strength": 0.4
-  },
+    "_reset_seconds_help": "Idle timeout. After this many seconds of no interaction (pointer, key, or MIDI), every control reverts to the defaults above. Set to 0 to disable.",
+    "reset_seconds": 0,
 
-  "_reset_seconds_help": "Idle timeout. After this many seconds of no interaction (pointer, key, or MIDI), every control reverts to the defaults above. Set to 0 to disable.",
-  "reset_seconds": 0,
+    "_denoise_session_gate_help": "On every session start (clicking Play) AND on song swaps, snap the engine's denoise value to 0 and play a visual-only display glide from the slider's prior value down to 0 over glide_ms. The engine value never moves with the glide; it's a 'hear the source first' onboarding cue, and the slide doubles as a hint that the top ribbon is a slider. The slide is only visible when denoise is non-zero at the moment of the gate (first session uses controls.denoise above; later sessions and swaps use wherever the operator left it). Set enabled to false to skip the snap and glide entirely. With the gate off, controls.denoise seeds first paint and the slider keeps the operator's last value across sessions and swaps.",
+    "denoise_session_gate": {
+      "enabled": true,
+      "glide_ms": 700
+    },
 
-  "_denoise_session_gate_help": "On every session start (clicking Play) AND on song swaps, snap the engine's denoise value to 0 and play a visual-only display glide from the slider's prior value down to 0 over glide_ms. The engine value never moves with the glide; it's a 'hear the source first' onboarding cue, and the slide doubles as a hint that the top ribbon is a slider. The slide is only visible when denoise is non-zero at the moment of the gate (first session uses controls.denoise above; later sessions and swaps use wherever the operator left it). Set enabled to false to skip the snap and glide entirely. With the gate off, controls.denoise seeds first paint and the slider keeps the operator's last value across sessions and swaps.",
-  "denoise_session_gate": {
-    "enabled": true,
-    "glide_ms": 700
-  },
-
-  "_restart_song_on_swap_help": "When true, picking a different song mid-session restarts playback from frame 0 of the new song. When false, the worklet keeps the playhead's phase across the swap, so swapping at 1:30 into a 4:00 track starts the new track at 1:30. Default true matches the ScriptProcessor fallback's existing behavior.",
-  "restart_song_on_swap": false,
-
-  "_swap_source_mode_help": "Default inference source for uploaded-track swaps. One of full, instruments, vocals. Built-in fixtures keep using their full source unless the track is present in the upload library.",
-  "swap_source_mode": "instruments"
+    "_restart_song_on_swap_help": "When true, picking a different song mid-session restarts playback from frame 0 of the new song. When false, the worklet keeps the playhead's phase across the swap, so swapping at 1:30 into a 4:00 track starts the new track at 1:30. Default true matches the ScriptProcessor fallback's existing behavior.",
+    "restart_song_on_swap": false
+  }
 }


### PR DESCRIPTION
## What
Splits the rtmg web demo's `config.json` into a portable **shared** config object and a browser-demo-only **`web`** block, and adds a `version` field.

- **Shared (top-level):** `version`, `engine`, `prompts`, `controls`, `channel_ranges`, `seed`, `swap_source_mode` — engine/generation intent plus the control surface that any frontend driving DEMON consumes.
- **`web` block:** `effects`, `audio` (LUFS), `reset_seconds`, `denoise_session_gate`, `restart_song_on_swap` — browser-demo presentation/playback. Named `web` rather than `ui` because every frontend (VST, M4L, browser) has a UI; other frontends read the shared fields and keep their own equivalent of this block.
- **`channel_ranges` stays shared:** per-channel `{min,max,reverse}` is a control-surface contract a native plugin's knob layout would honor, not web chrome.
- **Back-compat:** `normalizeConfigShape()` lifts pre-`web` flat configs into the new shape on load/import, so older `config.json` files and exported sounds keep working.

## Why
`config.json` mixed engine/generation intent with this demo's UI settings and had no schema version. The goal is one config object sharable across frontends (web demo, VST, Ableton M4L, MCP/headless).

## Tests
- `tsc --noEmit` clean
- 47 web unit tests pass
- The replay tier has a pre-existing failure on `main` (stale telemetry fields in canonical fixtures), unrelated to this change.

## Companion
Mirrored in the public demo: daydreamlive/demon-public-demo#357
