### PR TITLE
fix(sa3): follow upstream's dit_fp16mixed -> dit_fp16 ONNX rename

### DIFF
--- a/acestep/engine/trt/_engine_metadata.py
+++ b/acestep/engine/trt/_engine_metadata.py
@@ -64,21 +64,33 @@ def metadata_path(engine_path: str | os.PathLike[str]) -> Path:
 def expected_metadata(
     *,
     component: str,
-    onnx_path: str | os.PathLike[str],
+    onnx_path: str | os.PathLike[str] | None,
     config,
     env: dict,
 ) -> dict:
+    """Metadata an engine built right now, from ``onnx_path``, would carry.
+
+    ``onnx_path`` may be ``None`` when the graph is not obtainable — the
+    ONNX keys are then omitted, and the result is only good for asking
+    :func:`metadata_matches` whether an engine already on disk is current
+    in every respect *except* the graph hash (pass
+    ``ignore=("onnx_sha256",)``). Never hand a hash-less dict to
+    :func:`write_metadata`: a sidecar without ``onnx_sha256`` can't be
+    invalidated by a future re-export.
+    """
     gpu = env.get("active_gpu", {})
-    return {
+    meta = {
         "schema_version": _ENGINE_METADATA_SCHEMA,
         "component": component,
         "tensorrt_version": env["packages"]["tensorrt"],
         "gpu_compute_capability": gpu.get("compute_capability"),
         "gpu_name": gpu.get("name"),
         "config": _config_dict(config),
-        "onnx_path": str(Path(onnx_path).resolve()),
-        "onnx_sha256": _sha256_file(onnx_path),
     }
+    if onnx_path is not None:
+        meta["onnx_path"] = str(Path(onnx_path).resolve())
+        meta["onnx_sha256"] = _sha256_file(onnx_path)
+    return meta
 
 
 def write_metadata(
@@ -87,6 +99,11 @@ def write_metadata(
     expected: dict,
     env: dict,
 ) -> None:
+    if "onnx_sha256" not in expected:
+        raise ValueError(
+            "refusing to write an engine sidecar without onnx_sha256 — it "
+            "would never invalidate on an upstream re-export"
+        )
     payload = dict(expected)
     payload["built_at"] = datetime.now(timezone.utc).isoformat()
     payload["environment"] = env
@@ -95,9 +112,21 @@ def write_metadata(
     logger.info("Engine metadata saved to {}", path)
 
 
+_COMPATIBILITY_KEYS = (
+    "schema_version",
+    "component",
+    "tensorrt_version",
+    "gpu_compute_capability",
+    "config",
+    "onnx_sha256",
+)
+
+
 def metadata_matches(
     engine_path: str | os.PathLike[str],
     expected: dict,
+    *,
+    ignore: tuple[str, ...] = (),
 ) -> tuple[bool, str]:
     """Compare on-disk metadata sidecar against ``expected``.
 
@@ -106,6 +135,11 @@ def metadata_matches(
     sidecar is written. Compares the keys that govern engine
     compatibility (TRT version, GPU compute capability, build config,
     ONNX content hash); ignores metadata-only fields like ``built_at``.
+
+    ``ignore`` drops compatibility keys from the comparison. Only one
+    caller needs it — the ONNX-fetch fallback, which asks "is this engine
+    current apart from the graph hash I couldn't compute?" — and it
+    weakens the check, so don't reach for it elsewhere.
     """
     path = metadata_path(engine_path)
     if not path.exists():
@@ -115,14 +149,9 @@ def metadata_matches(
     except Exception as exc:
         return False, f"metadata unreadable: {exc}"
 
-    for key in (
-        "schema_version",
-        "component",
-        "tensorrt_version",
-        "gpu_compute_capability",
-        "config",
-        "onnx_sha256",
-    ):
+    for key in _COMPATIBILITY_KEYS:
+        if key in ignore:
+            continue
         if actual.get(key) != expected.get(key):
             return False, f"metadata mismatch: {key}"
     return True, "metadata match"

--- a/acestep/engine/trt/sa3_build.py
+++ b/acestep/engine/trt/sa3_build.py
@@ -13,7 +13,7 @@ compile Stability's OFFICIAL ONNX exports from
 ``stabilityai/stable-audio-3-optimized``, fetched via ``huggingface_hub``
 on first use.
 
-* **sa3-m DiT**: the pre-surgered FP16-mixed graph (``dit_fp16mixed.onnx``,
+* **sa3-m DiT**: the pre-surgered FP16-mixed graph (``dit_fp16.onnx``,
   FP16 trunk with FP32 islands around RMSNorm, attention softmax, and
   RoPE) compiled as a STRONGLY_TYPED network with no builder precision
   flags. This is upstream's canonical recipe. The BF16 recipe
@@ -26,8 +26,9 @@ on first use.
 * **sa3-m DiT (FP8, opt-in)**: ``dit_fp8.onnx`` (ModelOpt FP8 GEMM trunk on
   top of the fp16mixed graph) compiled to ``sa3_m_dit_fp8_l*`` engines,
   ~1.8x/step at compounded-euler cos ~0.976 vs fp16mixed. Built only with
-  ``--fp8`` (additive to the fp16mixed DiT). The ONNX is not yet on HF; pass
-  ``--fp8-onnx`` a producer-built graph until it is.
+  ``--fp8`` (additive to the fp16mixed DiT). The HF pair is not fetchable
+  yet (see :data:`DIT_FP8_ONNX_FILES`); pass ``--fp8-onnx`` a
+  producer-built graph until it is.
   :func:`acestep.engine.sa3_trt.find_dit_engine` prefers an fp8 engine when one
   covers the window, else fp16mixed.
 * **SAME-L window decoder**: ``dec_dynamic_triton_swa.onnx``,
@@ -92,14 +93,27 @@ from acestep.engine.sa3_trt import (
 HF_REPO = "stabilityai/stable-audio-3-optimized"
 # The medium DiT ONNX exceeds 2 GB, so the weights travel in an
 # external-data sidecar next to the proto.
+# Upstream renamed these `dit_fp16mixed.*` -> `dit_fp16.*` on 2026-08-02
+# (HF commits 3f29675c "Rename fp16mixed->fp16 ... (copies; deletes follow
+# after code merge)" then 48e34e2d, which deleted the old names 20 min
+# later — so every SA3 bake since 404s on the old path). The weights
+# sidecar is byte-identical across the rename; only the proto changed, and
+# only where it names its sidecar. That still moves its sha256, which the
+# engine metadata hashes, so the first build after this lands rebuilds the
+# two DiT engines once (~5 min) for a functionally identical result. The
+# SAME-L decoder ONNX is untouched and still skips.
 DIT_ONNX_FILES = (
-    "onnx/sa3-m/dit_fp16mixed.onnx",
-    "onnx/sa3-m/dit_fp16mixed.onnx.data",
+    "onnx/sa3-m/dit_fp16.onnx",
+    "onnx/sa3-m/dit_fp16.onnx.data",
 )
-# FP8-trunk DiT (opt-in, ~1.8x/step). Not yet published to HF, so the fetch
-# 404s until the upstream artifact upload; build it locally with the vendored
-# producer (optimized/tensorRT/build: make_calib.py then build_dit_fp8.py) and
-# pass --fp8-onnx. acestep.engine.sa3_trt does the runtime selection.
+# FP8-trunk DiT (opt-in, ~1.8x/step). Upstream published `dit_fp8.onnx` in
+# the 2026-08-02 sweep, but its sidecar landed as `dit_fp8lin.onnx.data`
+# (sa3-sm-* got matching `dit_fp8.onnx.data` names) — so this pair still
+# 404s on the second entry and --fp8 still needs a producer-built graph via
+# --fp8-onnx (vendored producer, optimized/tensorRT/build: make_calib.py
+# then build_dit_fp8.py). Switching the sidecar to the `fp8lin` name is a
+# one-liner once someone builds and parity-checks an engine from it.
+# acestep.engine.sa3_trt does the runtime selection.
 DIT_FP8_ONNX_FILES = (
     "onnx/sa3-m/dit_fp8.onnx",
     "onnx/sa3-m/dit_fp8.onnx.data",
@@ -202,6 +216,48 @@ def _fetch_onnx(rel_paths: list[str] | tuple[str, ...]) -> str:
     return local_paths[0]
 
 
+def _engine_survives_missing_onnx(
+    *,
+    engine_path: str,
+    component: str,
+    config,
+    env: dict,
+    force_rebuild: bool,
+) -> str | None:
+    """Reason the engine on disk stands in for an unfetchable ONNX, else None.
+
+    The ONNX is fetched on every run, including runs with nothing to
+    build, purely to hash it into the freshness check. That makes an
+    upstream artifact rename fatal to a bake that had zero engines to
+    build — which is exactly what Stability's 2026-08-02
+    ``dit_fp16mixed`` -> ``dit_fp16`` rename did to bake-warm #87. An
+    engine already built and current in every other respect doesn't need
+    the graph it came from, so a failed fetch is a reason to keep it, not
+    to fail the run.
+
+    Deliberately narrow: TRT version, compute capability and build config
+    are still compared, so a genuinely stale engine still demands the
+    ONNX and still surfaces the fetch error. What this cannot see is an
+    upstream *re-export* published under a new name — the engine would be
+    silently kept — hence the WARNING the caller logs.
+    """
+    if force_rebuild or not os.path.exists(engine_path):
+        return None
+    expected = _expected_metadata(
+        component=component, onnx_path=None, config=config, env=env,
+    )
+    matches, reason = _metadata_matches(
+        engine_path, expected, ignore=("onnx_sha256",),
+    )
+    if not matches:
+        return None
+    size_mb = os.path.getsize(engine_path) / 1e6
+    return (
+        f"{os.path.basename(engine_path)} ({size_mb:.0f} MB, {reason} "
+        "apart from the graph hash)"
+    )
+
+
 def _build_strongly_typed_engine(
     *,
     onnx_path: str,
@@ -280,6 +336,18 @@ def _build_dit_engine(
         try:
             onnx_path = _fetch_onnx(config.onnx_files)
         except Exception as exc:
+            kept = _engine_survives_missing_onnx(
+                engine_path=engine_path, component=component, config=config,
+                env=env, force_rebuild=force_rebuild,
+            )
+            if kept:
+                logger.warning(
+                    "ONNX fetch failed ({}) but nothing needed building — "
+                    "keeping {}. If upstream re-exported the graph under a "
+                    "new name, update the *_ONNX_FILES paths and rebuild.",
+                    exc, kept,
+                )
+                return (label, engine_path, 0.0, "SKIPPED")
             if precision_label == "fp8":
                 raise RuntimeError(
                     f"dit_fp8.onnx is not on HF ({HF_REPO}) yet. Build it with "
@@ -345,7 +413,22 @@ def _build_same_l_window_engine(
         f"_{config.opt_latents}_{config.max_latents}"
     )
 
-    onnx_path = _fetch_onnx(config.onnx_files)
+    try:
+        onnx_path = _fetch_onnx(config.onnx_files)
+    except Exception as exc:
+        kept = _engine_survives_missing_onnx(
+            engine_path=engine_path, component="same_l_decode_window",
+            config=config, env=env, force_rebuild=force_rebuild,
+        )
+        if not kept:
+            raise
+        logger.warning(
+            "ONNX fetch failed ({}) but nothing needed building — keeping "
+            "{}. If upstream re-exported the graph under a new name, update "
+            "the *_ONNX_FILES paths and rebuild.",
+            exc, kept,
+        )
+        return (label, engine_path, 0.0, "SKIPPED")
     expected = _expected_metadata(
         component="same_l_decode_window", onnx_path=onnx_path, config=config, env=env,
     )

--- a/tests/unit/test_engine_metadata_fallback.py
+++ b/tests/unit/test_engine_metadata_fallback.py
@@ -1,0 +1,150 @@
+"""Engine freshness when the source ONNX can't be fetched.
+
+The SA3 builder fetches its ONNX on every run — including runs with
+nothing to build — because the freshness check hashes the graph. That
+made Stability's 2026-08-02 `dit_fp16mixed` -> `dit_fp16` rename fatal
+to a bake whose three engines were all already current (bake-warm #87).
+
+The recovery is a hash-less `expected_metadata()` plus
+`metadata_matches(..., ignore=("onnx_sha256",))`: keep an engine that is
+current in every respect the sidecar can attest to without the graph.
+These tests pin that it stays *narrow* — a TRT bump or a config change
+must still demand the ONNX, and a hash-less expectation must never
+satisfy the ordinary comparison.
+
+Leaf module (loguru only): no GPU, no torch, no tensorrt.
+"""
+
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from acestep.engine.trt._engine_metadata import (
+    expected_metadata,
+    metadata_matches,
+    metadata_path,
+    write_metadata,
+)
+
+
+@dataclass
+class _Config:
+    min_latents: int = 1
+    opt_latents: int = 646
+    max_latents: int = 646
+    workspace_gb: float = 16.0
+
+
+def _env(*, trt: str = "10.13.2.6", cc: str = "12.0") -> dict:
+    return {
+        "packages": {"tensorrt": trt},
+        "active_gpu": {"compute_capability": cc, "name": "NVIDIA GeForce RTX 5090"},
+    }
+
+
+def _built_engine(tmp_path, *, onnx_bytes: bytes = b"graph", env=None):
+    """An engine + sidecar as a real build would leave them behind."""
+    onnx = tmp_path / "dit_fp16mixed.onnx"
+    onnx.write_bytes(onnx_bytes)
+    engine = tmp_path / "engine.trt"
+    engine.write_bytes(b"plan")
+    env = env or _env()
+    expected = expected_metadata(
+        component="sa3_m_dit", onnx_path=onnx, config=_Config(), env=env,
+    )
+    write_metadata(engine_path=engine, expected=expected, env=env)
+    return engine, onnx
+
+
+def test_hashless_expectation_omits_the_onnx_keys():
+    meta = expected_metadata(
+        component="sa3_m_dit", onnx_path=None, config=_Config(), env=_env(),
+    )
+    assert "onnx_sha256" not in meta
+    assert "onnx_path" not in meta
+    assert meta["component"] == "sa3_m_dit"
+    assert meta["tensorrt_version"] == "10.13.2.6"
+
+
+def test_current_engine_survives_a_vanished_onnx(tmp_path):
+    engine, onnx = _built_engine(tmp_path)
+    onnx.unlink()  # upstream renamed it out from under us
+
+    hashless = expected_metadata(
+        component="sa3_m_dit", onnx_path=None, config=_Config(), env=_env(),
+    )
+    matches, reason = metadata_matches(
+        engine, hashless, ignore=("onnx_sha256",),
+    )
+    assert matches, reason
+
+
+@pytest.mark.parametrize(
+    "kwargs, config, key",
+    [
+        ({"trt": "10.14.0.1"}, _Config(), "tensorrt_version"),
+        ({"cc": "9.0"}, _Config(), "gpu_compute_capability"),
+        ({}, _Config(max_latents=324), "config"),
+    ],
+)
+def test_stale_engine_still_demands_the_onnx(tmp_path, kwargs, config, key):
+    """Ignoring the graph hash must not wave through a stale engine."""
+    engine, _ = _built_engine(tmp_path)
+
+    hashless = expected_metadata(
+        component="sa3_m_dit", onnx_path=None, config=config, env=_env(**kwargs),
+    )
+    matches, reason = metadata_matches(
+        engine, hashless, ignore=("onnx_sha256",),
+    )
+    assert not matches
+    assert key in reason
+
+
+def test_hashless_expectation_fails_the_ordinary_comparison(tmp_path):
+    """Forgetting `ignore` must not silently pass — it must not match."""
+    engine, _ = _built_engine(tmp_path)
+
+    hashless = expected_metadata(
+        component="sa3_m_dit", onnx_path=None, config=_Config(), env=_env(),
+    )
+    matches, reason = metadata_matches(engine, hashless)
+    assert not matches
+    assert "onnx_sha256" in reason
+
+
+def test_a_re_export_still_invalidates_the_engine(tmp_path):
+    """The hash check itself is unchanged: new graph bytes -> rebuild."""
+    engine, onnx = _built_engine(tmp_path, onnx_bytes=b"graph")
+    onnx.write_bytes(b"graph v2")
+
+    expected = expected_metadata(
+        component="sa3_m_dit", onnx_path=onnx, config=_Config(), env=_env(),
+    )
+    matches, reason = metadata_matches(engine, expected)
+    assert not matches
+    assert "onnx_sha256" in reason
+
+
+def test_sidecar_without_a_hash_is_never_written(tmp_path):
+    """A hash-less sidecar could never be invalidated by a re-export."""
+    engine = tmp_path / "engine.trt"
+    engine.write_bytes(b"plan")
+    hashless = expected_metadata(
+        component="sa3_m_dit", onnx_path=None, config=_Config(), env=_env(),
+    )
+
+    with pytest.raises(ValueError, match="onnx_sha256"):
+        write_metadata(engine_path=engine, expected=hashless, env=_env())
+    assert not metadata_path(engine).exists()
+
+
+def test_written_sidecar_records_the_hash_and_build_env(tmp_path):
+    engine, onnx = _built_engine(tmp_path)
+    payload = json.loads(metadata_path(engine).read_text(encoding="utf-8"))
+
+    assert payload["onnx_sha256"]
+    assert payload["onnx_path"].endswith("dit_fp16mixed.onnx")
+    assert payload["environment"]["packages"]["tensorrt"] == "10.13.2.6"
+    assert payload["built_at"]


### PR DESCRIPTION
## What broke

`bake-warm` #87 (`:dev-sa3-5090`, full-rebuild) died in `sa3_build.py`:

```
huggingface_hub.errors.EntryNotFoundError: 404 Client Error.
Entry Not Found for url: https://huggingface.co/stabilityai/stable-audio-3-optimized/resolve/main/onnx/sa3-m/dit_fp16mixed.onnx.
SA3 build matrix: 0 to build, 3 existing
```

Not a DEMON change and not demon-public-demo#476 (which only touched docs, an echo, and an opt-in `SA3_REQUIRE_BASE` guard). Stability renamed the artifact:

| HF commit | when | what |
| --- | --- | --- |
| `3f29675c` | 2026-08-02 07:44 | "Rename fp16mixed->fp16 DiT/T5Gemma engines+onnx (copies; **deletes follow after code merge**)" |
| `48e34e2d` | 2026-08-02 08:05 | "Delete old fp16mixed names" |

The deletes landed 21 minutes later, not after any merge on our side. The last green SA3 bake was 2026-07-28, so #87 was simply the first bake to meet it.

## Why a bake with nothing to build still failed

`_fetch_onnx()` runs *before* the skip check in `_build_dit_engine`, because `expected_metadata()` hashes the ONNX proto to decide whether an engine is current. The fetch is unconditional even when every engine on disk is up to date — hence "0 to build, 3 existing" immediately above a fatal 404. (The ordering in the log is stdout buffering; the matrix is printed first.)

## The fix

`DIT_ONNX_FILES` -> `onnx/sa3-m/dit_fp16.{onnx,onnx.data}`.

Verified against the HF API rather than assumed:

- the weights sidecar is **byte-identical** across the rename — LFS oid `a038ae6d…` on both `dit_fp16mixed.onnx.data` and `dit_fp16.onnx.data`;
- the proto differs by 2,260 bytes: 428 external-data references, 5 chars shorter each, plus the protobuf length prefixes containing them. Same producer (`pytorch 2.6.0`), no `fp16mixed` string left. Same graph, re-pointed at the renamed sidecar;
- its sha256 moved anyway (`01844874…` -> `ede6d4f1…`), and `metadata_matches` compares `onnx_sha256`, so **the two DiT engines rebuild once (~5 min)** for a functionally identical result;
- `dec_dynamic_triton_swa.onnx` is untouched (oid `3f76e79f…`, unchanged since before the last green bake), so the SAME-L decoder still skips.

## Plus: a rename shouldn't be fatal

Second commit-worth of the diff: when the fetch fails and the engine on disk is current in every respect the sidecar can attest to *without* the graph, keep it and log a WARNING rather than failing the run. That turns this class of upstream breakage into a noisy no-op bake instead of a red workflow.

Deliberately narrow — `expected_metadata(onnx_path=None)` omits the ONNX keys and the caller passes `metadata_matches(..., ignore=("onnx_sha256",))`, so TRT version, compute capability and build config still have to match. A genuinely stale engine still demands the ONNX and still surfaces the fetch error. `write_metadata` now refuses a hash-less dict outright, so a sidecar that could never be invalidated can't be written by mistake.

What it can't see is an upstream *re-export* published under a new name; that engine would be silently kept, which is what the WARNING is for.

## Also noted, not changed

Upstream published `onnx/sa3-m/dit_fp8.onnx` in the same sweep, but its sidecar landed as `dit_fp8lin.onnx.data` (the `sa3-sm-*` variants got matching `dit_fp8.onnx.data` names). So `DIT_FP8_ONNX_FILES` still 404s on its second entry and `--fp8` still needs `--fp8-onnx`. Confirmed the published proto does reference `dit_fp8lin.onnx.data`, so the switch is a one-liner — but it wants an actual build + parity check behind it, not a blind rename. Comments corrected; behavior unchanged.

## Tests

`tests/unit/test_engine_metadata_fallback.py` — 9 cases over the metadata primitives: the hash-less expectation omits the ONNX keys, a current engine survives a vanished ONNX, a TRT bump / compute-capability change / config change still refuses to, a hash-less expectation fails the *ordinary* comparison (so forgetting `ignore` can't silently pass), a re-export still invalidates, and a hash-less sidecar is never written. No GPU, no torch, no tensorrt.

Run outside the repo venv against the real module source (loguru stubbed, leaf-loaded by path): 9 passed. Not run under `tests/conftest.py`, which imports torch — worth a CI/venv confirmation.

## Verification left to the bake

The rebuilt DiT engines aren't validated here. Worth one `scripts/sa3/sa3_trt_dit_cond_parity.py` run on the first host that rebuilds (expected: cos >= 0.9998/step vs eager) before the image is promoted past `:dev-sa3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)