### PR TITLE
docs: scrub personal path from mcp_server docstring

### DIFF
--- a/demos/realtime_motion_graph_web/mcp_server.py
+++ b/demos/realtime_motion_graph_web/mcp_server.py
@@ -28,7 +28,7 @@ Run as a stdio MCP server. Example Claude Code config:
             "run", "python", "-u",
             "-m", "demos.realtime_motion_graph_web.mcp_server"
           ],
-          "cwd": "C:/_dev/projects/DEMON"
+          "cwd": "C:/path/to/DEMON"
         }
       }
     }


### PR DESCRIPTION
Follow-up to #281. The example MCP config in `demos/realtime_motion_graph_web/mcp_server.py`'s module docstring hard-coded a personal absolute path (`C:/_dev/projects/DEMON`); replaced with a `C:/path/to/DEMON` placeholder.

Docstring only — no code or behavior change.