### PR TITLE
Load local env defaults for prompt enhancer

### DIFF
--- a/demos/realtime_motion_graph_web/local_env.py
+++ b/demos/realtime_motion_graph_web/local_env.py
@@ -1,0 +1,33 @@
+"""Local ``.env`` fallback for demo entrypoints.
+
+Deployment environments inject process variables directly. This helper only
+fills missing values from the repo-root ``.env`` so explicit environment wins.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+
+
+def load_repo_env_defaults(path: Path | None = None) -> int:
+    """Load missing environment variables from ``path`` or repo ``.env``."""
+    env_path = path or (ROOT_DIR / ".env")
+    if not env_path.is_file():
+        return 0
+
+    loaded = 0
+    for raw in env_path.read_text(encoding="utf-8-sig").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key or key in os.environ:
+            continue
+        os.environ[key] = value.strip().strip('"').strip("'")
+        loaded += 1
+    return loaded

--- a/demos/realtime_motion_graph_web/run.py
+++ b/demos/realtime_motion_graph_web/run.py
@@ -38,6 +38,12 @@ import urllib.request
 from pathlib import Path
 from typing import IO
 
+try:
+    from .local_env import load_repo_env_defaults
+except ImportError:  # direct script execution: python demos/.../run.py
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from demos.realtime_motion_graph_web.local_env import load_repo_env_defaults
+
 
 WEB_DIR = Path(__file__).parent / "web"
 ROOT_DIR = Path(__file__).resolve().parents[2]
@@ -145,6 +151,7 @@ def _wait_for_backend(
 
 def main() -> int:
     _harden_stdout()
+    load_repo_env_defaults()
     parser = argparse.ArgumentParser(
         description="Run the demo backend + Next.js frontend together.",
         epilog=(

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -25,6 +25,12 @@ import time
 import urllib.parse
 from pathlib import Path
 
+try:
+    from .local_env import load_repo_env_defaults
+except ImportError:  # direct script execution: python demos/.../server.py
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from demos.realtime_motion_graph_web.local_env import load_repo_env_defaults
+
 # Opt the CUDA caching allocator into expandable segments before torch
 # initializes it (first CUDA allocation). On long-uptime pods the torch
 # pool fragments across LoRA enable/disable rotations, stem-extraction
@@ -695,6 +701,8 @@ def _run_sa3_preflight(model_id: str) -> None:
 
 
 def main():
+    load_repo_env_defaults()
+
     # Wire logging FIRST so even the CLI-arg validation prints flow through
     # the configured sinks. configure() is idempotent so a duplicate call
     # in any nested entry point is a no-op.

--- a/tests/unit/test_local_env.py
+++ b/tests/unit/test_local_env.py
@@ -1,0 +1,38 @@
+import os
+
+from demos.realtime_motion_graph_web.local_env import load_repo_env_defaults
+
+
+def test_load_repo_env_defaults_sets_missing_values(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        """
+# comment
+ANTHROPIC_API_KEY=local-key
+ENHANCER_MODEL='local-model'
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ENHANCER_MODEL", raising=False)
+
+    loaded = load_repo_env_defaults(env_file)
+
+    assert loaded == 2
+    assert os.environ["ANTHROPIC_API_KEY"] == "local-key"
+    assert os.environ["ENHANCER_MODEL"] == "local-model"
+
+
+def test_load_repo_env_defaults_preserves_exported_values(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("ANTHROPIC_API_KEY=local-key\n", encoding="utf-8")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "exported-key")
+
+    loaded = load_repo_env_defaults(env_file)
+
+    assert loaded == 0
+    assert os.environ["ANTHROPIC_API_KEY"] == "exported-key"
+
+
+def test_load_repo_env_defaults_ignores_missing_file(tmp_path):
+    assert load_repo_env_defaults(tmp_path / "missing.env") == 0


### PR DESCRIPTION
## Summary
- load repo-root .env values as local defaults for the realtime demo launcher/backend
- preserve exported environment variables so deployed env injection remains authoritative
- add focused coverage for missing-file, fallback-load, and exported-env precedence

## Tests
- .venv\\Scripts\\python.exe -m pytest tests\\unit\\test_local_env.py tests\\unit\\test_prompt_enhancer.py