### PR TITLE
fix(deps): pin torchao — 0.18 needs torch>=2.11 and breaks model load

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,13 @@ dependencies = [
     "numba>=0.63.1",
     "vector-quantize-pytorch>=1.27.15",
     "torchcodec>=0.9.1",
-    "torchao",
+    # Pinned, like torch/torchvision/torchaudio above. torchao 0.18 requires
+    # torch>=2.11 and imports ScalingType from torch.nn.functional, which
+    # 2.9.1 does not export. Unpinned, a venv rebuild resolves to whatever is
+    # newest and the pod dies at model load, because diffusers imports torchao
+    # eagerly whenever it is installed. 0.14.1 is the newest that works
+    # against the torch pinned above.
+    "torchao==0.14.1",
     # Training dependencies
     "peft>=0.7.0",
     "lightning>=2.0.0",


### PR DESCRIPTION
## What breaks

`torch`, `torchvision` and `torchaudio` are pinned exactly. `torchao`, on the line below them, was bare — so a venv built today resolves it to **0.18.0**, which requires `torch>=2.11` and imports `ScalingType` from `torch.nn.functional`, a symbol the pinned **2.9.1** does not export.

`diffusers` imports `torchao` eagerly whenever it is installed, so this isn't a quiet degradation — it takes down every session at model load:

```
model_load_start decoder=tensorrt vae=tensorrt checkpoint=acestep-v15-turbo
model_context_load_failed_cleanup checkpoint=acestep-v15-turbo device=cuda
session_init_failed_cleanup decoder=tensorrt vae=tensorrt
ImportError: cannot import name 'ScalingType' from 'torch.nn.functional'
RuntimeError: Failed to import diffusers.models.autoencoders.autoencoder_oobleck
```

The client just sees the websocket close with **1011 during server init**.

## Why this matters beyond the pod I hit

Caught on a `:dev` pod, but nothing about it is dev-specific. The next `:warm` bake that rebuilds the venv resolves the same way, and every pod in the fleet would fail every session. A code-only bake reuses the cached venv layer, so this stays invisible right up until someone rebuilds it for an unrelated reason.

## Why 0.14.1

Newest release that imports against torch 2.9.1. It logs that it is skipping its cpp extensions on this torch — a warning, not a failure. We only use torchao for optional quantization (`acestep/engine/model_context.py`), and the TensorRT path doesn't take it.

## Verification

On the affected pod, before → after installing 0.14.1:

```
torchao   IMPORT FAIL: cannot import name 'ScalingType' from 'torch.nn.functional'
torchao   imports OK: 0.14.1+cu128
          diffusers oobleck OK
```

Engine restarted; sessions initialize again and have been clean since.