### PR TITLE
fix(sa3): seed the SAME decode noise so renders are reproducible

### DIFF
--- a/acestep/engine/sa3_context.py
+++ b/acestep/engine/sa3_context.py
@@ -221,10 +221,19 @@ class SA3SAMECodec:
         self._context = context
         self._helpers = context._helpers
 
-    def decode_full(self, latent_bct: torch.Tensor) -> torch.Tensor:
+    def decode_full(
+        self, latent_bct: torch.Tensor, *, decode_seed: int | None = None,
+    ) -> torch.Tensor:
         """Native ``[1, 256, T]`` latent -> ``[C, N]`` float audio at
-        44.1 kHz, clamped to [-1, 1]."""
-        audio = self._helpers.decode_sa3_latent(self._context.sam, latent_bct)
+        44.1 kHz, clamped to [-1, 1].
+
+        ``decode_seed`` pins the decode RNG (``sa3_decode_rng``) so the
+        SAME decoder's inference-time noise (bottleneck renoise +
+        decoder mask_noise) is reproducible: same latent + same seed →
+        bit-identical audio. ``None`` keeps the legacy unseeded draw.
+        """
+        with self._helpers.sa3_decode_rng(decode_seed, device=latent_bct.device):
+            audio = self._helpers.decode_sa3_latent(self._context.sam, latent_bct)
         return audio[0]
 
 
@@ -326,8 +335,12 @@ class SA3SAMEWindowCodec:
             out = torch.nn.functional.pad(out, (0, int(num) - out.shape[-1]))
         return out
 
-    def decode_full(self, latent_bct: torch.Tensor) -> torch.Tensor:
+    def decode_full(
+        self, latent_bct: torch.Tensor, *, decode_seed: int | None = None,
+    ) -> torch.Tensor:
         """Eager full decode (legacy full-buffer mode only; the hot path
-        never calls this for windowed-codec families)."""
-        audio = self._helpers.decode_sa3_latent(self._context.sam, latent_bct)
+        never calls this for windowed-codec families). ``decode_seed``
+        pins the decode RNG exactly as on :class:`SA3SAMECodec`."""
+        with self._helpers.sa3_decode_rng(decode_seed, device=latent_bct.device):
+            audio = self._helpers.decode_sa3_latent(self._context.sam, latent_bct)
         return audio[0]

--- a/acestep/engine/sa3_stream_helpers.py
+++ b/acestep/engine/sa3_stream_helpers.py
@@ -270,6 +270,42 @@ def resolve_sa3_decode_window(
     )
 
 
+# Salt mixed into the generation seed before pinning the decode RNG, so
+# the decode noise stream is decoupled from the (same-seeded) slot-init
+# and SDE renoise streams.
+SA3_DECODE_SEED_SALT = 0x53A3DEC0
+
+
+@contextmanager
+def sa3_decode_rng(seed: Optional[int], device=None):
+    """Pin the RNG for one SAME decode so its noise sources are reproducible.
+
+    SAME decode draws unseeded noise at inference — SoftNormBottleneck's
+    ``noise_regularize`` renoise plus the decoder's ``mask_noise`` on its
+    upsampling new-tokens — which makes decoding the SAME latent twice
+    audibly different (small-music: rms diff ~8e-2, ~-7 dB rel signal;
+    see ``scripts/sa3/sa3_decode_determinism_gate.py``). Seeding keeps the
+    shipped sound character (it is exactly a legacy decode with the RNG
+    pinned) while making repeated decodes of the same latent bit-identical.
+
+    ``fork_rng`` scopes the reseed: outer RNG streams (slot-init noise,
+    SDE renoise, anything unseeded) see no side effects. ``seed=None``
+    is a no-op passthrough (legacy unseeded behavior). ``device`` should
+    be the decode device; only that CUDA device's generator is forked
+    (single-GPU pods — a second CUDA device's stream would not be
+    restored).
+    """
+    if seed is None:
+        yield
+        return
+    devices = []
+    if device is not None and torch.device(device).type == "cuda":
+        devices = [torch.device(device)]
+    with torch.random.fork_rng(devices=devices):
+        torch.manual_seed(int(seed) ^ SA3_DECODE_SEED_SALT)
+        yield
+
+
 @contextmanager
 def sa3_decode_noise_mode(sam, *, enabled: bool):
     """Temporarily toggle SAME decode-time noise sources.

--- a/acestep/engine/stream.py
+++ b/acestep/engine/stream.py
@@ -1129,6 +1129,13 @@ class StreamPipeline:
                     and slot.step_idx >= len(slot.t_schedule) - 1
                 ):
                     finished = slot.xt
+                    # Keep last_finished_request's contract ("the request
+                    # the returned latent was generated from") on THIS
+                    # path too — it's the common one; without this the
+                    # attribute lags one generation behind, so the
+                    # emerged-params echo and the decode-seed pairing
+                    # describe the PREVIOUS latent.
+                    self.last_finished_request = slot.request
                     self._slots[i] = None
                     break
 

--- a/acestep/streaming/sa3_backend.py
+++ b/acestep/streaming/sa3_backend.py
@@ -248,6 +248,11 @@ class SA3Backend(DiffusionBackend):
         # the cache and decode per render instead — see render_window.
         self._rendered_for = None     # latent tensor identity
         self._rendered_48k = None     # np.ndarray [N, C] float32
+        # Seed pinning the SAME decoder's inference-time noise for the
+        # latest emerged latent (stamped in _after_produce), so repeated
+        # decodes — and re-runs of the same session inputs — produce
+        # bit-identical audio. None until the first fresh latent.
+        self._decode_seed = None
         self._windowed_codec = hasattr(codec, "decode_window")
 
         self.pipeline = self._build_pipeline(self._steps)
@@ -707,6 +712,15 @@ class SA3Backend(DiffusionBackend):
             # appendleft so latent_history[0] is the most recent;
             # tap_idx = depth-1 reads "N ticks back" (ACE convention).
             self._latent_history.appendleft(result_latent.detach().clone())
+            # Pin the decode RNG to the seed of the request that produced
+            # this latent (the emerged request survives DiT-pause "reuse"
+            # ticks, so the pairing holds there too). prep carries the
+            # same int in production; it covers non-int request seeds.
+            req_seed = getattr(self._emerged_request, "seed", None)
+            self._decode_seed = (
+                int(req_seed) if isinstance(req_seed, int)
+                else int(prep["seed"])
+            )
         if not is_fresh or self.state is None:
             return
         req = self._emerged_request
@@ -742,7 +756,9 @@ class SA3Backend(DiffusionBackend):
         import torchaudio
 
         t0 = time.perf_counter()
-        audio_ct = self.codec.decode_full(latent_btc.movedim(1, 2))
+        audio_ct = self.codec.decode_full(
+            latent_btc.movedim(1, 2), decode_seed=self._decode_seed,
+        )
         # The decode boundary (round_3 decision 2): one whole-window
         # resample per generation, so window slices share one filter
         # pass and seams can't come from per-slice resampling.

--- a/scripts/sa3/sa3_decode_determinism_gate.py
+++ b/scripts/sa3/sa3_decode_determinism_gate.py
@@ -1,0 +1,212 @@
+"""SA3 decode-determinism gate: prove or disprove decode-stage stochasticity.
+
+Loads the SA3 checkpoint locally (same loader as production), generates ONE
+real latent, then interrogates the latent->audio decode stage in-process:
+
+  [gen]        Is the offline generation path bit-stable for a fixed seed?
+               (two `sam.generate(..., return_latents=True)` calls, same seed)
+  [decode-on]  Production small-model path (`decode_sa3_latent`, i.e. what
+               `SA3SAMECodec.decode_full` runs): decode the SAME latent twice
+               with checkpoint-default noise flags. Any diff here is decode
+               noise, full stop.
+  [decode-off] Same, under `sa3_decode_noise_mode(enabled=False)` — the mode
+               the SAME-L windowed production path already uses. Expect
+               bit-identical.
+  [decode-seeded] Same, with noise flags untouched but the global RNG
+               reseeded before each decode. Expect bit-identical — shows
+               seeding (keep the noise, pin the RNG) is a viable fix shape.
+  [on-vs-off]  Magnitude of the noise contribution in audio space (how much
+               the inference-time regularizer noise actually changes the
+               waveform), for the "is disabling audible/harmful" call.
+
+Writes listening WAVs and prints a stats table. No production code is
+touched; this is the pre-change gate.
+
+Run:
+    .venv/Scripts/python.exe scripts/sa3/sa3_decode_determinism_gate.py \
+        --model small-music --prompt "warm analog house groove, 124 bpm" \
+        --duration 10 --steps 8 --seed 42
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = next(p for p in (_HERE, *_HERE.parents) if (p / "pyproject.toml").exists())
+for _p in (str(_REPO_ROOT),):
+    while _p in sys.path:
+        sys.path.remove(_p)
+sys.path.insert(0, str(_REPO_ROOT))
+
+import torch  # noqa: E402
+
+from acestep import paths  # noqa: E402
+from acestep.engine.sa3_helpers import ensure_sa3_paths, sa3_checkpoint_dir  # noqa: E402
+
+ensure_sa3_paths()
+
+import sa3_reference_generate as ref  # noqa: E402
+
+from acestep.engine.sa3_stream_helpers import (  # noqa: E402
+    decode_sa3_latent,
+    sa3_decode_noise_mode,
+)
+
+
+def stats(a: torch.Tensor, b: torch.Tensor) -> dict:
+    """Objective diff stats between two [B?, C, N] float audio tensors."""
+    a = a.float()
+    b = b.float()
+    d = (a - b).abs()
+    sig_rms = a.pow(2).mean().sqrt().item()
+    diff_rms = (a - b).pow(2).mean().sqrt().item()
+    return {
+        "bit_identical": bool(torch.equal(a, b)),
+        "max_abs_diff": d.max().item(),
+        "rms_diff": diff_rms,
+        "diff_db_rel_signal": (
+            20.0 * torch.log10(torch.tensor(diff_rms / sig_rms)).item()
+            if diff_rms > 0 and sig_rms > 0 else float("-inf")
+        ),
+    }
+
+
+def fmt(name: str, s: dict) -> str:
+    return (
+        f"{name:<28} identical={str(s['bit_identical']):<5} "
+        f"max_abs={s['max_abs_diff']:.3e} rms={s['rms_diff']:.3e} "
+        f"rel_dB={s['diff_db_rel_signal']:+.1f}"
+    )
+
+
+def save_wav(path: Path, audio_cn: torch.Tensor, sr: int) -> None:
+    import soundfile as sf
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(str(path), audio_cn.float().cpu().numpy().T, samplerate=sr)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", default="small-music")
+    ap.add_argument("--prompt", default="warm analog house groove, 124 bpm, deep bassline")
+    ap.add_argument("--duration", type=float, default=10.0)
+    ap.add_argument("--steps", type=int, default=8)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--out-dir", default=None)
+    args = ap.parse_args()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    out_dir = Path(args.out_dir) if args.out_dir else (
+        paths.models_dir() / "sa3" / "spike_out" / "decode_determinism"
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    dest = sa3_checkpoint_dir(args.model)
+    cfg = json.loads((dest / "model_config.json").read_text(encoding="utf-8"))
+    print(f"[load] {dest} device={device}")
+    t0 = time.time()
+    sam = ref.load_local_model(dest, device=device, model_half=(device == "cuda"))
+    print(f"[load] done in {time.time() - t0:.1f}s")
+    sr = int(sam.model.sample_rate)
+
+    bottleneck = getattr(sam.model.pretransform.model, "bottleneck", None)
+    print(f"[flags] bottleneck={type(bottleneck).__name__} "
+          f"noise_regularize={getattr(bottleneck, 'noise_regularize', None)} "
+          f"noise_augment_dim={getattr(bottleneck, 'noise_augment_dim', None)} "
+          f"pretransform_training={sam.model.pretransform.training}")
+    mask_noise_mods = [
+        m for m in sam.model.pretransform.model.decoder.modules()
+        if hasattr(m, "mask_noise")
+    ]
+    print(f"[flags] decoder modules with mask_noise: {len(mask_noise_mods)} "
+          f"values={sorted({float(m.mask_noise) for m in mask_noise_mods})}")
+
+    gen_kwargs = dict(
+        prompt=args.prompt, duration=args.duration, steps=args.steps,
+        seed=args.seed, cfg_scale=1.0, return_latents=True,
+    )
+    print(f"[gen] latent 1/2 (seed={args.seed}) ...")
+    latent1 = sam.generate(**gen_kwargs)
+    print(f"[gen] latent 2/2 (same seed) ...")
+    latent2 = sam.generate(**gen_kwargs)
+    print(f"[gen] latent shape={tuple(latent1.shape)} dtype={latent1.dtype}")
+
+    results: dict[str, dict] = {}
+    results["gen (same seed, twice)"] = stats(latent1.float(), latent2.float())
+
+    # --- decode-on: production SA3SAMECodec.decode_full semantics ---------
+    a1 = decode_sa3_latent(sam, latent1)
+    a2 = decode_sa3_latent(sam, latent1)
+    results["decode-on (default flags)"] = stats(a1, a2)
+
+    # --- decode-off: noise sources disabled (SAME-L windowed-path mode) ---
+    with sa3_decode_noise_mode(sam, enabled=False):
+        b1 = decode_sa3_latent(sam, latent1)
+    with sa3_decode_noise_mode(sam, enabled=False):
+        b2 = decode_sa3_latent(sam, latent1)
+    results["decode-off (noise disabled)"] = stats(b1, b2)
+
+    # --- decode-seeded: noise kept, RNG pinned per decode ------------------
+    torch.manual_seed(args.seed)
+    c1 = decode_sa3_latent(sam, latent1)
+    torch.manual_seed(args.seed)
+    c2 = decode_sa3_latent(sam, latent1)
+    results["decode-seeded (RNG pinned)"] = stats(c1, c2)
+
+    # --- decompose the two noise sources -----------------------------------
+    # bottleneck-only: mask_noise forced 0, noise_regularize left on
+    saved_mask = [(m, float(m.mask_noise)) for m in mask_noise_mods]
+    for m, _ in saved_mask:
+        m.mask_noise = 0.0
+    d1 = decode_sa3_latent(sam, latent1)
+    d2 = decode_sa3_latent(sam, latent1)
+    for m, v in saved_mask:
+        m.mask_noise = v
+    results["bottleneck-only (2 decodes)"] = stats(d1, d2)
+
+    # mask-only: noise_regularize off, mask_noise left on
+    if bottleneck is not None:
+        saved_reg = bottleneck.noise_regularize
+        bottleneck.noise_regularize = False
+        e1 = decode_sa3_latent(sam, latent1)
+        e2 = decode_sa3_latent(sam, latent1)
+        bottleneck.noise_regularize = saved_reg
+        results["mask-only (2 decodes)"] = stats(e1, e2)
+
+    # --- how big is the noise contribution, audibly? -----------------------
+    results["on-vs-off (same latent)"] = stats(a1, b1)
+    results["seeded-vs-off (same latent)"] = stats(c1, b1)
+
+    tag = f"{args.model}_seed{args.seed}_{int(args.duration)}s"
+    wavs = {
+        f"gate_{tag}_noise_on_run1.wav": a1,
+        f"gate_{tag}_noise_on_run2.wav": a2,
+        f"gate_{tag}_noise_off_run1.wav": b1,
+        f"gate_{tag}_noise_off_run2.wav": b2,
+        f"gate_{tag}_noise_seeded_run1.wav": c1,
+    }
+    for name, audio in wavs.items():
+        save_wav(out_dir / name, audio[0], sr)
+        print(f"[save] {out_dir / name}")
+
+    print("\n=== gate results ===")
+    for name, s in results.items():
+        print(fmt(name, s))
+
+    decode_stochastic = not results["decode-on (default flags)"]["bit_identical"]
+    off_deterministic = results["decode-off (noise disabled)"]["bit_identical"]
+    seeded_deterministic = results["decode-seeded (RNG pinned)"]["bit_identical"]
+    print(f"\nGATE: decode stage stochastic = {decode_stochastic} "
+          f"(noise-off deterministic = {off_deterministic}, "
+          f"seeded deterministic = {seeded_deterministic})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sa3/sa3_decode_determinism_verify.py
+++ b/scripts/sa3/sa3_decode_determinism_verify.py
@@ -126,6 +126,13 @@ def main() -> int:
         noiseless = codec.decode_full(latent)
     results["seeded vs noise-off (A/B)"] = stats(on1, noiseless)
 
+    # Windowed codecs (medium): the production per-tick render path.
+    if hasattr(codec, "decode_window"):
+        n = min(latent.shape[-1] * context.downsampling_ratio, 4 * sr)
+        w1 = codec.decode_window(latent, 0, n)
+        w2 = codec.decode_window(latent, 0, n)
+        results["hot path decode_window (x2)"] = stats(w1, w2)
+
     tag = f"{args.model}_seed{args.seed}_{int(args.duration)}s"
     wavs = {
         f"verify_{tag}_fixoff_run1.wav": off1,

--- a/scripts/sa3/sa3_decode_determinism_verify.py
+++ b/scripts/sa3/sa3_decode_determinism_verify.py
@@ -1,0 +1,157 @@
+"""SA3 deterministic-decode verification: production codec, repeat renders.
+
+Post-fix companion to ``sa3_decode_determinism_gate.py``. Where the gate
+proved the raw decode stage is stochastic, this drives the PRODUCTION
+surface (``SA3Context`` + ``make_codec`` → ``SA3SAMECodec.decode_full``)
+and shows:
+
+  [fix-off]   decode_seed=None (legacy behavior): decoding the same latent
+              twice still differs — the pre-fix contrast.
+  [fix-on]    decode_seed=<seed>: two decodes are bit-identical.
+  [seed-diff] a different decode_seed gives a different (but equally
+              plausible) render — seeds are distinct noise realizations.
+  [A/B]       seeded-noise vs noise-disabled decode of the same latent,
+              as listening artifacts for the sound-character call.
+
+Writes WAV pairs for listening and prints an objective-diff table.
+
+Run:
+    .venv/Scripts/python.exe scripts/sa3/sa3_decode_determinism_verify.py \
+        --model=small-music --prompt "warm analog house groove, 124 bpm" \
+        --duration 10 --steps 8 --seed 42
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = next(p for p in (_HERE, *_HERE.parents) if (p / "pyproject.toml").exists())
+for _p in (str(_REPO_ROOT),):
+    while _p in sys.path:
+        sys.path.remove(_p)
+sys.path.insert(0, str(_REPO_ROOT))
+
+import torch  # noqa: E402
+
+from acestep import paths  # noqa: E402
+from acestep.engine.sa3_context import SA3Context  # noqa: E402
+from acestep.engine.sa3_stream_helpers import sa3_decode_noise_mode  # noqa: E402
+
+
+def stats(a: torch.Tensor, b: torch.Tensor) -> dict:
+    a = a.float()
+    b = b.float()
+    d = (a - b).abs()
+    sig_rms = a.pow(2).mean().sqrt().item()
+    diff_rms = (a - b).pow(2).mean().sqrt().item()
+    return {
+        "bit_identical": bool(torch.equal(a, b)),
+        "max_abs_diff": d.max().item(),
+        "rms_diff": diff_rms,
+        "diff_db_rel_signal": (
+            20.0 * torch.log10(torch.tensor(diff_rms / sig_rms)).item()
+            if diff_rms > 0 and sig_rms > 0 else float("-inf")
+        ),
+    }
+
+
+def fmt(name: str, s: dict) -> str:
+    return (
+        f"{name:<34} identical={str(s['bit_identical']):<5} "
+        f"max_abs={s['max_abs_diff']:.3e} rms={s['rms_diff']:.3e} "
+        f"rel_dB={s['diff_db_rel_signal']:+.1f}"
+    )
+
+
+def save_wav(path: Path, audio_cn: torch.Tensor, sr: int) -> None:
+    import soundfile as sf
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(str(path), audio_cn.float().cpu().numpy().T, samplerate=sr)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", default="small-music")
+    ap.add_argument("--prompt", default="warm analog house groove, 124 bpm, deep bassline")
+    ap.add_argument("--duration", type=float, default=10.0)
+    ap.add_argument("--steps", type=int, default=8)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--out-dir", default=None)
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir) if args.out_dir else (
+        paths.models_dir() / "sa3" / "spike_out" / "decode_determinism"
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    t0 = time.time()
+    context = SA3Context(
+        model_id=args.model,
+        device="cuda" if torch.cuda.is_available() else "cpu",
+    )
+    print(f"[load] SA3Context({args.model!r}) in {time.time() - t0:.1f}s")
+    codec = context.make_codec()
+    print(f"[codec] {type(codec).__name__}")
+    sr = context.sample_rate
+
+    latent = context.sam.generate(
+        prompt=args.prompt, duration=args.duration, steps=args.steps,
+        seed=args.seed, cfg_scale=1.0, return_latents=True,
+    )
+    print(f"[gen] latent shape={tuple(latent.shape)} (seed={args.seed})")
+
+    results: dict[str, dict] = {}
+
+    # fix-off: the legacy unseeded path (decode_seed=None)
+    off1 = codec.decode_full(latent)
+    off2 = codec.decode_full(latent)
+    results["fix-off (unseeded, 2 decodes)"] = stats(off1, off2)
+
+    # fix-on: production decode with the generation seed pinned
+    on1 = codec.decode_full(latent, decode_seed=args.seed)
+    on2 = codec.decode_full(latent, decode_seed=args.seed)
+    results["fix-on (seeded, 2 decodes)"] = stats(on1, on2)
+
+    # a different decode seed is a different (valid) realization
+    other = codec.decode_full(latent, decode_seed=args.seed + 1)
+    results["fix-on seedA vs seedB"] = stats(on1, other)
+
+    # A/B: seeded noise vs noise disabled outright
+    with sa3_decode_noise_mode(context.sam, enabled=False):
+        noiseless = codec.decode_full(latent)
+    results["seeded vs noise-off (A/B)"] = stats(on1, noiseless)
+
+    tag = f"{args.model}_seed{args.seed}_{int(args.duration)}s"
+    wavs = {
+        f"verify_{tag}_fixoff_run1.wav": off1,
+        f"verify_{tag}_fixoff_run2.wav": off2,
+        f"verify_{tag}_fixon_run1.wav": on1,
+        f"verify_{tag}_fixon_run2.wav": on2,
+        f"verify_{tag}_fixon_otherseed.wav": other,
+        f"verify_{tag}_ab_noise_off.wav": noiseless,
+    }
+    for name, audio in wavs.items():
+        save_wav(out_dir / name, audio, sr)
+        print(f"[save] {out_dir / name}")
+
+    print("\n=== verify results ===")
+    for name, s in results.items():
+        print(fmt(name, s))
+
+    ok = (
+        results["fix-on (seeded, 2 decodes)"]["bit_identical"]
+        and not results["fix-off (unseeded, 2 decodes)"]["bit_identical"]
+        and not results["fix-on seedA vs seedB"]["bit_identical"]
+    )
+    print(f"\nVERIFY: {'PASS' if ok else 'FAIL'} "
+          "(seeded repeat identical, unseeded repeat differs, seeds distinct)")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_sa3_backend.py
+++ b/tests/unit/test_sa3_backend.py
@@ -51,9 +51,13 @@ class _FakeCodec:
 
     def __init__(self):
         self.decodes = 0
+        self.decode_seeds: list = []
 
-    def decode_full(self, latent_bct: torch.Tensor) -> torch.Tensor:
+    def decode_full(
+        self, latent_bct: torch.Tensor, *, decode_seed: int | None = None,
+    ) -> torch.Tensor:
         self.decodes += 1
+        self.decode_seeds.append(decode_seed)
         assert latent_bct.shape == (1, C, T), latent_bct.shape
         ramp = torch.linspace(-0.5, 0.5, N44)
         return torch.stack([ramp, -ramp])  # [2, N44]
@@ -418,3 +422,28 @@ def test_handle_swap_source_without_encoder_fails_loudly():
         assert "source_encoder" in str(exc)
     else:
         raise AssertionError("expected RuntimeError without source_encoder")
+
+
+def test_decode_seed_follows_the_emerged_request_seed():
+    """The render decode is pinned to the seed of the request that
+    produced the decoded latent, so identical session inputs replay to
+    bit-identical audio (the SAME decoder draws noise at inference)."""
+    b = _backend()
+
+    for _ in range(10):
+        b.produce(_knobs(b, seed=42), CTX, "generate")
+    b.render_window(0.0)
+    assert b.codec.decode_seeds == [42]
+
+    # A seed change pins subsequent fresh latents to the new seed.
+    for _ in range(10):
+        b.produce(_knobs(b, seed=99), CTX, "generate")
+    b.render_window(0.0)
+    assert b.codec.decode_seeds[-1] == 99
+
+    # DiT-pause "reuse" keeps the pairing: the re-adopted latent is the
+    # one seed 99 produced, and its render decode stays seed-99-pinned.
+    b._rendered_for = None  # drop the render cache to force a decode
+    b.produce(_knobs(b, seed=1234), CTX, "reuse")
+    b.render_window(0.0)
+    assert b.codec.decode_seeds[-1] == 99

--- a/tests/unit/test_sa3_stream_pipeline.py
+++ b/tests/unit/test_sa3_stream_pipeline.py
@@ -230,3 +230,54 @@ def test_depth2_pingpong_matches_independent_vendor_runs_per_seed():
     assert len(emitted) == len(expected)
     for out, ref in zip(emitted, expected):
         assert torch.allclose(out, ref)
+
+
+# ---- sa3_decode_rng: decode-noise seeding ----------------------------------
+
+from acestep.engine.sa3_stream_helpers import (  # noqa: E402
+    SA3_DECODE_SEED_SALT,
+    sa3_decode_rng,
+)
+
+
+def test_sa3_decode_rng_pins_the_noise_stream():
+    with sa3_decode_rng(123):
+        a = torch.randn(64)
+    with sa3_decode_rng(123):
+        b = torch.randn(64)
+    assert torch.equal(a, b)
+
+    # Distinct seeds are distinct noise streams.
+    with sa3_decode_rng(124):
+        c = torch.randn(64)
+    assert not torch.equal(a, c)
+
+    # The pinned stream is the salted seed's stream, decoupled from the
+    # raw generation seed's stream (slot-init noise uses that one).
+    torch.manual_seed(123 ^ SA3_DECODE_SEED_SALT)
+    assert torch.equal(a, torch.randn(64))
+    torch.manual_seed(123)
+    assert not torch.equal(a, torch.randn(64))
+
+
+def test_sa3_decode_rng_leaves_outer_stream_untouched():
+    torch.manual_seed(7)
+    before = torch.randn(16)
+    with sa3_decode_rng(123):
+        torch.randn(16)
+    after = torch.randn(16)
+
+    torch.manual_seed(7)
+    ref_before = torch.randn(16)
+    ref_after = torch.randn(16)
+    assert torch.equal(before, ref_before)
+    assert torch.equal(after, ref_after)
+
+
+def test_sa3_decode_rng_none_is_a_passthrough():
+    torch.manual_seed(7)
+    with sa3_decode_rng(None):
+        a = torch.randn(16)
+    torch.manual_seed(7)
+    b = torch.randn(16)
+    assert torch.equal(a, b)  # no reseed happened inside


### PR DESCRIPTION
## Problem

SAME decode draws unseeded noise at inference: `SoftNormBottleneck`'s `noise_regularize` renoise (both shipped checkpoints enable it) plus the decoder's `mask_noise` on its upsampling new-tokens. Decoding the SAME latent twice differs:

| checkpoint | repeat-decode diff (rel signal) | mask_noise |
|---|---|---|
| small-music | rms 8.4e-2, **-6.7 dB** (audible) | 0.01 |
| medium | rms 6.4e-4, -49.9 dB (subtle) | 0.1 |

So an SA3 session's renders were irreproducible even though the generation path is fully seed-deterministic (verified bit-stable for a fixed seed). Medium's per-tick windowed render path already decodes noise-free (`deterministic=True`) and is unchanged; the full-decode path (small's hot path, medium's legacy path) was the gap.

## Fix

Pin the decode RNG instead of disabling the noise (disabling changes the shipped sound character; a seeded render IS a legacy draw with the RNG pinned, so character is untouched):

- `sa3_decode_rng(seed, device)` in `sa3_stream_helpers`: `fork_rng` + salted `manual_seed`, zero side effects on outer RNG streams (slot-init, SDE renoise).
- `decode_full(..., decode_seed=)` on both codecs; `SA3Backend` stamps the seed from the emerged request when a fresh latent lands.

Also fixes a latent `StreamPipeline` bug found on the way: the same-tick delivery path (the common one) never set `last_finished_request`, so the emerged-params echo (`gen_seed`/`gen_sa3_denoise`/`gen_prompt`) lagged one generation behind.

## Verification

- `scripts/sa3/sa3_decode_determinism_gate.py` / `_verify.py` (new): prove the stochasticity on the raw decode stage and the fix on the production codecs, for both checkpoints; seeded repeat decodes are bit-identical, distinct seeds stay distinct, and medium's production `decode_window` path repeats bit-identically. Listening WAV pairs confirmed indistinguishable by ear.
- Unit suite green (405 passed), incl. new tests for `sa3_decode_rng` (pinning, outer-stream isolation, None passthrough) and the backend decode-seed pairing (incl. DiT-pause reuse ticks).
- Live smoke vs a local sa3-small pod: session creates, slices stream, `gen_seed` echoed correctly, `swap_source` still works, zero errors.

Scope note: live takes remain temporal mosaics (playhead-paced window patching); this makes per-latent/per-window renders deterministic, not byte-replay of a session.
