### PR TITLE
docs: point static demo docs at example apps repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,10 +340,11 @@ External static demo repos can be mounted at runtime with `--demo <path>`. DEMON
 uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\path\to\demo
 ```
 
-Those repos own any browser/CDN/build dependencies; DEMON only provides static hosting plus the shared browser SDK at `/sdk/demon-client.js`. For a concrete no-build example, point `--demo` at the external `demon-summon-frontend` demo:
+Those repos own any browser/CDN/build dependencies; DEMON only provides static hosting plus the shared browser SDK at `/sdk/demon-client.js`. For concrete no-build examples, see [`daydreamlive/demon-example-apps`](https://github.com/daydreamlive/demon-example-apps):
 
 ```bash
-uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\path\to\demon-summon-frontend
+git clone https://github.com/daydreamlive/demon-example-apps.git
+uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\path\to\demon-example-apps\apps\summon
 ```
 
 Highlights:

--- a/demos/realtime_motion_graph_web/README.md
+++ b/demos/realtime_motion_graph_web/README.md
@@ -77,12 +77,14 @@ Or pass the demo path to the launcher:
 uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\path\to\demo
 ```
 
-Example: `demon-summon-frontend` is a no-build external demo that uses the
-shared `/sdk/demon-client.js` bundle, server fixtures, live LoRA controls, and
+Example: [`daydreamlive/demon-example-apps`](https://github.com/daydreamlive/demon-example-apps)
+collects no-build static demos that use the shared `/sdk/demon-client.js`
+bundle. Its `apps/summon` demo uses server fixtures, live LoRA controls, and
 MediaPipe hand tracking as a control surface:
 
 ```powershell
-uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\path\to\demon-summon-frontend
+git clone https://github.com/daydreamlive/demon-example-apps.git
+uv run python -u -m demos.realtime_motion_graph_web.run --demo C:\path\to\demon-example-apps\apps\summon
 ```
 
 The backend prints each mounted static demo URL at startup, for example

--- a/packages/demon-client/README.md
+++ b/packages/demon-client/README.md
@@ -17,8 +17,9 @@ standalone. Two consumption modes ship in-repo:
 - **Static no-build pages** — `dist/` holds a committed esbuild bundle
   (`demon-client.js`, `sliceDecoder.worker.js`, `audio-worklet.js`) that
   the demo backend mounts at `/sdk/`. These pages live in external repos
-  mounted via the backend's `--demo <path>` flag (e.g. the
-  `demon-summon-frontend` demo), never inside this repo's `demos/` tree.
+  mounted via the backend's `--demo <path>` flag (e.g. demos from
+  [`daydreamlive/demon-example-apps`](https://github.com/daydreamlive/demon-example-apps)),
+  never inside this repo's `demos/` tree.
   Pass `RemoteBackendOptions.sliceWorkerUrl` and
   `AudioPlayerOptions.workletUrl` pointing at the mounted siblings.
   Regenerate after any SDK change: `npm install && npm run build` here


### PR DESCRIPTION
Updates the README, realtime web demo README, and demon-client README to point at daydreamlive/demon-example-apps instead of the archived standalone Summon demo repo.\n\nStacked on #277 so the root README change applies cleanly after the overhaul.