### PR TITLE
feat(client-sdk): extract the portable inputs codec into the SDK

### DIFF
--- a/demos/realtime_motion_graph_web/web/lib/inputBundle.ts
+++ b/demos/realtime_motion_graph_web/web/lib/inputBundle.ts
@@ -38,107 +38,28 @@ import {
   type DecodedFixture,
   type StemSourceMode,
 } from "@/engine/audio/loadFixture";
+import {
+  arrayBufferToBase64,
+  base64ToArrayBuffer,
+  encodeWavInterleaved,
+  type SerializedInput,
+  type SerializedInputs,
+} from "@demon/client";
+
 import { getConfig } from "@/lib/config";
 import { trimAudioBuffer } from "@/lib/audio/trimAudioBuffer";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { usePerformanceStore, type RefSource } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
 
+// The SerializedInput(s) shape + WAV/base64 codec now live in the SDK (the
+// single source of truth shared with the M4L bridge and the VST). Re-export
+// the types so existing `@/lib/inputBundle` consumers keep their imports.
+export type { SerializedInput, SerializedInputs };
+
 // Fallback ref-duration cap when engine.max_source_duration_s is unset.
 // Mirrors RefControl / TrackPicker.
 const DEFAULT_TRIM_CAP_S = 120;
-
-/** One serialized input. `fixture` is a library track the server can
- *  load by name (no audio on the wire). `clip` embeds the trimmed PCM as
- *  a base64 WAV so an upload survives the round-trip even on a machine
- *  that never had the original file. */
-export type SerializedInput =
-  | { kind: "fixture"; name: string }
-  | {
-      kind: "clip";
-      name: string;
-      sourceMode?: StemSourceMode;
-      /** 16-bit PCM WAV, base64-encoded. Sample rate + channel count
-       *  ride in the WAV header, so decode re-derives them. */
-      wavBase64: string;
-    };
-
-/** The three inputs as captured for export. A field is null when that
- *  input axis simply has nothing active. */
-export interface SerializedInputs {
-  track?: SerializedInput | null;
-  timbre?: SerializedInput | null;
-  structure?: SerializedInput | null;
-}
-
-// ── WAV + base64 codec ─────────────────────────────────────────────────
-
-function writeAscii(view: DataView, offset: number, text: string): void {
-  for (let i = 0; i < text.length; i++) {
-    view.setUint8(offset + i, text.charCodeAt(i));
-  }
-}
-
-/** Encode already-interleaved float32 PCM as a 16-bit WAV ArrayBuffer.
- *  Parallels lib/audio/encodeWav.ts (which takes an AudioBuffer); here
- *  the source is the interleaved Float32Array a DecodedFixture already
- *  holds, so we skip the channel de-interleave. */
-function encodeWavInterleaved(
-  interleaved: Float32Array,
-  channels: number,
-  sampleRate: number,
-): ArrayBuffer {
-  const frames = Math.floor(interleaved.length / channels);
-  const bytesPerSample = 2;
-  const dataLen = frames * channels * bytesPerSample;
-  const out = new ArrayBuffer(44 + dataLen);
-  const view = new DataView(out);
-
-  writeAscii(view, 0, "RIFF");
-  view.setUint32(4, 36 + dataLen, true);
-  writeAscii(view, 8, "WAVE");
-  writeAscii(view, 12, "fmt ");
-  view.setUint32(16, 16, true);
-  view.setUint16(20, 1, true); // PCM
-  view.setUint16(22, channels, true);
-  view.setUint32(24, sampleRate, true);
-  view.setUint32(28, sampleRate * channels * bytesPerSample, true);
-  view.setUint16(32, channels * bytesPerSample, true);
-  view.setUint16(34, 8 * bytesPerSample, true);
-  writeAscii(view, 36, "data");
-  view.setUint32(40, dataLen, true);
-
-  const pcm = new Int16Array(out, 44, frames * channels);
-  const n = frames * channels;
-  for (let i = 0; i < n; i++) {
-    const s = interleaved[i];
-    const c = s < -1 ? -1 : s > 1 ? 1 : s;
-    // Asymmetric scaling (mirrors encodeWav.ts) keeps the full negative
-    // range without wrapping.
-    pcm[i] = c < 0 ? c * 0x8000 : c * 0x7fff;
-  }
-  return out;
-}
-
-function arrayBufferToBase64(buf: ArrayBuffer): string {
-  const bytes = new Uint8Array(buf);
-  // Chunk to stay clear of the argument-count ceiling on
-  // String.fromCharCode for multi-MB clips.
-  const chunk = 0x8000;
-  let binary = "";
-  for (let i = 0; i < bytes.length; i += chunk) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
-  }
-  return btoa(binary);
-}
-
-function base64ToArrayBuffer(b64: string): ArrayBuffer {
-  const binary = atob(b64);
-  const len = binary.length;
-  const bytes = new Uint8Array(len);
-  for (let i = 0; i < len; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes.buffer;
-}
 
 function encodeClip(
   name: string,

--- a/demos/realtime_motion_graph_web/web/tests/unit/inputsCodec.test.ts
+++ b/demos/realtime_motion_graph_web/web/tests/unit/inputsCodec.test.ts
@@ -1,0 +1,101 @@
+// The portable inputs codec (@demon/client/inputs) must be byte-identical
+// across clients: a clip the web encodes has to decode the same in the M4L
+// bridge (Node) and a future C++/VST consumer. These guard the two things
+// that would silently diverge — base64 and the 16-bit WAV layout — against
+// an independent oracle (Node's Buffer = RFC 4648) and a full round-trip.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  arrayBufferToBase64,
+  base64ToArrayBuffer,
+  encodeWavInterleaved,
+} from "@demon/client";
+
+function bytesOf(buf: ArrayBuffer): Uint8Array {
+  return new Uint8Array(buf);
+}
+
+describe("base64 (environment-neutral)", () => {
+  // Cover every residue class mod 3 so the padding logic is exercised.
+  const cases = [0, 1, 2, 3, 4, 5, 17, 256, 1023, 65537];
+
+  it("matches Node Buffer base64 exactly (the RFC 4648 oracle)", () => {
+    for (const n of cases) {
+      const bytes = new Uint8Array(n);
+      for (let i = 0; i < n; i++) bytes[i] = (i * 37 + 11) & 0xff;
+      const ours = arrayBufferToBase64(bytes.buffer);
+      const oracle = Buffer.from(bytes).toString("base64");
+      expect(ours, `encode n=${n}`).toBe(oracle);
+    }
+  });
+
+  it("round-trips arbitrary bytes (decode ∘ encode = identity)", () => {
+    for (const n of cases) {
+      const bytes = new Uint8Array(n);
+      for (let i = 0; i < n; i++) bytes[i] = (i * 101 + 7) & 0xff;
+      const back = bytesOf(base64ToArrayBuffer(arrayBufferToBase64(bytes.buffer)));
+      expect(back.length, `len n=${n}`).toBe(n);
+      expect(Array.from(back), `bytes n=${n}`).toEqual(Array.from(bytes));
+    }
+  });
+
+  it("decodes a Buffer-produced base64 string (cross-impl decode)", () => {
+    const bytes = new Uint8Array(300);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 13) & 0xff;
+    const fromNode = Buffer.from(bytes).toString("base64");
+    const decoded = bytesOf(base64ToArrayBuffer(fromNode));
+    expect(Array.from(decoded)).toEqual(Array.from(bytes));
+  });
+});
+
+describe("encodeWavInterleaved", () => {
+  it("writes a valid 16-bit PCM WAV header", () => {
+    const sampleRate = 48000;
+    const channels = 2;
+    const frames = 100;
+    const interleaved = new Float32Array(frames * channels);
+    const wav = encodeWavInterleaved(interleaved, channels, sampleRate);
+    const view = new DataView(wav);
+    const ascii = (o: number, n: number) =>
+      String.fromCharCode(...new Uint8Array(wav, o, n));
+
+    expect(ascii(0, 4)).toBe("RIFF");
+    expect(ascii(8, 4)).toBe("WAVE");
+    expect(ascii(12, 4)).toBe("fmt ");
+    expect(view.getUint16(20, true)).toBe(1); // PCM
+    expect(view.getUint16(22, true)).toBe(channels);
+    expect(view.getUint32(24, true)).toBe(sampleRate);
+    expect(view.getUint16(34, true)).toBe(16); // bits/sample
+    expect(ascii(36, 4)).toBe("data");
+    expect(view.getUint32(40, true)).toBe(frames * channels * 2);
+    expect(wav.byteLength).toBe(44 + frames * channels * 2);
+  });
+
+  it("quantizes samples to 16-bit and recovers them within tolerance", () => {
+    const sampleRate = 44100;
+    const channels = 1;
+    const src = new Float32Array([0, 0.5, -0.5, 1, -1, 0.25]);
+    const wav = encodeWavInterleaved(src, channels, sampleRate);
+    const pcm = new Int16Array(wav, 44, src.length);
+    // Full-scale and zero are exact; mid values within one 16-bit step.
+    expect(pcm[0]).toBe(0);
+    expect(pcm[3]).toBe(0x7fff); // +1 → max positive
+    expect(pcm[4]).toBe(-0x8000); // -1 → min negative
+    for (let i = 0; i < src.length; i++) {
+      expect(Math.abs(pcm[i] / 0x8000 - src[i])).toBeLessThan(1 / 32767 + 1e-6);
+    }
+  });
+
+  it("survives a full clip round-trip: PCM → WAV → base64 → bytes", () => {
+    const interleaved = new Float32Array(2000);
+    for (let i = 0; i < interleaved.length; i++) {
+      interleaved[i] = Math.sin(i / 12) * 0.8;
+    }
+    const wav = encodeWavInterleaved(interleaved, 2, 48000);
+    const b64 = arrayBufferToBase64(wav);
+    const back = base64ToArrayBuffer(b64);
+    expect(bytesOf(back).length).toBe(bytesOf(wav).length);
+    expect(Array.from(bytesOf(back))).toEqual(Array.from(bytesOf(wav)));
+  });
+});

--- a/packages/demon-client/dist/demon-client.js
+++ b/packages/demon-client/dist/demon-client.js
@@ -445,6 +445,83 @@ function captureConfigFromState(snapshot, base) {
   );
 }
 
+// inputs.ts
+function writeAscii(view, offset, text) {
+  for (let i = 0; i < text.length; i++) {
+    view.setUint8(offset + i, text.charCodeAt(i));
+  }
+}
+function encodeWavInterleaved(interleaved, channels, sampleRate) {
+  const frames = Math.floor(interleaved.length / channels);
+  const bytesPerSample = 2;
+  const dataLen = frames * channels * bytesPerSample;
+  const out = new ArrayBuffer(44 + dataLen);
+  const view = new DataView(out);
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataLen, true);
+  writeAscii(view, 8, "WAVE");
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * channels * bytesPerSample, true);
+  view.setUint16(32, channels * bytesPerSample, true);
+  view.setUint16(34, 8 * bytesPerSample, true);
+  writeAscii(view, 36, "data");
+  view.setUint32(40, dataLen, true);
+  const pcm = new Int16Array(out, 44, frames * channels);
+  const n = frames * channels;
+  for (let i = 0; i < n; i++) {
+    const s = interleaved[i];
+    const c = s < -1 ? -1 : s > 1 ? 1 : s;
+    pcm[i] = c < 0 ? c * 32768 : c * 32767;
+  }
+  return out;
+}
+var B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+var B64_LOOKUP = (() => {
+  const t = new Int16Array(256).fill(-1);
+  for (let i = 0; i < B64.length; i++) t[B64.charCodeAt(i)] = i;
+  return t;
+})();
+function arrayBufferToBase64(buf) {
+  const bytes = new Uint8Array(buf);
+  const len = bytes.length;
+  let out = "";
+  let i = 0;
+  for (; i + 2 < len; i += 3) {
+    const n = bytes[i] << 16 | bytes[i + 1] << 8 | bytes[i + 2];
+    out += B64[n >> 18 & 63] + B64[n >> 12 & 63] + B64[n >> 6 & 63] + B64[n & 63];
+  }
+  const rem = len - i;
+  if (rem === 1) {
+    const n = bytes[i] << 16;
+    out += B64[n >> 18 & 63] + B64[n >> 12 & 63] + "==";
+  } else if (rem === 2) {
+    const n = bytes[i] << 16 | bytes[i + 1] << 8;
+    out += B64[n >> 18 & 63] + B64[n >> 12 & 63] + B64[n >> 6 & 63] + "=";
+  }
+  return out;
+}
+function base64ToArrayBuffer(b64) {
+  const bytes = new Uint8Array(Math.floor(b64.length * 3 / 4));
+  let bi = 0;
+  let acc = 0;
+  let accBits = 0;
+  for (let i = 0; i < b64.length; i++) {
+    const v = B64_LOOKUP[b64.charCodeAt(i)];
+    if (v < 0) continue;
+    acc = acc << 6 | v;
+    accBits += 6;
+    if (accBits >= 8) {
+      accBits -= 8;
+      bytes[bi++] = acc >> accBits & 255;
+    }
+  }
+  return bytes.buffer.slice(0, bi);
+}
+
 // node_modules/fzstd/esm/index.mjs
 var ab = ArrayBuffer;
 var u8 = Uint8Array;
@@ -3193,7 +3270,10 @@ export {
   VALID_TIME_SIGNATURES,
   WsReconnector,
   applyConfigToState,
+  arrayBufferToBase64,
+  base64ToArrayBuffer,
   captureConfigFromState,
+  encodeWavInterleaved,
   fetchKnobManifest,
   fetchWireContract,
   fetchWithRetry,

--- a/packages/demon-client/dist/demon-client.node.cjs
+++ b/packages/demon-client/dist/demon-client.node.cjs
@@ -38,7 +38,10 @@ __export(node_exports, {
   SLICE_HDR_SIZE: () => SLICE_HDR_SIZE,
   VALID_TIME_SIGNATURES: () => VALID_TIME_SIGNATURES,
   applyConfigToState: () => applyConfigToState,
+  arrayBufferToBase64: () => arrayBufferToBase64,
+  base64ToArrayBuffer: () => base64ToArrayBuffer,
   captureConfigFromState: () => captureConfigFromState,
+  encodeWavInterleaved: () => encodeWavInterleaved,
   float16ArrayToFloat32: () => float16ArrayToFloat32,
   getUnknownKeys: () => getUnknownKeys,
   isDcwMode: () => isDcwMode,
@@ -2165,6 +2168,83 @@ function captureConfigFromState(snapshot, base) {
     getUnknownKeys(base)
   );
 }
+
+// inputs.ts
+function writeAscii(view, offset, text) {
+  for (let i = 0; i < text.length; i++) {
+    view.setUint8(offset + i, text.charCodeAt(i));
+  }
+}
+function encodeWavInterleaved(interleaved, channels, sampleRate) {
+  const frames = Math.floor(interleaved.length / channels);
+  const bytesPerSample = 2;
+  const dataLen = frames * channels * bytesPerSample;
+  const out = new ArrayBuffer(44 + dataLen);
+  const view = new DataView(out);
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataLen, true);
+  writeAscii(view, 8, "WAVE");
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * channels * bytesPerSample, true);
+  view.setUint16(32, channels * bytesPerSample, true);
+  view.setUint16(34, 8 * bytesPerSample, true);
+  writeAscii(view, 36, "data");
+  view.setUint32(40, dataLen, true);
+  const pcm = new Int16Array(out, 44, frames * channels);
+  const n = frames * channels;
+  for (let i = 0; i < n; i++) {
+    const s = interleaved[i];
+    const c = s < -1 ? -1 : s > 1 ? 1 : s;
+    pcm[i] = c < 0 ? c * 32768 : c * 32767;
+  }
+  return out;
+}
+var B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+var B64_LOOKUP = (() => {
+  const t = new Int16Array(256).fill(-1);
+  for (let i = 0; i < B64.length; i++) t[B64.charCodeAt(i)] = i;
+  return t;
+})();
+function arrayBufferToBase64(buf) {
+  const bytes = new Uint8Array(buf);
+  const len = bytes.length;
+  let out = "";
+  let i = 0;
+  for (; i + 2 < len; i += 3) {
+    const n = bytes[i] << 16 | bytes[i + 1] << 8 | bytes[i + 2];
+    out += B64[n >> 18 & 63] + B64[n >> 12 & 63] + B64[n >> 6 & 63] + B64[n & 63];
+  }
+  const rem = len - i;
+  if (rem === 1) {
+    const n = bytes[i] << 16;
+    out += B64[n >> 18 & 63] + B64[n >> 12 & 63] + "==";
+  } else if (rem === 2) {
+    const n = bytes[i] << 16 | bytes[i + 1] << 8;
+    out += B64[n >> 18 & 63] + B64[n >> 12 & 63] + B64[n >> 6 & 63] + "=";
+  }
+  return out;
+}
+function base64ToArrayBuffer(b64) {
+  const bytes = new Uint8Array(Math.floor(b64.length * 3 / 4));
+  let bi = 0;
+  let acc = 0;
+  let accBits = 0;
+  for (let i = 0; i < b64.length; i++) {
+    const v = B64_LOOKUP[b64.charCodeAt(i)];
+    if (v < 0) continue;
+    acc = acc << 6 | v;
+    accBits += 6;
+    if (accBits >= 8) {
+      accBits -= 8;
+      bytes[bi++] = acc >> accBits & 255;
+    }
+  }
+  return bytes.buffer.slice(0, bi);
+}
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
   COMMAND_NAMES,
@@ -2186,7 +2266,10 @@ function captureConfigFromState(snapshot, base) {
   SLICE_HDR_SIZE,
   VALID_TIME_SIGNATURES,
   applyConfigToState,
+  arrayBufferToBase64,
+  base64ToArrayBuffer,
   captureConfigFromState,
+  encodeWavInterleaved,
   float16ArrayToFloat32,
   getUnknownKeys,
   isDcwMode,

--- a/packages/demon-client/index.ts
+++ b/packages/demon-client/index.ts
@@ -20,6 +20,11 @@ export * from "./types/protocol";
 // /api/knobs and /api/protocol contracts above. See ./config and README.
 export * from "./config";
 
+// Portable inputs codec: SerializedInput(s) shape + the shared WAV/base64
+// codec the DemonExport `inputs` field rides on (the store/DOM capture/apply
+// stays per-client). See ./inputs.
+export * from "./inputs";
+
 // WebSocket session client (binary slice stream, swap/stem state
 // machines, typed senders).
 export { RemoteBackend, float16ArrayToFloat32 } from "./protocol";

--- a/packages/demon-client/inputs.ts
+++ b/packages/demon-client/inputs.ts
@@ -1,0 +1,142 @@
+// Portable inputs codec — the `SerializedInput(s)` shape plus the pure
+// WAV + base64 codec the DemonExport `inputs` field rides on. Lifted out of
+// the web app's `inputBundle.ts` (which is store-/DOM-coupled) so every
+// client shares ONE codec: the web (browser), the M4L bridge (Node), and a
+// future C++/VST consumer must all produce byte-identical `wavBase64`.
+//
+// Dependency-free and environment-neutral on PURPOSE: no `btoa`/`atob`
+// (browser globals) and no `Buffer` (Node) — base64 is hand-rolled over a
+// `Uint8Array` so the same bytes come out everywhere. The store/DOM wiring
+// that CAPTURES and APPLIES inputs (AudioContext decode, zustand reads)
+// stays per-client; only the wire shape + codec are shared here.
+
+/** Which stem of a clip source the server should use. */
+export type StemSourceMode = "full" | "vocals" | "instruments";
+
+/** One serialized input. `fixture` is a library track the server can load
+ *  by name (no audio on the wire). `clip` embeds the trimmed PCM as a base64
+ *  WAV so an upload survives the round-trip even on a machine that never had
+ *  the original file. */
+export type SerializedInput =
+  | { kind: "fixture"; name: string }
+  | {
+      kind: "clip";
+      name: string;
+      sourceMode?: StemSourceMode;
+      /** 16-bit PCM WAV, base64-encoded. Sample rate + channel count ride in
+       *  the WAV header, so decode re-derives them. */
+      wavBase64: string;
+    };
+
+/** The three inputs as captured for export. A field is null when that input
+ *  axis simply has nothing active. */
+export interface SerializedInputs {
+  track?: SerializedInput | null;
+  timbre?: SerializedInput | null;
+  structure?: SerializedInput | null;
+}
+
+// ── WAV codec ──────────────────────────────────────────────────────────
+
+function writeAscii(view: DataView, offset: number, text: string): void {
+  for (let i = 0; i < text.length; i++) {
+    view.setUint8(offset + i, text.charCodeAt(i));
+  }
+}
+
+/** Encode already-interleaved float32 PCM as a 16-bit WAV ArrayBuffer. The
+ *  source is the interleaved Float32Array a decoded fixture already holds,
+ *  so there is no channel de-interleave step. */
+export function encodeWavInterleaved(
+  interleaved: Float32Array,
+  channels: number,
+  sampleRate: number,
+): ArrayBuffer {
+  const frames = Math.floor(interleaved.length / channels);
+  const bytesPerSample = 2;
+  const dataLen = frames * channels * bytesPerSample;
+  const out = new ArrayBuffer(44 + dataLen);
+  const view = new DataView(out);
+
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataLen, true);
+  writeAscii(view, 8, "WAVE");
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true); // PCM
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * channels * bytesPerSample, true);
+  view.setUint16(32, channels * bytesPerSample, true);
+  view.setUint16(34, 8 * bytesPerSample, true);
+  writeAscii(view, 36, "data");
+  view.setUint32(40, dataLen, true);
+
+  const pcm = new Int16Array(out, 44, frames * channels);
+  const n = frames * channels;
+  for (let i = 0; i < n; i++) {
+    const s = interleaved[i];
+    const c = s < -1 ? -1 : s > 1 ? 1 : s;
+    // Asymmetric scaling keeps the full negative range without wrapping.
+    pcm[i] = c < 0 ? c * 0x8000 : c * 0x7fff;
+  }
+  return out;
+}
+
+// ── base64 (environment-neutral) ───────────────────────────────────────
+// Standard RFC 4648 base64 (alphabet `A–Za–z0–9+/`, `=` padding) — the same
+// output `btoa`/`Buffer.toString("base64")` produce, so a clip encoded in
+// any client decodes identically in every other.
+
+const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const B64_LOOKUP = (() => {
+  const t = new Int16Array(256).fill(-1);
+  for (let i = 0; i < B64.length; i++) t[B64.charCodeAt(i)] = i;
+  return t;
+})();
+
+export function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  const len = bytes.length;
+  let out = "";
+  let i = 0;
+  for (; i + 2 < len; i += 3) {
+    const n = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+    out +=
+      B64[(n >> 18) & 63] +
+      B64[(n >> 12) & 63] +
+      B64[(n >> 6) & 63] +
+      B64[n & 63];
+  }
+  const rem = len - i;
+  if (rem === 1) {
+    const n = bytes[i] << 16;
+    out += B64[(n >> 18) & 63] + B64[(n >> 12) & 63] + "==";
+  } else if (rem === 2) {
+    const n = (bytes[i] << 16) | (bytes[i + 1] << 8);
+    out += B64[(n >> 18) & 63] + B64[(n >> 12) & 63] + B64[(n >> 6) & 63] + "=";
+  }
+  return out;
+}
+
+export function base64ToArrayBuffer(b64: string): ArrayBuffer {
+  // Decode 6 bits at a time, flushing a byte every 8. Padding (`=`) and any
+  // stray bytes (whitespace, newlines) map to -1 in the lookup and are
+  // skipped, the way the browser's atob tolerates our own well-formed
+  // payloads. `bi` is therefore the exact decoded length.
+  const bytes = new Uint8Array(Math.floor((b64.length * 3) / 4));
+  let bi = 0;
+  let acc = 0;
+  let accBits = 0;
+  for (let i = 0; i < b64.length; i++) {
+    const v = B64_LOOKUP[b64.charCodeAt(i)];
+    if (v < 0) continue;
+    acc = (acc << 6) | v;
+    accBits += 6;
+    if (accBits >= 8) {
+      accBits -= 8;
+      bytes[bi++] = (acc >> accBits) & 0xff;
+    }
+  }
+  return bytes.buffer.slice(0, bi);
+}

--- a/packages/demon-client/node.ts
+++ b/packages/demon-client/node.ts
@@ -63,3 +63,14 @@ export type {
   ConfigStateSnapshot,
   ConfigApplyPatch,
 } from "./config/wire";
+
+// Portable inputs codec — the SerializedInput(s) shape + the dependency-free
+// WAV/base64 codec the DemonExport `inputs` field rides on. Environment-
+// neutral (no btoa/atob/Buffer) so the bridge produces byte-identical
+// `wavBase64` to the web. The capture/apply (audio decode) stays per-client.
+export {
+  encodeWavInterleaved,
+  arrayBufferToBase64,
+  base64ToArrayBuffer,
+} from "./inputs";
+export type { StemSourceMode, SerializedInput, SerializedInputs } from "./inputs";


### PR DESCRIPTION
The `SerializedInput(s)` shape and the WAV + base64 codec the `DemonExport.inputs` field rides on lived only in the web app's store-/DOM-coupled `inputBundle.ts`, so the M4L bridge and the VST had no shared way to produce byte-identical `wavBase64`. Lift the pure pieces into a new dependency-free `@demon/client` module (`packages/demon-client/inputs.ts`):

- `SerializedInput` / `SerializedInputs` / `StemSourceMode` types
- `encodeWavInterleaved` (interleaved Float32 → 16-bit PCM WAV)
- `arrayBufferToBase64` / `base64ToArrayBuffer`

base64 is hand-rolled over a `Uint8Array` (no `btoa`/`atob`, no `Buffer`) so it is **environment-neutral**: browser, Node bridge, and a future C++/VST consumer all emit identical bytes. Re-exported from `index.ts` and `node.ts`; the web's `inputBundle.ts` now imports the codec + types (re-exporting the types so its consumers are unchanged). The store/DOM capture/apply stays web-side.

**Tests:** new `web/tests/unit/inputsCodec.test.ts` (6) — base64 matches Node `Buffer` (RFC 4648 oracle), round-trips every residue class, decodes Buffer-produced strings, WAV header + 16-bit quantization + full clip round-trip. Web unit suite **58/58 green**; `tsc --noEmit` clean; verified the rebuilt Node bundle exports the codec with no `btoa`/`atob`.

Stacked on #272. Shared prerequisite for the `inputs.{timbre,structure}` round-trip in the M4L (Plan 05 Phase 2) and VST (Plan 06) preset work.