### PR TITLE
fix(deps): torchao 0.17.0 — 0.14.1 broke training, 0.18 breaks inference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,20 @@ dependencies = [
     "numba>=0.63.1",
     "vector-quantize-pytorch>=1.27.15",
     "torchcodec>=0.9.1",
-    # Pinned, like torch/torchvision/torchaudio above. torchao 0.18 requires
-    # torch>=2.11 and imports ScalingType from torch.nn.functional, which
-    # 2.9.1 does not export. Unpinned, a venv rebuild resolves to whatever is
-    # newest and the pod dies at model load, because diffusers imports torchao
-    # eagerly whenever it is installed. 0.14.1 is the newest that works
-    # against the torch pinned above.
-    "torchao==0.14.1",
+    # Pinned to a WINDOW, not a floor — both edges are load-bearing:
+    #
+    #   >= 0.17  peft's is_torchao_available() rejects anything <= 0.16.0,
+    #            so training dies before it writes a safetensors.
+    #   <  0.18  0.18 requires torch>=2.11 and imports ScalingType from
+    #            torch.nn.functional, which the 2.9.1 pinned above does not
+    #            export; diffusers imports torchao eagerly whenever it is
+    #            installed, so inference dies at model load.
+    #
+    # 0.17.0 is the only release that satisfies both, and is what the fleet
+    # ran for months before this was pinned at all. Unpinned, a venv rebuild
+    # resolves to newest and breaks inference; pinned too low it breaks
+    # training. Change either bound only with both paths retested.
+    "torchao==0.17.0",
     # Training dependencies
     "peft>=0.7.0",
     "lightning>=2.0.0",


### PR DESCRIPTION
My previous pin (#323, `torchao==0.14.1`) fixed inference and broke training.

A run reached the GPU, prepped its dataset, held a pool pod for four minutes and then died before writing a safetensors:

```
ImportError: Found an incompatible version of torchao.
Found version 0.14.1, but only versions above 0.16.0 are supported
  peft/import_utils.py:147  is_torchao_available()
```

## It's a window, not a floor

Both edges are load-bearing:

| Bound | Why |
|---|---|
| **≥ 0.17** | `peft`'s `TORCHAO_MINIMUM_VERSION = 0.16.0`; below it, training can't write an adapter |
| **< 0.18** | 0.18 requires `torch>=2.11` and imports `ScalingType` from `torch.nn.functional`, which the pinned 2.9.1 doesn't export. `diffusers` imports torchao eagerly, so inference dies at model load (WS 1011 on session init) |

**0.17.0 is the only release that satisfies both.** It's also what the fleet ran for months before any pin existed, and what the bake agent's partitions still hold — so this restores the known-good state rather than picking a new one.

## Verified

- `peft/import_utils.py:131` → `TORCHAO_MINIMUM_VERSION = parse("0.16.0")`, checked as `torchao_version < MINIMUM` → 0.17.0 passes
- 0.17's `quantization/quantize_/workflows/__init__.py` has no `ScalingType` import (that's the 0.18 path); its only occurrence is `prototype/mx_formats/mx_tensor.py`, which nothing on the eager import chain reaches

## Deploying this needs a venv rebuild

`pyproject.toml` only takes effect when the venv is rebuilt, which a code-only bake-agent run does **not** do — so this needs the GPU-pod path, or an explicit `uv sync` on the bake host before baking.

Until then the fleet keeps whatever it was baked with. Inference is fine on 0.14.1; **training is broken fleet-wide** until a rebake lands.

## What went wrong in #323

I had this evidence at the time — the bake agent was on 0.17.0, and I noted 0.17 was "what your fleet is proven on" — and pinned 0.14.1 anyway on the strength of a single import test on a dead pod. That test only exercised inference. Nothing exercised training, and the training path is where the floor lives.