### PR TITLE
feat(enhance): model-specific prompt enhancement for Stable Audio 3

### DIFF
--- a/demos/realtime_motion_graph_web/prompt_enhancer.py
+++ b/demos/realtime_motion_graph_web/prompt_enhancer.py
@@ -45,6 +45,57 @@ RULES:
   options, no explanation, no line breaks, no "Prompt:" label.
 """.strip()
 
+# Stable Audio 3 policy. SA3 is the same engine theDAW documents (T5Gemma text
+# encoder + separate duration signal), so its prompting guide
+# (theDAW/docs/guides/prompting.md) is the authoritative reference here. SA3
+# reads the prompt as a producer's natural-language DESCRIPTION of a track, not a
+# bare tag list, so this system prompt asks for compact descriptive phrases,
+# genre + hook instrument first (they carry the most weight and the first phrases
+# dominate the result). BPM stays OUT of the clean output on purpose: the M4L
+# wire helper (demon::promptMeta) appends the REAL project tempo/key downstream
+# for backend=="sa3", so a genre-typical number here would ship two conflicting
+# BPMs. _sanitize's bpm-strip is shared and stays active for both backends.
+_SYSTEM_SA3 = """
+You expand a user's rough music idea into ONE vivid prompt for the Stable Audio 3
+generative-music model.
+
+SA3 reads the prompt as a producer's DESCRIPTION of a track — the way one producer
+describes a song to another — NOT a list of bare tags. Its text encoder conditions
+on MEANING, so short DESCRIPTIVE PHRASES beat isolated one-word keywords, while
+dense, compact phrasing beats long prose. Write ONE line.
+
+Draw only from the dimensions that matter for the intended sound:
+- genre / subgenre
+- instrumentation (name the hook / lead instrument especially)
+- tempo / feel — qualitative words ONLY ("uptempo", "half-time", "rolling", "driving")
+- mood / energy
+- production / mix texture
+- structure / motion
+
+Genre and the hook instrument carry the most weight, and THE FIRST PHRASES DOMINATE
+the result — lead with the genre and the key instrument.
+
+Follow this pattern: <genre>, <key instruments>, <tempo/feel>, <mood>, <production texture>
+
+Examples:
+lo-fi boom bap, dusty Rhodes chords, vinyl crackle, lazy swung drums, nostalgic
+liquid drum & bass, lush reverb pads, rolling sub bass, chopped soul vocal, uplifting
+cinematic orchestral build, low strings, taiko hits, rising tension, percussion entering at the climax
+bossa nova, nylon guitar, soft brushes, upright bass, intimate jazz club, warm
+melodic techno, hypnotic arpeggio, deep kick, analog bass, wide stereo
+
+RULES:
+- Stay faithful to the user's idea — honor any named artist, genre, era, or instrument
+  they mention (e.g. "boards of canada style" -> that hazy, nostalgic analog sound).
+- Describe the DESIRED trait directly ("clean, dry, minimal reverb") — NEVER phrase it
+  as what to avoid.
+- NEVER include a bpm/tempo NUMBER or a duration in seconds — describe tempo with words
+  only. The real tempo and key are added downstream, not by you.
+- Roughly 5-9 comma-separated phrases. Lowercase. One cohesive vibe.
+- Reply with ONLY the single comma-separated line. No preamble, no quotes, no options,
+  no explanation, no line breaks, no "Prompt:" label.
+""".strip()
+
 
 def llm_available() -> bool:
     """True when an Anthropic key is configured in the environment."""
@@ -97,8 +148,14 @@ def _ask_haiku(system: str, user: str) -> str | None:
     return None
 
 
-def enhance_prompt(idea: str) -> tuple[str, bool]:
-    """Expand a rough idea into a rich ACE-Step prompt.
+def enhance_prompt(idea: str, backend: str = "acestep") -> tuple[str, bool]:
+    """Expand a rough idea into a rich prompt for the active backend.
+
+    ``backend`` selects the LLM policy: ``"sa3"`` uses the Stable Audio 3
+    natural-language description style; anything else (default) uses the legacy
+    ACE-Step comma-tag style. The default keeps the pre-existing no-``backend``
+    call path byte-identical. ``_sanitize`` (incl. the bpm-strip) is shared, so
+    both backends stay bpm-number-free.
 
     Returns ``(text, ok)``. ``ok=False`` means enhancement was unavailable or
     failed and ``text`` is the caller's input echoed back unchanged, so the
@@ -107,8 +164,13 @@ def enhance_prompt(idea: str) -> tuple[str, bool]:
     idea = (idea or "").strip()
     if not idea:
         return idea, False
-    user = f'Rough idea: "{idea[:300]}". Expand it into one rich ACE-Step prompt.'
-    raw = _ask_haiku(_SYSTEM, user)
+    if backend == "sa3":
+        system = _SYSTEM_SA3
+        user = f'Rough idea: "{idea[:300]}". Expand it into one rich Stable Audio 3 prompt.'
+    else:
+        system = _SYSTEM
+        user = f'Rough idea: "{idea[:300]}". Expand it into one rich ACE-Step prompt.'
+    raw = _ask_haiku(system, user)
     if not raw:
         return idea, False
     out = _sanitize(raw)

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -87,10 +87,36 @@ _DEFAULT_MODE = "graph"
 _CHECKPOINT: str = "acestep-v15-turbo"
 _VALID_MODES = ("graph", "video")
 
+# Backend FAMILY of the active checkpoint ("acestep" | "sa3"), captured in
+# main() from resolve_checkpoint() at CLI parse. Kept separate from _CHECKPOINT
+# because _CHECKPOINT holds the resolved MODEL ID (e.g. "medium"), which no
+# longer carries the family — so the prompt enhancer must read the family here,
+# not sniff the checkpoint string. Defaults to acestep for --no-backend.
+_BACKEND_FAMILY: str = "acestep"
+
 # --checkpoint aliases live in acestep.streaming.families
 # (CHECKPOINT_ALIASES / resolve_checkpoint): each alias names a
 # (backend family, model id) pair, e.g. "xl" -> acestep, "sa3-small"
 # -> the sa3 family. Resolved in main() at CLI parse.
+
+# Prompt-enhancer backends: which LLM policy /api/enhance selects. The pod
+# already knows its own family via _BACKEND_FAMILY, so it INFERS the backend and
+# a client `backend=` query param is only an optional override.
+_ENHANCE_BACKENDS = ("acestep", "sa3")
+
+
+def _resolve_enhance_backend(override: str) -> str:
+    """Pick the enhancer backend: a valid client override wins, else infer.
+
+    Inference reads the pod's resolved backend family (``_BACKEND_FAMILY``): the
+    ``sa3`` family selects the Stable Audio 3 natural-language policy, everything
+    else keeps ACE-Step tags. An unknown/blank override never errors — it falls
+    back to the inferred backend, so a stale client can't break enhancement.
+    """
+    o = (override or "").strip().lower()
+    if o in _ENHANCE_BACKENDS:
+        return o
+    return _BACKEND_FAMILY if _BACKEND_FAMILY in _ENHANCE_BACKENDS else "acestep"
 
 _NO_CACHE_HEADERS = [
     ("Cache-Control", "no-store, must-revalidate"),
@@ -213,21 +239,27 @@ def _process_request(connection, request):
             body,
         )
 
-    # API: prompt enhancer — expand a short music idea into a rich ACE-Step
-    # tag line via Haiku. Key-gated on ANTHROPIC_API_KEY (read from the pod's
-    # env; the key never ships to a client). With no key or any API error it
-    # returns the caller's text unchanged with ok=false, so every frontend
-    # treats enhance as best-effort and never blocks. The prompt rides the
-    # query string to stay on this all-GET probe surface; it's redacted from
-    # the access log.
+    # API: prompt enhancer — expand a short music idea into a rich prompt via
+    # Haiku. The policy is backend-specific (ACE-Step comma tags vs SA3
+    # natural-language): the pod infers the backend from its own checkpoint
+    # family, and an optional client `backend=` hint can override it. Key-gated
+    # on ANTHROPIC_API_KEY (read from the pod's env; the key never ships to a
+    # client). With no key or any API error it returns the caller's text
+    # unchanged with ok=false, so every frontend treats enhance as best-effort
+    # and never blocks. The prompt rides the query string to stay on this
+    # all-GET probe surface; it's redacted from the access log.
     if path_only == "/api/enhance":
         from urllib.parse import parse_qs
 
         from .prompt_enhancer import enhance_prompt
 
         query = url.split("?", 1)[1] if "?" in url else ""
-        idea = (parse_qs(query).get("prompt", [""])[0] or "").strip()
-        enhanced, ok = enhance_prompt(idea)
+        params = parse_qs(query)
+        idea = (params.get("prompt", [""])[0] or "").strip()
+        # Pod infers the backend from its own checkpoint family; the client's
+        # optional backend= hint only overrides when it names a known policy.
+        backend = _resolve_enhance_backend(params.get("backend", [""])[0])
+        enhanced, ok = enhance_prompt(idea, backend)
         body = json.dumps({"enhanced": enhanced, "ok": ok}).encode()
         _log_http(remote, 200, "GET", "/api/enhance")  # redact prompt
         return Response(
@@ -754,11 +786,13 @@ def main():
         )
 
     global _NO_BACKEND, _ACCEL, _KIOSK, _DEFAULT_MODE, _CHECKPOINT, _STATIC_MOUNTS
+    global _BACKEND_FAMILY
     _NO_BACKEND = no_backend
     _ACCEL = accel
     _KIOSK = kiosk
     _DEFAULT_MODE = default_mode
     _CHECKPOINT = checkpoint
+    _BACKEND_FAMILY = backend_family
 
     try:
         _STATIC_MOUNTS = build_static_mounts(static_demo_paths)

--- a/tests/unit/test_prompt_enhancer.py
+++ b/tests/unit/test_prompt_enhancer.py
@@ -1,0 +1,164 @@
+"""Unit tests for the backend-specific prompt enhancer.
+
+Covers the policy split added for Stable Audio 3: the pod infers the enhancer
+backend from its own resolved checkpoint FAMILY (``_BACKEND_FAMILY``: the ``sa3``
+family selects the SA3 natural-language policy, everything else keeps ACE-Step
+tags), and an optional client ``backend=`` query param can override it. The LLM
+call itself is mocked (``_ask_haiku``) so these tests are deterministic and need
+no network / API key.
+
+The one live-model check — does the SA3 few-shot actually steer Haiku — lives
+outside the suite (it needs a real ANTHROPIC_API_KEY); this file pins the policy
+selection, sanitize behavior, and failure shape.
+"""
+
+import pytest
+
+from demos.realtime_motion_graph_web import prompt_enhancer as pe
+from demos.realtime_motion_graph_web import server
+
+
+@pytest.fixture(autouse=True)
+def _restore_family():
+    """Keep _BACKEND_FAMILY mutations from leaking across tests."""
+    saved = server._BACKEND_FAMILY
+    yield
+    server._BACKEND_FAMILY = saved
+
+
+def _capture_system(monkeypatch):
+    """Patch _ask_haiku to record the system prompt it was handed and echo a
+    canned reply, so a test can assert WHICH policy was selected without a
+    network call. Returns a dict that receives the system + user text.
+    """
+    seen = {}
+
+    def fake(system, user):
+        seen["system"] = system
+        seen["user"] = user
+        # A reply carrying a bpm number so _sanitize's strip is exercised too.
+        return "melodic techno, hypnotic arpeggio, deep kick, 128 bpm, wide stereo"
+
+    monkeypatch.setattr(pe, "_ask_haiku", fake)
+    return seen
+
+
+# ── policy selection in enhance_prompt ──────────────────────────────────────
+
+def test_default_backend_uses_acestep_policy(monkeypatch):
+    """No backend arg == legacy ACE-Step path, byte-identical selection."""
+    seen = _capture_system(monkeypatch)
+    out, ok = pe.enhance_prompt("dreamy synthwave")
+    assert ok is True
+    assert seen["system"] is pe._SYSTEM
+    assert "ACE-Step" in seen["user"]
+
+
+def test_acestep_backend_uses_acestep_policy(monkeypatch):
+    seen = _capture_system(monkeypatch)
+    pe.enhance_prompt("dreamy synthwave", "acestep")
+    assert seen["system"] is pe._SYSTEM
+
+
+def test_sa3_backend_uses_sa3_policy(monkeypatch):
+    seen = _capture_system(monkeypatch)
+    out, ok = pe.enhance_prompt("dreamy synthwave", "sa3")
+    assert ok is True
+    assert seen["system"] is pe._SYSTEM_SA3
+    assert "Stable Audio 3" in seen["user"]
+
+
+def test_bpm_number_stripped_for_both_backends(monkeypatch):
+    """_sanitize's bpm-strip is shared: neither backend emits a numeric bpm."""
+    for backend in ("acestep", "sa3"):
+        _capture_system(monkeypatch)
+        out, ok = pe.enhance_prompt("techno", backend)
+        assert ok is True
+        assert "bpm" not in out.lower()
+
+
+def test_sa3_system_prompt_is_bpm_free_and_natural_language():
+    """The SA3 few-shot must not seed the model with numeric bpm, and must ask
+    for descriptive phrases rather than a bare tag list (guide-grounded)."""
+    import re
+    sys_l = pe._SYSTEM_SA3.lower()
+    assert not re.search(r"\d+\s*bpm", sys_l)  # no numeric bpm in examples/instructions
+    assert "description" in sys_l
+    assert "stable audio 3" in sys_l
+
+
+def test_empty_prompt_returns_unchanged_not_ok(monkeypatch):
+    # Should never even reach the model.
+    called = {"n": 0}
+    monkeypatch.setattr(pe, "_ask_haiku", lambda s, u: called.__setitem__("n", called["n"] + 1) or "x")
+    for backend in ("acestep", "sa3"):
+        out, ok = pe.enhance_prompt("   ", backend)
+        assert out == ""
+        assert ok is False
+    assert called["n"] == 0
+
+
+def test_model_failure_echoes_input_unchanged(monkeypatch):
+    """No key / API error path: _ask_haiku returns None -> (idea, False)."""
+    monkeypatch.setattr(pe, "_ask_haiku", lambda s, u: None)
+    for backend in ("acestep", "sa3", "unknown-passed-straight-through"):
+        out, ok = pe.enhance_prompt("dreamy synthwave", backend)
+        assert out == "dreamy synthwave"
+        assert ok is False
+
+
+# ── backend resolution in the server route ──────────────────────────────────
+
+def test_resolve_infers_from_backend_family():
+    """With no override, the resolved checkpoint family drives the policy.
+
+    _BACKEND_FAMILY is set in main() from resolve_checkpoint(); e.g. an
+    ``sa3-medium`` checkpoint resolves to family "sa3" (model id "medium").
+    """
+    server._BACKEND_FAMILY = "acestep"
+    assert server._resolve_enhance_backend("") == "acestep"
+    server._BACKEND_FAMILY = "sa3"
+    assert server._resolve_enhance_backend("") == "sa3"
+
+
+def test_resolve_prefers_valid_override():
+    server._BACKEND_FAMILY = "acestep"
+    assert server._resolve_enhance_backend("sa3") == "sa3"
+    server._BACKEND_FAMILY = "sa3"
+    assert server._resolve_enhance_backend("acestep") == "acestep"
+
+
+def test_resolve_falls_back_on_unknown_override():
+    """Unknown override never errors: falls back to the inferred family."""
+    server._BACKEND_FAMILY = "sa3"
+    assert server._resolve_enhance_backend("bogus") == "sa3"
+    server._BACKEND_FAMILY = "acestep"
+    assert server._resolve_enhance_backend("bogus") == "acestep"
+
+
+def test_resolve_unknown_family_defaults_to_acestep():
+    """A family not in the enhancer set (future model) can't crash enhance."""
+    server._BACKEND_FAMILY = "some-future-family"
+    assert server._resolve_enhance_backend("") == "acestep"
+
+
+def test_resolve_override_is_case_insensitive():
+    server._BACKEND_FAMILY = "acestep"
+    assert server._resolve_enhance_backend("SA3") == "sa3"
+    assert server._resolve_enhance_backend(" Sa3 ") == "sa3"
+
+
+def test_family_matches_resolve_checkpoint_for_sa3():
+    """Guard the inference contract end-to-end: an sa3 alias really does resolve
+    to family 'sa3' via the same helper main() uses, so a pod started with
+    --checkpoint sa3-medium enhances with the SA3 policy."""
+    from acestep.streaming.families import resolve_checkpoint
+    family, model_id = resolve_checkpoint("sa3-medium")
+    assert family == "sa3"
+    server._BACKEND_FAMILY = family
+    assert server._resolve_enhance_backend("") == "sa3"
+    # And a plain ACE checkpoint name resolves to acestep.
+    fam2, _ = resolve_checkpoint("acestep-v15-turbo")
+    assert fam2 == "acestep"
+    server._BACKEND_FAMILY = fam2
+    assert server._resolve_enhance_backend("") == "acestep"


### PR DESCRIPTION
## Model-specific prompt enhancement for Stable Audio 3

Adds an SA3 natural-language prompt policy to `/api/enhance` alongside the existing
ACE-Step tag policy. Today the enhancer always rewrites into ACE-Step comma-tags;
SA3 wants a producer's natural-language description instead. This makes the policy
backend-specific while keeping the legacy path byte-identical.

### Backend inference (not a client requirement)
The pod infers the enhancer backend from its **resolved checkpoint family**
(`_BACKEND_FAMILY`, captured in `main()` from `resolve_checkpoint()`), not by
sniffing the checkpoint string. `--checkpoint sa3-medium` resolves to model id
`medium`, so a naive `startswith("sa3")` on `_CHECKPOINT` would misclassify SA3 as
ACE-Step — the family is the correct signal. A client `backend=` query param is an
optional override. The endpoint stays **GET** and keeps the `ok=false` / HTTP-200
best-effort failure shape (no key or any API error → input echoed back unchanged).

### Grounding
`_SYSTEM_SA3` is grounded in theDAW prompting guide (SA3 is the same
T5Gemma-conditioned engine): descriptive phrases over bare tags, genre + hook
instrument first (first phrases dominate), tempo described qualitatively only.
Numeric BPM is deliberately kept **out** of the clean text because
`demon::promptMeta` appends the real project tempo/key downstream for M4L SA3
sessions — emitting a genre-typical BPM here would ship two conflicting values.
`_sanitize` (incl. the bpm-strip) stays shared, so both backends stay bpm-free.

### Independently verified the few-shot
Ran `_SYSTEM_SA3` through real Haiku (`claude-haiku-4-5`) on a spread of ideas
(twice): output is compact single-line, genre-first, BPM-number-free even when the
idea says "174 bpm please", honors named artists (e.g. "boards of canada" leads),
no negative phrasing — distinct from the ACE-Step tag lists.

### Sibling PR
- rtmg-vst shared-surface drift tests (guard the enhance→wire→meta seam):
  daydreamlive/rtmg-vst#131

### Tests
- `tests/unit/test_prompt_enhancer.py` — 13 pass: policy selection per backend,
  shared sanitize/bpm-strip, empty-prompt and API-failure shapes, override
  precedence/case-insensitivity, and an end-to-end guard that
  `resolve_checkpoint("sa3-medium")` family is `sa3`.

### Follow-up (not in this PR)
- Warm-pod rebake + verify the deployed source. Server code ships via bake, not
  merge alone, so the SA3 policy only goes live after the image is rebaked.
