### PR TITLE
perf(sa3): skip wasted random init on model load (~30s -> ~12s)

### DIFF
--- a/acestep/engine/sa3_helpers.py
+++ b/acestep/engine/sa3_helpers.py
@@ -12,6 +12,7 @@ with a local checkout.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import subprocess
 import sys
@@ -246,3 +247,53 @@ def import_loader_helpers():
     import sa3_reference_generate  # noqa: PLC0415
 
     return sa3_reference_generate
+
+
+@contextlib.contextmanager
+def skip_param_init():
+    """No-op the expensive random parameter inits during model construction.
+
+    SA3's loader (``stable_audio_3.loading_utils.load_diffusion_cond``)
+    builds the DiT + SAME + conditioner with full random init on CPU
+    (~20s for the medium checkpoint), then ``copy_state_dict``
+    immediately overwrites every parameter with the checkpoint's weights
+    — so the init is pure wasted work. Wrapping construction in this
+    context manager no-ops only the random *fills* (``kaiming_*``,
+    ``xavier_*``, ``normal_``, ``uniform_``, ``trunc_normal_`` — plus the
+    in-place ``Tensor.normal_``/``uniform_`` some inits call directly).
+    Weight *loading* (``load_state_dict``) is untouched, and deterministic
+    buffers (rotary ``inv_freq``, etc.) are arange-computed rather than
+    randomly filled, so they are unaffected.
+
+    Verified bit-identical to the un-skipped load across every parameter
+    and buffer of the medium checkpoint (see
+    ``tests/unit/test_sa3_fastload.py`` for the property test); cuts the
+    medium ``SA3Context`` load from ~30s to ~12s cold.
+
+    Safe only because every constructed parameter is subsequently
+    overwritten from the checkpoint (``missing_keys == 0``). A future SA3
+    model that ships parameters *not* present in its checkpoint would get
+    uninitialized values here — if that ever happens, gate this off or
+    re-init the leftover keys.
+    """
+    import torch  # noqa: PLC0415
+    import torch.nn.init as init  # noqa: PLC0415
+
+    fill_names = (
+        "kaiming_uniform_", "kaiming_normal_", "xavier_uniform_",
+        "xavier_normal_", "uniform_", "normal_", "trunc_normal_",
+    )
+    saved_init = {n: getattr(init, n) for n in fill_names if hasattr(init, n)}
+    saved_normal_ = torch.Tensor.normal_
+    saved_uniform_ = torch.Tensor.uniform_
+    for name in saved_init:
+        setattr(init, name, lambda tensor, *a, **k: tensor)
+    torch.Tensor.normal_ = lambda self, *a, **k: self
+    torch.Tensor.uniform_ = lambda self, *a, **k: self
+    try:
+        yield
+    finally:
+        for name, fn in saved_init.items():
+            setattr(init, name, fn)
+        torch.Tensor.normal_ = saved_normal_
+        torch.Tensor.uniform_ = saved_uniform_

--- a/scripts/sa3/sa3_reference_generate.py
+++ b/scripts/sa3/sa3_reference_generate.py
@@ -48,6 +48,7 @@ from acestep.engine.sa3_helpers import (  # noqa: E402
     ensure_sa3_paths,
     require_sa3_vendor,
     sa3_checkpoint_dir,
+    skip_param_init,
 )
 
 ensure_sa3_paths()
@@ -102,9 +103,15 @@ def load_local_model(dest: Path, device: str, model_half: bool):
     if not patched:
         raise RuntimeError("No t5gemma conditioner found in model_config to patch.")
 
-    model = load_diffusion_cond(
-        model_config, str(ckpt_path), device=device, model_half=model_half
-    )
+    # skip_param_init no-ops the wasted random init inside
+    # load_diffusion_cond's construct step (~20s for medium); the weights
+    # are overwritten from the checkpoint immediately after, so the init
+    # is pure waste. Bit-identical result — see skip_param_init's docstring
+    # and tests/unit/test_sa3_fastload.py.
+    with skip_param_init():
+        model = load_diffusion_cond(
+            model_config, str(ckpt_path), device=device, model_half=model_half
+        )
     model.use_lora = False
     model.lora_names = []
     return StableAudioModel(model, model_config, device, model_half)

--- a/tests/unit/test_sa3_fastload.py
+++ b/tests/unit/test_sa3_fastload.py
@@ -1,0 +1,105 @@
+"""Property tests for the SA3 fast-load optimization (skip_param_init).
+
+These use a tiny toy module rather than the real SA3 checkpoint, so they
+run in CI without GPU or the 9 GB weights: what we need to guarantee is
+the *contract* of skip_param_init — random inits are no-op'd during
+construction, deterministic buffers are untouched, and a
+construct-then-load is bit-identical to the un-skipped path.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+torch = pytest.importorskip("torch")
+import torch.nn as nn  # noqa: E402
+import torch.nn.init as init  # noqa: E402
+
+from acestep.engine import sa3_helpers  # noqa: E402
+
+
+class _Toy(nn.Module):
+    """Stand-in for the SA3 model shape: random-init'd params (Linear/
+    Embedding call nn.init in reset_parameters) plus a deterministic,
+    arange-computed buffer (like a rotary ``inv_freq``)."""
+
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(64, 128)
+        self.fc2 = nn.Linear(128, 32)
+        self.emb = nn.Embedding(16, 64)
+        self.register_buffer(
+            "inv_freq", 1.0 / (10000 ** (torch.arange(0, 64, 2).float() / 64))
+        )
+
+
+def test_random_fills_are_noop_inside_context():
+    t = torch.ones(10, 10)
+    with sa3_helpers.skip_param_init():
+        init.kaiming_uniform_(t)
+        init.xavier_uniform_(t)
+        init.normal_(t)
+        init.uniform_(t)
+        init.trunc_normal_(t)
+        t.normal_()
+        t.uniform_()
+        assert torch.equal(t, torch.ones(10, 10)), "fills should be no-ops"
+
+
+def test_fills_restored_after_context():
+    with sa3_helpers.skip_param_init():
+        pass
+    t = torch.ones(10, 10)
+    init.normal_(t)
+    assert not torch.equal(t, torch.ones(10, 10)), "init must work again after"
+    # in-place Tensor methods restored too
+    assert torch.Tensor.normal_ is not (lambda self: self)
+    u = torch.ones(10)
+    u.uniform_()
+    assert not torch.equal(u, torch.ones(10))
+
+
+def test_fills_restored_on_exception():
+    with pytest.raises(RuntimeError):
+        with sa3_helpers.skip_param_init():
+            raise RuntimeError("boom")
+    t = torch.ones(8)
+    init.normal_(t)
+    assert not torch.equal(t, torch.ones(8)), "must restore even if body raises"
+
+
+def test_construct_then_load_is_bit_identical():
+    """The property that makes the optimization safe: skipping init and
+    then loading the checkpoint yields exactly the un-skipped result,
+    for every parameter AND buffer."""
+    torch.manual_seed(0)
+    reference = _Toy().eval()
+    saved = {k: v.clone() for k, v in reference.state_dict().items()}
+
+    # Mirror production: construct AND load inside the context.
+    with sa3_helpers.skip_param_init():
+        fast = _Toy()
+        missing, unexpected = fast.load_state_dict(saved, strict=False)
+    fast.eval()
+
+    assert list(missing) == [], f"unexpected missing keys: {missing}"
+    assert list(unexpected) == [], f"unexpected keys: {unexpected}"
+    for name, ref_val in reference.state_dict().items():
+        assert torch.equal(fast.state_dict()[name], ref_val), name
+
+
+def test_computed_buffer_unaffected_by_skip():
+    """A deterministic (arange-computed) buffer must be identical whether
+    or not init is skipped — the no-ops only touch random fills."""
+    torch.manual_seed(0)
+    normal = _Toy()
+    with sa3_helpers.skip_param_init():
+        skipped = _Toy()
+    assert torch.equal(normal.inv_freq, skipped.inv_freq)


### PR DESCRIPTION
SA3's loader builds the model with random weights on CPU (~20s), then immediately overwrites every parameter from the checkpoint — so the init is pure wasted work.

`skip_param_init()` (in `acestep.engine.sa3_helpers`) no-ops the random fills during construction only; `load_state_dict` and deterministic buffers are untouched. `load_local_model` wraps `load_diffusion_cond` in it.

- **Bit-identical** to the un-skipped load across every param and buffer of the medium checkpoint.
- Cold `SA3Context` load drops **~30s → ~12s** on a 5090.
- `tests/unit/test_sa3_fastload.py` locks the contract with a toy module (no GPU/weights in CI).