### PR TITLE
fix(enhance): choose SA3 solo policy from prompt intent

### DIFF
--- a/demos/realtime_motion_graph_web/prompt_enhancer.py
+++ b/demos/realtime_motion_graph_web/prompt_enhancer.py
@@ -45,28 +45,71 @@ RULES:
   options, no explanation, no line breaks, no "Prompt:" label.
 """.strip()
 
-# Stable Audio 3 policy. SA3 is the same engine theDAW documents (T5Gemma text
-# encoder + separate duration signal), so its prompting guide
+# Stable Audio 3 policies. SA3 is the same engine theDAW documents (T5Gemma
+# text encoder + separate duration signal), so its prompting guide
 # (theDAW/docs/guides/prompting.md) is the authoritative reference here. SA3
 # reads the prompt as a producer's natural-language DESCRIPTION, not a bare tag
-# list, so this system prompt asks for compact descriptive phrases.
+# list, so both policies ask for compact descriptive phrases.
 #
-# SA3 ships as the SOLO INSTRUMENT workflow ("generate a solo stem" — the
-# acestep family is the FULL MIX workflow), so this policy must describe ONE
-# instrument playing alone. The encoder conditions on meaning: a single stray
-# arrangement phrase ("rolling sub bass", a track-genre like "liquid drum &
-# bass") pulls the generation back to a full mix, and negations don't subtract
-# ("no drums" still embeds "drums") — hence the one-instrument / positive
-# "unaccompanied" rules below. BPM stays OUT of the clean output on purpose:
-# the M4L wire helper (demon::promptMeta) appends the REAL project tempo/key
-# downstream for backend=="sa3", so a genre-typical number here would ship two
-# conflicting BPMs. _sanitize's bpm-strip is shared and stays active for both
-# backends.
+# SA3 can generate either full tracks or a single instrument. Full-track is the
+# default so a backend choice never silently throws away SA3's arrangement
+# capability. Explicit solo intent in the rough idea selects the narrower
+# policy below. The encoder conditions on meaning: a single stray arrangement
+# phrase ("rolling sub bass", a track-genre like "liquid drum & bass") can pull
+# a requested solo back to a full mix, and negations don't subtract ("no drums"
+# still embeds "drums") — hence the one-instrument / positive "unaccompanied"
+# rules in _SYSTEM_SA3_SOLO.
+#
+# BPM stays OUT of clean output on purpose: the M4L wire helper
+# (demon::promptMeta) appends the REAL project tempo/key downstream for
+# backend=="sa3", so a genre-typical number here would ship two conflicting
+# BPMs. _sanitize's bpm-strip is shared and stays active for both backends.
 _SYSTEM_SA3 = """
 You expand a user's rough music idea into ONE vivid prompt for the Stable Audio 3
-generative-music model in its SOLO INSTRUMENT mode: the prompt must describe a
-SINGLE instrument playing completely alone — an isolated solo stem — never a full
-mix, band, or arrangement.
+generative-music model.
+
+SA3 reads the prompt as a producer's DESCRIPTION of a track — the way one producer
+describes a song to another — NOT a list of bare tags. Its text encoder conditions
+on MEANING, so short DESCRIPTIVE PHRASES beat isolated one-word keywords, while
+dense, compact phrasing beats long prose. Write ONE line.
+
+Draw only from the dimensions that matter for the intended sound:
+- genre / subgenre
+- instrumentation (name the hook / lead instrument especially)
+- tempo / feel — qualitative words ONLY ("uptempo", "half-time", "rolling", "driving")
+- mood / energy
+- production / mix texture
+- structure / motion
+
+Genre and the hook instrument carry the most weight, and THE FIRST PHRASES DOMINATE
+the result — lead with the genre and the key instrument.
+
+Follow this pattern: <genre>, <key instruments>, <tempo/feel>, <mood>, <production texture>
+
+Examples:
+lo-fi boom bap, dusty Rhodes chords, vinyl crackle, lazy swung drums, nostalgic
+liquid drum & bass, lush reverb pads, rolling sub bass, chopped soul vocal, uplifting
+cinematic orchestral build, low strings, taiko hits, rising tension, percussion entering at the climax
+bossa nova, nylon guitar, soft brushes, upright bass, intimate jazz club, warm
+melodic techno, hypnotic arpeggio, deep kick, analog bass, wide stereo
+
+RULES:
+- Stay faithful to the user's idea — honor any named artist, genre, era, or instrument
+  they mention (e.g. "boards of canada style" -> that hazy, nostalgic analog sound).
+- Describe the DESIRED trait directly ("clean, dry, minimal reverb") — NEVER phrase it
+  as what to avoid.
+- NEVER include a bpm/tempo NUMBER or a duration in seconds — describe tempo with words
+  only. The real tempo and key are added downstream, not by you.
+- Roughly 5-9 comma-separated phrases. Lowercase. One cohesive vibe.
+- Reply with ONLY the single comma-separated line. No preamble, no quotes, no options,
+  no explanation, no line breaks, no "Prompt:" label.
+""".strip()
+
+_SYSTEM_SA3_SOLO = """
+You expand a user's rough music idea into ONE vivid prompt for the Stable Audio 3
+generative-music model. The user explicitly requested a SOLO INSTRUMENT: the prompt
+must describe a SINGLE instrument playing completely alone — an isolated solo stem —
+never a full mix, band, or arrangement.
 
 SA3 reads the prompt as a producer's DESCRIPTION of a recording — the way one
 producer describes it to another — NOT a list of bare tags. Its text encoder
@@ -110,6 +153,22 @@ RULES:
 - Reply with ONLY the single comma-separated line. No preamble, no quotes, no options,
   no explanation, no line breaks, no "Prompt:" label.
 """.strip()
+
+# Deliberately require explicit performance/stem language. A bare mood such as
+# "alone at night" or "isolated atmosphere" must not discard a full arrangement.
+_SA3_SOLO_CUE_RE = re.compile(
+    r"\b(?:solo(?:ist)?|unaccompanied|a\s+cappella|acapella)\b"
+    r"|\b(?:single|one)[ -](?:instrument|voice|vocal|performer)\b"
+    r"|\bisolated(?:[ -][\w-]+){0,3}[ -](?:instrument|voice|vocal|vocals|stem)\b"
+    r"|\b(?:instrument|voice|vocal|vocals)\s+(?:playing\s+)?alone\b"
+    r"|\bplaying\s+(?:completely\s+)?alone\b",
+    re.IGNORECASE,
+)
+
+
+def _sa3_wants_solo(idea: str) -> bool:
+    """Return whether the rough idea explicitly asks for an isolated performer."""
+    return bool(_SA3_SOLO_CUE_RE.search(idea))
 
 
 def llm_available() -> bool:
@@ -166,12 +225,12 @@ def _ask_haiku(system: str, user: str) -> str | None:
 def enhance_prompt(idea: str, backend: str = "acestep") -> tuple[str, bool]:
     """Expand a rough idea into a rich prompt for the active backend.
 
-    ``backend`` selects the LLM policy: ``"sa3"`` uses the Stable Audio 3
-    SOLO INSTRUMENT style (a natural-language description of ONE instrument
-    playing alone — SA3 ships as the solo-stem workflow); anything else
-    (default) uses the legacy ACE-Step full-mix comma-tag style. The default
-    keeps the pre-existing no-``backend`` call path byte-identical.
-    ``_sanitize`` (incl. the bpm-strip) is shared, so both backends stay
+    ``backend`` selects the model family policy. ``"sa3"`` uses a full-track
+    Stable Audio 3 description by default and switches to its solo-instrument
+    policy only when the rough idea contains an explicit solo cue. Anything
+    else (default) uses the legacy ACE-Step full-mix comma-tag style. The
+    default keeps the pre-existing no-``backend`` call path byte-identical.
+    ``_sanitize`` (incl. the bpm-strip) is shared, so every path stays
     bpm-number-free.
 
     Returns ``(text, ok)``. ``ok=False`` means enhancement was unavailable or
@@ -182,11 +241,18 @@ def enhance_prompt(idea: str, backend: str = "acestep") -> tuple[str, bool]:
     if not idea:
         return idea, False
     if backend == "sa3":
-        system = _SYSTEM_SA3
-        user = (
-            f'Rough idea: "{idea[:300]}". Expand it into one Stable Audio 3 '
-            "solo-instrument prompt (one instrument, playing alone)."
-        )
+        if _sa3_wants_solo(idea):
+            system = _SYSTEM_SA3_SOLO
+            user = (
+                f'Rough idea: "{idea[:300]}". Expand it into one Stable Audio 3 '
+                "solo-instrument prompt (one instrument, playing alone)."
+            )
+        else:
+            system = _SYSTEM_SA3
+            user = (
+                f'Rough idea: "{idea[:300]}". Expand it into one rich '
+                "Stable Audio 3 prompt."
+            )
     else:
         system = _SYSTEM
         user = f'Rough idea: "{idea[:300]}". Expand it into one rich ACE-Step prompt.'

--- a/tests/unit/test_prompt_enhancer.py
+++ b/tests/unit/test_prompt_enhancer.py
@@ -66,6 +66,7 @@ def test_sa3_backend_uses_sa3_policy(monkeypatch):
     assert ok is True
     assert seen["system"] is pe._SYSTEM_SA3
     assert "Stable Audio 3" in seen["user"]
+    assert "solo" not in seen["user"].lower()
 
 
 def test_bpm_number_stripped_for_both_backends(monkeypatch):
@@ -81,22 +82,21 @@ def test_sa3_system_prompt_is_bpm_free_and_natural_language():
     """The SA3 few-shot must not seed the model with numeric bpm, and must ask
     for descriptive phrases rather than a bare tag list (guide-grounded)."""
     import re
-    sys_l = pe._SYSTEM_SA3.lower()
-    assert not re.search(r"\d+\s*bpm", sys_l)  # no numeric bpm in examples/instructions
-    assert "description" in sys_l
-    assert "stable audio 3" in sys_l
+    for system in (pe._SYSTEM_SA3, pe._SYSTEM_SA3_SOLO):
+        sys_l = system.lower()
+        assert not re.search(r"\d+\s*bpm", sys_l)
+        assert "description" in sys_l
+        assert "stable audio 3" in sys_l
 
 
-def test_sa3_policy_is_solo_instrument():
-    """SA3 ships as the SOLO INSTRUMENT workflow (acestep is FULL MIX), so its
-    policy must steer toward one instrument playing alone — the full-mix drift
-    this policy replaced came from arrangement-style few-shot examples."""
-    sys_l = pe._SYSTEM_SA3.lower()
+def test_sa3_solo_policy_is_solo_instrument():
+    """Explicit solo intent uses a policy with no arrangement-style examples."""
+    sys_l = pe._SYSTEM_SA3_SOLO.lower()
     assert "solo" in sys_l
     assert "unaccompanied" in sys_l
     assert "full mix" in sys_l  # the never-a-full-mix rule is stated
     # Every few-shot example line must lead with the solo instrument.
-    lines = pe._SYSTEM_SA3.splitlines()
+    lines = pe._SYSTEM_SA3_SOLO.splitlines()
     examples = lines[lines.index("Examples:") + 1:]
     example_lines = []
     for ln in examples:
@@ -108,11 +108,42 @@ def test_sa3_policy_is_solo_instrument():
         assert ln.startswith("solo "), f"example does not lead with solo: {ln!r}"
 
 
-def test_sa3_user_message_asks_for_solo(monkeypatch):
-    """The per-request user message reinforces the solo-stem framing too."""
+@pytest.mark.parametrize(
+    "idea",
+    [
+        "solo grand piano",
+        "unaccompanied bebop saxophone",
+        "a cappella soul vocal",
+        "single instrument ambient piece",
+        "isolated guitar stem",
+        "voice playing alone",
+        "cello playing completely alone",
+    ],
+)
+def test_sa3_explicit_solo_cues_select_solo_policy(monkeypatch, idea):
+    """Explicit performance/stem cues select and reinforce the solo policy."""
     seen = _capture_system(monkeypatch)
-    pe.enhance_prompt("dreamy synthwave", "sa3")
+    pe.enhance_prompt(idea, "sa3")
+    assert seen["system"] is pe._SYSTEM_SA3_SOLO
     assert "solo" in seen["user"].lower()
+
+
+@pytest.mark.parametrize(
+    "idea",
+    [
+        "dreamy synthwave",
+        "liquid drum and bass with chopped vocals",
+        "alone at night, cinematic and melancholy",
+        "isolated atmosphere with a huge chorus",
+        "solomon burke style soul",
+    ],
+)
+def test_sa3_without_explicit_solo_cue_keeps_full_track_policy(monkeypatch, idea):
+    """Backend selection and mood words alone must not discard arrangements."""
+    seen = _capture_system(monkeypatch)
+    pe.enhance_prompt(idea, "sa3")
+    assert seen["system"] is pe._SYSTEM_SA3
+    assert "solo-instrument" not in seen["user"].lower()
 
 
 def test_empty_prompt_returns_unchanged_not_ok(monkeypatch):


### PR DESCRIPTION
## Summary
- keep SA3 full-track enhancement as the default
- route explicit solo intent (`solo`, `unaccompanied`, `a cappella`, `single instrument`, isolated-stem phrasing, or playing alone) through the strict one-instrument policy from #306
- keep ambiguous mood language such as "alone at night" and "isolated atmosphere" on the full-track path

## Why
SA3 is useful for both full arrangements and solo instruments. The VST's solo-instrument positioning should not make the backend family itself synonymous with solo generation; the user's prompt should choose the narrower behavior.

This is stacked directly on #306 and targets Hunter's head branch so merging it updates that PR.

## Tests
- `.venv/Scripts/python.exe -m pytest tests/unit/test_prompt_enhancer.py` (26 passed)
- `.venv/Scripts/python.exe -m pytest tests/unit` (421 passed, 4 skipped)
