### PR TITLE
test(replay): exclude non-deterministic params telemetry from wire eq…

### DIFF
--- a/demos/realtime_motion_graph_web/web/tests/replay/replay.test.ts
+++ b/demos/realtime_motion_graph_web/web/tests/replay/replay.test.ts
@@ -159,7 +159,35 @@ function driveRecordedSend(
   );
   const wire = ws.sent[ws.sent.length - 1];
   expect(typeof wire).toBe("string");
-  expect(JSON.parse(wire as string)).toEqual(data);
+  // params carries telemetry the replay can't and shouldn't match byte-for-
+  // byte: client_time is a wall-clock performance.now() send stamp (never
+  // deterministic), and slice_bytes_rx / slice_lead_s are runtime flow-control
+  // feedback whose values depend on live receive/apply timing, not on the
+  // recorded input bytes. They postdate the golden transcripts (added in
+  // #256). The replay's contract is decode/apply + command-shape fidelity, so
+  // drop these fields from both sides before comparing.
+  expect(stripParamsTelemetry(JSON.parse(wire as string))).toEqual(
+    stripParamsTelemetry(data),
+  );
+}
+
+const PARAMS_TELEMETRY_FIELDS = [
+  "client_time",
+  "slice_bytes_rx",
+  "slice_lead_s",
+] as const;
+
+function stripParamsTelemetry<T>(msg: T): T {
+  if (
+    msg === null ||
+    typeof msg !== "object" ||
+    (msg as { type?: unknown }).type !== "params"
+  ) {
+    return msg;
+  }
+  const copy = { ...(msg as Record<string, unknown>) };
+  for (const field of PARAMS_TELEMETRY_FIELDS) delete copy[field];
+  return copy as T;
 }
 
 async function replayScenario(bundle: ScenarioBundle): Promise<ReplayOutcome> {


### PR DESCRIPTION
…uality

#256 added client_time / slice_bytes_rx / slice_lead_s to the params wire message, but the replay golden transcripts predate those fields, so every replay scenario failed its exact JSON-equality assertion on each recorded send. client_time is a performance.now() send stamp and the others are runtime flow-control feedback, none of which the deterministic replay can match byte-for-byte — re-recording would not fix client_time.

Strip those three telemetry fields from both sides before comparing. The replay's contract is decode/apply + command-shape fidelity, which is unaffected.