### PR TITLE
fix(rtmg/web): re-send the active loop band on reconnect

### DIFF
--- a/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
+++ b/demos/realtime_motion_graph_web/web/hooks/useStartSession.ts
@@ -430,6 +430,36 @@ async function restoreRefs(remote: RemoteBackend): Promise<void> {
   );
 }
 
+/** Minimum loop-region length in seconds. Mirrors `MIN_BAND_SEC` in
+ *  WaveformScrubBox — below this the band is meaningless and the editor
+ *  never mirrors it to the worklet / server. */
+const MIN_LOOP_BAND_SEC = 0.05;
+
+/**
+ * Re-send the operator's active loop band to a freshly (re)connected
+ * backend. Like timbre / structure refs, the loop band is NOT part of
+ * SessionConfig, and the only other sender (WaveformScrubBox's sync
+ * effect) does not re-run on reconnect — the AudioPlayer persists and
+ * `loopBand` is unchanged. So without this the new server session never
+ * learns the band: it decodes against the full timeline while the
+ * worklet keeps looping locally, drifting into a stale loop at the seam.
+ * Mirrors restoreRefs: read the source-of-truth store and re-apply to
+ * the new remote. The activity gate matches WaveformScrubBox exactly so
+ * we only send a band the listener is actually hearing loop.
+ */
+export function restoreLoopBand(remote: RemoteBackend): void {
+  const perf = usePerformanceStore.getState();
+  const band = perf.loopBand;
+  const active =
+    band !== null &&
+    perf.bandLoopEnabled &&
+    band.end - band.start >= MIN_LOOP_BAND_SEC &&
+    band.start >= 0;
+  if (active) {
+    remote.sendLoopBand(band.start, band.end);
+  }
+}
+
 export function useStartSession() {
   return useCallback(async () => {
     const { setStatus, setSession, reset } = useSessionStore.getState();
@@ -620,6 +650,12 @@ export function useStartSession() {
           // refs aren't carried in buildConfig, so without this a
           // reconnect silently drops them.
           await restoreRefs(remote);
+          // Same story for the active loop band: not in buildConfig, and
+          // WaveformScrubBox's sender effect doesn't re-run on reconnect
+          // (the AudioPlayer persists, loopBand unchanged). Without this
+          // the worklet keeps looping locally while the new server
+          // decodes the full timeline → drift / stale loop at the seam.
+          restoreLoopBand(remote);
         },
         {
           onAttempt: ({ attempt, maxAttempts }) => {

--- a/demos/realtime_motion_graph_web/web/tests/unit/wsReconnect.test.ts
+++ b/demos/realtime_motion_graph_web/web/tests/unit/wsReconnect.test.ts
@@ -3,6 +3,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { WsReconnector, type ReconnectAttempt } from "@demon/client";
+import type { RemoteBackend } from "@demon/client";
+import { restoreLoopBand } from "@/hooks/useStartSession";
+import { usePerformanceStore } from "@/store/usePerformanceStore";
 
 describe("WsReconnector", () => {
   beforeEach(() => {
@@ -121,5 +124,57 @@ describe("WsReconnector", () => {
     const r = new WsReconnector(vi.fn());
     r.cancel();
     r.cancel();
+  });
+});
+
+// Regression: the reconnect success path re-applies session state that
+// isn't carried in SessionConfig (timbre/structure refs, and — the bug
+// this guards — the active loop band). WaveformScrubBox's sender effect
+// doesn't re-run on reconnect (the AudioPlayer persists, `loopBand`
+// unchanged), so without `restoreLoopBand` the freshly reconnected
+// backend never learns the band: the worklet keeps looping locally
+// while the server decodes the full timeline → drift / stale loop.
+describe("restoreLoopBand on reconnect", () => {
+  const pristine = usePerformanceStore.getState();
+  beforeEach(() => {
+    usePerformanceStore.setState(pristine, true);
+  });
+
+  function fakeRemote(): { remote: RemoteBackend; sendLoopBand: ReturnType<typeof vi.fn> } {
+    const sendLoopBand = vi.fn();
+    return { remote: { sendLoopBand } as unknown as RemoteBackend, sendLoopBand };
+  }
+
+  it("re-sends the active loop band with its exact region", () => {
+    usePerformanceStore.getState().setLoopBand({ start: 2.5, end: 6.0 });
+    usePerformanceStore.getState().setBandLoopEnabled(true);
+    const { remote, sendLoopBand } = fakeRemote();
+    restoreLoopBand(remote);
+    expect(sendLoopBand).toHaveBeenCalledTimes(1);
+    expect(sendLoopBand).toHaveBeenCalledWith(2.5, 6.0);
+  });
+
+  it("does not send anything when no band is set", () => {
+    // Pristine store: loopBand is null even though bandLoopEnabled defaults on.
+    expect(usePerformanceStore.getState().loopBand).toBeNull();
+    const { remote, sendLoopBand } = fakeRemote();
+    restoreLoopBand(remote);
+    expect(sendLoopBand).not.toHaveBeenCalled();
+  });
+
+  it("does not send a band that is armed-but-off (loop disabled)", () => {
+    usePerformanceStore.getState().setLoopBand({ start: 1.0, end: 4.0 });
+    usePerformanceStore.getState().setBandLoopEnabled(false);
+    const { remote, sendLoopBand } = fakeRemote();
+    restoreLoopBand(remote);
+    expect(sendLoopBand).not.toHaveBeenCalled();
+  });
+
+  it("ignores a degenerate sub-50ms region", () => {
+    usePerformanceStore.getState().setLoopBand({ start: 1.0, end: 1.02 });
+    usePerformanceStore.getState().setBandLoopEnabled(true);
+    const { remote, sendLoopBand } = fakeRemote();
+    restoreLoopBand(remote);
+    expect(sendLoopBand).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Root cause (confirmed)

After an automatic reconnect (network blip), the **active loop band is silently dropped server-side**.

The `WsReconnector` success callback in `demos/realtime_motion_graph_web/web/hooks/useStartSession.ts` re-applies detected metadata, the LoRA catalog/cap/strengths, the network monitor, and timbre/structure refs (`await restoreRefs(remote)`), but **never re-sends the loop band**:

- The loop band is **not** part of `buildConfig` (`useStartSession.ts` `buildConfig`, ~L100-136) — it carries prompts, LoRAs, fixture, source mode, client id, but no band.
- The **only** code that calls `remote.sendLoopBand(...)` is the `WaveformScrubBox` sync effect (`components/Performance/WaveformScrubBox.tsx` ~L361-384), which depends on `[bandState, bandLoopEnabled, hasPlayer, player]`. On reconnect the `AudioPlayer` persists and `loopBand`/`bandLoopEnabled` are unchanged, so the effect does **not** re-run.

Result: the new `RemoteBackend` never learns the band. The worklet keeps looping the region locally while the new server session decodes against the full timeline → drift / a stale loop window at the seam.

`sendLoopBand` is a real SDK method (`packages/demon-client/protocol.ts` ~L1070), so the fix is wire-supported.

## Fix

Mirror the established "re-apply session state on reconnect" pattern (`restoreRefs`):

- Add `restoreLoopBand(remote)` next to `restoreRefs`. It reads the source-of-truth performance store (`usePerformanceStore` `loopBand` / `bandLoopEnabled`) and, when a band is **active**, re-sends it via `remote.sendLoopBand(start, end)`.
- The activity gate matches `WaveformScrubBox` exactly (`band != null && bandLoopEnabled && end-start >= 0.05 && start >= 0`) so we only re-send a band the listener is actually hearing loop.
- Call it right after `await restoreRefs(remote)` in the `WsReconnector` success callback.

No new subsystem; ~30 lines including doc comment, following the same extracted-function shape as `restoreRefs`.

## No regression

Extended `tests/unit/wsReconnect.test.ts` with a `restoreLoopBand on reconnect` block asserting:
- the active loop band is re-sent with its exact region after a reconnect;
- nothing is sent when no band is set;
- nothing is sent for an armed-but-off (loop-disabled) band;
- a degenerate sub-50ms region is ignored.

## Verification

Run in `demos/realtime_motion_graph_web/web/`:

- `npx vitest run tests/unit/wsReconnect.test.ts` → **11 passed** (7 existing + 4 new).
- `npm run typecheck` → clean (exit 0).
- `npm run build` → compiled successfully (exit 0).

(The full `tests/unit` run shows 8 pre-existing failures in `sliceEpoch.test.ts` due to `Math.f16round is not a function` on this Node build — unrelated to this change; the touched test file passes.)

Made with [Cursor](https://cursor.com)