### PR TITLE
feat(lora): server-owned catalog compatibility + reference resolution

### DIFF
--- a/acestep/lora_metadata.py
+++ b/acestep/lora_metadata.py
@@ -93,6 +93,27 @@ class LoraMetadata:
         return asdict(self)
 
 
+def lora_scale_compatible(
+    lora_scale: Optional[str],
+    checkpoint_scale: Optional[str],
+) -> bool:
+    """True iff a LoRA trained at ``lora_scale`` can load against a
+    checkpoint of ``checkpoint_scale`` ("2B" / "5B" labels, see
+    :func:`acestep.paths.checkpoint_scale`).
+
+    Unknown on EITHER side is compatible — same permissive stance as
+    the module-level ``base_model_scale`` comment above and the demo's
+    ``isLoraCompatibleWithScale`` — so undocumented LoRAs and
+    unrecognized checkpoints are never hidden or excluded. This is the
+    scale AXIS only; the per-session predicate lives on the generator
+    backend (``GeneratorBackend.lora_compatible``) so families can add
+    axes beyond scale.
+    """
+    if not checkpoint_scale or not lora_scale:
+        return True
+    return lora_scale == checkpoint_scale
+
+
 # (sidecar_path_str, mtime_ns) -> parsed record
 _cache: dict[tuple[str, int], LoraMetadata] = {}
 

--- a/acestep/streaming/ace_backend.py
+++ b/acestep/streaming/ace_backend.py
@@ -27,6 +27,7 @@ import torch
 
 from acestep.engine.dcw import DCWAdvanced
 from acestep.engine.obs import logger
+from acestep.lora_metadata import lora_scale_compatible
 from acestep.nodes.types import ChannelGuidanceEntry, Latent
 from acestep.nodes.interpolation import INTERPOLATIONS
 from acestep.nodes.vae_nodes import EmptyLatent, LatentBlend
@@ -180,6 +181,7 @@ class ACEStepBackend(DiffusionBackend):
         walk_window_s=60.0,
         neg_conditioning=None,
         steering: SteeringController | None = None,
+        checkpoint_scale: str | None = None,
     ):
         # The family codec is the engine Session: its windowed VAE
         # decode is what render_window()/render_full() drive. The
@@ -194,6 +196,10 @@ class ACEStepBackend(DiffusionBackend):
         self.use_lora = use_lora
         self.midi_knobs = midi_knobs
         self.engine_obj = engine_obj
+        # Model-scale label of the active checkpoint ("2B" / "5B",
+        # None = unknown), resolved by the factory from the session's
+        # checkpoint name. Drives lora_compatible below.
+        self.checkpoint_scale = checkpoint_scale
         # Use the effective Session value after engine-profile clamps.
         # The web config may still carry an old multi-second value, but
         # scheduling must match the slice length session.decode() emits.
@@ -337,6 +343,14 @@ class ACEStepBackend(DiffusionBackend):
             curves=True,
             notes_conditioning=False,
             steering=self.steering.is_loaded,
+        )
+
+    def lora_compatible(self, metadata: dict) -> bool:
+        """ACE's only compatibility axis today: a 2B-trained LoRA
+        cannot refit onto the XL (5B) DiT and vice versa. Unknown
+        scale on either side is compatible per the seam contract."""
+        return lora_scale_compatible(
+            metadata.get("base_model_scale"), self.checkpoint_scale,
         )
 
     def geometry(self) -> AudioGeometry:

--- a/acestep/streaming/diffusion_backend.py
+++ b/acestep/streaming/diffusion_backend.py
@@ -80,6 +80,12 @@ class DiffusionBackend:
     def has_pending_refit(self) -> bool:
         return False
 
+    def lora_compatible(self, metadata: dict) -> bool:
+        # Permissive default per the seam contract: a family that can't
+        # classify a LoRA against its engine treats it as loadable.
+        # Families with a real axis override (ACE: base-model scale).
+        return True
+
     def rebuild_imminent(self, knobs: dict) -> bool:
         return False
 

--- a/acestep/streaming/families.py
+++ b/acestep/streaming/families.py
@@ -20,6 +20,7 @@ from acestep.engine.obs import logger
 
 
 def _make_acestep(ss):
+    from acestep.paths import checkpoint_scale
     from acestep.steering import SteeringController, ensure_steering_vectors
     from acestep.streaming.ace_backend import ACEStepBackend
 
@@ -43,6 +44,9 @@ def _make_acestep(ss):
         walk_window_s=ss.walk_window_s,
         neg_conditioning=ss.cond_negative,
         steering=steering,
+        # Scale label for the lora_compatible predicate; None for
+        # checkpoints outside the scale map = "don't filter".
+        checkpoint_scale=checkpoint_scale(ss.checkpoint),
     )
 
 

--- a/acestep/streaming/generator_backend.py
+++ b/acestep/streaming/generator_backend.py
@@ -229,6 +229,25 @@ class GeneratorBackend(Protocol):
         """
         ...
 
+    def lora_compatible(self, metadata: dict) -> bool:
+        """Whether a catalog LoRA can actually load on this backend's
+        engine. ``metadata`` is the wire-shaped sidecar record
+        (``load_lora_metadata(...).to_wire()``) already carried by every
+        catalog entry.
+
+        Backend-owned so the compatibility axes can grow per family:
+        today ACE checks the trained base-model scale against its
+        checkpoint; an SA3 LoRA lineage would add its own checks here
+        without the session or the wire changing. The session projects
+        this verdict as the ``compatible`` bool on every catalog entry
+        (clients decide whether to hide or grey incompatible rows) and
+        restricts enable-time alias resolution to the compatible
+        subset. Implementations must be permissive on unknowns —
+        a LoRA or engine the predicate can't classify is compatible,
+        never hidden.
+        """
+        ...
+
     # ---- hot loop --------------------------------------------------------
 
     def sync_source(self, ctx: TickContext) -> None:

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -58,12 +58,13 @@ from acestep.engine.trt.profile_manager import (
     TRTProfileManager,
 )
 from acestep.fixtures import KNOWN_FIXTURES, audio_fixture
-from acestep.lora_metadata import load_lora_metadata
+from acestep.lora_metadata import load_lora_metadata, lora_scale_compatible
 from acestep.nodes.interpolation import INTERP_METHOD_NAMES
 from acestep.nodes.types import Audio, Latent
 from acestep.paths import (
     EngineNotBuiltError,
     available_dreamvae_decode_engine,
+    checkpoint_scale,
     checkpoints_dir,
     dreamvae_decode_engine_name,
     max_profile_duration_s,
@@ -196,6 +197,34 @@ def _cleanup_create_resource(name: str, close_fn: Callable[[], None]) -> None:
             "streaming_create_cleanup_raised resource={} error={}",
             name, exc,
         )
+
+
+def resolve_lora_reference(requested: str, entries) -> str | None:
+    """Resolve a client LoRA reference to a canonical catalog id.
+
+    ``entries`` is an iterable of ``(lora_id, display_name, compatible)``
+    triples covering the FULL catalog. An exact id match wins outright
+    (even on an incompatible entry — exact-id clients keep today's
+    behavior, including today's engine-side failure). Otherwise the
+    reference is looked up case-insensitively against each entry's
+    filename stem (its id) and sidecar display name, restricted to the
+    COMPATIBLE subset — so a scale-agnostic reference like "Ambient",
+    shared by ``ambient-v1`` (2B) and ``ambient-xl-v1`` (5B), resolves
+    to the variant the active engine can actually load. Mirrors the
+    demo webapp's ``buildLoraAliasMap`` (last write wins on the
+    degenerate same-name collision). Returns ``None`` on a miss.
+    """
+    entries = list(entries)
+    if any(requested == lid for lid, _, _ in entries):
+        return requested
+    aliases: dict = {}
+    for lid, name, compatible in entries:
+        if not compatible:
+            continue
+        aliases[lid.lower()] = lid
+        if name:
+            aliases[str(name).lower()] = lid
+    return aliases.get(requested.lower())
 
 
 # ---------------------------------------------------------------------------
@@ -675,8 +704,39 @@ class StreamingSession:
                 "strength": d.strength,
                 "materialized_bytes": d.materialized_bytes,
                 "metadata": metadata,
+                # Backend verdict: can this engine actually load the
+                # entry? Advisory — the full catalog still ships so
+                # clients can show incompatible rows greyed instead of
+                # hidden (the demo's show_incompatible_loras toggle).
+                "compatible": bool(self.backend.lora_compatible(metadata)),
             })
         return out
+
+    def _resolve_lora_id(self, requested: str) -> str:
+        """Map a client LoRA reference (exact id, or a case-insensitive
+        stem/display-name alias) to the canonical catalog id via
+        :func:`resolve_lora_reference`. Falls through to the original
+        string on a miss so downstream behavior (engine-side
+        enable/disable failure logs) is unchanged for ids that never
+        existed."""
+        if not (self.lora_available and self.engine_obj is not None):
+            return requested
+        entries = []
+        for d in self.engine_obj.list_loras():
+            metadata = load_lora_metadata(d.path).to_wire()
+            entries.append((
+                d.id,
+                metadata.get("name") or d.name,
+                self.backend.lora_compatible(metadata),
+            ))
+        resolved = resolve_lora_reference(requested, entries)
+        if resolved is None:
+            return requested
+        if resolved != requested:
+            logger.info(
+                "lora_alias_resolved requested={} id={}", requested, resolved,
+            )
+        return resolved
 
     def snapshot(self) -> dict:
         """JSON-serialisable snapshot of the session's current state.
@@ -1823,10 +1883,16 @@ class StreamingSession:
     ) -> None:
         """Stage a LoRA enable. The atomic-strength contract holds:
         the next refit lands at ``strength`` in one shot (no
-        first-window-without-LoRA artifact)."""
+        first-window-without-LoRA artifact).
+
+        ``lora_id`` may be an exact catalog id or a case-insensitive
+        stem/display-name alias; the enable is staged (and later echoed
+        by ``lora_enabled`` and the catalog broadcast) under the
+        canonical id."""
         self.state.last_activity_ts = time.monotonic()
+        lora_id = self._resolve_lora_id(str(lora_id))
         with self.state._lock:
-            self.state.pending_enable.append((str(lora_id), strength))
+            self.state.pending_enable.append((lora_id, strength))
         logger.info(
             "enable_lora_requested origin={} id={} strength={}",
             origin.value, lora_id, strength,
@@ -1839,9 +1905,12 @@ class StreamingSession:
         *,
         origin: CommandOrigin = CommandOrigin.PRIMARY,
     ) -> None:
+        """Same alias resolution as :meth:`enable_lora` — a client that
+        enabled by alias must be able to disable by the same name."""
         self.state.last_activity_ts = time.monotonic()
+        lora_id = self._resolve_lora_id(str(lora_id))
         with self.state._lock:
-            self.state.pending_disable.append(str(lora_id))
+            self.state.pending_disable.append(lora_id)
         logger.info(
             "disable_lora_requested origin={} id={}",
             origin.value, lora_id,
@@ -2439,12 +2508,39 @@ class StreamingSession:
 
             initial_enable_ids: list[str] = []
             if use_lora:
-                catalog_ids = {d.id for d in engine_obj.list_loras()}
+                # Same reference resolution as the runtime enable_lora
+                # path, but the backend (and its lora_compatible
+                # predicate) doesn't exist until __init__ — this IS the
+                # ACE-family create path, so the scale axis is applied
+                # directly, mirroring ACEStepBackend.lora_compatible.
+                scale = checkpoint_scale(checkpoint)
+                entries = []
+                for d in engine_obj.list_loras():
+                    md = load_lora_metadata(d.path)
+                    entries.append((
+                        d.id,
+                        md.name or d.name,
+                        lora_scale_compatible(md.base_model_scale, scale),
+                    ))
                 for lid in enabled_lora_ids:
-                    if lid in catalog_ids:
-                        initial_enable_ids.append(lid)
-                    else:
+                    resolved = resolve_lora_reference(lid, entries)
+                    if resolved is None:
                         logger.warning("lora_id_not_in_catalog id={}", lid)
+                        continue
+                    if resolved != lid:
+                        logger.info(
+                            "lora_alias_resolved requested={} id={}",
+                            lid, resolved,
+                        )
+                        # Re-key any client-supplied strength so the
+                        # first-tick enable picks it up under the
+                        # canonical id.
+                        if lid in lora_strengths_init:
+                            lora_strengths_init.setdefault(
+                                resolved, lora_strengths_init[lid],
+                            )
+                    if resolved not in initial_enable_ids:
+                        initial_enable_ids.append(resolved)
                 for p in extra_lora_paths:
                     pp = Path(p)
                     if not pp.exists():

--- a/demos/realtime_motion_graph_web/protocol.py
+++ b/demos/realtime_motion_graph_web/protocol.py
@@ -322,7 +322,12 @@ COMMANDS: tuple = (
         "enable_lora",
         fields=(
             FieldSpec("id", "str", required=True,
-                      description="LoRA id/stem (see /api/loras)."),
+                      description="LoRA id/stem (see /api/loras). A value "
+                                  "matching no catalog id exactly is resolved "
+                                  "as a case-insensitive stem/display-name "
+                                  "alias over the compatible subset of the "
+                                  "catalog; the enable lands on (and the "
+                                  "catalog echo shows) the canonical id."),
             FieldSpec("strength", "float",
                       description="Target strength the refit lands at."),
         ),
@@ -331,7 +336,9 @@ COMMANDS: tuple = (
     ),
     CommandSpec(
         "disable_lora",
-        fields=(FieldSpec("id", "str", required=True),),
+        fields=(FieldSpec("id", "str", required=True,
+                          description="LoRA id/stem; same alias resolution "
+                                      "as enable_lora."),),
         requires="lora",
         description="Disable a LoRA and drop its lora_str_<id> knob.",
     ),
@@ -503,7 +510,12 @@ EVENTS: tuple = (
             FieldSpec("duration", "float", required=True),
             FieldSpec("channels", "int", required=True),
             FieldSpec("sample_rate", "int", required=True),
-            FieldSpec("lora_catalog", "list"),
+            FieldSpec("lora_catalog", "list",
+                      description="Full catalog; entries carry a server-"
+                                  "computed `compatible` bool (backend "
+                                  "predicate — can this engine load it?) so "
+                                  "clients filter/grey without re-deriving "
+                                  "scale rules."),
             FieldSpec("lora_dir", "str"),
             FieldSpec("bpm", "float", nullable=True),
             FieldSpec("key", "str", nullable=True),
@@ -618,7 +630,10 @@ EVENTS: tuple = (
     ),
     EventSpec(
         "lora_catalog",
-        fields=(FieldSpec("catalog", "list", required=True),),
+        fields=(FieldSpec("catalog", "list", required=True,
+                          description="Same entry shape as "
+                                      "ready.lora_catalog, including the "
+                                      "server-computed `compatible` bool."),),
         description="Refreshed LoRA catalog after enable/disable.",
     ),
     EventSpec(

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -284,7 +284,7 @@ def _process_request(connection, request):
     # resolution the WebSocket pipeline uses, so everyone agrees on
     # what's in the catalog.
     if path_only == "/api/loras":
-        from acestep.lora_metadata import load_lora_metadata
+        from acestep.lora_metadata import load_lora_metadata, lora_scale_compatible
         from acestep.paths import (
             checkpoint_scale,
             discover_all_loras,
@@ -298,6 +298,7 @@ def _process_request(connection, request):
             # engine-side catalog stay in lockstep.
             entries = []
             seen_ids: set[str] = set()
+            scale = checkpoint_scale(_CHECKPOINT)
             for p in discover_all_loras():
                 # Same-stem dedup mirrors LoRAManager.register_lora's
                 # first-wins behavior so the UI can't see a phantom id
@@ -314,6 +315,13 @@ def _process_request(connection, request):
                     "strength": 0.0,
                     "materialized_bytes": 0,
                     "metadata": md,
+                    # Pre-session there is no backend to ask, so the
+                    # scale axis is applied directly — same verdict the
+                    # WS catalog's backend.lora_compatible produces for
+                    # ACE checkpoints. Advisory; the full catalog ships.
+                    "compatible": lora_scale_compatible(
+                        md.get("base_model_scale"), scale,
+                    ),
                 })
         except Exception as e:
             entries = []

--- a/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
+++ b/demos/realtime_motion_graph_web/web/store/useLoraStore.ts
@@ -21,6 +21,10 @@ export function isLoraCompatibleWithScale(
   entry: LoraCatalogEntry,
   sessionScale: string | null,
 ): boolean {
+  // Prefer the server's backend-owned verdict when present — it can
+  // grow axes beyond scale (SA3 LoRA lineage) without a client change.
+  // The local scale comparison below remains the old-server fallback.
+  if (typeof entry.compatible === "boolean") return entry.compatible;
   if (sessionScale === null || sessionScale === undefined) return true;
   const loraScale = entry.metadata?.base_model_scale;
   if (!loraScale) return true;

--- a/packages/demon-client/types/protocol.ts
+++ b/packages/demon-client/types/protocol.ts
@@ -62,6 +62,13 @@ export interface LoraCatalogEntry {
   /** Full normalized metadata record. Always present from servers that
    *  speak the v2 catalog shape; older servers may omit it. */
   metadata?: LoraMetadata;
+  /** Server-computed backend verdict: can the active engine actually
+   *  load this LoRA (today: trained base_model_scale vs the session
+   *  checkpoint's scale)? Advisory — the full catalog still ships so
+   *  clients can grey instead of hide. Absent from older servers;
+   *  clients fall back to the local scale comparison
+   *  (isLoraCompatibleWithScale) when missing. */
+  compatible?: boolean;
 }
 
 /** Sent by the client at session start (config phase). Generated from the

--- a/packages/demon-client/types/wireContract.gen.hpp
+++ b/packages/demon-client/types/wireContract.gen.hpp
@@ -109,7 +109,7 @@ namespace command {
 
   namespace enable_lora {
     inline constexpr const char* kType = "enable_lora";
-    /** LoRA id/stem (see /api/loras). */
+    /** LoRA id/stem (see /api/loras). A value matching no catalog id exactly is resolved as a case-insensitive stem/display-name alias over the compatible subset of the catalog; the enable lands on (and the catalog echo shows) the canonical id. */
     inline constexpr const char* kId = "id";
     /** Target strength the refit lands at. */
     inline constexpr const char* kStrength = "strength";
@@ -117,6 +117,7 @@ namespace command {
 
   namespace disable_lora {
     inline constexpr const char* kType = "disable_lora";
+    /** LoRA id/stem; same alias resolution as enable_lora. */
     inline constexpr const char* kId = "id";
   }  // namespace disable_lora
 
@@ -231,6 +232,7 @@ namespace event {
     inline constexpr const char* kDuration = "duration";
     inline constexpr const char* kChannels = "channels";
     inline constexpr const char* kSampleRate = "sample_rate";
+    /** Full catalog; entries carry a server-computed `compatible` bool (backend predicate — can this engine load it?) so clients filter/grey without re-deriving scale rules. */
     inline constexpr const char* kLoraCatalog = "lora_catalog";
     inline constexpr const char* kLoraDir = "lora_dir";
     inline constexpr const char* kBpm = "bpm";
@@ -292,6 +294,7 @@ namespace event {
 
   namespace lora_catalog {
     inline constexpr const char* kType = "lora_catalog";
+    /** Same entry shape as ready.lora_catalog, including the server-computed `compatible` bool. */
     inline constexpr const char* kCatalog = "catalog";
   }  // namespace lora_catalog
 

--- a/packages/demon-client/types/wireContract.gen.ts
+++ b/packages/demon-client/types/wireContract.gen.ts
@@ -183,7 +183,7 @@ export interface SetDepthCommand {
 
 export interface EnableLoraCommand {
   type: "enable_lora";
-  /** LoRA id/stem (see /api/loras). */
+  /** LoRA id/stem (see /api/loras). A value matching no catalog id exactly is resolved as a case-insensitive stem/display-name alias over the compatible subset of the catalog; the enable lands on (and the catalog echo shows) the canonical id. */
   id: string;
   /** Target strength the refit lands at. */
   strength?: number;
@@ -191,6 +191,7 @@ export interface EnableLoraCommand {
 
 export interface DisableLoraCommand {
   type: "disable_lora";
+  /** LoRA id/stem; same alias resolution as enable_lora. */
   id: string;
 }
 
@@ -285,6 +286,7 @@ export interface ReadyEvent {
   duration: number;
   channels: number;
   sample_rate: number;
+  /** Full catalog; entries carry a server-computed `compatible` bool (backend predicate — can this engine load it?) so clients filter/grey without re-deriving scale rules. */
   lora_catalog?: unknown[];
   lora_dir?: string;
   bpm?: number | null;
@@ -346,6 +348,7 @@ export interface PromptAppliedEvent {
 
 export interface LoraCatalogEvent {
   type: "lora_catalog";
+  /** Same entry shape as ready.lora_catalog, including the server-computed `compatible` bool. */
   catalog: unknown[];
 }
 

--- a/tests/unit/test_lora_resolution.py
+++ b/tests/unit/test_lora_resolution.py
@@ -1,0 +1,193 @@
+"""Server-side LoRA reference resolution + catalog compatibility.
+
+Covers the two pieces that moved LoRA name/scale resolution from
+clients into the server:
+
+* ``lora_scale_compatible`` — the scale axis of the backend-owned
+  ``lora_compatible`` predicate (permissive on unknowns).
+* ``resolve_lora_reference`` — exact catalog id first, then a
+  case-insensitive stem/display-name alias lookup restricted to the
+  compatible subset (mirrors the demo webapp's ``buildLoraAliasMap``).
+* The session plumbing that uses them: ``lora_catalog_payload``
+  annotating each entry with the backend verdict, and
+  ``_resolve_lora_id`` mapping aliases to canonical ids. Exercised
+  against stub engine/backend objects — no GPU, no model load.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from acestep.lora_metadata import clear_cache, lora_scale_compatible
+from acestep.streaming.session import StreamingSession, resolve_lora_reference
+
+
+# ---------------------------------------------------------------------------
+# lora_scale_compatible
+# ---------------------------------------------------------------------------
+
+
+class TestLoraScaleCompatible:
+    def test_matching_scales(self):
+        assert lora_scale_compatible("2B", "2B")
+        assert lora_scale_compatible("5B", "5B")
+
+    def test_mismatched_scales(self):
+        assert not lora_scale_compatible("2B", "5B")
+        assert not lora_scale_compatible("5B", "2B")
+
+    def test_unknown_on_either_side_is_compatible(self):
+        assert lora_scale_compatible(None, "2B")
+        assert lora_scale_compatible("2B", None)
+        assert lora_scale_compatible(None, None)
+        assert lora_scale_compatible("", "2B")
+
+
+# ---------------------------------------------------------------------------
+# resolve_lora_reference
+# ---------------------------------------------------------------------------
+
+_ENTRIES = [
+    ("ambient-v1", "Ambient", True),
+    ("ambient-xl-v1", "Ambient", False),
+    ("deep_house-v1", "Deep House", True),
+    ("metalcore-xl-v1", "Metalcore", False),
+    ("bare-lora", None, True),
+]
+
+
+class TestResolveLoraReference:
+    def test_exact_id_wins(self):
+        assert resolve_lora_reference("ambient-v1", _ENTRIES) == "ambient-v1"
+
+    def test_exact_id_wins_even_when_incompatible(self):
+        # Exact-id clients keep today's behavior, including today's
+        # engine-side refusal for an entry the engine can't load.
+        assert (
+            resolve_lora_reference("ambient-xl-v1", _ENTRIES)
+            == "ambient-xl-v1"
+        )
+
+    def test_stem_alias_is_case_insensitive(self):
+        assert resolve_lora_reference("AMBIENT-V1", _ENTRIES) == "ambient-v1"
+
+    def test_display_name_resolves_to_compatible_variant(self):
+        # "Ambient" names both scale variants; only the compatible one
+        # enters the alias map, so the reference lands on it.
+        assert resolve_lora_reference("Ambient", _ENTRIES) == "ambient-v1"
+        assert resolve_lora_reference("ambient", _ENTRIES) == "ambient-v1"
+
+    def test_alias_of_incompatible_only_entry_misses(self):
+        # "Metalcore" exists only as an incompatible variant: alias
+        # lookup is restricted to the compatible subset, so no match.
+        assert resolve_lora_reference("Metalcore", _ENTRIES) is None
+        assert resolve_lora_reference("metalcore", _ENTRIES) is None
+
+    def test_unknown_reference_misses(self):
+        assert resolve_lora_reference("synthwave", _ENTRIES) is None
+
+    def test_none_display_name_is_safe(self):
+        assert resolve_lora_reference("bare-lora", _ENTRIES) == "bare-lora"
+        assert resolve_lora_reference("BARE-LORA", _ENTRIES) == "bare-lora"
+
+
+# ---------------------------------------------------------------------------
+# Session plumbing (stubbed engine/backend, unbound methods)
+# ---------------------------------------------------------------------------
+
+
+class _Desc:
+    def __init__(self, path: Path):
+        self.id = path.stem
+        self.name = path.stem
+        self.path = str(path)
+        self.state = "registered"
+        self.strength = 0.0
+        self.materialized_bytes = 0
+
+
+class _StubEngine:
+    def __init__(self, descs):
+        self._descs = descs
+
+    def list_loras(self):
+        return self._descs
+
+
+class _ScaleBackend:
+    """Backend stub whose predicate is the ACE scale axis for a 2B
+    checkpoint."""
+
+    def lora_compatible(self, metadata: dict) -> bool:
+        return lora_scale_compatible(metadata.get("base_model_scale"), "2B")
+
+
+class _StubSession:
+    lora_available = True
+
+    def __init__(self, descs):
+        self.engine_obj = _StubEngine(descs)
+        self.backend = _ScaleBackend()
+
+    lora_catalog_payload = StreamingSession.lora_catalog_payload
+    _resolve_lora_id = StreamingSession._resolve_lora_id
+
+
+def _write_lora(tmp_path: Path, stem: str, name: str, scale: str) -> Path:
+    p = tmp_path / f"{stem}.safetensors"
+    p.write_bytes(b"")
+    sidecar = tmp_path / f"{stem}.metadata.json"
+    sidecar.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "id": stem,
+            "name": name,
+            "model": {"base_model": "acestep", "base_model_scale": scale},
+        }),
+        encoding="utf-8",
+    )
+    return p
+
+
+def _stub_session(tmp_path: Path) -> _StubSession:
+    clear_cache()
+    return _StubSession([
+        _Desc(_write_lora(tmp_path, "ambient-v1", "Ambient", "2B")),
+        _Desc(_write_lora(tmp_path, "ambient-xl-v1", "Ambient", "5B")),
+        _Desc(_write_lora(tmp_path, "metalcore-xl-v1", "Metalcore", "5B")),
+    ])
+
+
+class TestSessionPlumbing:
+    def test_catalog_entries_carry_backend_verdict(self, tmp_path):
+        catalog = _stub_session(tmp_path).lora_catalog_payload()
+        verdicts = {e["id"]: e["compatible"] for e in catalog}
+        assert verdicts == {
+            "ambient-v1": True,
+            "ambient-xl-v1": False,
+            "metalcore-xl-v1": False,
+        }
+        # Annotation only — the full catalog still ships (the demo's
+        # show_incompatible_loras toggle needs the incompatible rows).
+        assert len(catalog) == 3
+
+    def test_resolve_lora_id_prefers_exact_then_alias(self, tmp_path):
+        ss = _stub_session(tmp_path)
+        assert ss._resolve_lora_id("ambient-xl-v1") == "ambient-xl-v1"
+        assert ss._resolve_lora_id("Ambient") == "ambient-v1"
+        assert ss._resolve_lora_id("ambient") == "ambient-v1"
+
+    def test_resolve_lora_id_falls_through_on_miss(self, tmp_path):
+        ss = _stub_session(tmp_path)
+        # Alias restricted to the compatible subset: "Metalcore" only
+        # exists as a 5B variant on this 2B stub, so the reference
+        # passes through unchanged (and fails engine-side, as today).
+        assert ss._resolve_lora_id("Metalcore") == "Metalcore"
+        assert ss._resolve_lora_id("nope") == "nope"
+
+    def test_resolve_lora_id_without_engine_is_identity(self, tmp_path):
+        ss = _stub_session(tmp_path)
+        ss.engine_obj = None
+        assert ss._resolve_lora_id("Ambient") == "Ambient"


### PR DESCRIPTION
## What

Moves LoRA scale-filtering and name resolution from clients into the server. Companion VST PR: daydreamlive/rtmg-vst#197.

- **`compatible` on every catalog entry** — `ready.lora_catalog`, the `lora_catalog` frame, and `GET /api/loras` each annotate entries with a server-computed `compatible` bool. The verdict is a backend-owned predicate (`GeneratorBackend.lora_compatible`, permissive default in `DiffusionBackend`); ACE implements the base-model-scale axis (`lora_scale_compatible` against the checkpoint's scale). Future SA3 LoRA support extends the predicate without touching the session or the wire. Annotation only: the full catalog still ships, so the demo's `show_incompatible_loras` toggle keeps working. The demo's `isLoraCompatibleWithScale` now prefers the server verdict, keeping the local scale comparison as the old-server fallback.
- **Reference resolution in `enable_lora` / `disable_lora` and the startup `enabled_loras` set** — exact catalog id first (exact-id clients unaffected, including today's engine-side failure for unloadable ids), then a case-insensitive stem/display-name alias lookup restricted to the compatible subset, mirroring the demo's `buildLoraAliasMap`. A scale-agnostic reference like `Ambient` (shared by `ambient-v1` 2B and `ambient-xl-v1` 5B) lands on the variant the pod can load; the enable is staged, logged (`lora_enabled`), and echoed in the catalog under the canonical id, and startup strengths are re-keyed to it. `disable_lora` resolves too so an alias-enabled LoRA can be alias-disabled.
- **Contract** — `LoraCatalogEntry` gains `compatible?`; registry descriptions updated; `wireContract.gen.ts` / `.hpp` regenerated.

## Merge order

**Merge this PR first.** The rtmg-vst companion consumes the `compatible` annotation and relies on alias resolution for its renamed scale-agnostic slot defaults (`ambient`, `deep_house`); it degrades gracefully against old servers (local scale-compare fallback), but the paired behavior should land server-side before the VST ships.

## Testing

- New `tests/unit/test_lora_resolution.py`: predicate semantics, resolver semantics (exact-wins, case-insensitive, compatible-subset restriction), and the session plumbing via stub engine/backend.
- Full unit suite: 444 passed, 4 skipped. Wire-contract drift guard green.
- `tsc --noEmit` clean for the web app + SDK.
