### PR TITLE
fix(lora): register through the backend seam, not engine_obj

### DIFF
--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -1061,7 +1061,15 @@ class StreamingSession:
         # the weights are materialized inside enable_lora.
         for path in local_register:
             try:
-                lid = self.engine_obj.register_lora(str(path))
+                # Through the backend, not engine_obj: engine_obj is ACE's
+                # diffusion engine and is None for SA3, whose LoRA library
+                # lives behind SA3Backend. The enable/disable calls below
+                # already go through the backend seam; this one was missed,
+                # so every runtime-fetched Style on an SA3 session failed to
+                # register with 'NoneType' object has no attribute
+                # 'register_lora' — and a Style that never registers can
+                # never be enabled.
+                lid = self.backend.register_lora(str(path))
                 logger.info("lora_registered id={} path={}", lid, path)
             except Exception as e:
                 logger.exception(


### PR DESCRIPTION
`_apply_lora_pending` routes disable/enable through `self.backend`, but registration still went through `self.engine_obj` — ACE's diffusion engine, which is `None` on SA3.

Observed on a pod running the SA3 LoRA path:

```
lora_fetched id=gioele-sa3-v2-3f359904 bytes=41494632 in=1.5s
lora_register_failed ... error='NoneType' object has no attribute 'register_lora'
```

A Style that never registers can never be enabled, so no runtime-fetched LoRA could work on an SA3 session.

`register_lora` is already on the backend contract and implemented by `SA3Backend`; this call site was just missed.

No behaviour change for ACE — `DiffusionBackend.register_lora` delegates to the same engine this called directly.

### Note, separate from this fix

The same pod logs:

```
sa3_refit_manifest_missing engine=sa3_m_dit_refit_l1_646_646
  — LoRA will use the eager-DiT swap; generate the manifest with
    scripts/sa3/gen_sa3_refit_manifest.py
```

So even with registration fixed, that image falls back to the eager-DiT swap rather than TRT refit. The manifest needs generating and shipping in the image — an asset gap, not a code one.

Also unfixed here: `_drop_fetched_loras` (session teardown) still calls `engine_obj.remove_lora`, which `remove_lora` isn't on the backend contract to support. It's inside a try/except on the teardown path and the file is still unlinked, so it degrades to a warning rather than a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)