### PR TITLE
chore(sa3): repin current upstream and version SAME-L engines

### DIFF
--- a/acestep/engine/sa3_context.py
+++ b/acestep/engine/sa3_context.py
@@ -254,7 +254,8 @@ class SA3SAMEWindowCodec:
     Two execution paths, identical interface:
 
     * **TRT** when ``use_trt`` and the built window engine exists
-      (``same_l_decode_window_t*``): ~9-10 ms per ~1 s window, latent
+      (``same_l_decode_window_<plugin_tag>_t*``): ~9-10 ms per ~1 s
+      window, latent
       scaled by ``pretransform.scale`` before the call (spike
       ``scale_mode="pretransform"``, rel_rms ~8e-3 vs eager full).
     * **Eager** fallback: the spike's ``decode_sa3_latent_window``

--- a/acestep/engine/sa3_helpers.py
+++ b/acestep/engine/sa3_helpers.py
@@ -25,7 +25,10 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 # DEMON tracks this fork branch until the SA3 TensorRT/FP8 producer work
 # merges upstream. The hash is the reproducibility boundary for installs.
 SA3_VENDOR_URL = "https://github.com/ryanontheinside/stable-audio-3"
-SA3_VENDOR_SHA = "03992120a3e296562271f209f4dd61dcfb55afff"
+SA3_VENDOR_SHA = "c07698548567fe6f163806f692d282bbaa57aba3"
+# Revision that last changed the source compiled into the SAME-L TensorRT
+# engine. Keep this stable across vendor bumps that only touch other code.
+SA3_SAME_L_PLUGIN_REVISION = "c07698548567fe6f163806f692d282bbaa57aba3"
 SA3_VENDOR_ENV = "DEMON_SA3_SRC"
 SA3_VENDOR_DIRNAME = "stable-audio-3"
 
@@ -152,7 +155,9 @@ def ensure_sa3_vendor(
     reported as an error instead of being overwritten.
     """
     vendor = sa3_vendor_dir()
-    if not (vendor / ".git").is_dir():
+    # A normal clone has a .git directory; a git worktree has a .git file
+    # pointing at the parent repository. Both are valid developer overrides.
+    if not (vendor / ".git").exists():
         if check_only:
             raise FileNotFoundError(f"SA3 vendor source is missing at {vendor}")
         vendor.parent.mkdir(parents=True, exist_ok=True)

--- a/acestep/engine/sa3_trt.py
+++ b/acestep/engine/sa3_trt.py
@@ -48,6 +48,7 @@ TRT (engine discovery then simply reports nothing).
 from __future__ import annotations
 
 import math
+import os
 import re
 import sys
 import threading
@@ -58,7 +59,7 @@ import torch
 
 from acestep import paths
 from acestep.engine.obs import logger
-from acestep.engine.sa3_helpers import sa3_vendor_dir
+from acestep.engine.sa3_helpers import SA3_SAME_L_PLUGIN_REVISION, sa3_vendor_dir
 
 IO_CHANNELS = 256
 T5_TOKENS = 256
@@ -95,7 +96,10 @@ _DIT_FP8_DIR_RE = re.compile(
 _DIT_REFIT_DIR_RE = re.compile(
     r"^(?P<prefix>.+_dit)_refit_l(?P<lo>\d+)_(?P<opt>\d+)_(?P<hi>\d+)$"
 )
-_SAME_L_DIR_RE = re.compile(r"^same_l_decode_window_t(?P<lo>\d+)_(?P<opt>\d+)_(?P<hi>\d+)$")
+_SAME_L_DIR_RE = re.compile(
+    r"^same_l_decode_window_(?P<tag>[a-z0-9_]+)_t"
+    r"(?P<lo>\d+)_(?P<opt>\d+)_(?P<hi>\d+)$"
+)
 
 # Deserialized-engine process cache. Engines are immutable post-load and
 # support multiple execution contexts, so sharing one deserialization
@@ -106,6 +110,23 @@ _SAME_L_DIR_RE = re.compile(r"^same_l_decode_window_t(?P<lo>\d+)_(?P<opt>\d+)_(?
 _ENGINE_CACHE: dict = {}
 _ENGINE_CACHE_LOCK = threading.Lock()
 _SAME_PLUGIN_REGISTERED = False
+
+
+def same_l_plugin_build_tag() -> str:
+    """Identity of the plugin implementation compiled into a SAME-L engine.
+
+    The upstream plugin is part of the serialized TensorRT engine, so changing
+    the vendored source revision or its selected AOT backend requires a new
+    engine even when the ONNX graph is unchanged.
+    """
+    requested_plugin = os.environ.get("SA3_SWA_PLUGIN", "aot").strip().lower()
+    plugin = "jit" if requested_plugin == "jit" else "aot"
+    if plugin == "jit":
+        implementation = "jit"
+    else:
+        requested_backend = os.environ.get("SA3_SWA_AOT", "mma").strip().lower()
+        implementation = "mma" if requested_backend == "mma" else "ptx"
+    return f"{plugin}_{implementation}_v{SA3_SAME_L_PLUGIN_REVISION[:12]}"
 
 
 def trt_engines_dir() -> Path:
@@ -286,9 +307,10 @@ def find_same_l_window_engine() -> Optional[tuple]:
     base = trt_engines_dir()
     if not base.is_dir():
         return None
+    expected_tag = same_l_plugin_build_tag()
     for sub in base.iterdir():
         m = _SAME_L_DIR_RE.match(sub.name)
-        if not m:
+        if not m or m.group("tag") != expected_tag:
             continue
         f = sub / f"{sub.name}.trt"
         if f.is_file():

--- a/acestep/engine/trt/sa3_build.py
+++ b/acestep/engine/trt/sa3_build.py
@@ -87,6 +87,7 @@ from acestep.engine.sa3_trt import (
     SAMPLES_PER_LATENT,
     T5_TOKENS,
     _register_same_plugin,
+    same_l_plugin_build_tag,
     trt_engines_dir,
 )
 
@@ -218,10 +219,11 @@ class SameLWindowBuildConfig:
     max_latents: int
     workspace_gb: float = 16.0
     onnx_files: list[str] = field(default_factory=lambda: list(SAME_L_ONNX_FILES))
+    plugin_build_tag: str = field(default_factory=same_l_plugin_build_tag)
 
     def engine_name(self) -> str:
         return (
-            f"same_l_decode_window_t{self.min_latents}"
+            f"same_l_decode_window_{self.plugin_build_tag}_t{self.min_latents}"
             f"_{self.opt_latents}_{self.max_latents}"
         )
 
@@ -292,6 +294,7 @@ def _build_strongly_typed_engine(
     workspace_gb: float,
     profile_shapes: dict[str, tuple[tuple, tuple, tuple]],
     refit: bool = False,
+    python_plugin_preference: str | None = None,
 ) -> None:
     """Parse + build one STRONGLY_TYPED engine and serialize it to disk.
 
@@ -304,9 +307,16 @@ def _build_strongly_typed_engine(
 
     trt_logger = trt.Logger(trt.Logger.WARNING)
     builder = trt.Builder(trt_logger)
-    network = builder.create_network(
-        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
-    )
+    network_flags = 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+    if python_plugin_preference == "aot":
+        network_flags |= 1 << int(
+            trt.NetworkDefinitionCreationFlag.PREFER_AOT_PYTHON_PLUGINS
+        )
+    elif python_plugin_preference == "jit":
+        network_flags |= 1 << int(
+            trt.NetworkDefinitionCreationFlag.PREFER_JIT_PYTHON_PLUGINS
+        )
+    network = builder.create_network(network_flags)
     parser = trt.OnnxParser(network, trt_logger)
     if not parser.parse_from_file(onnx_path):
         for i in range(parser.num_errors):
@@ -494,6 +504,9 @@ def _build_same_l_window_engine(
         profile_shapes={
             "latent": ((1, IO_CHANNELS, lo), (1, IO_CHANNELS, opt), (1, IO_CHANNELS, hi)),
         },
+        python_plugin_preference=(
+            "jit" if config.plugin_build_tag.startswith("jit_") else "aot"
+        ),
     )
     _write_metadata(engine_path=engine_path, expected=expected, env=env)
     elapsed = time.time() - t0

--- a/acestep/engine/trt/sa3_build.py
+++ b/acestep/engine/trt/sa3_build.py
@@ -110,10 +110,19 @@ DIT_ONNX_FILES = (
 # FP8-trunk DiT (opt-in, ~1.8x/step). Upstream published `dit_fp8.onnx` in
 # the 2026-08-02 sweep, but its sidecar landed as `dit_fp8lin.onnx.data`
 # (sa3-sm-* got matching `dit_fp8.onnx.data` names) — so this pair still
-# 404s on the second entry and --fp8 still needs a producer-built graph via
-# --fp8-onnx (vendored producer, optimized/tensorRT/build: make_calib.py
-# then build_dit_fp8.py). Switching the sidecar to the `fp8lin` name is a
-# one-liner once someone builds and parity-checks an engine from it.
+# 404s on the second entry and --fp8 still needs a graph passed via
+# --fp8-onnx. Switching the sidecar to the `fp8lin` name is a one-liner
+# once someone builds and parity-checks an engine from it, and upstream's
+# own consumer recipe (`build_from_onnx.py sa3-m-fp8`) confirms that pair
+# is what HF now serves.
+# Producing that graph locally is NOT a vendored-tree operation at the
+# pinned revision: the ModelOpt PTQ builder (`build_dit_fp8.py`) lives in
+# Stability PR #47 and is not merged into the pinned tree. What IS vendored
+# is the rest of the chain — `make_calib.py` (real-conditioning capture),
+# `build_dit_bf16.py` (shared RoPE-baker) and `transplant_scales.py` (grafts
+# #47's calibrated scales onto the baked graph) — but the transplant still
+# consumes a `dit_fp8_calib.onnx` that only #47 produces. See
+# optimized/tensorRT/build/README.md in the vendored tree for the full flow.
 # acestep.engine.sa3_trt does the runtime selection.
 DIT_FP8_ONNX_FILES = (
     "onnx/sa3-m/dit_fp8.onnx",
@@ -391,12 +400,18 @@ def _build_dit_engine(
                 return (label, engine_path, 0.0, "SKIPPED")
             if precision_label == "fp8":
                 raise RuntimeError(
-                    f"dit_fp8.onnx is not on HF ({HF_REPO}) yet. Build it with "
-                    "the managed vendored producer "
-                    "(<MODELS_DIR>/sa3/vendor/stable-audio-3/optimized/"
-                    "tensorRT/build: make_calib.py then build_dit_fp8.py) and "
-                    "pass --fp8-onnx <dit_fp8.onnx>, or wait for the upstream "
-                    "artifact upload."
+                    f"dit_fp8.onnx is not fetchable from HF ({HF_REPO}) under "
+                    "the names this builder expects — upstream's sidecar is "
+                    "published as dit_fp8lin.onnx.data (see "
+                    "DIT_FP8_ONNX_FILES). Pass an already-built graph with "
+                    "--fp8-onnx <dit_fp8.onnx>. It cannot be produced from "
+                    "the vendored tree alone at the pinned revision: the "
+                    "ModelOpt PTQ builder (build_dit_fp8.py) lives in "
+                    "Stability PR #47, not in the pin, and the vendored "
+                    "transplant_scales.py needs that builder's "
+                    "dit_fp8_calib.onnx. See <MODELS_DIR>/sa3/vendor/"
+                    "stable-audio-3/optimized/tensorRT/build/README.md "
+                    "('Medium fp8')."
                 ) from exc
             raise
     expected = _expected_metadata(

--- a/tests/unit/test_sa3_trt_engine_identity.py
+++ b/tests/unit/test_sa3_trt_engine_identity.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+from acestep.engine import sa3_trt
+from acestep.engine.trt.sa3_build import SameLWindowBuildConfig
+
+
+def _engine(root: Path, name: str) -> Path:
+    path = root / "sa3" / "trt_engines" / name / f"{name}.trt"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"engine")
+    return path
+
+
+def test_same_l_engine_name_carries_plugin_build_identity(monkeypatch):
+    monkeypatch.delenv("SA3_SWA_AOT", raising=False)
+    config = SameLWindowBuildConfig(32, 56, 96)
+
+    assert config.plugin_build_tag == sa3_trt.same_l_plugin_build_tag()
+    assert config.engine_name() == (
+        f"same_l_decode_window_{config.plugin_build_tag}_t32_56_96"
+    )
+
+
+def test_same_l_discovery_ignores_legacy_engine(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACESTEP_MODELS_DIR", str(tmp_path))
+    monkeypatch.delenv("SA3_SWA_AOT", raising=False)
+    _engine(tmp_path, "same_l_decode_window_t32_56_96")
+
+    assert sa3_trt.find_same_l_window_engine() is None
+
+
+def test_same_l_discovery_selects_current_plugin_engine(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACESTEP_MODELS_DIR", str(tmp_path))
+    monkeypatch.delenv("SA3_SWA_AOT", raising=False)
+    tag = sa3_trt.same_l_plugin_build_tag()
+    expected = _engine(tmp_path, f"same_l_decode_window_{tag}_t32_56_96")
+
+    assert sa3_trt.find_same_l_window_engine() == (expected, 32, 96)
+
+
+def test_same_l_aot_backend_is_part_of_identity(monkeypatch):
+    monkeypatch.setenv("SA3_SWA_PLUGIN", "aot")
+    monkeypatch.setenv("SA3_SWA_AOT", "mma")
+    mma = sa3_trt.same_l_plugin_build_tag()
+    monkeypatch.setenv("SA3_SWA_AOT", "ptx")
+    ptx = sa3_trt.same_l_plugin_build_tag()
+
+    assert mma != ptx
+    assert mma.startswith("aot_mma_v")
+    assert ptx.startswith("aot_ptx_v")
+
+
+def test_same_l_plugin_kind_is_part_of_identity(monkeypatch):
+    monkeypatch.setenv("SA3_SWA_PLUGIN", "aot")
+    aot = sa3_trt.same_l_plugin_build_tag()
+    monkeypatch.setenv("SA3_SWA_PLUGIN", "jit")
+    jit = sa3_trt.same_l_plugin_build_tag()
+
+    assert aot != jit
+    assert jit.startswith("jit_jit_v")

--- a/tests/unit/test_sa3_vendor.py
+++ b/tests/unit/test_sa3_vendor.py
@@ -148,6 +148,25 @@ def test_ensure_vendor_updates_clean_existing_tree(monkeypatch, tmp_path):
     ) in calls
 
 
+def test_ensure_vendor_accepts_git_worktree_override(monkeypatch, tmp_path):
+    vendor = tmp_path / "stable-audio-3-worktree"
+    vendor.mkdir()
+    (vendor / ".git").write_text("gitdir: ../repo/.git/worktrees/vendor\n")
+    monkeypatch.setenv(sa3_helpers.SA3_VENDOR_ENV, str(vendor))
+
+    def fake_git(args: list[str], cwd: Path | None = None) -> str:
+        assert cwd == vendor
+        if args == ["status", "--porcelain"]:
+            return ""
+        if args == ["rev-parse", "HEAD"]:
+            return sa3_helpers.SA3_VENDOR_SHA
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(sa3_helpers, "_git", fake_git)
+
+    assert sa3_helpers.ensure_sa3_vendor() == vendor
+
+
 def test_ensure_vendor_refuses_dirty_wrong_commit(monkeypatch, tmp_path):
     monkeypatch.delenv(sa3_helpers.SA3_VENDOR_ENV, raising=False)
     monkeypatch.setenv("ACESTEP_MODELS_DIR", str(tmp_path))


### PR DESCRIPTION
## Summary

Two changes that travel together:

1. **Repin the vendored SA3** to `c076985`, the head of Stability PR #49
   (SWA plugin int-attribute fix for TensorRT 10.16 / NumPy 2.x). Without
   it the same-L decoder engine cannot be built at all on current
   TRT/NumPy.
2. **Version the SAME-L decode engine identity by plugin build tag**
   (`{aot|jit}_{mma|ptx|jit}_v<plugin-revision>`). Engines built against a
   different plugin revision or implementation are no longer silently
   reused: discovery filters by the expected tag, metadata sidecars gate
   rebuild/skip, and a missing engine falls back loudly to the eager
   decoder (logged `mode=eager reason=no_trt_engine`, realtime holds).

Also includes a worktree-aware vendor `.git` check and unit tests for the
engine-identity scheme.

## Validation (2026-08-17, RTX 5090, TRT 10.16.1.11)

- Full unit suite green (the 4 `test_lora_facade_session` failures
  reproduce identically on clean `main`, pre-existing).
- Tagged engine builds; a second builder run reports SKIP (idempotent);
  8.47 ms vs 8.44 ms legacy per T=56 decode, VRAM delta nil.
- Real-latent battery vs eager references: 84 checks, 0 failures.
- Live runtime battery over the headless client: versioned engine
  selected, LoRA TRT refit, source swaps/uploads, denoise sweeps,
  restart; 0 stale ticks throughout.
- Missing-engine path: legacy (untagged) engine correctly ignored, loud
  eager fallback, stream stays realtime.

## Merge handoff

- This is the base of a 3-PR stack: merge **#319 -> #320 -> #321** in that
  order. Branch history was rewritten onto current `main` (`d29d5f9`), so
  review the current diff, not older revisions.
- After merge, hosts pick up the new vendor pin on next setup/boot
  (`ensure_sa3_vendor` moves a clean checkout automatically; dirty
  checkouts error loudly instead).
- Hosts without a tagged same-L engine degrade to eager (logged, slower
  decode, still realtime on a 5090) until the builder is run once.
