### PR TITLE
feat(fixtures): register 23 new curated loops in KNOWN_FIXTURES

### DIFF
--- a/acestep/fixtures.py
+++ b/acestep/fixtures.py
@@ -76,6 +76,31 @@ KNOWN_FIXTURES: frozenset[str] = frozenset({
     "low_fi_Gm_loop_60s_gnm.wav",
     "prog_rock_loop_60s_enm.wav",
     "thrash_metal_loop_60s_enm.wav",
+    # --- classical loops (key carried in filename suffix) ---
+    "amazing_grace_loop_55s_cM.wav",
+    "beethoven_9_scherzo_loop_37s_dnm.wav",
+    "bridal_chorus_loop_55s_bfM.wav",
+    "canon_in_d_loop_46s_dM.wav",
+    "gymnopedie_loop_49s_dM.wav",
+    "hall_of_the_mountain_king_loop_58s_bnm.wav",
+    "mozart_symphony_40_loop_49s_gnm.wav",
+    "toccata_and_fugue_loop_58s_dnm.wav",
+    # --- genre loops (bpm in seeded track.json; key in filename + track.json) ---
+    "acoustic_folk_loop_55s_gM.wav",
+    "baroque_quartet_loop_53s_dM.wav",
+    "cinematic_orchestral_loop_54s_dnm.wav",
+    "dark_ambient_drone_loop_56s_dnm.wav",
+    "deep_house_loop_54s_anm.wav",
+    "dub_reggae_loop_53s_anm.wav",
+    "glitch_idm_loop_57s_anm.wav",
+    "indian_raga_loop_59s_dfM.wav",
+    "jazz_organ_trio_loop_59s_fM.wav",
+    "latin_cumbia_loop_56s_enm.wav",
+    "liquid_dnb_loop_56s_fsm.wav",
+    "lofi_loop_51s_anm.wav",
+    "piano_nocturne_loop_58s_bfm.wav",
+    "synthpop_loop_58s_enm.wav",
+    "trap_beat_loop_55s_fnm.wav",
 })
 
 


### PR DESCRIPTION
Adds 23 curated loops to KNOWN_FIXTURES so they're available in the demo's
source / timbre / structure pickers.

The audio and sidecars are already on the daydreamlive/demon-fixtures-v2
dataset, in the same per-track layout as the existing fixtures (source.wav,
track.json, full + vocals/instruments sidecars, and the two stem WAVs). This
PR is only the code half: the runtime gates on KNOWN_FIXTURES, so the loops
won't appear anywhere until this merges and a build ships.

HF dataset commit:
https://huggingface.co/datasets/daydreamlive/demon-fixtures-v2/commit/cfa20cb106f1004e70e1df04b5a444e6226bc1a7

The set:
- 8 classical loops with the key in the filename suffix
  (canon_in_d_loop_46s_dM, beethoven_9_scherzo_loop_37s_dnm, ...)
- 15 genre loops in the existing <name>_loop_<dur>s_<key> style
  (deep house, liquid dnb, lofi, trap, jazz organ, ...)

bpm / key / time_signature are seeded per fixture in track.json. A few needed
a human call: the ambient drone has no beat so its bpm is nominal, the indian
raga is modal so it got the nearest western key (Db major), and two librosa
bpm guesses were corrected by hand (canon to 60, bridal to 128). Three of the
classical pieces are in 3/4.

Encoded with scripts/calibration/precompute_fixture_sidecars (with stems),
same path as the originals, and spot-checked in the demo before upload.
