### PR TITLE
fix(lora): isolate fetched LoRAs per session and wipe them on close

### DIFF
--- a/acestep/paths.py
+++ b/acestep/paths.py
@@ -142,6 +142,22 @@ def loras_dir() -> Path:
     return models_dir() / "loras"
 
 
+def user_loras_dir() -> Path:
+    """Directory for LoRAs fetched onto a running pod at a user's request.
+
+    Deliberately NOT ``loras_dir()``. A pod is handed to whoever the pool
+    allocates it to next, so anything a user fetches has to be separable
+    from the baked catalog — both to wipe it when their session ends, and
+    so a leftover file can never be mistaken for a stock LoRA. The engine
+    only scans ``loras_dir()`` at boot, so nothing here is picked up
+    except by an explicit register.
+
+    Override with ``ACESTEP_USER_LORAS_DIR``.
+    """
+    override = os.environ.get("ACESTEP_USER_LORAS_DIR", "").strip()
+    return Path(override) if override else models_dir() / "user_loras"
+
+
 def melband_roformer_dir() -> Path:
     """Directory containing the Mel-Band RoFormer stem-separation checkpoint."""
     return models_dir() / "MelBandRoFormer"

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -630,6 +630,9 @@ class StreamingSession:
         # Event bus: typed events the runner thread and operation
         # methods publish; transport adapters subscribe and serialize.
         self.bus = EventBus()
+        # Ids this session fetched via add_lora. close() wipes exactly
+        # these — never the baked catalog, which it must not touch.
+        self._fetched_loras: set[str] = set()
 
         # Set at the end of close(), after GPU state is released. A
         # preempting connection (ws_adapter's single-active-session
@@ -919,6 +922,30 @@ class StreamingSession:
         finally:
             self.close()
 
+    def _drop_fetched_loras(self) -> None:
+        """Remove every LoRA this session fetched, from the catalog and disk.
+
+        Never raises: this runs on the teardown path, and a session that
+        fails to clean up must still finish closing rather than leaving the
+        engine half-destroyed.
+        """
+        ids = list(getattr(self, "_fetched_loras", ()))
+        if not ids:
+            return
+        from acestep.paths import user_loras_dir
+
+        for lid in ids:
+            try:
+                self.engine_obj.remove_lora(lid)
+            except Exception as exc:
+                logger.warning("user_lora_unregister_failed id={} error={}", lid, exc)
+            try:
+                (user_loras_dir() / f"{lid}.safetensors").unlink(missing_ok=True)
+            except Exception as exc:
+                logger.warning("user_lora_unlink_failed id={} error={}", lid, exc)
+        logger.info("user_loras_dropped count={}", len(ids))
+        self._fetched_loras.clear()
+
     def close(self) -> None:
         """Tear down GPU state even when a session exits before ``run``."""
         # Order matters: stream.close() drops the StreamPipeline's
@@ -926,6 +953,12 @@ class StreamingSession:
         # actually destroys the engine + ModelContext.
         # session.close() ends with gc.collect() + cuda.empty_cache().
         self.state.running = False
+        # Drop anything this session fetched. A pool pod is handed to a
+        # stranger next: without this their catalog would list the previous
+        # user's styles by name, under "Catalog" where they read as stock,
+        # and the weights would load. Files and registrations both, because
+        # either one alone still leaks.
+        self._drop_fetched_loras()
         try:
             self.bus.close()
         except Exception as exc:
@@ -2053,9 +2086,11 @@ class StreamingSession:
         """Worker body for :meth:`add_lora`. Never raises into the thread
         runner — a failed fetch is logged and the client simply never sees
         the id appear."""
-        from acestep.paths import loras_dir
+        from acestep.paths import user_loras_dir
 
-        dest = loras_dir() / f"{lora_id}.safetensors"
+        # Isolated from the baked catalog: this pod goes to someone else
+        # next, and close() wipes exactly what this session fetched.
+        dest = user_loras_dir() / f"{lora_id}.safetensors"
         if dest.exists():
             # Already on disk from an earlier session. Re-register rather
             # than re-download: register_lora is idempotent, and this is
@@ -2063,6 +2098,7 @@ class StreamingSession:
             logger.info("lora_fetch_skipped id={} reason=already_present", lora_id)
             with self.state._lock:
                 self.state.pending_register.append(str(dest))
+                self._fetched_loras.add(lora_id)
             return
         # Download to a temp sibling and rename, so a dropped connection
         # can't leave a truncated .safetensors that the next scan would
@@ -2099,6 +2135,7 @@ class StreamingSession:
             )
             with self.state._lock:
                 self.state.pending_register.append(str(dest))
+                self._fetched_loras.add(lora_id)
         except Exception as e:
             logger.warning("lora_fetch_failed id={} error={}", lora_id, e)
             try:


### PR DESCRIPTION
A pod goes to whoever the pool allocates it to next. A LoRA fetched by `add_lora` was written into `loras_dir()` — the baked catalog's own directory — registered into the engine's in-memory catalog, and then left there. Nothing removed either.

**So the next user on that pod got the previous user's styles.** Listed by name in their dropdown, and loadable.

And since the "My Styles" grouping is client-side, their plugin doesn't know the ids — so the entries land under **Catalog**, where they read as stock LoRAs rather than someone else's private work.

## Two leaks, either sufficient on its own

- **The name.** User-chosen, and can identify someone (`sarahs-demo-album`).
- **The weights.** A model they paid GPU time to train, usable by a stranger.

That second one is also the thing the Styles marketplace plan is built on *not* happening.

## Fixed at both ends

**`user_loras_dir()`** — `models_dir()/user_loras`, `ACESTEP_USER_LORAS_DIR` to override. The engine only scans `loras_dir()` at boot, so nothing here is ever picked up except by an explicit register. That also means a file which somehow outlives its session still can't be mistaken for a stock LoRA.

**`close()` → `_drop_fetched_loras()`** — unregisters and unlinks exactly the ids this session fetched. Both halves matter: leaving the registration leaks the name, leaving the file leaves the weights for anyone who guesses the id.

The helper never raises. It runs on the teardown path, and a session that fails to clean up must still finish closing rather than leaving the engine half-destroyed — each id is attempted independently, so one bad unlink doesn't strand the rest.

## Cost

The warm-reuse path goes away: a returning user re-downloads their ~170 MB style instead of re-registering a file that happened to still be there. That was never worth a cross-user leak, and the fetch measured 5.6s in practice.

## Test plan

- [ ] Connect signed in with a style → it appears, loads, sounds right
- [ ] Disconnect → `ls $ACESTEP_USER_LORAS_DIR` is empty, `user_loras_dropped count=N` in the log
- [ ] Second user connects to the **same pod** → their catalog has only stock LoRAs
- [ ] Stock catalog is untouched throughout (`loras_dir()` never written to, never cleaned)
- [ ] Session that fetched nothing closes normally (helper early-returns)
- [ ] Kill a session mid-fetch → close still completes, no half-destroyed engine