### PR TITLE
feat(client-sdk): move user-facing control copy into the SDK

### DIFF
--- a/demos/realtime_motion_graph_web/web/components/Performance/HeroMacros.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/HeroMacros.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/store/useRecordingStore";
 import { useSessionStore } from "@/store/useSessionStore";
 import { LORA_SLIDER_MAX } from "@/types/engine";
+import { STEM_SECTION_DESCRIPTION } from "@demon/client";
 
 import { Knob } from "./Knob";
 import { MidiInToggle } from "./MidiInToggle";
@@ -164,9 +165,8 @@ function HeroStyleFader({ slotIndex }: HeroStyleFaderProps) {
 
 // Keyboard hold-chord shortcuts (V/I + ▲▼) still work via
 // useKeyboardShortcuts.ts — they're documented in the section-header
-// tooltip below rather than under each panner.
-const STEM_SECTION_TOOLTIP =
-  "Vocal and instrumental stems extracted from the source track. Drag a panner right to mix that layer into the model output. Click the layer name to mute or unmute without losing the level. Hold V (vocals) or I (instruments) + ▲▼ to nudge from the keyboard.";
+// tooltip below (STEM_SECTION_DESCRIPTION, from @demon/client/controls)
+// rather than under each panner.
 
 export function HeroMacros() {
   const status = useSessionStore((s) => s.status);
@@ -270,7 +270,7 @@ export function HeroMacros() {
           <div className="hero-macros-stems">
             <div
               className="hero-macros-group-label"
-              data-dd-tooltip={STEM_SECTION_TOOLTIP}
+              data-dd-tooltip={STEM_SECTION_DESCRIPTION}
               data-dd-tooltip-wide=""
               data-dd-tooltip-title="Stem Layers"
             >

--- a/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/OperatorStrip.tsx
@@ -37,6 +37,7 @@ import {
   VALID_TIME_SIGNATURES,
   isTimeSignature,
 } from "@/types/engine";
+import { INTERP_PATH_DESCRIPTIONS } from "@demon/client";
 
 import { ExportDialog } from "./ExportDialog";
 import { MidiBadge } from "./MidiBadge";
@@ -72,16 +73,8 @@ const INTERP_METHOD_OPTIONS: { value: InterpMethod; label: string }[] = [
   { value: "linear", label: "Linear" },
 ];
 
-const INTERP_PATH_TOOLTIPS: Record<InterpPath, string> = {
-  structure:
-    "How structural (semantic-hint) guidance blends in. Slerp holds the latent's norm constant; linear averages.",
-  timbre:
-    "How the timbre reference blends from silence to full. Slerp holds the conditioning norm constant; linear averages.",
-  prompt:
-    "How prompt A crossfades to prompt B. Slerp avoids the washed-out midpoint a linear average produces between unrelated prompts.",
-  feedback:
-    "How the latent feedback tap mixes into the source. Slerp holds the latent's norm constant; linear averages.",
-};
+// Interp-method copy (slerp vs linear, per blend path) now lives in the SDK
+// at @demon/client/controls (INTERP_PATH_DESCRIPTIONS).
 
 // One labelled dropdown per live blend path, using the same RefSelect
 // component as the core input / structure / timbre pickers so they match
@@ -98,7 +91,7 @@ function InterpRow({ path }: { path: InterpPath }) {
       groups={[]}
       onSelect={(v) => setMethod(path, v as InterpMethod)}
       ariaLabel={`${INTERP_PATH_LABELS[path]} interpolation method`}
-      tooltip={INTERP_PATH_TOOLTIPS[path]}
+      tooltip={INTERP_PATH_DESCRIPTIONS[path]}
     />
   );
 }

--- a/demos/realtime_motion_graph_web/web/components/Performance/RefControl.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/RefControl.tsx
@@ -14,7 +14,11 @@ import { trimAudioBuffer } from "@/lib/audio/trimAudioBuffer";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 import { usePerformanceStore, type RefSource } from "@/store/usePerformanceStore";
 import { useSessionStore } from "@/store/useSessionStore";
-import type { RemoteBackend } from "@demon/client";
+import {
+  STRUCTURE_REF_DESCRIPTION,
+  TIMBRE_REF_DESCRIPTION,
+  type RemoteBackend,
+} from "@demon/client";
 
 import { RefSelect } from "./RefSelect";
 
@@ -308,9 +312,7 @@ export function RefControl({ kind }: { kind: RefKind }) {
         onUpload={() => fileInputRef.current?.click()}
         uploadLabel={`Upload ${bind.label}`}
         tooltip={
-          kind === "timbre"
-            ? "Optional reference audio for the timbre channel. Picking a track here biases the model's instrument character toward what's in that file, leaving structure (rhythm, sections) free to follow the playing input. Default 'Input Track' uses the playing source's own latent."
-            : "Optional reference audio for the structure channel. Picking a track here biases the model's section/rhythm/dynamics layout toward that file, leaving timbre (instrument character) free to follow the playing input. Default 'Input Track' uses the playing source's own latent."
+          kind === "timbre" ? TIMBRE_REF_DESCRIPTION : STRUCTURE_REF_DESCRIPTION
         }
       />
       <input

--- a/demos/realtime_motion_graph_web/web/components/Performance/SliderTile.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/SliderTile.tsx
@@ -11,123 +11,19 @@ interface Props {
   params: { param: string; label: string; max?: number }[];
 }
 
-// Display names — anchored in traditional audio vocabulary (synth /
-// multi-FX / EQ heritage) so the labels read instantly to anyone who's
-// touched a hardware unit or plugin. Where the underlying concept has
-// no clean analog (shift, noise_share), the technical label stays.
-// CSS uppercases these on render via .slider-label / .mixer-tile-label.
-const DISPLAY_NAMES: Record<string, string> = {
-  // Macros where the friendly name reads more clearly than the
-  // engine-honest one: `strength` for `denoise` (the "denoise"
-  // engine-internal naming refers to the diffusion step, but users
-  // perceive this knob as "how strong is the remix"), `structure` for
-  // `hint_strength`, `timbre` for `timbre_strength` (drop the
-  // "strength" suffix on knobs — the value readout already conveys
-  // magnitude). Everything else falls back to defaultLabelFor
-  // (underscore → space) so the UI matches what the engine, MIDI map,
-  // and config files call them.
-  denoise: "strength",
-  hint_strength: "structure",
-  timbre_strength: "timbre",
-  // dcw_* keep their engine-honest "DCW low" / "DCW high" — these are
-  // DCW-internal scalers, not generic EQ.
-  dcw_scaler: "DCW low",
-  dcw_high_scaler: "DCW high",
-};
+// User-facing control copy (tooltips) + display names now live in the SDK at
+// @demon/client/controls — the portable, hand-authored editorial layer,
+// distinct from the terse agent-facing descriptions on /api/knobs. They are
+// re-exported here under the web's historical names so existing call sites
+// (SliderGroup, Knob, CoreTile, ModTile, VoiceTile, GraphLaneLabels, …) stay
+// unchanged. To surface a manifest fallback for runtime-only knobs, use the
+// SDK's resolveControlDescription directly.
+export { describeControl as tooltipFor, displayNameFor as defaultLabelFor } from "@demon/client";
 
-// Tooltip copy for each tweakable param, surfaced via the slider label's
-// hover tooltip in SliderGroup. Aim: a 1–2 second read that tells the
-// user WHEN to reach for this knob — what musical outcome it produces,
-// not the diffusion-process plumbing underneath. Renders via
-// data-dd-tooltip-wide (white-space: normal, max-width 280px).
-const PARAM_TOOLTIPS: Record<string, string> = {
-  // ── Main remix controls ──
-  denoise:
-    "How much the model reshapes the source audio. Keep it low for a subtle remix that stays close to the original; push it high to fully transform the track into something new. The most expressive knob — try sweeping it during playback.",
-  hint_strength:
-    "How closely the model follows the original song's structure — sections, rhythm, dynamics. Crank it up to keep the arrangement intact; drop it to let the model rearrange more freely.",
-  timbre_strength:
-    "How much of the source's instrument character (tone, color) carries into the output. High keeps the original instruments recognizable; low frees the model to swap them for whatever fits the prompt.",
-
-  // ── Engine internals ──
-  feedback:
-    "How similar each new generation is to the previous one. Low values give you variety on every refresh; higher values give you a continuous evolution where each generation flows into the next. 0.3–0.5 is the sweet spot for smooth continuity without everything sounding the same.",
-  feedback_depth:
-    "How far back in time the Feedback knob reaches. 1 (default) blends with the most recent generation. Higher values reach back several ticks for an echo / ghost effect — a faint repeat of an earlier moment surfaces in the current output. Lets you get distant feedback without cranking Feedback all the way up.",
-  shift:
-    "Advanced: changes where the model concentrates its work across denoising. The default is tuned for the turbo engine and works well in most cases — leave it alone unless you're chasing a specific feel.",
-  steps_override:
-    "Diffusion step count. Lower steps = lower quality. Higher steps = more latency. Default 8 is the turbo balance. Changing this rebuilds the streaming pipeline, so expect a brief audio glitch when you move it.",
-  guidance_scale:
-    "CFG strength. Only takes effect when the RCFG mode dropdown below is NOT 'off'. Higher values push the output further toward the prompt at the cost of more artifacts. Turbo is CFG-distilled, so the useful range is narrower than a base SD model — try 3–8.",
-  cfg_rescale:
-    "After CFG, mix the guided velocity's magnitude back toward what the positive forward produced. 0 keeps raw CFG; 1 fully snaps the magnitude. Pair with high guidance_scale to keep the prompt-push without the harshness that high CFG causes on its own.",
-
-  // ── Activation steering (auto path) ──
-  // Each tooltip names the underlying probe cell so the operator can
-  // recreate the effect on a manual slot.
-  steer_bright:
-    "Activation-steering: positive alpha shifts spectral centroid up (brighter, more highs). 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector brightness_l09_t3 at layer = 9, step = round(3/8 x steps_count).",
-  steer_warm:
-    "Activation-steering: positive alpha tilts the spectrum toward bass (warmer). The raw vector points the wrong way for this axis, so this knob folds in a -1 sign. 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector warmth_l15_t0 at layer = 15, step = 0, then INVERT alpha sign (manual mode is sign-agnostic).",
-  steer_rough:
-    "Activation-steering: positive alpha increases spectral flatness (grittier, noisier). Vector magnitude at this probe cell is small, so effect builds slowly. 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector roughness_l09_t3 at layer = 9, step = round(3/8 x steps_count).",
-  steer_density:
-    "Activation-steering: positive alpha thins the texture toward sparse/minimal. Inject layer is shifted 3 shallower than the probe layer (Phase-3 transfer finding). 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector density_l18_t3 at layer = 15 (probe 18 minus 3), step = round(3/8 x steps_count).",
-
-  // ── DCW ──
-  dcw_scaler:
-    "Experimental — adjusts the low-band strength of an internal correction the model applies to itself during generation (DCW). This scaler is active in the early part of the run. The exact audio mapping is still being explored — sweep it to discover what it does for your source. Extreme values can be unpredictable but cool.",
-  dcw_high_scaler:
-    "Experimental — adjusts the high-band strength of an internal correction the model applies to itself during generation (DCW). This scaler is active in the later part of the run. The exact audio mapping is still being explored — sweep it to discover what it does for your source. Extreme values can be unpredictable but cool.",
-};
-
-// Per-channel tooltips. The 64-channel latent space hasn't been fully
-// mapped to perceptual qualities yet, so the copy frames each channel
-// as something to discover by ear — not a labeled knob with a known
-// purpose. Generated programmatically to avoid 14 near-identical
-// hand-written strings.
-const CHANNEL_GAINS = ["ch_g0", "ch_g1", "ch_g2", "ch_g3", "ch_g4", "ch_g5", "ch_g6", "ch_g7"] as const;
-const NAMED_CHANNELS = ["ch13", "ch14", "ch19", "ch23", "ch29", "ch56"] as const;
-for (const [i, p] of CHANNEL_GAINS.entries()) {
-  PARAM_TOOLTIPS[p] =
-    `Experimental — adjusts the strength of one of the model's internal latent channels (channel ${i}). Each channel encodes a different aspect of the sound (frequency band, dynamics, transients); the exact mapping is still being explored. Sweep it to discover what it does for your source.`;
-}
-for (const p of NAMED_CHANNELS) {
-  const idx = p.slice(2);
-  PARAM_TOOLTIPS[p] =
-    `Experimental — a hand-picked internal latent channel (#${idx}) that produces a noticeable perceptual change. Sweep it to hear what this specific channel controls for your source.`;
-}
-
-export function tooltipFor(param: string): string | undefined {
-  // LoRA strength sliders (param like `lora_str_<id>`) get a generic
-  // tooltip rather than per-LoRA copy — the row already shows the
-  // LoRA's name as its visible label.
-  if (param.startsWith("lora_str_")) {
-    return "How strongly this LoRA shapes the output. LoRAs are little style packs — set a low value for a subtle flavor, crank past 1.0 to make this LoRA dominate the sound. Multiple LoRAs stack — turn several on at once for combined styles.";
-  }
-  if (param === "lora_blend") {
-    return "Crossfade between LoRA A and LoRA B. 0 = A only, 1 = B only, 0.5 = both at half strength. Use this to morph between two styles smoothly.";
-  }
-  // Manual steering tooltips share copy across all slots.
-  if (param.startsWith("man_src_")) {
-    return "Catalog index of the steering vector this slot fires. The catalog enumerates every pre-built (axis, build_layer, build_step) cell on disk in stable axis-major order. Double-click the readout to type an exact index; query the MCP list_manual_steering_vectors tool for the full table. Has no effect until α is non-zero.";
-  }
-  if (param.startsWith("man_layer_")) {
-    return "DiT inject layer (0-23). The vector is added to this layer's post-block residual. Bypasses the auto path's density layer offset — the value lands exactly where you point it.";
-  }
-  if (param.startsWith("man_step_")) {
-    return "Diffusion inject step (0-15). Bypasses the auto path's fractional step mapping; the engine fires the injection only on the step that matches this value. If you pick a step past the current steps count - 1, the slot stays silent until you raise the step count.";
-  }
-  if (param.startsWith("man_alpha_")) {
-    return "Strength of this manual slot's injection. 0 disables the slot. Negative α inverts the vector's direction at injection time (no sign correction is applied; what you set is what the engine receives). Sweep range and breakage point mirror the perceptual steering knobs.";
-  }
-  return PARAM_TOOLTIPS[param];
-}
-
-// Map slider param → keyboard hint shown beneath the slider. Mirrors the
-// chord layout in hooks/useKeyboardShortcuts.ts; if you change one, change
-// the other.
+// Map slider param → keyboard hint shown beneath the slider. WEB-ONLY: these
+// are this demo's keyboard chords, not portable control semantics, so they
+// stay here rather than in the SDK. Mirrors the chord layout in
+// hooks/useKeyboardShortcuts.ts; if you change one, change the other.
 const KBD_FOR_PARAM: Record<string, string> = {
   denoise: "A + ▲▼",
   hint_strength: "G + ▲▼",
@@ -174,8 +70,4 @@ export function SliderTile({ label, params }: Props) {
       </div>
     </div>
   );
-}
-
-export function defaultLabelFor(param: string): string {
-  return DISPLAY_NAMES[param] ?? param.replace(/_/g, " ");
 }

--- a/demos/realtime_motion_graph_web/web/components/Performance/SourceModeSwitch.tsx
+++ b/demos/realtime_motion_graph_web/web/components/Performance/SourceModeSwitch.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { SOURCE_MODE_HINTS } from "@demon/client";
+
 import type { StemSourceMode } from "@/engine/audio/loadFixture";
 import { useCustomTracksStore } from "@/store/useCustomTracksStore";
 
@@ -18,13 +20,9 @@ const MODES: ReadonlyArray<{
   label: string;
   hint: string;
 }> = [
-  { mode: "full", label: "Full", hint: "Feed the whole mix to inference" },
-  {
-    mode: "instruments",
-    label: "Instr",
-    hint: "Feed only the instrumental bed to inference",
-  },
-  { mode: "vocals", label: "Vocals", hint: "Feed only the vocal stem to inference" },
+  { mode: "full", label: "Full", hint: SOURCE_MODE_HINTS.full },
+  { mode: "instruments", label: "Instr", hint: SOURCE_MODE_HINTS.instruments },
+  { mode: "vocals", label: "Vocals", hint: SOURCE_MODE_HINTS.vocals },
 ];
 
 interface Props {

--- a/packages/demon-client/AGENTS.md
+++ b/packages/demon-client/AGENTS.md
@@ -122,6 +122,24 @@ Unlike the manifests, this file is hand-edited (comment-heavy `_comment` /
 `_*_help` keys): read ignores unknown keys, write preserves them, and a
 `version` field is present from day one.
 
+## Control copy (`controls/`) — user-facing, also not a manifest
+
+The descriptions and display names you render ON the controls. Two layers,
+don't conflate them: the `/api/knobs` manifest's `description` is the **terse,
+agent-facing** one-liner (registry-generated); `controls/` is the **editorial,
+when-to-reach-for-it** prose (hand-authored, client-side). Import from the
+package root:
+
+- `describeControl(param)` → rich description or `undefined` (LoRA / manual
+  slots share one string each, matched by prefix).
+- `displayNameFor(param)` → friendly label (`denoise` → `strength`, else
+  snake_case → spaced).
+- `resolveControlDescription(param, manifest?)` → prefer rich copy, fall back
+  to the manifest's `description` so runtime-only knobs still read something.
+
+The tooltip-rendering machinery and web-only affordance hints (keyboard
+chords, MIDI-learn) stay in your client — only the copy is shared.
+
 ## Reference implementations in the demo app
 
 - `demos/realtime_motion_graph_web/web/components/Performance/DynamicKnobPanel.tsx` — a complete control
@@ -147,6 +165,12 @@ Unlike the manifests, this file is hand-edited (comment-heavy `_comment` /
 - `config/` is the operator-defaults `config.json` schema + pure transforms
   (the one hand-authored, client-side contract — not generated). Keep it
   pure: no store/DOM imports cross into it, so M4L / VST can consume it.
+- `controls/` is the user-facing knob/input copy (the second hand-authored,
+  client-side layer — editorial prose, not the registry's terse
+  `description`). Pure data + pure functions, no store/DOM imports.
+- If you change the SDK's bundled surface (`controls/`, `config/`, etc.),
+  rebuild so the committed `dist/` static-demo bundles don't go stale:
+  `cd packages/demon-client && npm run build`.
 
 ## Agent-driven control without a browser
 

--- a/packages/demon-client/README.md
+++ b/packages/demon-client/README.md
@@ -69,6 +69,29 @@ ignore-unknown; write = preserve-unknown; a `version` field is present from
 day one so a later loader can branch. Each client keeps its own state
 wiring — only the schema + transforms are shared.
 
+## Control copy (`controls/`)
+
+The **user-facing** descriptions and display names a frontend renders on its
+knobs/inputs — "how much the model reshapes the source audio…", `denoise` →
+`strength`. Like `config.json` this is hand-authored, client-side copy, and
+it is a second, distinct layer from the `/api/knobs` manifest's `description`
+field: the manifest carries the **terse, agent-facing** one-liner generated
+from the Python registry; [`controls/`](./controls) carries the **editorial,
+when-to-reach-for-it** prose. Same param ids, different audience.
+
+| Export | What it does |
+|---|---|
+| `describeControl(param)` | Rich user-facing description for a param id, or `undefined`. LoRA/manual-slot families share one string each (matched by prefix). |
+| `displayNameFor(param)` | Friendly label (overrides win; else snake_case → spaced words). |
+| `resolveControlDescription(param, manifest?)` | One lookup that prefers the rich copy and falls back to the manifest's terse `description` — so runtime-only knobs (LoRAs, manual slots) still surface *something*. Pass the `/api/knobs` manifest as the second arg. |
+
+Also exported: the raw maps/strings (`CONTROL_DESCRIPTIONS`,
+`CONTROL_DISPLAY_NAMES`, `INTERP_PATH_DESCRIPTIONS`, `SOURCE_MODE_HINTS`,
+`TIMBRE_REF_DESCRIPTION` / `STRUCTURE_REF_DESCRIPTION`,
+`STEM_SECTION_DESCRIPTION`). The tooltip-**rendering** machinery (hover
+readouts, DOM wiring) and web-only affordance hints (keyboard chords,
+MIDI-learn) stay per-client.
+
 ## Quickstart
 
 ```ts

--- a/packages/demon-client/controls/copy.ts
+++ b/packages/demon-client/controls/copy.ts
@@ -1,0 +1,147 @@
+// Portable, hand-authored USER-FACING control copy: the prose tooltips and
+// display names a DEMON frontend shows on its knobs and inputs. Keyed by the
+// same param ids the backend registry uses, but the copy here is editorial
+// ("what musical outcome this produces / when to reach for it"), NOT the
+// terse, agent-facing one-liners the backend serves at /api/knobs
+// (KnobManifestEntry.description). The two are intentionally distinct
+// audiences; controls/index.ts `resolveControlDescription` is the merge point
+// when a consumer wants the rich copy with a graceful fallback to the manifest
+// for knobs that only exist at runtime (LoRAs, manual slots).
+//
+// This mirrors the config/ module's "client-side, hand-authored, distinct from
+// the generated contracts" stance. What stays per-client: the DOM/tooltip
+// rendering machinery (useTooltipHover, the help readouts) and web-only
+// affordance hints (keyboard chords, MIDI-learn, kiosk/LUFS toggles).
+
+// Display names — anchored in traditional audio vocabulary (synth /
+// multi-FX / EQ heritage) so the labels read instantly to anyone who's
+// touched a hardware unit or plugin. Where the underlying concept has
+// no clean analog (shift, noise_share), the technical label stays.
+// Hosts typically uppercase these on render.
+export const CONTROL_DISPLAY_NAMES: Record<string, string> = {
+  // Macros where the friendly name reads more clearly than the
+  // engine-honest one: `strength` for `denoise` (the "denoise"
+  // engine-internal naming refers to the diffusion step, but users
+  // perceive this knob as "how strong is the remix"), `structure` for
+  // `hint_strength`, `timbre` for `timbre_strength` (drop the
+  // "strength" suffix on knobs — the value readout already conveys
+  // magnitude). Everything else falls back to displayNameFor
+  // (underscore → space) so the UI matches what the engine, MIDI map,
+  // and config files call them.
+  denoise: "strength",
+  hint_strength: "structure",
+  timbre_strength: "timbre",
+  // dcw_* keep their engine-honest "DCW low" / "DCW high" — these are
+  // DCW-internal scalers, not generic EQ.
+  dcw_scaler: "DCW low",
+  dcw_high_scaler: "DCW high",
+};
+
+// Tooltip copy for each tweakable param, surfaced via the slider/knob label's
+// hover tooltip. Aim: a 1–2 second read that tells the user WHEN to reach for
+// this knob — what musical outcome it produces, not the diffusion-process
+// plumbing underneath.
+export const CONTROL_DESCRIPTIONS: Record<string, string> = {
+  // ── Main remix controls ──
+  denoise:
+    "How much the model reshapes the source audio. Keep it low for a subtle remix that stays close to the original; push it high to fully transform the track into something new. The most expressive knob — try sweeping it during playback.",
+  hint_strength:
+    "How closely the model follows the original song's structure — sections, rhythm, dynamics. Crank it up to keep the arrangement intact; drop it to let the model rearrange more freely.",
+  timbre_strength:
+    "How much of the source's instrument character (tone, color) carries into the output. High keeps the original instruments recognizable; low frees the model to swap them for whatever fits the prompt.",
+
+  // ── Engine internals ──
+  feedback:
+    "How similar each new generation is to the previous one. Low values give you variety on every refresh; higher values give you a continuous evolution where each generation flows into the next. 0.3–0.5 is the sweet spot for smooth continuity without everything sounding the same.",
+  feedback_depth:
+    "How far back in time the Feedback knob reaches. 1 (default) blends with the most recent generation. Higher values reach back several ticks for an echo / ghost effect — a faint repeat of an earlier moment surfaces in the current output. Lets you get distant feedback without cranking Feedback all the way up.",
+  shift:
+    "Advanced: changes where the model concentrates its work across denoising. The default is tuned for the turbo engine and works well in most cases — leave it alone unless you're chasing a specific feel.",
+  steps_override:
+    "Diffusion step count. Lower steps = lower quality. Higher steps = more latency. Default 8 is the turbo balance. Changing this rebuilds the streaming pipeline, so expect a brief audio glitch when you move it.",
+  guidance_scale:
+    "CFG strength. Only takes effect when the RCFG mode dropdown below is NOT 'off'. Higher values push the output further toward the prompt at the cost of more artifacts. Turbo is CFG-distilled, so the useful range is narrower than a base SD model — try 3–8.",
+  cfg_rescale:
+    "After CFG, mix the guided velocity's magnitude back toward what the positive forward produced. 0 keeps raw CFG; 1 fully snaps the magnitude. Pair with high guidance_scale to keep the prompt-push without the harshness that high CFG causes on its own.",
+
+  // ── Activation steering (auto path) ──
+  // Each tooltip names the underlying probe cell so the operator can
+  // recreate the effect on a manual slot.
+  steer_bright:
+    "Activation-steering: positive alpha shifts spectral centroid up (brighter, more highs). 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector brightness_l09_t3 at layer = 9, step = round(3/8 x steps_count).",
+  steer_warm:
+    "Activation-steering: positive alpha tilts the spectrum toward bass (warmer). The raw vector points the wrong way for this axis, so this knob folds in a -1 sign. 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector warmth_l15_t0 at layer = 15, step = 0, then INVERT alpha sign (manual mode is sign-agnostic).",
+  steer_rough:
+    "Activation-steering: positive alpha increases spectral flatness (grittier, noisier). Vector magnitude at this probe cell is small, so effect builds slowly. 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector roughness_l09_t3 at layer = 9, step = round(3/8 x steps_count).",
+  steer_density:
+    "Activation-steering: positive alpha thins the texture toward sparse/minimal. Inject layer is shifted 3 shallower than the probe layer (Phase-3 transfer finding). 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector density_l18_t3 at layer = 15 (probe 18 minus 3), step = round(3/8 x steps_count).",
+
+  // ── DCW ──
+  dcw_scaler:
+    "Experimental — adjusts the low-band strength of an internal correction the model applies to itself during generation (DCW). This scaler is active in the early part of the run. The exact audio mapping is still being explored — sweep it to discover what it does for your source. Extreme values can be unpredictable but cool.",
+  dcw_high_scaler:
+    "Experimental — adjusts the high-band strength of an internal correction the model applies to itself during generation (DCW). This scaler is active in the later part of the run. The exact audio mapping is still being explored — sweep it to discover what it does for your source. Extreme values can be unpredictable but cool.",
+};
+
+// Per-channel tooltips. The 64-channel latent space hasn't been fully
+// mapped to perceptual qualities yet, so the copy frames each channel
+// as something to discover by ear — not a labeled knob with a known
+// purpose. Generated programmatically to avoid 14 near-identical
+// hand-written strings.
+const CHANNEL_GAINS = ["ch_g0", "ch_g1", "ch_g2", "ch_g3", "ch_g4", "ch_g5", "ch_g6", "ch_g7"] as const;
+const NAMED_CHANNELS = ["ch13", "ch14", "ch19", "ch23", "ch29", "ch56"] as const;
+for (const [i, p] of CHANNEL_GAINS.entries()) {
+  CONTROL_DESCRIPTIONS[p] =
+    `Experimental — adjusts the strength of one of the model's internal latent channels (channel ${i}). Each channel encodes a different aspect of the sound (frequency band, dynamics, transients); the exact mapping is still being explored. Sweep it to discover what it does for your source.`;
+}
+for (const p of NAMED_CHANNELS) {
+  const idx = p.slice(2);
+  CONTROL_DESCRIPTIONS[p] =
+    `Experimental — a hand-picked internal latent channel (#${idx}) that produces a noticeable perceptual change. Sweep it to hear what this specific channel controls for your source.`;
+}
+
+// Prefix-matched copy for the runtime-generated knob families (one shared
+// string across every LoRA / manual-steering slot). describeControl()
+// reaches for these before the static map.
+export const LORA_STRENGTH_DESCRIPTION =
+  "How strongly this LoRA shapes the output. LoRAs are little style packs — set a low value for a subtle flavor, crank past 1.0 to make this LoRA dominate the sound. Multiple LoRAs stack — turn several on at once for combined styles.";
+export const LORA_BLEND_DESCRIPTION =
+  "Crossfade between LoRA A and LoRA B. 0 = A only, 1 = B only, 0.5 = both at half strength. Use this to morph between two styles smoothly.";
+export const MANUAL_SRC_DESCRIPTION =
+  "Catalog index of the steering vector this slot fires. The catalog enumerates every pre-built (axis, build_layer, build_step) cell on disk in stable axis-major order. Double-click the readout to type an exact index; query the MCP list_manual_steering_vectors tool for the full table. Has no effect until α is non-zero.";
+export const MANUAL_LAYER_DESCRIPTION =
+  "DiT inject layer (0-23). The vector is added to this layer's post-block residual. Bypasses the auto path's density layer offset — the value lands exactly where you point it.";
+export const MANUAL_STEP_DESCRIPTION =
+  "Diffusion inject step (0-15). Bypasses the auto path's fractional step mapping; the engine fires the injection only on the step that matches this value. If you pick a step past the current steps count - 1, the slot stays silent until you raise the step count.";
+export const MANUAL_ALPHA_DESCRIPTION =
+  "Strength of this manual slot's injection. 0 disables the slot. Negative α inverts the vector's direction at injection time (no sign correction is applied; what you set is what the engine receives). Sweep range and breakage point mirror the perceptual steering knobs.";
+
+// Interpolation-method copy, keyed by blend path (structure / timbre /
+// prompt / feedback). Explains what slerp-vs-linear does for each lane.
+export const INTERP_PATH_DESCRIPTIONS: Record<string, string> = {
+  structure:
+    "How structural (semantic-hint) guidance blends in. Slerp holds the latent's norm constant; linear averages.",
+  timbre:
+    "How the timbre reference blends from silence to full. Slerp holds the conditioning norm constant; linear averages.",
+  prompt:
+    "How prompt A crossfades to prompt B. Slerp avoids the washed-out midpoint a linear average produces between unrelated prompts.",
+  feedback:
+    "How the latent feedback tap mixes into the source. Slerp holds the latent's norm constant; linear averages.",
+};
+
+// Inference-source hints, keyed by stem source mode.
+export const SOURCE_MODE_HINTS: Record<string, string> = {
+  full: "Feed the whole mix to inference",
+  instruments: "Feed only the instrumental bed to inference",
+  vocals: "Feed only the vocal stem to inference",
+};
+
+// Reference-audio picker copy for the timbre / structure channels.
+export const TIMBRE_REF_DESCRIPTION =
+  "Optional reference audio for the timbre channel. Picking a track here biases the model's instrument character toward what's in that file, leaving structure (rhythm, sections) free to follow the playing input. Default 'Input Track' uses the playing source's own latent.";
+export const STRUCTURE_REF_DESCRIPTION =
+  "Optional reference audio for the structure channel. Picking a track here biases the model's section/rhythm/dynamics layout toward that file, leaving timbre (instrument character) free to follow the playing input. Default 'Input Track' uses the playing source's own latent.";
+
+// Stem-layer section copy (the vocal/instrumental panners overview).
+export const STEM_SECTION_DESCRIPTION =
+  "Vocal and instrumental stems extracted from the source track. Drag a panner right to mix that layer into the model output. Click the layer name to mute or unmute without losing the level. Hold V (vocals) or I (instruments) + ▲▼ to nudge from the keyboard.";

--- a/packages/demon-client/controls/index.ts
+++ b/packages/demon-client/controls/index.ts
@@ -1,0 +1,51 @@
+// Portable control copy — the user-facing descriptions and display names a
+// DEMON frontend renders on its knobs/inputs. Hand-authored and client-side,
+// distinct from the backend-served /api/knobs manifest (whose `description` is
+// the terse, agent-facing layer). See ./copy.ts for the data and the audience
+// split; `resolveControlDescription` below is the merge point between the two.
+
+import type { KnobManifest } from "../types/knobs";
+import {
+  CONTROL_DESCRIPTIONS,
+  CONTROL_DISPLAY_NAMES,
+  LORA_STRENGTH_DESCRIPTION,
+  LORA_BLEND_DESCRIPTION,
+  MANUAL_SRC_DESCRIPTION,
+  MANUAL_LAYER_DESCRIPTION,
+  MANUAL_STEP_DESCRIPTION,
+  MANUAL_ALPHA_DESCRIPTION,
+} from "./copy";
+
+export * from "./copy";
+
+/** User-facing display label for a param id. Friendly overrides win; the
+ *  fallback turns engine snake_case into spaced words so the UI still matches
+ *  what the engine, MIDI map, and config files call it. */
+export function displayNameFor(param: string): string {
+  return CONTROL_DISPLAY_NAMES[param] ?? param.replace(/_/g, " ");
+}
+
+/** Rich user-facing description for a param id, or undefined if none is
+ *  authored. The runtime-generated knob families (LoRA strength sliders,
+ *  manual-steering slots) share one string each and are matched by prefix —
+ *  the visible row label already carries their per-instance name. */
+export function describeControl(param: string): string | undefined {
+  if (param.startsWith("lora_str_")) return LORA_STRENGTH_DESCRIPTION;
+  if (param === "lora_blend") return LORA_BLEND_DESCRIPTION;
+  if (param.startsWith("man_src_")) return MANUAL_SRC_DESCRIPTION;
+  if (param.startsWith("man_layer_")) return MANUAL_LAYER_DESCRIPTION;
+  if (param.startsWith("man_step_")) return MANUAL_STEP_DESCRIPTION;
+  if (param.startsWith("man_alpha_")) return MANUAL_ALPHA_DESCRIPTION;
+  return CONTROL_DESCRIPTIONS[param];
+}
+
+/** One lookup that prefers the rich editorial copy and falls back to the live
+ *  knob manifest's terse description — so knobs that only exist at runtime
+ *  (and thus have no hand-authored copy) still surface *something*. Pass the
+ *  `/api/knobs` manifest (from fetchKnobManifest) as the second arg. */
+export function resolveControlDescription(
+  param: string,
+  manifest?: KnobManifest,
+): string | undefined {
+  return describeControl(param) ?? manifest?.[param]?.description;
+}

--- a/packages/demon-client/dist/demon-client.js
+++ b/packages/demon-client/dist/demon-client.js
@@ -522,6 +522,95 @@ function base64ToArrayBuffer(b64) {
   return bytes.buffer.slice(0, bi);
 }
 
+// controls/copy.ts
+var CONTROL_DISPLAY_NAMES = {
+  // Macros where the friendly name reads more clearly than the
+  // engine-honest one: `strength` for `denoise` (the "denoise"
+  // engine-internal naming refers to the diffusion step, but users
+  // perceive this knob as "how strong is the remix"), `structure` for
+  // `hint_strength`, `timbre` for `timbre_strength` (drop the
+  // "strength" suffix on knobs — the value readout already conveys
+  // magnitude). Everything else falls back to displayNameFor
+  // (underscore → space) so the UI matches what the engine, MIDI map,
+  // and config files call them.
+  denoise: "strength",
+  hint_strength: "structure",
+  timbre_strength: "timbre",
+  // dcw_* keep their engine-honest "DCW low" / "DCW high" — these are
+  // DCW-internal scalers, not generic EQ.
+  dcw_scaler: "DCW low",
+  dcw_high_scaler: "DCW high"
+};
+var CONTROL_DESCRIPTIONS = {
+  // ── Main remix controls ──
+  denoise: "How much the model reshapes the source audio. Keep it low for a subtle remix that stays close to the original; push it high to fully transform the track into something new. The most expressive knob \u2014 try sweeping it during playback.",
+  hint_strength: "How closely the model follows the original song's structure \u2014 sections, rhythm, dynamics. Crank it up to keep the arrangement intact; drop it to let the model rearrange more freely.",
+  timbre_strength: "How much of the source's instrument character (tone, color) carries into the output. High keeps the original instruments recognizable; low frees the model to swap them for whatever fits the prompt.",
+  // ── Engine internals ──
+  feedback: "How similar each new generation is to the previous one. Low values give you variety on every refresh; higher values give you a continuous evolution where each generation flows into the next. 0.3\u20130.5 is the sweet spot for smooth continuity without everything sounding the same.",
+  feedback_depth: "How far back in time the Feedback knob reaches. 1 (default) blends with the most recent generation. Higher values reach back several ticks for an echo / ghost effect \u2014 a faint repeat of an earlier moment surfaces in the current output. Lets you get distant feedback without cranking Feedback all the way up.",
+  shift: "Advanced: changes where the model concentrates its work across denoising. The default is tuned for the turbo engine and works well in most cases \u2014 leave it alone unless you're chasing a specific feel.",
+  steps_override: "Diffusion step count. Lower steps = lower quality. Higher steps = more latency. Default 8 is the turbo balance. Changing this rebuilds the streaming pipeline, so expect a brief audio glitch when you move it.",
+  guidance_scale: "CFG strength. Only takes effect when the RCFG mode dropdown below is NOT 'off'. Higher values push the output further toward the prompt at the cost of more artifacts. Turbo is CFG-distilled, so the useful range is narrower than a base SD model \u2014 try 3\u20138.",
+  cfg_rescale: "After CFG, mix the guided velocity's magnitude back toward what the positive forward produced. 0 keeps raw CFG; 1 fully snaps the magnitude. Pair with high guidance_scale to keep the prompt-push without the harshness that high CFG causes on its own.",
+  // ── Activation steering (auto path) ──
+  // Each tooltip names the underlying probe cell so the operator can
+  // recreate the effect on a manual slot.
+  steer_bright: "Activation-steering: positive alpha shifts spectral centroid up (brighter, more highs). 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector brightness_l09_t3 at layer = 9, step = round(3/8 x steps_count).",
+  steer_warm: "Activation-steering: positive alpha tilts the spectrum toward bass (warmer). The raw vector points the wrong way for this axis, so this knob folds in a -1 sign. 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector warmth_l15_t0 at layer = 15, step = 0, then INVERT alpha sign (manual mode is sign-agnostic).",
+  steer_rough: "Activation-steering: positive alpha increases spectral flatness (grittier, noisier). Vector magnitude at this probe cell is small, so effect builds slowly. 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector roughness_l09_t3 at layer = 9, step = round(3/8 x steps_count).",
+  steer_density: "Activation-steering: positive alpha thins the texture toward sparse/minimal. Inject layer is shifted 3 shallower than the probe layer (Phase-3 transfer finding). 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector density_l18_t3 at layer = 15 (probe 18 minus 3), step = round(3/8 x steps_count).",
+  // ── DCW ──
+  dcw_scaler: "Experimental \u2014 adjusts the low-band strength of an internal correction the model applies to itself during generation (DCW). This scaler is active in the early part of the run. The exact audio mapping is still being explored \u2014 sweep it to discover what it does for your source. Extreme values can be unpredictable but cool.",
+  dcw_high_scaler: "Experimental \u2014 adjusts the high-band strength of an internal correction the model applies to itself during generation (DCW). This scaler is active in the later part of the run. The exact audio mapping is still being explored \u2014 sweep it to discover what it does for your source. Extreme values can be unpredictable but cool."
+};
+var CHANNEL_GAINS = ["ch_g0", "ch_g1", "ch_g2", "ch_g3", "ch_g4", "ch_g5", "ch_g6", "ch_g7"];
+var NAMED_CHANNELS = ["ch13", "ch14", "ch19", "ch23", "ch29", "ch56"];
+for (const [i, p] of CHANNEL_GAINS.entries()) {
+  CONTROL_DESCRIPTIONS[p] = `Experimental \u2014 adjusts the strength of one of the model's internal latent channels (channel ${i}). Each channel encodes a different aspect of the sound (frequency band, dynamics, transients); the exact mapping is still being explored. Sweep it to discover what it does for your source.`;
+}
+for (const p of NAMED_CHANNELS) {
+  const idx = p.slice(2);
+  CONTROL_DESCRIPTIONS[p] = `Experimental \u2014 a hand-picked internal latent channel (#${idx}) that produces a noticeable perceptual change. Sweep it to hear what this specific channel controls for your source.`;
+}
+var LORA_STRENGTH_DESCRIPTION = "How strongly this LoRA shapes the output. LoRAs are little style packs \u2014 set a low value for a subtle flavor, crank past 1.0 to make this LoRA dominate the sound. Multiple LoRAs stack \u2014 turn several on at once for combined styles.";
+var LORA_BLEND_DESCRIPTION = "Crossfade between LoRA A and LoRA B. 0 = A only, 1 = B only, 0.5 = both at half strength. Use this to morph between two styles smoothly.";
+var MANUAL_SRC_DESCRIPTION = "Catalog index of the steering vector this slot fires. The catalog enumerates every pre-built (axis, build_layer, build_step) cell on disk in stable axis-major order. Double-click the readout to type an exact index; query the MCP list_manual_steering_vectors tool for the full table. Has no effect until \u03B1 is non-zero.";
+var MANUAL_LAYER_DESCRIPTION = "DiT inject layer (0-23). The vector is added to this layer's post-block residual. Bypasses the auto path's density layer offset \u2014 the value lands exactly where you point it.";
+var MANUAL_STEP_DESCRIPTION = "Diffusion inject step (0-15). Bypasses the auto path's fractional step mapping; the engine fires the injection only on the step that matches this value. If you pick a step past the current steps count - 1, the slot stays silent until you raise the step count.";
+var MANUAL_ALPHA_DESCRIPTION = "Strength of this manual slot's injection. 0 disables the slot. Negative \u03B1 inverts the vector's direction at injection time (no sign correction is applied; what you set is what the engine receives). Sweep range and breakage point mirror the perceptual steering knobs.";
+var INTERP_PATH_DESCRIPTIONS = {
+  structure: "How structural (semantic-hint) guidance blends in. Slerp holds the latent's norm constant; linear averages.",
+  timbre: "How the timbre reference blends from silence to full. Slerp holds the conditioning norm constant; linear averages.",
+  prompt: "How prompt A crossfades to prompt B. Slerp avoids the washed-out midpoint a linear average produces between unrelated prompts.",
+  feedback: "How the latent feedback tap mixes into the source. Slerp holds the latent's norm constant; linear averages."
+};
+var SOURCE_MODE_HINTS = {
+  full: "Feed the whole mix to inference",
+  instruments: "Feed only the instrumental bed to inference",
+  vocals: "Feed only the vocal stem to inference"
+};
+var TIMBRE_REF_DESCRIPTION = "Optional reference audio for the timbre channel. Picking a track here biases the model's instrument character toward what's in that file, leaving structure (rhythm, sections) free to follow the playing input. Default 'Input Track' uses the playing source's own latent.";
+var STRUCTURE_REF_DESCRIPTION = "Optional reference audio for the structure channel. Picking a track here biases the model's section/rhythm/dynamics layout toward that file, leaving timbre (instrument character) free to follow the playing input. Default 'Input Track' uses the playing source's own latent.";
+var STEM_SECTION_DESCRIPTION = "Vocal and instrumental stems extracted from the source track. Drag a panner right to mix that layer into the model output. Click the layer name to mute or unmute without losing the level. Hold V (vocals) or I (instruments) + \u25B2\u25BC to nudge from the keyboard.";
+
+// controls/index.ts
+function displayNameFor(param) {
+  return CONTROL_DISPLAY_NAMES[param] ?? param.replace(/_/g, " ");
+}
+function describeControl(param) {
+  if (param.startsWith("lora_str_")) return LORA_STRENGTH_DESCRIPTION;
+  if (param === "lora_blend") return LORA_BLEND_DESCRIPTION;
+  if (param.startsWith("man_src_")) return MANUAL_SRC_DESCRIPTION;
+  if (param.startsWith("man_layer_")) return MANUAL_LAYER_DESCRIPTION;
+  if (param.startsWith("man_step_")) return MANUAL_STEP_DESCRIPTION;
+  if (param.startsWith("man_alpha_")) return MANUAL_ALPHA_DESCRIPTION;
+  return CONTROL_DESCRIPTIONS[param];
+}
+function resolveControlDescription(param, manifest) {
+  return describeControl(param) ?? manifest?.[param]?.description;
+}
+
 // node_modules/fzstd/esm/index.mjs
 var ab = ArrayBuffer;
 var u8 = Uint8Array;
@@ -3251,15 +3340,24 @@ async function fetchKnobManifest(sde = false, toUrl = (p) => p) {
 export {
   AudioPlayer,
   COMMAND_NAMES,
+  CONTROL_DESCRIPTIONS,
+  CONTROL_DISPLAY_NAMES,
   CROSSFADE_SECONDS,
   DCW_MODES,
   DCW_WAVELETS,
   DEFAULT_CONFIG,
   DEFAULT_TIME_SIGNATURE,
   EVENT_NAMES,
+  INTERP_PATH_DESCRIPTIONS,
   KNOB_SCHEMA_VERSION,
   KNOWN_TOP_LEVEL_KEYS,
   LOOP_GRID_ORDER,
+  LORA_BLEND_DESCRIPTION,
+  LORA_STRENGTH_DESCRIPTION,
+  MANUAL_ALPHA_DESCRIPTION,
+  MANUAL_LAYER_DESCRIPTION,
+  MANUAL_SRC_DESCRIPTION,
+  MANUAL_STEP_DESCRIPTION,
   PREEMPTED_CLOSE_CODE,
   PROTOCOL_VERSION,
   RCFG_MODES,
@@ -3268,13 +3366,19 @@ export {
   SLICE_FLAG_DELTA,
   SLICE_FLAG_RAW,
   SLICE_HDR_SIZE,
+  SOURCE_MODE_HINTS,
+  STEM_SECTION_DESCRIPTION,
+  STRUCTURE_REF_DESCRIPTION,
   T,
+  TIMBRE_REF_DESCRIPTION,
   VALID_TIME_SIGNATURES,
   WsReconnector,
   applyConfigToState,
   arrayBufferToBase64,
   base64ToArrayBuffer,
   captureConfigFromState,
+  describeControl,
+  displayNameFor,
   encodeWavInterleaved,
   fetchKnobManifest,
   fetchWireContract,
@@ -3296,6 +3400,7 @@ export {
   measureLoudness,
   mergeConfig,
   normalizeConfigShape,
+  resolveControlDescription,
   resolveLoraCapForSource,
   rtmgConfigToSessionConfig,
   selectVariant,

--- a/packages/demon-client/dist/demon-client.node.cjs
+++ b/packages/demon-client/dist/demon-client.node.cjs
@@ -20,14 +20,23 @@ var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: tru
 var node_exports = {};
 __export(node_exports, {
   COMMAND_NAMES: () => COMMAND_NAMES,
+  CONTROL_DESCRIPTIONS: () => CONTROL_DESCRIPTIONS,
+  CONTROL_DISPLAY_NAMES: () => CONTROL_DISPLAY_NAMES,
   DCW_MODES: () => DCW_MODES,
   DCW_WAVELETS: () => DCW_WAVELETS,
   DEFAULT_CONFIG: () => DEFAULT_CONFIG,
   DEFAULT_TIME_SIGNATURE: () => DEFAULT_TIME_SIGNATURE,
   EVENT_NAMES: () => EVENT_NAMES,
+  INTERP_PATH_DESCRIPTIONS: () => INTERP_PATH_DESCRIPTIONS,
   KNOB_SCHEMA_VERSION: () => KNOB_SCHEMA_VERSION,
   KNOWN_TOP_LEVEL_KEYS: () => KNOWN_TOP_LEVEL_KEYS,
   LOOP_GRID_ORDER: () => LOOP_GRID_ORDER,
+  LORA_BLEND_DESCRIPTION: () => LORA_BLEND_DESCRIPTION,
+  LORA_STRENGTH_DESCRIPTION: () => LORA_STRENGTH_DESCRIPTION,
+  MANUAL_ALPHA_DESCRIPTION: () => MANUAL_ALPHA_DESCRIPTION,
+  MANUAL_LAYER_DESCRIPTION: () => MANUAL_LAYER_DESCRIPTION,
+  MANUAL_SRC_DESCRIPTION: () => MANUAL_SRC_DESCRIPTION,
+  MANUAL_STEP_DESCRIPTION: () => MANUAL_STEP_DESCRIPTION,
   PREEMPTED_CLOSE_CODE: () => PREEMPTED_CLOSE_CODE,
   PROTOCOL_VERSION: () => PROTOCOL_VERSION,
   RCFG_MODES: () => RCFG_MODES,
@@ -36,11 +45,17 @@ __export(node_exports, {
   SLICE_FLAG_DELTA: () => SLICE_FLAG_DELTA,
   SLICE_FLAG_RAW: () => SLICE_FLAG_RAW,
   SLICE_HDR_SIZE: () => SLICE_HDR_SIZE,
+  SOURCE_MODE_HINTS: () => SOURCE_MODE_HINTS,
+  STEM_SECTION_DESCRIPTION: () => STEM_SECTION_DESCRIPTION,
+  STRUCTURE_REF_DESCRIPTION: () => STRUCTURE_REF_DESCRIPTION,
+  TIMBRE_REF_DESCRIPTION: () => TIMBRE_REF_DESCRIPTION,
   VALID_TIME_SIGNATURES: () => VALID_TIME_SIGNATURES,
   applyConfigToState: () => applyConfigToState,
   arrayBufferToBase64: () => arrayBufferToBase64,
   base64ToArrayBuffer: () => base64ToArrayBuffer,
   captureConfigFromState: () => captureConfigFromState,
+  describeControl: () => describeControl,
+  displayNameFor: () => displayNameFor,
   encodeWavInterleaved: () => encodeWavInterleaved,
   float16ArrayToFloat32: () => float16ArrayToFloat32,
   getUnknownKeys: () => getUnknownKeys,
@@ -52,6 +67,7 @@ __export(node_exports, {
   isTimeSignature: () => isTimeSignature,
   mergeConfig: () => mergeConfig,
   normalizeConfigShape: () => normalizeConfigShape,
+  resolveControlDescription: () => resolveControlDescription,
   resolveLoraCapForSource: () => resolveLoraCapForSource,
   rtmgConfigToSessionConfig: () => rtmgConfigToSessionConfig,
   selectVariant: () => selectVariant,
@@ -2247,17 +2263,115 @@ function base64ToArrayBuffer(b64) {
   }
   return bytes.buffer.slice(0, bi);
 }
+
+// controls/copy.ts
+var CONTROL_DISPLAY_NAMES = {
+  // Macros where the friendly name reads more clearly than the
+  // engine-honest one: `strength` for `denoise` (the "denoise"
+  // engine-internal naming refers to the diffusion step, but users
+  // perceive this knob as "how strong is the remix"), `structure` for
+  // `hint_strength`, `timbre` for `timbre_strength` (drop the
+  // "strength" suffix on knobs — the value readout already conveys
+  // magnitude). Everything else falls back to displayNameFor
+  // (underscore → space) so the UI matches what the engine, MIDI map,
+  // and config files call them.
+  denoise: "strength",
+  hint_strength: "structure",
+  timbre_strength: "timbre",
+  // dcw_* keep their engine-honest "DCW low" / "DCW high" — these are
+  // DCW-internal scalers, not generic EQ.
+  dcw_scaler: "DCW low",
+  dcw_high_scaler: "DCW high"
+};
+var CONTROL_DESCRIPTIONS = {
+  // ── Main remix controls ──
+  denoise: "How much the model reshapes the source audio. Keep it low for a subtle remix that stays close to the original; push it high to fully transform the track into something new. The most expressive knob \u2014 try sweeping it during playback.",
+  hint_strength: "How closely the model follows the original song's structure \u2014 sections, rhythm, dynamics. Crank it up to keep the arrangement intact; drop it to let the model rearrange more freely.",
+  timbre_strength: "How much of the source's instrument character (tone, color) carries into the output. High keeps the original instruments recognizable; low frees the model to swap them for whatever fits the prompt.",
+  // ── Engine internals ──
+  feedback: "How similar each new generation is to the previous one. Low values give you variety on every refresh; higher values give you a continuous evolution where each generation flows into the next. 0.3\u20130.5 is the sweet spot for smooth continuity without everything sounding the same.",
+  feedback_depth: "How far back in time the Feedback knob reaches. 1 (default) blends with the most recent generation. Higher values reach back several ticks for an echo / ghost effect \u2014 a faint repeat of an earlier moment surfaces in the current output. Lets you get distant feedback without cranking Feedback all the way up.",
+  shift: "Advanced: changes where the model concentrates its work across denoising. The default is tuned for the turbo engine and works well in most cases \u2014 leave it alone unless you're chasing a specific feel.",
+  steps_override: "Diffusion step count. Lower steps = lower quality. Higher steps = more latency. Default 8 is the turbo balance. Changing this rebuilds the streaming pipeline, so expect a brief audio glitch when you move it.",
+  guidance_scale: "CFG strength. Only takes effect when the RCFG mode dropdown below is NOT 'off'. Higher values push the output further toward the prompt at the cost of more artifacts. Turbo is CFG-distilled, so the useful range is narrower than a base SD model \u2014 try 3\u20138.",
+  cfg_rescale: "After CFG, mix the guided velocity's magnitude back toward what the positive forward produced. 0 keeps raw CFG; 1 fully snaps the magnitude. Pair with high guidance_scale to keep the prompt-push without the harshness that high CFG causes on its own.",
+  // ── Activation steering (auto path) ──
+  // Each tooltip names the underlying probe cell so the operator can
+  // recreate the effect on a manual slot.
+  steer_bright: "Activation-steering: positive alpha shifts spectral centroid up (brighter, more highs). 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector brightness_l09_t3 at layer = 9, step = round(3/8 x steps_count).",
+  steer_warm: "Activation-steering: positive alpha tilts the spectrum toward bass (warmer). The raw vector points the wrong way for this axis, so this knob folds in a -1 sign. 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector warmth_l15_t0 at layer = 15, step = 0, then INVERT alpha sign (manual mode is sign-agnostic).",
+  steer_rough: "Activation-steering: positive alpha increases spectral flatness (grittier, noisier). Vector magnitude at this probe cell is small, so effect builds slowly. 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector roughness_l09_t3 at layer = 9, step = round(3/8 x steps_count).",
+  steer_density: "Activation-steering: positive alpha thins the texture toward sparse/minimal. Inject layer is shifted 3 shallower than the probe layer (Phase-3 transfer finding). 0 = off; useful range 5-15 by ear. Recreate as a manual slot: vector density_l18_t3 at layer = 15 (probe 18 minus 3), step = round(3/8 x steps_count).",
+  // ── DCW ──
+  dcw_scaler: "Experimental \u2014 adjusts the low-band strength of an internal correction the model applies to itself during generation (DCW). This scaler is active in the early part of the run. The exact audio mapping is still being explored \u2014 sweep it to discover what it does for your source. Extreme values can be unpredictable but cool.",
+  dcw_high_scaler: "Experimental \u2014 adjusts the high-band strength of an internal correction the model applies to itself during generation (DCW). This scaler is active in the later part of the run. The exact audio mapping is still being explored \u2014 sweep it to discover what it does for your source. Extreme values can be unpredictable but cool."
+};
+var CHANNEL_GAINS = ["ch_g0", "ch_g1", "ch_g2", "ch_g3", "ch_g4", "ch_g5", "ch_g6", "ch_g7"];
+var NAMED_CHANNELS = ["ch13", "ch14", "ch19", "ch23", "ch29", "ch56"];
+for (const [i, p] of CHANNEL_GAINS.entries()) {
+  CONTROL_DESCRIPTIONS[p] = `Experimental \u2014 adjusts the strength of one of the model's internal latent channels (channel ${i}). Each channel encodes a different aspect of the sound (frequency band, dynamics, transients); the exact mapping is still being explored. Sweep it to discover what it does for your source.`;
+}
+for (const p of NAMED_CHANNELS) {
+  const idx = p.slice(2);
+  CONTROL_DESCRIPTIONS[p] = `Experimental \u2014 a hand-picked internal latent channel (#${idx}) that produces a noticeable perceptual change. Sweep it to hear what this specific channel controls for your source.`;
+}
+var LORA_STRENGTH_DESCRIPTION = "How strongly this LoRA shapes the output. LoRAs are little style packs \u2014 set a low value for a subtle flavor, crank past 1.0 to make this LoRA dominate the sound. Multiple LoRAs stack \u2014 turn several on at once for combined styles.";
+var LORA_BLEND_DESCRIPTION = "Crossfade between LoRA A and LoRA B. 0 = A only, 1 = B only, 0.5 = both at half strength. Use this to morph between two styles smoothly.";
+var MANUAL_SRC_DESCRIPTION = "Catalog index of the steering vector this slot fires. The catalog enumerates every pre-built (axis, build_layer, build_step) cell on disk in stable axis-major order. Double-click the readout to type an exact index; query the MCP list_manual_steering_vectors tool for the full table. Has no effect until \u03B1 is non-zero.";
+var MANUAL_LAYER_DESCRIPTION = "DiT inject layer (0-23). The vector is added to this layer's post-block residual. Bypasses the auto path's density layer offset \u2014 the value lands exactly where you point it.";
+var MANUAL_STEP_DESCRIPTION = "Diffusion inject step (0-15). Bypasses the auto path's fractional step mapping; the engine fires the injection only on the step that matches this value. If you pick a step past the current steps count - 1, the slot stays silent until you raise the step count.";
+var MANUAL_ALPHA_DESCRIPTION = "Strength of this manual slot's injection. 0 disables the slot. Negative \u03B1 inverts the vector's direction at injection time (no sign correction is applied; what you set is what the engine receives). Sweep range and breakage point mirror the perceptual steering knobs.";
+var INTERP_PATH_DESCRIPTIONS = {
+  structure: "How structural (semantic-hint) guidance blends in. Slerp holds the latent's norm constant; linear averages.",
+  timbre: "How the timbre reference blends from silence to full. Slerp holds the conditioning norm constant; linear averages.",
+  prompt: "How prompt A crossfades to prompt B. Slerp avoids the washed-out midpoint a linear average produces between unrelated prompts.",
+  feedback: "How the latent feedback tap mixes into the source. Slerp holds the latent's norm constant; linear averages."
+};
+var SOURCE_MODE_HINTS = {
+  full: "Feed the whole mix to inference",
+  instruments: "Feed only the instrumental bed to inference",
+  vocals: "Feed only the vocal stem to inference"
+};
+var TIMBRE_REF_DESCRIPTION = "Optional reference audio for the timbre channel. Picking a track here biases the model's instrument character toward what's in that file, leaving structure (rhythm, sections) free to follow the playing input. Default 'Input Track' uses the playing source's own latent.";
+var STRUCTURE_REF_DESCRIPTION = "Optional reference audio for the structure channel. Picking a track here biases the model's section/rhythm/dynamics layout toward that file, leaving timbre (instrument character) free to follow the playing input. Default 'Input Track' uses the playing source's own latent.";
+var STEM_SECTION_DESCRIPTION = "Vocal and instrumental stems extracted from the source track. Drag a panner right to mix that layer into the model output. Click the layer name to mute or unmute without losing the level. Hold V (vocals) or I (instruments) + \u25B2\u25BC to nudge from the keyboard.";
+
+// controls/index.ts
+function displayNameFor(param) {
+  return CONTROL_DISPLAY_NAMES[param] ?? param.replace(/_/g, " ");
+}
+function describeControl(param) {
+  if (param.startsWith("lora_str_")) return LORA_STRENGTH_DESCRIPTION;
+  if (param === "lora_blend") return LORA_BLEND_DESCRIPTION;
+  if (param.startsWith("man_src_")) return MANUAL_SRC_DESCRIPTION;
+  if (param.startsWith("man_layer_")) return MANUAL_LAYER_DESCRIPTION;
+  if (param.startsWith("man_step_")) return MANUAL_STEP_DESCRIPTION;
+  if (param.startsWith("man_alpha_")) return MANUAL_ALPHA_DESCRIPTION;
+  return CONTROL_DESCRIPTIONS[param];
+}
+function resolveControlDescription(param, manifest) {
+  return describeControl(param) ?? manifest?.[param]?.description;
+}
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
   COMMAND_NAMES,
+  CONTROL_DESCRIPTIONS,
+  CONTROL_DISPLAY_NAMES,
   DCW_MODES,
   DCW_WAVELETS,
   DEFAULT_CONFIG,
   DEFAULT_TIME_SIGNATURE,
   EVENT_NAMES,
+  INTERP_PATH_DESCRIPTIONS,
   KNOB_SCHEMA_VERSION,
   KNOWN_TOP_LEVEL_KEYS,
   LOOP_GRID_ORDER,
+  LORA_BLEND_DESCRIPTION,
+  LORA_STRENGTH_DESCRIPTION,
+  MANUAL_ALPHA_DESCRIPTION,
+  MANUAL_LAYER_DESCRIPTION,
+  MANUAL_SRC_DESCRIPTION,
+  MANUAL_STEP_DESCRIPTION,
   PREEMPTED_CLOSE_CODE,
   PROTOCOL_VERSION,
   RCFG_MODES,
@@ -2266,11 +2380,17 @@ function base64ToArrayBuffer(b64) {
   SLICE_FLAG_DELTA,
   SLICE_FLAG_RAW,
   SLICE_HDR_SIZE,
+  SOURCE_MODE_HINTS,
+  STEM_SECTION_DESCRIPTION,
+  STRUCTURE_REF_DESCRIPTION,
+  TIMBRE_REF_DESCRIPTION,
   VALID_TIME_SIGNATURES,
   applyConfigToState,
   arrayBufferToBase64,
   base64ToArrayBuffer,
   captureConfigFromState,
+  describeControl,
+  displayNameFor,
   encodeWavInterleaved,
   float16ArrayToFloat32,
   getUnknownKeys,
@@ -2282,6 +2402,7 @@ function base64ToArrayBuffer(b64) {
   isTimeSignature,
   mergeConfig,
   normalizeConfigShape,
+  resolveControlDescription,
   resolveLoraCapForSource,
   rtmgConfigToSessionConfig,
   selectVariant,

--- a/packages/demon-client/index.ts
+++ b/packages/demon-client/index.ts
@@ -25,6 +25,13 @@ export * from "./config";
 // stays per-client). See ./inputs.
 export * from "./inputs";
 
+// Portable control copy: user-facing knob/input descriptions + display names
+// (describeControl / displayNameFor / resolveControlDescription). Client-side,
+// hand-authored — the editorial layer, distinct from the terse agent-facing
+// descriptions on the /api/knobs manifest. The tooltip-rendering machinery
+// stays per-client. See ./controls.
+export * from "./controls";
+
 // WebSocket session client (binary slice stream, swap/stem state
 // machines, typed senders).
 export { RemoteBackend, float16ArrayToFloat32 } from "./protocol";

--- a/packages/demon-client/node.ts
+++ b/packages/demon-client/node.ts
@@ -74,3 +74,9 @@ export {
   base64ToArrayBuffer,
 } from "./inputs";
 export type { StemSourceMode, SerializedInput, SerializedInputs } from "./inputs";
+
+// Portable control copy — user-facing knob/input descriptions + display names
+// for the native preset path (M4L bridge / VST codegen). Pure data + pure
+// functions (no DOM/fetch), so the whole module is safe in the CJS bundle.
+// See ./controls.
+export * from "./controls";


### PR DESCRIPTION
## What

Moves the **user-facing control copy** (tooltip prose + friendly display names a frontend renders ON its knobs/inputs) out of the web demo and into `@demon/client/controls` — a hand-authored, client-side layer alongside `config/`.

This is distinct from the backend `/api/knobs` manifest's `description` field: same param ids, two audiences.

- **Manifest `description`** (in `acestep/streaming/knobs.py`, served over the wire) = terse, agent/MCP-facing. **Untouched.**
- **`controls/` copy** = editorial, "when to reach for this knob" prose. Now the SDK's job.

`resolveControlDescription(param, manifest?)` merges them: prefer the rich copy, fall back to the manifest's terse description for runtime-only knobs (LoRAs, manual slots).

## Changes

- New `packages/demon-client/controls/` (`copy.ts` + `index.ts`): `CONTROL_DESCRIPTIONS`, `CONTROL_DISPLAY_NAMES`, interp/source-mode/ref/stem strings, `describeControl()`, `displayNameFor()`, `resolveControlDescription()`. Exported from both `index.ts` and `node.ts` (pure data + functions, safe for the Node/CJS target).
- Web demo becomes a thin consumer: `SliderTile` re-exports the SDK helpers under its historical names; `OperatorStrip`, `SourceModeSwitch`, `RefControl`, `HeroMacros` import their copy from `@demon/client`. ~146 lines of copy removed from web components.
- Web-only affordances (keyboard chords, MIDI-learn) and the tooltip-rendering machinery stay per-client.

## Verification

- SDK `npm run build` — all bundles, symbols confirmed in `dist/`.
- Web `tsc --noEmit` — clean.
- vitest unit + replay — 66 passed, 1 pre-existing skip.
- `tests/unit/test_client_sdk.py` (import boundary) — 3 passed.
- Spot-checked in the running app: knob tooltips/labels resolve from the SDK.
