### PR TITLE
docs: overhaul README with hero, badges, and paper/demo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,68 @@
 # DEMON
 
-**Diffusion Engine for Musical Orchestrated Noise**
+<p align="center"><strong>StreamDiffusion, for audio.</strong></p>
+<p align="center"><sub>Diffusion Engine for Musical Orchestrated Noise</sub></p>
 
-DEMON is a streaming diffusion engine for ACE-Step v1.5. Think StreamDiffusion, for audio: a ring buffer holds several in-flight generations at different denoising stages, advanced together per tick. After warmup, finished latents stream out at a steady rate of `depth/steps` generations per tick. End-to-end TensorRT keeps the tick tight; per-frame modulation knobs accept scalars or `[T]` curves and are hot-mutable mid-stream; ring buffer depth itself is hot-resizable. Streaming output is bit-identical to batch.
+<p align="center">
+  <a href="LICENSE"><img alt="License: AGPL-3.0-or-later + MIT" src="https://img.shields.io/badge/license-AGPL--3.0--or--later%20%2B%20MIT-blue.svg"></a>
+  <img alt="Python 3.11" src="https://img.shields.io/badge/python-3.11-blue.svg">
+  <a href="https://huggingface.co/ACE-Step/Ace-Step1.5"><img alt="Built on ACE-Step v1.5" src="https://img.shields.io/badge/built%20on-ACE--Step%20v1.5-yellow.svg"></a>
+</p>
+
+<p align="center">
+  <a href="https://arxiv.org/abs/2605.28657"><img alt="DEMON paper on arXiv" src="https://img.shields.io/badge/Read%20the%20paper-arXiv%3A2605.28657-b31b1b.svg"></a>
+  <a href="https://music.daydream.live"><img alt="Try the hosted instance" src="https://img.shields.io/badge/Try%20hosted%20instance-music.daydream.live-ff7a00.svg"></a>
+</p>
+
+<p align="center">
+  <img src="docs/assets/img/poster-hero.jpg" width="820" alt="The DEMON web demo: a live control drawer with automation curves and audio-reactive WebGL visuals reacting to generated music">
+</p>
+<p align="center"><sub><em>The DEMON realtime web demo — live control drawer, automation curves, and audio-reactive visuals.</em></sub></p>
+
+DEMON is **StreamDiffusion, for audio** — a GPU-accelerated streaming diffusion engine that generates and transforms music in real time, built on [ACE-Step v1.5](https://huggingface.co/ACE-Step/Ace-Step1.5). It streams continuous, low-latency audio you can steer live: every modulation parameter is a per-frame knob you can sweep while the model plays, and the streaming output is bit-identical to a batch run.
 
 > Don't have a GPU, or just want to play first? Try the hosted instance at **[music.daydream.live](https://music.daydream.live)**.
 
+## Contents
+
+- [What DEMON is](#what-demon-is)
+- [Quickstart](#quickstart)
+- [Features](#features)
+- [Performance](#performance)
+- [Tuning](#tuning)
+- [Acceleration backends](#acceleration-backends)
+- [Programmatic use: the Session API](#programmatic-use-the-session-api)
+- [Building TensorRT engines](#building-tensorrt-engines)
+- [Demo applications](#demo-applications)
+- [Engine internals](#engine-internals)
+- [How DEMON compares](#how-demon-compares)
+- [Research & citation](#research--citation)
+- [Contributing](#contributing)
+- [Acknowledgments](#acknowledgments)
+- [Authors](#authors)
+- [License](#license)
+
+## What DEMON is
+
+DEMON is a streaming diffusion engine for ACE-Step v1.5. Think StreamDiffusion, for audio: a ring buffer holds several in-flight generations at different denoising stages, advanced together per tick. After warmup, finished latents stream out at a steady rate of `depth/steps` generations per tick. End-to-end TensorRT keeps the tick tight; per-frame modulation knobs accept scalars or `[T]` curves and are hot-mutable mid-stream; ring buffer depth itself is hot-resizable. Streaming output is bit-identical to batch.
+
+**Who it's for:**
+
+- **Live performers and VJs** driving audio from MIDI and automation curves in real time.
+- **Researchers** extending the typed node graph or studying ACE-Step v1.5 internals.
+- **App and plugin developers** building on a small, stable programmatic Session API.
+- **ML engineers** who want TensorRT-accelerated streaming audio that stays bit-identical to batch.
+
+The engine lives in [`acestep/`](acestep/). One process loads the model once and exposes two things:
+
+1. A programmatic **Session API** ([`acestep/engine/session.py`](acestep/engine/session.py)) that wraps the streaming pipeline, the typed node graph, and the TRT runtime in a small set of methods (`prepare_source`, `encode_text`, `generate`, `decode`, `stream`, `apply_lora`).
+2. A **typed node graph** ([`acestep/nodes/`](acestep/nodes/)) of 32 composable operations (latent / audio / conditioning / curve / mask / solver / config / DCW / channel guidance) wired through `NodeDefinition` / `NodePort` / `NodeParam`, with kwarg-validation at registration.
+
+Anything on top — a CLI, a notebook, a VST, the bundled web demo, an MCP tool, or your own protocol — drives the same primitives. The library does not know or care which one you use.
+
 ## Quickstart
 
-You need: an NVIDIA GPU (tested on RTX 3090 / 4090 / 5090), [uv](https://docs.astral.sh/uv/), Node.js 20+ (web demo only), and about 40 GB of free disk.
+**You need:** an NVIDIA GPU (tested on RTX 3090 / 4090 / 5090; the demo fits on a 24 GB card), [uv](https://docs.astral.sh/uv/), Node.js 20+ (web demo only), and about 40 GB of free disk. Python 3.11 is installed for you by `uv sync`.
 
 ```bash
 git clone https://github.com/daydreamlive/DEMON.git
@@ -17,7 +71,7 @@ uv sync
 uv run demon-setup
 ```
 
-`demon-setup` checks your environment, downloads the ACE-Step v1.5 checkpoints (~18 GB from [`ACE-Step/Ace-Step1.5`](https://huggingface.co/ACE-Step/Ace-Step1.5) on Hugging Face, with a ModelScope fallback) plus a starter pack of genre LoRAs, and builds the minimal TensorRT engine set (the 60 s profile: decoder + VAE encode/decode, plus the fixed 1 s windowed VAE decode — a few minutes on a recent GPU since the ONNX comes prebuilt; older cards can take longer). It is idempotent: re-run it any time, finished work is skipped.
+`demon-setup` checks your environment, downloads the ACE-Step v1.5 checkpoints (~18 GB from [`ACE-Step/Ace-Step1.5`](https://huggingface.co/ACE-Step/Ace-Step1.5) on Hugging Face, with a ModelScope fallback) plus a starter pack of genre LoRAs, and builds the minimal TensorRT engine set (the 60 s profile: decoder + VAE encode/decode, plus the fixed 1 s windowed VAE decode — a few minutes on a recent GPU since the ONNX comes prebuilt; older cards can take longer). It is idempotent: re-run it any time, finished work is skipped. (A first run is dominated by the ~18 GB checkpoint download plus the engine build; later runs skip straight to launch.)
 
 Then launch the web demo:
 
@@ -26,62 +80,27 @@ uv run python -u -m demos.realtime_motion_graph_web.run
 # open http://localhost:6660
 ```
 
-Once a session is playing, the spectral-control sliders live in the control drawer's **Experimental** tab. They steer generation itself, so changes land on the upcoming audio after a moment - sweep slowly and listen.
+**What you'll see and hear.** The page loads with a default fixture already selected. Click **Play** — browsers gate audio behind a click, so this also unlocks sound. The first start takes ~15 s while the model and TensorRT engines load (longer under `--accel compile`); then the HUD goes live and audio streams continuously. Once a session is playing, the spectral-control sliders live in the control drawer's **Experimental** tab — they steer generation itself, so changes land on the upcoming audio after a moment; sweep slowly and listen.
 
-**Where things live.** Everything downloads to `~/.daydream-scope/models/demon/` (override with the `ACESTEP_MODELS_DIR` environment variable), *not* into the repository: checkpoints under `<models dir>/checkpoints/`, TensorRT engines under `<models dir>/trt_engines/`. The models must be the ACE-Step v1.5 weights fetched by `demon-setup` (equivalently: `uv run acestep-download`) — do not substitute other checkpoints or paths.
+> **The bare launch command runs all-TensorRT by default**, which needs the engines `demon-setup` just built. If they are missing, the server exits at boot and prints the exact fix. If you ran `demon-setup --skip-engines`, you **must** launch with `-- --accel compile` (no engines needed; expect a long `torch.compile` warmup on the first tick).
 
-Don't want to build TensorRT engines yet? Run `uv run demon-setup --skip-engines`, then launch with `-- --accel compile` (no engines needed; expect a long `torch.compile` warmup on the first tick).
+**Where things live.** Everything downloads to `~/.daydream-scope/models/demon/` (override with the `ACESTEP_MODELS_DIR` environment variable), *not* into the repository: checkpoints under `<models dir>/checkpoints/`, TensorRT engines under `<models dir>/trt_engines/`. The models must be the ACE-Step v1.5 weights fetched by `demon-setup` (equivalently `uv run acestep-download`) — do not substitute other checkpoints or paths. Full directory tree, manual download, engine-build options, headless/pod notes, and a troubleshooting table are in [docs/INSTALL.md](docs/INSTALL.md).
 
-Full walkthrough — manual model download, engine build options, headless/pod notes, troubleshooting — in [docs/INSTALL.md](docs/INSTALL.md).
+**Audio fixtures** pull on first use from the [`daydreamlive/demon-fixtures-v2`](https://huggingface.co/datasets/daydreamlive/demon-fixtures-v2) Hugging Face dataset (the older `daydreamlive/demon-fixtures` is kept as a fallback) and materialize under `<models dir>/fixtures/`. See [`acestep/fixtures.py`](acestep/fixtures.py) for the canonical set.
 
-## What DEMON is
+**Starter LoRAs.** `demon-setup` downloads a starter pack of 16 genre LoRAs (jazz, phonk, lo-fi, punk, acoustic, ambient, and deep house in 2B and XL variants, plus funk and deathstep; skip with `--skip-loras`). To add your own, drop a `.safetensors` file (optionally with a `<stem>.metadata.json` sidecar) anywhere under `$ACESTEP_MODELS_DIR/loras/` (defaults to `~/.daydream-scope/models/demon/loras/`) and it will appear in any consumer that scans the library on next refresh. See [`acestep/paths.py`](acestep/paths.py) and [`acestep/lora_metadata.py`](acestep/lora_metadata.py).
 
-The engine lives in [`acestep/`](acestep/). One process loads the model once and exposes two things:
+## Features
 
-1. A programmatic **Session API** ([`acestep/engine/session.py`](acestep/engine/session.py)) that wraps the streaming pipeline, the typed node graph, and the TRT runtime in a small set of methods (`prepare_source`, `encode_text`, `generate`, `decode`, `stream`, `apply_lora`).
-2. A **typed node graph** ([`acestep/nodes/`](acestep/nodes/)) of 32 composable operations (latent / audio / conditioning / curve / mask / solver / config / DCW / channel guidance) wired through `NodeDefinition` / `NodePort` / `NodeParam`, with kwarg-validation at registration.
+- **Streaming diffusion for ACE-Step v1.5** — a ring buffer of in-flight generations advanced one denoise step per tick; throughput is `depth/steps` finished generations per tick, and depth is hot-resizable mid-stream.
+- **End-to-end TensorRT** — the DiT decoder and VAE encode/decode all run through TRT, and the decoder is refit-enabled so LoRA swaps never rebuild an engine.
+- **Per-frame steering** — velocity, guidance, noise injection, x0 targets, and more each accept a scalar *or* a `[T]` curve, all hot-mutable mid-stream.
+- **Heterogeneous slots** — mix a full regeneration, a style transfer, and an RCFG request in a single batched forward pass.
+- **Typed 32-node graph + Session API** — compose latent / audio / conditioning / curve / mask / solver operations, and drive them from Python, a notebook, a VST, the web demo, or an MCP client.
+- **Onboard MCP server** — every user-facing action in the web demo is exposed as an MCP tool, so an agent can drive a live session.
+- **Bit-identical streaming vs. batch** — the streaming and one-shot paths compose the same pure step primitives and produce the same output.
 
-Anything on top, a CLI, a notebook, a VST, the bundled web demo, an MCP tool, or your own protocol, drives the same primitives. The library does not know or care which one you use.
-
-## What the engine does
-
-- **Streaming diffusion for ACE-Step v1.5.** `StreamPipeline` ([`acestep/engine/stream.py`](acestep/engine/stream.py)) maintains a ring buffer of in-flight generations. Each tick runs a batched decoder forward pass (two when CFG is active: positive + negative) that advances every active slot by one denoising step. The decoder dispatches to TensorRT or PyTorch through the same code path. Depth is hot-resizable mid-stream (`pipeline.set_depth(n)`); active slots drain naturally.
-- **Heterogeneous slots.** Every in-flight slot carries its own `SlotRequest`: its own seed, its own `denoise` strength (with its own cached timestep schedule), its own source latent, its own per-frame curves, its own conditioning (one or more `SlotCondition`s with per-frame `temporal_weight` and per-condition `step_range`), its own CFG mode, its own x0 target, and its own latent-noise mask. A single ring buffer can mix a `denoise=1.0` regeneration, a `denoise=0.5` style transfer, and an RCFG-`self` request simultaneously and batch them in one forward pass.
-- **Scalar-or-curve per-frame modulation.** Velocity scale, SDE re-noise, ODE noise injection, guidance scale, x0 target strength, x0 target curve, initial noise mix, APG momentum, CFG rescale, DCW scalers, and condition temporal weights all accept either a Python scalar or a `[T]` tensor, canonicalized through `normalize_curve` at the boundary so the kernels see one shape.
-- **Channel guidance.** A `[1, T, 64]` per-channel gain applied to `xt` before each forward pass. Lives in its own surface (set via `pipeline.set_channel_gain_tensor(...)`) because its per-channel-and-per-frame shape doesn't fit the `[T]`-curve pattern.
-- **Shared mutable curves.** Layered on top of the heterogeneous slots: `pipeline.set_shared_curve(name, value)` overrides one of the curve-shaped fields (`velocity_scale`, `sde_denoise_curve`, `ode_noise_curve`, `apg_momentum`, `x0_target_strength`, `cfg_rescale_curve`) for the next tick on every in-flight slot at once. The override takes effect immediately rather than waiting for new submissions to make their way through the pipeline. Pass `None` to revert that name to per-slot behavior.
-- **Multi-condition compositing.** Within a single slot, the decoder runs once per active condition and velocities are blended per frame by `temporal_weight`; conditions are gated in and out of the schedule by `step_range`. `ConditioningBlend` (scalar alpha) and `ConditioningCombine` (per-frame temporal weights) are the typed entry points.
-- **Three CFG modes.** Standard CFG (uncond forward every step), RCFG-`initialize` (one uncond forward per slot, cached for the rest of the schedule), and RCFG-`self` (zero uncond forwards: the slot's initial noise stands in as the virtual uncond velocity). All three layer APG momentum and an optional per-frame CFG rescale curve on top.
-- **Latent-noise-mask inpainting.** Two-sided x0 blending matching ComfyUI semantics: pre-blend on `xt` (so the decoder sees correctly-noised context in preserved regions) and post-blend on the predicted `x0`. Supports a per-step strength function for progressive masking.
-- **DCW post-step correction.** Wavelet-domain sampler-side correction from Yu et al. CVPR 2026, ported from upstream ACE-Step v0.1.7. Four modes (low / high / double / pix), with an optional advanced surface (`mult_blend`, `mag_phase`, `soft_thresh`) that at zero is byte-identical to the upstream reference. Hot-updatable via `pipeline.set_dcw(...)`.
-- **Hot LoRA.** Register a directory once, then enable / set_strength / remove without rebuilding anything. The LoRA manager ([`acestep/engine/lora.py`](acestep/engine/lora.py)) handles the lifecycle and delta math; when the decoder is in TRT mode, applies route through a refitter against the live engine.
-- **TRT acceleration end-to-end.** The DiT decoder, VAE encode, and VAE decode each pick `tensorrt | compile | eager` independently. The TRT decoder is refit-enabled, so LoRA swaps do not rebuild the engine. The VAE decode has a windowed variant (`vae_decode_fp16_1s_fixed`, a fixed 1 s profile) that is built once and reused across all durations; the caller specifies the window start via `t_start`.
-- **Bit-identical streaming vs. batch.** The streaming and one-shot paths compose the same pure step primitives from [`acestep/engine/ode_steps.py`](acestep/engine/ode_steps.py); they produce the same output.
-
-## Tested on
-
-NVIDIA RTX 3090, 4090, and 5090. The headline numbers below are from a 5090.
-
-## Tuning: ring buffer depth, song duration, VAE windowing
-
-Three knobs trade off against each other. Picking the right point on the curve is what makes DEMON run well on a given card.
-
-**Ring buffer depth (`pipeline_depth`, 1 to 8).** The pipeline keeps `depth` in-flight generations at different denoise stages, advanced together each tick. After warmup, throughput is `depth/steps` finished generations per tick.
-
-- Higher depth: parameter sweeps glide more smoothly (more slots in different denoise phases, so a curve change blends through finer intermediate states), at the cost of more per-tick batch compute and higher VRAM.
-- Lower depth: knob changes feel snappier and more discrete (fewer slots between a parameter override and the next finished latent), with lower per-tick VRAM and compute.
-
-**Song duration.** TRT engines are profile-specific. Each engine reserves workspace sized to its profile, so a 240 s engine costs more VRAM than a 60 s engine even when the workload is only 60 seconds. Per-engine peak workspace, each measured in isolation on a 5090:
-
-| Component       | 60s engine | 240s engine |          Δ |
-|-----------------|-----------:|------------:|-----------:|
-| Decoder (refit) |  13,511 MB |   15,911 MB |  +2,400 MB |
-| VAE decode      |  10,547 MB |   10,814 MB |    +267 MB |
-| VAE encode      |   4,178 MB |   10,614 MB |  +6,436 MB |
-
-These are per-engine peaks captured in separate subprocesses, not a live-runtime sum. At inference time the decoder peak dominates and the VAE workspaces do not peak alongside it, which is why the live demo fits on a 24 GB card. The comparison is what matters: switching three engines from 240 s to 60 s frees about 9 GB. Source: [`scripts/benchmarks/vram_60s_vs_240s_results.md`](scripts/benchmarks/vram_60s_vs_240s_results.md). Longer engines also pay more per-tick latency since the diffusion sequence length scales with duration. Build only the durations you need.
-
-**VAE windowing.** Optional, and the demo's default. When `vae_window > 0`, every streaming decode runs through the fixed 1 s windowed engine: 25 latent frames go in, the middle `vae_window` seconds (keep range 0.04 to 0.36 s) come out, and the surrounding frames are receptive-field margin that gets trimmed. Only the requested window is decoded per call rather than the full latent — this is what unlocks low-latency streaming updates. Set to 0 to fall back to full-length decode through the `vae_decode` engine for the duration.
+See [Engine internals](#engine-internals) for the full mechanism behind each of these.
 
 ## Performance
 
@@ -95,6 +114,31 @@ RTX 5090, ACE-Step v1.5 turbo (2B), all-TRT, `depth=4`, `steps=8`, `vae_window=3
 | Parameter convergence | ~248 ms |
 | Per-frame control resolution | 25 Hz (40 ms latent steps) |
 | Streaming vs. batch quality | bit-identical output |
+
+Tested on NVIDIA RTX 3090, 4090, and 5090. The demo fits comfortably on a 24 GB card such as an RTX 4090 (see the VRAM breakdown under [Tuning](#tuning)).
+
+## Tuning
+
+Three knobs trade off against each other. Picking the right point on the curve is what makes DEMON run well on a given card.
+
+- **Ring buffer depth (`pipeline_depth`, 1 to 8).** The pipeline keeps `depth` in-flight generations at different denoise stages, advanced together each tick. Higher depth makes parameter sweeps glide more smoothly (more slots in different denoise phases, so a curve change blends through finer intermediate states) at the cost of more per-tick batch compute and higher VRAM; lower depth feels snappier and more discrete, with lower per-tick VRAM and compute.
+- **Song duration.** TRT engines are profile-specific, and each reserves workspace sized to its profile — so a 240 s engine costs more VRAM and more per-tick latency than a 60 s engine even when the workload is only 60 seconds. Build only the durations you need (see the VRAM breakdown below).
+- **VAE windowing.** Optional, and the demo's default. When `vae_window > 0`, every streaming decode runs through the fixed 1 s windowed engine: 25 latent frames go in, the middle `vae_window` seconds (keep range 0.04 to 0.36 s) come out, and the surrounding frames are receptive-field margin that gets trimmed. Only the requested window is decoded per call rather than the full latent — this is what unlocks low-latency streaming updates. Set to 0 to fall back to full-length decode through the `vae_decode` engine.
+
+<details>
+<summary><strong>Per-engine VRAM: 60 s vs 240 s profiles (5090)</strong></summary>
+
+Each engine reserves workspace sized to its profile, so a 240 s engine costs more VRAM than a 60 s engine even when the workload is only 60 seconds. Per-engine peak workspace, each measured in isolation on a 5090:
+
+| Component       | 60s engine | 240s engine |          Δ |
+|-----------------|-----------:|------------:|-----------:|
+| Decoder (refit) |  13,511 MB |   15,911 MB |  +2,400 MB |
+| VAE decode      |  10,547 MB |   10,814 MB |    +267 MB |
+| VAE encode      |   4,178 MB |   10,614 MB |  +6,436 MB |
+
+These are per-engine peaks captured in separate subprocesses, not a live-runtime sum. At inference time the decoder peak dominates and the VAE workspaces do not peak alongside it, which is why the live demo fits on a 24 GB card. The comparison is what matters: switching three engines from 240 s to 60 s frees about 9 GB. Source: [`scripts/benchmarks/vram_60s_vs_240s_results.md`](scripts/benchmarks/vram_60s_vs_240s_results.md). Longer engines also pay more per-tick latency since the diffusion sequence length scales with duration.
+
+</details>
 
 ## Acceleration backends
 
@@ -121,21 +165,6 @@ uv run python -u -m demos.realtime_motion_graph_web.run -- \
 ```
 
 **Recommended baseline: TRT windowed VAE decoder at minimum.** It is the cheapest TRT engine to build, it is checkpoint- and duration-agnostic, and it unlocks the low-latency streaming path. Pair it with `--decoder-accel compile` if you do not want to build the decoder engine yet.
-
-## Requirements
-
-- Python 3.11 (managed by `uv sync`)
-- NVIDIA GPU. Tested on RTX 3090, 4090, and 5090.
-- ACE-Step v1.5 checkpoints in `~/.daydream-scope/models/demon/checkpoints/` — downloaded by `demon-setup` (see [Quickstart](#quickstart)), or automatically on first model load
-- Node.js 20+ (only if you run the bundled web demo; first run installs `web/node_modules` automatically)
-
-## Setup
-
-See the [Quickstart](#quickstart) above — `uv sync` then `uv run demon-setup` — or [docs/INSTALL.md](docs/INSTALL.md) for the step-by-step version.
-
-Audio fixtures pull on first use from the [`daydreamlive/demon-fixtures`](https://huggingface.co/datasets/daydreamlive/demon-fixtures) Hugging Face dataset and cache under `~/.cache/huggingface/`. See [`acestep/fixtures.py`](acestep/fixtures.py) for the canonical set.
-
-`demon-setup` downloads a starter pack of 16 genre LoRAs (jazz, phonk, lo-fi, punk, acoustic, ambient, deep house, funk, deathstep — 2B and XL variants; skip with `--skip-loras`). To add your own, drop a `.safetensors` file (optionally with a `<stem>.metadata.json` sidecar) anywhere under `$ACESTEP_MODELS_DIR/loras/` (defaults to `~/.daydream-scope/models/demon/loras/`) and it will appear in any consumer that scans the library on next refresh. See [`acestep/paths.py`](acestep/paths.py) and [`acestep/lora_metadata.py`](acestep/lora_metadata.py).
 
 ## Programmatic use: the Session API
 
@@ -195,6 +224,9 @@ Quick-start scripts:
 - [`examples/realtime_cover.py`](examples/realtime_cover.py): a full real-time cover workflow with dual prompts, dual LoRAs, timbre / hint references, temporal masking, and engine-exclusive per-frame curves.
 - [`examples/covers/`](examples/covers/): one standalone script per feature.
 
+<details>
+<summary><strong>All per-feature example scripts</strong></summary>
+
 | Script | Feature |
 |---|---|
 | `cover_basic.py` | Standard cover pipeline (encode, condition, generate, decode) |
@@ -211,9 +243,20 @@ Quick-start scripts:
 | `cover_semantic_blend.py` | Blend semantic hints from two sources |
 | `x0_target_from_reference.py` | Pre-generate a target latent, morph toward it |
 
+</details>
+
 ## Building TensorRT engines
 
-DEMON targets TensorRT 10.16.x. Plans are version- and GPU-architecture-specific by default, so rebuild after changing TensorRT, CUDA, driver, or the GPU used for inference.
+DEMON targets TensorRT 10.16.x. Plans are version- and GPU-architecture-specific by default, so rebuild after changing TensorRT, CUDA, driver, or the GPU used for inference. The minimal set for the realtime web demo (what `demon-setup` builds) is the 60 s profile (decoder + VAE encode/decode) plus the fixed 1 s windowed VAE decode:
+
+```bash
+uv run python -m acestep.engine.trt.build --preset minimal
+```
+
+ONNX intermediates are duration-agnostic and auto-reused across builds; the model is only loaded when an export is actually needed. For the full build matrix, precision recipes, the XL/FP8 path, and engine naming, see [docs/TRT.md](docs/TRT.md).
+
+<details>
+<summary><strong>All build commands &amp; on-disk engine layout</strong></summary>
 
 ```bash
 # Minimal set for the realtime web demo (what `demon-setup` builds):
@@ -238,8 +281,6 @@ uv run python -m acestep.engine.trt.build --all --force-rebuild
 # Force ONNX re-export as well.
 uv run python -m acestep.engine.trt.build --all --duration 60 --force-rebuild --force-onnx
 ```
-
-ONNX intermediates are duration-agnostic and auto-reused across builds; the model is only loaded when an export is actually needed.
 
 ```
 ~/.daydream-scope/models/demon/trt_engines/
@@ -271,6 +312,8 @@ session = Session(
 )
 ```
 
+</details>
+
 ## Demo applications
 
 The engine is meant to be driven. The repository ships a flagship reference application plus a handful of focused entry points.
@@ -284,28 +327,23 @@ uv run python -u -m demos.realtime_motion_graph_web.run
 # then open http://localhost:6660
 ```
 
-The launcher starts the backend on `:1318` and the Next.js dev server on `:6660`. Forward backend flags after `--`:
+The launcher starts the backend on `:1318` and the Next.js dev server on `:6660`. First run installs the web app and shared SDK (`packages/demon-client`) `node_modules` automatically. Forward backend flags after `--`:
 
 ```bash
 uv run python -u -m demos.realtime_motion_graph_web.run -- --accel tensorrt
 uv run python -u -m demos.realtime_motion_graph_web.run -- --checkpoint xl
 ```
 
-External static demo repos can be mounted at runtime with `--demo <path>`.
-DEMON serves them as already-built static files and prints their direct
-URLs at startup:
+External static demo repos can be mounted at runtime with `--demo <path>`. DEMON serves them as already-built static files and prints their direct URLs at startup:
 
 ```bash
 uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\path\to\demo
 ```
 
-Those repos own any browser/CDN/build dependencies; DEMON only provides
-static hosting plus the shared browser SDK at `/sdk/demon-client.js`.
-For a concrete no-build example, see the external
-`demon-summon-frontend` demo:
+Those repos own any browser/CDN/build dependencies; DEMON only provides static hosting plus the shared browser SDK at `/sdk/demon-client.js`. For a concrete no-build example, point `--demo` at the external `demon-summon-frontend` demo:
 
 ```bash
-uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\_dev\projects\demos\demon-summon-frontend
+uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\path\to\demon-summon-frontend
 ```
 
 Highlights:
@@ -321,7 +359,11 @@ Highlights:
 - **Config import / export.** Snapshot full live session state (knobs, prompts, LoRAs, curves) to JSON.
 - **Onboard MCP server.** Every user-facing action exposed as an MCP tool. Drive the demo from Claude Code or any MCP client.
 
-All defaults (knob positions, MIDI map seed, walk-window behavior, idle reset, LUFS matcher, audio-reactive shader params, XL-checkpoint overrides) live in [`demos/realtime_motion_graph_web/web/public/config.json`](demos/realtime_motion_graph_web/web/public/config.json). Edit, refresh, done.
+<p align="center">
+  <img src="docs/assets/img/poster-mcp-agent.jpg" width="720" alt="An AI agent driving a live DEMON session through the onboard MCP server">
+</p>
+
+All defaults (knob positions, walk-window behavior, idle reset, LUFS matcher, audio-reactive shader params, XL-checkpoint overrides) live in [`demos/realtime_motion_graph_web/web/public/config.json`](demos/realtime_motion_graph_web/web/public/config.json). Edit, refresh, done.
 
 See [`demos/realtime_motion_graph_web/README.md`](demos/realtime_motion_graph_web/README.md) for backend args, wire protocol, onboard MCP setup, and the front-end architecture.
 
@@ -329,24 +371,86 @@ See [`demos/realtime_motion_graph_web/README.md`](demos/realtime_motion_graph_we
 
 - [`examples/session_demo.py`](examples/session_demo.py): one-shot generation, persistent session.
 - [`examples/realtime_cover.py`](examples/realtime_cover.py): real-time cover workflow exercising dual prompts, dual LoRAs, timbre / hint references, temporal masking, and engine-exclusive per-frame curves.
-- [`examples/covers/`](examples/covers/): standalone per-feature scripts (see table above).
+- [`examples/covers/`](examples/covers/): standalone per-feature scripts (see the table under [Programmatic use](#programmatic-use-the-session-api)).
 - [`demos/test_stream_cover_graph.py`](demos/test_stream_cover_graph.py): a streaming cover graph driven from Python.
 
-## Tests
+## Engine internals
 
-```bash
-uv run pytest tests/ -v
+The capabilities listed under [Features](#features) come from a handful of mechanisms in the streaming pipeline. The full surface:
+
+<details>
+<summary><strong>The full engine surface (click to expand)</strong></summary>
+
+- **Streaming diffusion for ACE-Step v1.5.** `StreamPipeline` ([`acestep/engine/stream.py`](acestep/engine/stream.py)) maintains a ring buffer of in-flight generations. Each tick runs a batched decoder forward pass (two when CFG is active: positive + negative) that advances every active slot by one denoising step. The decoder dispatches to TensorRT or PyTorch through the same code path. Depth is hot-resizable mid-stream (`pipeline.set_depth(n)`); active slots drain naturally.
+- **Heterogeneous slots.** Every in-flight slot carries its own `SlotRequest`: its own seed, its own `denoise` strength (with its own cached timestep schedule), its own source latent, its own per-frame curves, its own conditioning (one or more `SlotCondition`s with per-frame `temporal_weight` and per-condition `step_range`), its own CFG mode, its own x0 target, and its own latent-noise mask. A single ring buffer can mix a `denoise=1.0` regeneration, a `denoise=0.5` style transfer, and an RCFG-`self` request simultaneously and batch them in one forward pass.
+- **Scalar-or-curve per-frame modulation.** Velocity scale, SDE re-noise, ODE noise injection, guidance scale, x0 target strength, x0 target curve, initial noise mix, APG momentum, CFG rescale, DCW scalers, and condition temporal weights all accept either a Python scalar or a `[T]` tensor, canonicalized through `normalize_curve` at the boundary so the kernels see one shape.
+- **Channel guidance.** A `[1, T, 64]` per-channel gain applied to `xt` before each forward pass. Lives in its own surface (set via `pipeline.set_channel_gain_tensor(...)`) because its per-channel-and-per-frame shape doesn't fit the `[T]`-curve pattern.
+- **Shared mutable curves.** Layered on top of the heterogeneous slots: `pipeline.set_shared_curve(name, value)` overrides one of the curve-shaped fields (`velocity_scale`, `sde_denoise_curve`, `ode_noise_curve`, `guidance_curve`, `apg_momentum`, `x0_target_strength`, `cfg_rescale_curve`) for the next tick on every in-flight slot at once. The override takes effect immediately rather than waiting for new submissions to make their way through the pipeline. Pass `None` to revert that name to per-slot behavior.
+- **Multi-condition compositing.** Within a single slot, the decoder runs once per active condition and velocities are blended per frame by `temporal_weight`; conditions are gated in and out of the schedule by `step_range`. `ConditioningBlend` (scalar alpha) and `ConditioningCombine` (per-frame temporal weights) are the typed entry points.
+- **Three CFG modes.** Standard CFG (uncond forward every step), RCFG-`initialize` (one uncond forward per slot, cached for the rest of the schedule), and RCFG-`self` (zero uncond forwards: the slot's initial noise stands in as the virtual uncond velocity). All three layer APG momentum and an optional per-frame CFG rescale curve on top.
+- **Latent-noise-mask inpainting.** Two-sided x0 blending matching ComfyUI semantics: pre-blend on `xt` (so the decoder sees correctly-noised context in preserved regions) and post-blend on the predicted `x0`. Supports a per-step strength function for progressive masking.
+- **DCW post-step correction.** Wavelet-domain sampler-side correction from Yu et al. CVPR 2026, ported from upstream ACE-Step v0.1.7. Four modes (low / high / double / pix), with an optional advanced surface (`mult_blend`, `mag_phase`, `soft_thresh`) that at zero is byte-identical to the upstream reference. Hot-updatable via `pipeline.set_dcw(...)`.
+- **Hot LoRA.** Register a directory once, then enable / set_strength / remove without rebuilding anything. The LoRA manager ([`acestep/engine/lora.py`](acestep/engine/lora.py)) handles the lifecycle and delta math; when the decoder is in TRT mode, applies route through a refitter against the live engine.
+- **TRT acceleration end-to-end.** The DiT decoder, VAE encode, and VAE decode each pick `tensorrt | compile | eager` independently. The TRT decoder is refit-enabled, so LoRA swaps do not rebuild the engine. The VAE decode has a windowed variant (`vae_decode_fp16_1s_fixed`, a fixed 1 s profile) that is built once and reused across all durations; the caller specifies the window start via `t_start`.
+- **Bit-identical streaming vs. batch.** The streaming and one-shot paths compose the same pure step primitives from [`acestep/engine/ode_steps.py`](acestep/engine/ode_steps.py); they produce the same output.
+
+</details>
+
+## How DEMON compares
+
+DEMON is to audio what StreamDiffusion is to images: a streaming, real-time-steerable diffusion runtime. Here is how it relates to its closest points of reference — a relationship map, not a benchmark:
+
+| | DEMON | ACE-Step v1.5 (upstream) | StreamDiffusion |
+|---|---|---|---|
+| Modality | Music / audio | Music / audio | Images |
+| Generation | Streaming ring buffer of in-flight denoise stages | One-shot batch | Streaming ring buffer (the image analogue) |
+| Per-frame control | Every knob is a scalar or a `[T]` curve, hot-mutable mid-stream | Per-generation parameters | — |
+| Ring-buffer depth | Hot-resizable mid-stream | — | — |
+| Streaming vs. batch | Bit-identical output | Batch only | — |
+| Acceleration | End-to-end TensorRT (decoder + VAE) | — | TensorRT |
+
+## Research & citation
+
+The main DEMON paper is on arXiv; two companion technical notes are forthcoming:
+
+- **[DEMON: Diffusion Engine for Musical Orchestrated Noise](https://arxiv.org/abs/2605.28657)** — the main paper (arXiv:2605.28657)
+- FastOobleckDecoder (VAE distillation) — *forthcoming*
+- Latent Channel Semantics (64-channel VAE characterization) — *forthcoming*
+
+If you use DEMON in your work, please cite both DEMON and the underlying ACE-Step model:
+
+```bibtex
+@article{fosdick2026demon,
+  title   = {DEMON: Diffusion Engine for Musical Orchestrated Noise},
+  author  = {Fosdick, Ryan},
+  journal = {arXiv preprint arXiv:2605.28657},
+  year    = {2026}
+}
+
+@software{demon,
+  author = {Fosdick, Ryan},
+  title  = {DEMON: Diffusion Engine for Musical Orchestrated Noise},
+  year   = {2026},
+  url    = {https://github.com/daydreamlive/DEMON}
+}
+
+@article{acestep2026,
+  title   = {ACE-Step 1.5: Pushing the Boundaries of Open-Source Music Generation},
+  author  = {Gong and others},
+  journal = {arXiv preprint arXiv:2602.00744},
+  year    = {2026}
+}
 ```
 
-## Research
+## Contributing
 
-The DEMON paper and two companion technical notes are forthcoming:
+Contributions are welcome. The maintained agent/developer guide is [AGENTS.md](AGENTS.md) — it covers the dev setup, the contract-first control surface (knobs and the wire protocol each live in exactly one registry), and how to regenerate the generated TypeScript types after a registry change. Run the test suite with:
 
-- DEMON paper (main)
-- FastOobleckDecoder (VAE distillation)
-- Latent Channel Semantics (64-channel VAE characterization)
+```bash
+uv run pytest tests/
+```
 
-Links land here as artifacts are released.
+Then open a pull request or file an issue on GitHub.
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary

Overhauls the top-level README for first-screen clarity — adds a hero image, a badge row, paper/demo links, a table of contents, and a tiered Features list — while **preserving every existing fact** (content was reordered, collapsed into `<details>`, or linked out, never removed).

## Presentation
- Hero image (`docs/assets/img/poster-hero.jpg`, unlinked) + table of contents.
- Info badge row (AGPL-3.0-or-later + MIT, Python 3.11, built on ACE-Step v1.5) and a links row for the arXiv paper and the hosted instance.
- "StreamDiffusion, for audio." promoted to the tagline; added a "Who it's for" framing and a tiered Features list.
- The three scattered install sections merged into one Quickstart (requirements first) with a "what you'll see and hear" note.
- Heavy reference (full TRT build commands + engine tree, the per-feature examples table, the VRAM table, and the engine internals) collapsed into `<details>` blocks.
- Added Research & citation (paper now on [arXiv:2605.28657](https://arxiv.org/abs/2605.28657)), Contributing, and a small "how DEMON compares" table.

## Fact-checks against main
Verified the README's claims against the codebase and corrected:
- Fixtures dataset → `daydreamlive/demon-fixtures-v2` (legacy kept as fallback).
- First run installs the web app **and** shared SDK (`packages/demon-client`) `node_modules`.
- Removed the non-existent "MIDI map seed" from the `config.json` defaults list.
- Replaced a personal absolute `--demo` path with a placeholder.
- Added `guidance_curve` to the `set_shared_curve` shared-override field list.
- Corrected the starter-LoRA variant breakdown (16 total).

## Follow-up — addressed in #281
The two out-of-scope nits originally flagged here are fixed in #281:
- `docs/index.html` footer "MIT License" → "AGPL-3.0-or-later + MIT", and the citation updated to include the published paper.
- `demos/realtime_motion_graph_web/README.md` personal absolute paths replaced with placeholders.