### PR TITLE
feat(streaming): support stationary render anchors

### DIFF
--- a/acestep/streaming/audio_engine.py
+++ b/acestep/streaming/audio_engine.py
@@ -35,6 +35,10 @@ class AudioEngine:
         # its anchor by this much so delayed reports don't drag the
         # estimate into the past. 0.0 when reports carry no send stamp.
         self.position_staleness_s = 0.0
+        # Explicit stationary render placement in absolute buffer seconds.
+        # None means normal transport-driven placement. The params command
+        # owns its sticky absent/value/null lifetime; source swaps hard-clear it.
+        self.render_anchor_s = None
         # Client-observed slice landing lead (seconds; negative = the
         # slice patched audio the listener already played) and the wall
         # time the report arrived. None until the client sends one. The

--- a/acestep/streaming/pipeline_runner.py
+++ b/acestep/streaming/pipeline_runner.py
@@ -593,6 +593,29 @@ class PipelineRunner:
             if se > ss:
                 self.on_audio_ready(buf[ss:se].copy(), ss, se)
 
+    def _patch_wrapped(self, backend, current, anchor_s, wrap_start, wrap_len):
+        """Render at ``anchor_s`` and patch the requested wrapped region."""
+        chunk = backend.render_window(anchor_s)
+        if chunk is None:
+            return
+        wrap_np = chunk.pcm[:wrap_len].copy()
+        wrap_end = wrap_start + wrap_np.shape[0]
+        xfade = min(1200, wrap_np.shape[0] // 4)
+        if wrap_start > 0 and xfade > 0:
+            t_in = np.linspace(0.0, 1.0, xfade).reshape(-1, 1)
+            wrap_np[:xfade] = (
+                current[wrap_start:wrap_start + xfade] * (1 - t_in)
+                + wrap_np[:xfade] * t_in
+            )
+        if wrap_end < current.shape[0] and xfade > 0:
+            t_out = np.linspace(1.0, 0.0, xfade).reshape(-1, 1)
+            wrap_np[-xfade:] = (
+                wrap_np[-xfade:] * t_out
+                + current[wrap_end - xfade:wrap_end] * (1 - t_out)
+            )
+        self.audio_eng.patch_window(wrap_np, wrap_start)
+        self.on_audio_ready(wrap_np, wrap_start, wrap_end)
+
     def _reset_emit_trim_frontier(self) -> None:
         """Drop trim's monotonic frontier after an untrimmed emission.
 
@@ -603,8 +626,23 @@ class PipelineRunner:
         """
         self._emit_hwm = None
 
+    def _should_trim_window_emit(self, band_end_sample, anchored: bool) -> bool:
+        """Transport-only trim gate; stationary anchors require full slices."""
+        return self._emit_trim and band_end_sample is None and not anchored
+
     def _playhead_seconds_now(self) -> float:
         return self._playhead_clock.seconds()
+
+    def _render_placement(self, eff_dur: float, position_chase_only: bool):
+        """Return ``(playhead, advance, decode_start, anchored)`` for a tick."""
+        playhead_now = self._playhead_seconds_now()
+        anchor = getattr(self.audio_eng, "render_anchor_s", None)
+        anchored = anchor is not None and not position_chase_only
+        advance_s = 0.0 if anchored else self._decode_advance_s()
+        decode_start = float(anchor) if anchored else playhead_now + advance_s
+        if eff_dur > 0:
+            decode_start %= eff_dur
+        return playhead_now, advance_s, decode_start, anchored
 
     # ---- the loop -------------------------------------------------------------
 
@@ -812,17 +850,14 @@ class PipelineRunner:
                     # transport lead before sizing this tick's advance.
                     self._fold_slice_lead_report()
 
-                    playhead_now = self._playhead_seconds_now()
+                    playhead_now, advance_s, decode_start, anchored = (
+                        self._render_placement(eff_dur, position_chase_only)
+                    )
                     # Predictive render start: target where the playhead
                     # WILL be by the time this slice lands in the buffer.
                     # The lead is the adaptive interval EMA (+ stall bump),
                     # NOT the render span — see ``_decode_advance_s``. Wrap
                     # modulo ``eff_dur`` since the render supports cyclic.
-                    advance_s = self._decode_advance_s()
-                    decode_start = playhead_now + advance_s
-                    if eff_dur > 0:
-                        decode_start = decode_start % eff_dur
-
                     # Loop-band awareness. When the client arms a band
                     # [A, B] the worklet replays only that region (hard-
                     # wrapping B→A) while we keep generating. Chasing the
@@ -841,7 +876,10 @@ class PipelineRunner:
                     band_end_sample = None
                     band_wrap_start_s = None
                     band = getattr(self.audio_eng, "loop_band", None)
-                    if band is not None and eff_dur > 0 and not position_chase_only:
+                    if (
+                        band is not None and eff_dur > 0
+                        and not position_chase_only and not anchored
+                    ):
                         a_s = max(0.0, min(float(band[0]), eff_dur))
                         b_s = max(0.0, min(float(band[1]), eff_dur))
                         span = b_s - a_s
@@ -930,7 +968,15 @@ class PipelineRunner:
                         # overlapping window. Falls back to the full window
                         # while a loop band is armed (the band-wrap second
                         # render below keeps the legacy path). See __init__.
-                        if self._emit_trim and band_end_sample is None:
+                        # A stationary anchor must reach the client in full.
+                        # Emit-trim is a monotonic transport-frontier
+                        # optimization; at a repeated/retreating anchor its
+                        # high-water mark intentionally emits nothing, which
+                        # would leave the client's pad onset stale even though
+                        # the server buffer was correctly patched.
+                        if self._should_trim_window_emit(
+                            band_end_sample, anchored,
+                        ):
                             self._emit_finalized(current, win_start)
                         else:
                             self.on_audio_ready(patched, win_start, win_end)
@@ -999,32 +1045,27 @@ class PipelineRunner:
                                 band_end_sample - band_start_sample,
                             )
                             if wrap_len > 0:
-                                wrap_chunk = backend.render_window(band_wrap_start_s)
-                                if wrap_chunk is not None:
-                                    wrap_np = wrap_chunk.pcm[:wrap_len].copy()
-                                    wrap_start = band_start_sample
-                                    wrap_end = wrap_start + wrap_np.shape[0]
-                                    xfade_wrap = min(1200, wrap_np.shape[0] // 4)
-                                    if wrap_start > 0 and xfade_wrap > 0:
-                                        t_in = np.linspace(
-                                            0.0, 1.0, xfade_wrap,
-                                        ).reshape(-1, 1)
-                                        wrap_np[:xfade_wrap] = (
-                                            current[wrap_start:wrap_start + xfade_wrap]
-                                            * (1 - t_in)
-                                            + wrap_np[:xfade_wrap] * t_in
-                                        )
-                                    if wrap_end < current.shape[0] and xfade_wrap > 0:
-                                        t_out = np.linspace(
-                                            1.0, 0.0, xfade_wrap,
-                                        ).reshape(-1, 1)
-                                        wrap_np[-xfade_wrap:] = (
-                                            wrap_np[-xfade_wrap:] * t_out
-                                            + current[wrap_end - xfade_wrap:wrap_end]
-                                            * (1 - t_out)
-                                        )
-                                    self.audio_eng.patch_window(wrap_np, wrap_start)
-                                    self.on_audio_ready(wrap_np, wrap_start, wrap_end)
+                                self._patch_wrapped(
+                                    backend, current, band_wrap_start_s,
+                                    band_start_sample, wrap_len,
+                                )
+                        elif (
+                            not anchored
+                            and band_end_sample is None
+                            and not position_chase_only
+                            and eff_dur > 0
+                        ):
+                            loop_len = min(
+                                current.shape[0],
+                                int(round(eff_dur * SAMPLE_RATE)),
+                            )
+                            desired_start = int(round(decode_start * SAMPLE_RATE))
+                            spill = desired_start + win_np.shape[0] - loop_len
+                            if 0 < spill and win_np.shape[0] < loop_len:
+                                self._patch_wrapped(
+                                    backend, current, 0.0, 0,
+                                    min(spill, loop_len),
+                                )
                 else:
                     # Legacy full-buffer mode. Gap-fill never reaches
                     # here (it requires vae_window > 0), so only fresh

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -129,6 +129,9 @@ from acestep.streaming.stems import (
 )
 
 
+_RENDER_ANCHOR_UNSET = object()
+
+
 # ---------------------------------------------------------------------------
 # Pipeline depth bounds + idle pause threshold
 # ---------------------------------------------------------------------------
@@ -1547,16 +1550,24 @@ class StreamingSession:
     def set_knobs(
         self,
         raw: dict,
-        playback_pos: float = 0.0,
+        playback_pos: float | None = None,
         *,
         origin: CommandOrigin = CommandOrigin.PRIMARY,
         client_time: float | None = None,
         slice_lead_s: float | None = None,
+        render_anchor_s=_RENDER_ANCHOR_UNSET,
     ) -> None:
         """Apply or echo a knob update. ``raw`` is the unfiltered
         wire dict; values land in ``virtual_knobs`` only on PRIMARY.
         EXTERNAL emits :class:`ParamsEcho` so the primary transport's
         UI tween owns the smoothed sequence.
+
+        ``playback_pos`` is the client's audible playhead, or ``None`` when
+        this frame carries no clock. A missing clock leaves the prior position
+        untouched.
+
+        ``render_anchor_s`` is sticky three-state placement: omitted retains
+        the current anchor, a finite float sets it, and ``None`` clears it.
 
         ``client_time`` is the client's monotonic send stamp (seconds,
         arbitrary origin) when the transport carries one. It feeds the
@@ -1586,7 +1597,9 @@ class StreamingSession:
                 logger.info(
                     "lat_knob origin={} playback_s={:.3f} changed={} "
                     "denoise={}",
-                    origin.value, float(playback_pos), _changed,
+                    origin.value,
+                    float(playback_pos) if playback_pos is not None else -1.0,
+                    _changed,
                     raw.get("denoise"),
                 )
             state.last_params_raw = dict(raw)
@@ -1613,9 +1626,12 @@ class StreamingSession:
         with state._lock:
             self.virtual_knobs.update(clean)
             try:
-                self.audio_eng.position = int(playback_pos * SAMPLE_RATE) % max(
-                    1, len(self.audio_eng.current),
-                )
+                if playback_pos is not None:
+                    self.audio_eng.position = int(playback_pos * SAMPLE_RATE) % max(
+                        1, len(self.audio_eng.current),
+                    )
+                if render_anchor_s is not _RENDER_ANCHOR_UNSET:
+                    self.audio_eng.render_anchor_s = render_anchor_s
                 self.audio_eng.position_staleness_s = staleness_s
                 if slice_lead_s is not None:
                     self.audio_eng.observed_slice_lead_s = slice_lead_s
@@ -2053,6 +2069,9 @@ class StreamingSession:
         :class:`SwapFailed` when the swap completes."""
         state = self.state
         state.last_activity_ts = time.monotonic()
+        # Placement belongs to the old source's coordinate space. Clear as
+        # soon as a swap is requested, before the runner can consume it again.
+        self.audio_eng.render_anchor_s = None
         effective_tags = tags or state.prompt_text
         with state._lock:
             state.swap_pending["waveform"] = audio.waveform

--- a/demos/realtime_motion_graph_web/protocol.py
+++ b/demos/realtime_motion_graph_web/protocol.py
@@ -215,6 +215,12 @@ COMMANDS: tuple = (
             FieldSpec("playback_pos", "float", default=0.0,
                       description="Playhead position in SECONDS (not a 0..1 "
                                   "ratio); used for time-keyed curve sampling."),
+            FieldSpec("render_anchor_s", "float", nullable=True,
+                      description="Optional stationary render placement in "
+                                  "absolute buffer/song seconds. A finite value "
+                                  "renders exactly at that position, bypassing "
+                                  "transport lead and loop-band snapping. Absent "
+                                  "retains the prior anchor; null clears it."),
             FieldSpec("client_time", "float", nullable=True,
                       description="Client monotonic send time in seconds "
                                   "(performance.now()/1000; arbitrary origin). "

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -26,6 +26,7 @@ imports :func:`handle_client` directly from here.
 
 import contextlib
 import json
+import math
 import os
 import queue
 import socket
@@ -1670,10 +1671,23 @@ def _handle_client_body(
 
         try:
             if mtype == "params":
+                pp_raw = data.get("playback_pos")
                 try:
-                    pp = float(data.get("playback_pos", 0.0))
+                    pp = float(pp_raw) if pp_raw is not None else None
                 except (TypeError, ValueError):
-                    pp = 0.0
+                    pp = None
+                if pp is not None and not math.isfinite(pp):
+                    pp = None
+                anchor_kwargs = {}
+                if "render_anchor_s" in data:
+                    anchor_raw = data.get("render_anchor_s")
+                    try:
+                        anchor = float(anchor_raw) if anchor_raw is not None else None
+                    except (TypeError, ValueError):
+                        anchor = None
+                    if anchor is not None and not math.isfinite(anchor):
+                        anchor = None
+                    anchor_kwargs["render_anchor_s"] = anchor
                 ct = data.get("client_time")
                 try:
                     ct = float(ct) if ct is not None else None
@@ -1700,6 +1714,7 @@ def _handle_client_body(
                 streaming.set_knobs(
                     data.get("raw") or {}, pp, origin=origin,
                     client_time=ct, slice_lead_s=sl,
+                    **anchor_kwargs,
                 )
             elif mtype == "loop_band":
                 streaming.set_loop_band(

--- a/packages/demon-client/types/wireContract.gen.hpp
+++ b/packages/demon-client/types/wireContract.gen.hpp
@@ -43,6 +43,8 @@ namespace command {
     inline constexpr const char* kRaw = "raw";
     /** Playhead position in SECONDS (not a 0..1 ratio); used for time-keyed curve sampling. */
     inline constexpr const char* kPlaybackPos = "playback_pos";
+    /** Optional stationary render placement in absolute buffer/song seconds. A finite value renders exactly at that position, bypassing transport lead and loop-band snapping. Absent retains the prior anchor; null clears it. */
+    inline constexpr const char* kRenderAnchorS = "render_anchor_s";
     /** Client monotonic send time in seconds (performance.now()/1000; arbitrary origin). Lets the server estimate how stale a playback_pos report is when messages queue (network congestion, recv backlog) and advance its playhead estimate accordingly. Optional: absent on older clients, which get the uncompensated behavior. */
     inline constexpr const char* kClientTime = "client_time";
     /** Flow-control ack: cumulative bytes of binary slice frames received on this connection. The server holds back slice emission while its sent-bytes minus this ack exceeds the in-flight window (DEMON_SLICE_WINDOW_BYTES, default 256 KiB) so a bandwidth-limited link receives fresh slices at link rate instead of an ever-staler buffered backlog. Optional; absent on older clients = no flow control. */

--- a/packages/demon-client/types/wireContract.gen.ts
+++ b/packages/demon-client/types/wireContract.gen.ts
@@ -129,6 +129,8 @@ export interface ParamsCommand {
   raw: Record<string, unknown>;
   /** Playhead position in SECONDS (not a 0..1 ratio); used for time-keyed curve sampling. */
   playback_pos?: number;
+  /** Optional stationary render placement in absolute buffer/song seconds. A finite value renders exactly at that position, bypassing transport lead and loop-band snapping. Absent retains the prior anchor; null clears it. */
+  render_anchor_s?: number | null;
   /** Client monotonic send time in seconds (performance.now()/1000; arbitrary origin). Lets the server estimate how stale a playback_pos report is when messages queue (network congestion, recv backlog) and advance its playhead estimate accordingly. Optional: absent on older clients, which get the uncompensated behavior. */
   client_time?: number | null;
   /** Flow-control ack: cumulative bytes of binary slice frames received on this connection. The server holds back slice emission while its sent-bytes minus this ack exceeds the in-flight window (DEMON_SLICE_WINDOW_BYTES, default 256 KiB) so a bandwidth-limited link receives fresh slices at link rate instead of an ever-staler buffered backlog. Optional; absent on older clients = no flow control. */

--- a/tests/unit/test_render_anchor.py
+++ b/tests/unit/test_render_anchor.py
@@ -1,0 +1,135 @@
+"""Focused coverage for explicit stationary render placement."""
+
+from types import SimpleNamespace
+import threading
+
+import numpy as np
+import pytest
+
+from acestep.streaming.audio_engine import AudioEngine
+from acestep.streaming.generator_backend import LeadProfile
+from acestep.streaming.pipeline_runner import PipelineRunner, SAMPLE_RATE
+from acestep.streaming.session import StreamingSession
+
+
+class _Backend:
+    name = "fake"
+
+    def playable_duration_s(self):
+        return 10.0
+
+    def lead_profile(self):
+        return LeadProfile()
+
+
+class _State:
+    running = False
+    params = {}
+    last_activity_ts = 0.0
+
+
+def _engine(duration_s=10.0):
+    return AudioEngine(
+        np.zeros((int(duration_s * SAMPLE_RATE), 2), dtype=np.float32),
+        SAMPLE_RATE,
+    )
+
+
+def _runner():
+    eng = _engine()
+    return PipelineRunner(_Backend(), eng, state=_State(), vae_window=0.36), eng
+
+
+def test_anchor_zero_bypasses_transport_lead(monkeypatch):
+    runner, eng = _runner()
+    eng.render_anchor_s = 0.0
+    monkeypatch.setattr(runner, "_playhead_seconds_now", lambda: 4.0)
+    playhead, advance, start, anchored = runner._render_placement(10.0, False)
+    assert playhead == 4.0
+    assert advance == 0.0
+    assert start == 0.0
+    assert anchored is True
+
+
+def test_audio_engine_starts_with_anchor_cleared():
+    assert _engine().render_anchor_s is None
+
+
+def test_anchor_uses_absolute_song_seconds_with_cyclic_wrap(monkeypatch):
+    runner, eng = _runner()
+    eng.render_anchor_s = 12.25
+    monkeypatch.setattr(runner, "_playhead_seconds_now", lambda: 4.0)
+    _, advance, start, anchored = runner._render_placement(10.0, False)
+    assert advance == 0.0
+    assert start == pytest.approx(2.25)
+    assert anchored is True
+
+
+def test_cleared_anchor_resumes_transport_lead(monkeypatch):
+    runner, eng = _runner()
+    eng.render_anchor_s = None
+    monkeypatch.setattr(runner, "_playhead_seconds_now", lambda: 4.0)
+    monkeypatch.setattr(runner, "_decode_advance_s", lambda: 0.25)
+    _, advance, start, anchored = runner._render_placement(10.0, False)
+    assert advance == 0.25
+    assert start == pytest.approx(4.25)
+    assert anchored is False
+
+
+def test_anchor_is_ignored_by_walk_mode(monkeypatch):
+    runner, eng = _runner()
+    eng.render_anchor_s = 2.0
+    monkeypatch.setattr(runner, "_playhead_seconds_now", lambda: 4.0)
+    monkeypatch.setattr(runner, "_decode_advance_s", lambda: 0.25)
+    _, advance, start, anchored = runner._render_placement(10.0, True)
+    assert advance == 0.25
+    assert start == 4.25
+    assert anchored is False
+
+
+def _session_for_params():
+    session = StreamingSession.__new__(StreamingSession)
+    session.audio_eng = _engine()
+    session.state = SimpleNamespace(
+        last_params_raw={}, last_activity_ts=0.0, _lock=threading.RLock(),
+    )
+    session.virtual_knobs = {}
+    session._knob_specs_by_name = {}
+    session._report_staleness = SimpleNamespace(staleness_s=lambda *_: 0.0)
+    return session
+
+
+def test_anchor_absent_retains_and_null_clears():
+    session = _session_for_params()
+    session.set_knobs({}, 1.0, render_anchor_s=0.0)
+    assert session.audio_eng.render_anchor_s == 0.0
+    session.set_knobs({}, 2.0)
+    assert session.audio_eng.render_anchor_s == 0.0
+    session.set_knobs({}, 3.0, render_anchor_s=None)
+    assert session.audio_eng.render_anchor_s is None
+
+
+def test_clockless_params_do_not_reset_playhead():
+    session = _session_for_params()
+    session.audio_eng.position = 7 * SAMPLE_RATE
+    session.set_knobs({}, None)
+    assert session.audio_eng.position == 7 * SAMPLE_RATE
+
+
+def test_patch_wrapped_writes_and_emits():
+    runner, eng = _runner()
+    pcm = np.full((SAMPLE_RATE, 2), 0.5, dtype=np.float32)
+    backend = SimpleNamespace(render_window=lambda _: SimpleNamespace(pcm=pcm))
+    emitted = []
+    runner.on_audio_ready = lambda wav, start, end: emitted.append((start, end))
+    runner._patch_wrapped(backend, eng.current, 0.0, 0, SAMPLE_RATE // 2)
+    assert eng.current[0, 0] == pytest.approx(0.5)
+    assert emitted == [(0, SAMPLE_RATE // 2)]
+
+
+def test_emit_trim_never_suppresses_stationary_anchor_window():
+    runner, _ = _runner()
+    runner._emit_trim = True
+    assert runner._should_trim_window_emit(None, anchored=False) is True
+    assert runner._should_trim_window_emit(None, anchored=True) is False
+    assert runner._should_trim_window_emit(48000, anchored=False) is False


### PR DESCRIPTION
## Summary
- add sticky absent/value/null render-anchor semantics to params commands
- render stationary anchors without transport lead or loop-band snapping
- emit full anchored windows and cover cyclic transport spill
- add focused render-anchor and contract tests

## Paired change
Paired with rtmg-vst PR https://github.com/daydreamlive/rtmg-vst/pull/172.

**Merge this PR and the rtmg-vst PR together. Do not deploy either side independently.** The server adds the `render_anchor_s` protocol behavior consumed by the paired VST change.

## Verification
- `pytest tests/unit`: 417 passed, 4 skipped
- diff passes `git diff --check`