### PR TITLE
docs: correct site license/citation and scrub personal paths

### DIFF
--- a/demos/realtime_motion_graph_web/README.md
+++ b/demos/realtime_motion_graph_web/README.md
@@ -82,7 +82,7 @@ shared `/sdk/demon-client.js` bundle, server fixtures, live LoRA controls, and
 MediaPipe hand tracking as a control surface:
 
 ```powershell
-uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\_dev\projects\demos\demon-summon-frontend
+uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\path\to\demon-summon-frontend
 ```
 
 The backend prints each mounted static demo URL at startup, for example
@@ -417,7 +417,7 @@ then point Claude Code at the MCP server:
         "run", "python", "-u",
         "-m", "demos.realtime_motion_graph_web.mcp_server"
       ],
-      "cwd": "C:/_dev/projects/DEMON"
+      "cwd": "C:/path/to/DEMON"
     }
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -417,7 +417,14 @@
     </p>
 
     <h3 style="margin-top:2.5rem;">DEMON</h3>
-    <pre class="code-block">@software{fosdick2026demon,
+    <pre class="code-block">@article{fosdick2026demon,
+  title   = {DEMON: Diffusion Engine for Musical Orchestrated Noise},
+  author  = {Fosdick, Ryan},
+  journal = {arXiv preprint arXiv:2605.28657},
+  year    = {2026}
+}
+
+@software{demon,
   author = {Fosdick, Ryan},
   title  = {DEMON: Diffusion Engine for Musical Orchestrated Noise},
   year   = {2026},
@@ -440,7 +447,7 @@
      ============================================================ -->
 <footer>
   <div class="row">
-    <div>DEMON · MIT License</div>
+    <div>DEMON · AGPL-3.0-or-later + MIT</div>
     <div>
       <a href="https://github.com/daydreamlive/DEMON">GITHUB</a>
       &nbsp;&nbsp;·&nbsp;&nbsp;


### PR DESCRIPTION
Small follow-up nits flagged in #277.

## Changes
- **`docs/index.html` footer** read "MIT License" — but DEMON is **AGPL-3.0-or-later** (only the embedded ACE-Step portions are MIT). Corrected to "AGPL-3.0-or-later + MIT".
- **`docs/index.html` citation** now includes the published DEMON paper (`@article{… arXiv:2605.28657}`) alongside the `@software` entry, matching the root README.
- **`demos/realtime_motion_graph_web/README.md`**: replaced two personal absolute paths (`C:\_dev\projects\...`) with `C:\path\to\...` placeholders.

Docs only — no code or behavior changes.