### PR TITLE
feat(provenance): Level 1 action log — server-side session recipe logging

### DIFF
--- a/acestep/provenance/__init__.py
+++ b/acestep/provenance/__init__.py
@@ -1,0 +1,46 @@
+"""Local provenance: the Level-1 session action log.
+
+The lightweight cut of the DEMON provenance architecture (see the
+demon-provenance design doc, "Level 1: Log Actions"): record what
+happened in a session — actions, parameter changes, prompts,
+input-source hashes, models — locally and to the cloud action log.
+Deliberately NO cryptographic machinery here (no slice hashes, no
+receipts, no C2PA); that is the follow-up tier.
+
+- :mod:`~acestep.provenance.session_log` — local JSONL session logs
+  using the same event schema as the cloud action log, tapped off the
+  streaming event bus.
+- :mod:`~acestep.provenance.ledger_client` — thin batched event POST
+  client, a complete no-op until ``DEMON_LEDGER_URL`` is set.
+
+Everything here degrades to a no-op (one logged warning, never an
+exception on a write path).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_ENV_PROVENANCE_DIR = "ACESTEP_PROVENANCE_DIR"
+_DEFAULT_PROVENANCE_DIR = os.path.join(
+    os.path.expanduser("~"), ".daydream-scope", "provenance",
+)
+
+
+def provenance_dir() -> Path:
+    """Root directory for local provenance state (session logs).
+
+    Resolution order mirrors :func:`acestep.paths.models_dir`:
+        1. ACESTEP_PROVENANCE_DIR environment variable
+        2. ~/.daydream-scope/provenance
+
+    Deliberately NOT memoized: tests point it at a tmp dir per case,
+    and it is read only on session start, never per tick.
+    """
+    return Path(os.environ.get(_ENV_PROVENANCE_DIR, _DEFAULT_PROVENANCE_DIR))
+
+
+def session_logs_dir() -> Path:
+    """Directory holding per-session JSONL event logs."""
+    return provenance_dir() / "sessions"

--- a/acestep/provenance/ledger_client.py
+++ b/acestep/provenance/ledger_client.py
@@ -1,0 +1,316 @@
+"""Thin client for the Provenance Action Log service.
+
+Best-effort background reporter for one session's event stream. It
+batches events and POSTs them to::
+
+    POST {DEMON_LEDGER_URL}/sessions/{sessionId}/events
+    Authorization: Bearer {DEMON_LEDGER_TOKEN}
+    { "events": [ {seq, type, ts, ppq?, payload}, ... ] }
+
+This is the Level-1 "recipe log" tier: the service acknowledges with a
+plain ``{event_count}`` — no hash chains, no signed receipts.
+
+``DEMON_LEDGER_URL`` already includes the ``/v1`` prefix (it is the
+``ledgerBaseUrl`` the queue broker hands the pod at session bootstrap).
+The bearer token is the per-session **pod ledger token** (``dlt_pod_…``),
+delivered to the pod in the broker→pod session assignment; it is
+supplied here via ``DEMON_LEDGER_TOKEN`` and/or a constructor param.
+With **either** the URL or the token unset the whole client is a
+**complete no-op**: construction is free, every method returns
+immediately, and no thread is started.
+
+**Dev bootstrap (broker emulation).** Until the real queue broker calls
+``POST /internal/v1/sessions``, nothing delivers a per-session pod token
+to a pod. For staging/dev E2E testing the client can emulate the broker
+itself: when the token is unset but ``DEMON_LEDGER_INTERNAL_SECRET`` is,
+the worker thread mints this session via the internal endpoint before
+its first flush (user id from ``DEMON_LEDGER_USER_ID``, default
+``"dev"``). Fail-open like the rest of the client: a failed mint logs
+one WARNING and reporting stays off. Production pods must never hold the
+internal secret — the broker delivers the token instead.
+
+Async-safe by construction: callers (the bus drainer thread, the WS
+dispatch thread, async handlers) only ever enqueue onto a bounded
+in-memory queue; one daemon worker owns all network I/O and is the sole
+assigner of the per-stream ``seq``. Overflow drops the *oldest*
+un-flushed event — the local session log, not this client, is the
+durable record, and provenance reporting is fail-open for playback.
+Because ``seq`` is assigned by the worker at flush time (never at
+enqueue time), a dropped event never punches a hole in the sequence:
+the surviving events stay contiguous from 0 and the ledger's seq-gap
+check is not tripped by best-effort drops.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Optional
+
+from loguru import logger
+
+__all__ = [
+    "LEDGER_URL_ENV",
+    "LEDGER_TOKEN_ENV",
+    "LEDGER_INTERNAL_SECRET_ENV",
+    "LEDGER_USER_ENV",
+    "LedgerClient",
+]
+
+LEDGER_URL_ENV = "DEMON_LEDGER_URL"
+LEDGER_TOKEN_ENV = "DEMON_LEDGER_TOKEN"
+# Dev-only broker emulation (see module docstring): with the token unset,
+# these let the worker mint the session itself.
+LEDGER_INTERNAL_SECRET_ENV = "DEMON_LEDGER_INTERNAL_SECRET"
+LEDGER_USER_ENV = "DEMON_LEDGER_USER_ID"
+
+_QUEUE_MAX = 1024
+_REQUEST_TIMEOUT_S = 5.0
+# Batch caps (max 500 events / 1 MiB per request on the service side).
+_BATCH_MAX = 500
+# Flush cadence: whichever comes first, a full batch or this interval.
+_FLUSH_INTERVAL_S = 2.0
+
+
+def _now_ms() -> int:
+    """Wall-clock ms since epoch — the on-the-wire timestamp form
+    (ISO-8601 is never used on the wire)."""
+    return int(time.time() * 1000)
+
+
+class LedgerClient:
+    """Fire-and-forget batched event reporter for one session's action
+    log. A no-op unless both a base URL and a bearer token are
+    configured."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        *,
+        session_id: str = "",
+        token: str | None = None,
+    ) -> None:
+        self.base_url = (
+            base_url if base_url is not None
+            else os.environ.get(LEDGER_URL_ENV, "")
+        ).rstrip("/")
+        self.token = (
+            token if token is not None
+            else os.environ.get(LEDGER_TOKEN_ENV, "")
+        )
+        # Dev bootstrap (module docstring): armed only when no token was
+        # delivered. The mint happens on the worker thread, never here.
+        self._bootstrap_secret = (
+            "" if self.token
+            else os.environ.get(LEDGER_INTERNAL_SECRET_ENV, "")
+        )
+        self._bootstrap_user = os.environ.get(LEDGER_USER_ENV, "dev")
+        self.session_id = session_id
+        self._warned = False
+        self._queue: Optional[queue.Queue] = None
+        self._worker: Optional[threading.Thread] = None
+        # Assigned by the worker thread only (single writer): the next
+        # per-stream seq. Contiguous from 0 by construction.
+        self._next_seq = 0
+        # Last event count the service acknowledged.
+        self._acked_count: Optional[int] = None
+
+    @property
+    def enabled(self) -> bool:
+        """Reporting is live only when the pod holds both the ledger URL
+        and its write-scoped pod token — or, in dev, the internal secret
+        with which the worker can mint one."""
+        return bool(self.base_url) and bool(
+            self.token or self._bootstrap_secret
+        )
+
+    @property
+    def acked_count(self) -> Optional[int]:
+        """Latest server-acknowledged event count for this session."""
+        return self._acked_count
+
+    # ---- reporting -------------------------------------------------------
+
+    def post_event(
+        self,
+        type: str,
+        payload: dict | None = None,
+        *,
+        ts: int | None = None,
+        ppq: float | None = None,
+    ) -> None:
+        """Enqueue one authorship / config event. ``seq`` is assigned
+        later, by the worker, so best-effort drops never create gaps."""
+        if not self.enabled:
+            return
+        self._enqueue(type, payload or {}, ts=ts, ppq=ppq)
+
+    def close(self, timeout: float = 2.0) -> None:
+        if self._queue is None:
+            return
+        try:
+            self._queue.put_nowait(None)
+        except queue.Full:
+            # Make room for the sentinel so the worker can drain + exit.
+            try:
+                self._queue.get_nowait()
+                self._queue.put_nowait(None)
+            except (queue.Empty, queue.Full):
+                pass
+        if self._worker is not None:
+            self._worker.join(timeout=timeout)
+
+    # ---- worker ----------------------------------------------------------
+
+    def _enqueue(
+        self,
+        type: str,
+        payload: dict,
+        *,
+        ts: int | None,
+        ppq: float | None,
+    ) -> None:
+        if self._queue is None:
+            self._queue = queue.Queue(maxsize=_QUEUE_MAX)
+            self._worker = threading.Thread(
+                target=self._drain, name="ledger-client", daemon=True,
+            )
+            self._worker.start()
+        item = {
+            "type": type,
+            "ts": _now_ms() if ts is None else int(ts),
+            "payload": payload,
+        }
+        if ppq is not None:
+            item["ppq"] = float(ppq)
+        try:
+            self._queue.put_nowait(item)
+        except queue.Full:
+            # Drop the oldest un-flushed item to make room (fail-open):
+            # the local log is the durable record. seq is assigned at
+            # flush, so the drop leaves the surviving stream contiguous.
+            try:
+                self._queue.get_nowait()
+                self._queue.put_nowait(item)
+            except (queue.Empty, queue.Full):
+                pass
+
+    def _drain(self) -> None:
+        assert self._queue is not None
+        if not self.token and self._bootstrap_secret:
+            self._bootstrap()
+        batch: list[dict] = []
+        while True:
+            timeout = _FLUSH_INTERVAL_S if batch else None
+            try:
+                item = self._queue.get(timeout=timeout)
+            except queue.Empty:
+                # Idle flush interval elapsed with events pending.
+                self._flush(batch)
+                batch = []
+                continue
+            if item is None:
+                self._flush(batch)
+                return
+            batch.append(item)
+            if len(batch) >= _BATCH_MAX:
+                self._flush(batch)
+                batch = []
+
+    def _flush(self, batch: list[dict]) -> None:
+        if not batch:
+            return
+        if not self.token:
+            # Bootstrap failed (or never armed): fail-open — the local
+            # session log remains the durable record.
+            return
+        # Assign contiguous seq now (worker is the single seq writer).
+        events = []
+        for item in batch:
+            event = {"seq": self._next_seq, "type": item["type"],
+                     "ts": item["ts"], "payload": item["payload"]}
+            if "ppq" in item:
+                event["ppq"] = item["ppq"]
+            events.append(event)
+            self._next_seq += 1
+        body = json.dumps({"events": events}, default=str).encode("utf-8")
+        url = f"{self.base_url}/sessions/{self.session_id}/events"
+        try:
+            req = urllib.request.Request(
+                url,
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {self.token}",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_S) as resp:
+                raw = resp.read()
+            try:
+                data = json.loads(raw)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return
+            if isinstance(data, dict):
+                count = data.get("event_count")
+                if isinstance(count, int):
+                    self._acked_count = count
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            if not self._warned:
+                self._warned = True
+                logger.warning(
+                    "ledger post failed url={} error={} "
+                    "(further failures silenced)",
+                    url, exc,
+                )
+
+    def _bootstrap(self) -> None:
+        """Dev-only broker emulation (module docstring): mint this
+        session via ``POST /internal/v1/sessions`` and adopt the returned
+        pod token. Runs once, on the worker thread, before the first
+        flush. Fail-open: on any failure reporting stays disabled and one
+        WARNING is logged."""
+        # DEMON_LEDGER_URL includes the public /v1 prefix; the internal
+        # surface lives beside it at /internal/v1.
+        origin = (
+            self.base_url[: -len("/v1")]
+            if self.base_url.endswith("/v1") else self.base_url
+        )
+        url = f"{origin}/internal/v1/sessions"
+        body = json.dumps({
+            "session_id": self.session_id,
+            "user_id": self._bootstrap_user,
+        }).encode("utf-8")
+        try:
+            req = urllib.request.Request(
+                url,
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {self._bootstrap_secret}",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_S) as resp:
+                data = json.loads(resp.read())
+            token = data.get("pod_ledger_token") if isinstance(data, dict) else None
+            if not isinstance(token, str) or not token:
+                raise ValueError("response carried no pod_ledger_token")
+            self.token = token
+            logger.info(
+                "ledger dev bootstrap minted session={} user={} "
+                "(broker emulation)",
+                self.session_id, self._bootstrap_user,
+            )
+        except (urllib.error.URLError, OSError, ValueError,
+                json.JSONDecodeError) as exc:
+            logger.warning(
+                "ledger dev bootstrap failed url={} session={} error={} "
+                "(reporting disabled; local session log unaffected)",
+                url, self.session_id, exc,
+            )

--- a/acestep/provenance/session_log.py
+++ b/acestep/provenance/session_log.py
@@ -1,0 +1,655 @@
+"""Local session log: a JSONL event stream mirroring the ledger schema.
+
+One file per streaming session under
+``<provenance dir>/sessions/<session_id>.jsonl``. Every line is one
+event envelope in the **shared** schema of the cloud action log, so
+"upload my local history" can replay these files into the cloud ledger
+unchanged::
+
+    {"stream": "local", "seq": 0, "type": "session.config",
+     "ts": 1751871234567, "payload": {...}}
+
+| Field | Meaning |
+|---|---|
+| ``stream`` | Always ``"local"`` for this file. |
+| ``seq`` | Per-file, contiguous from 0 (single local stream). |
+| ``type`` | Namespaced event type (``session.config``, ``action.prompt``, ``action.param``, ``action.lora``, ``action.seed_audio``, ``action.transport``, ``input.source``, ``session.note`` …), matching what :mod:`ledger_client` sends. |
+| ``ts`` | Wall-clock **milliseconds since epoch** (ISO-8601 is never on the wire). |
+| ``ppq`` | Optional DAW playhead in PPQ; omitted when unknown. |
+| ``payload`` | Type-specific object. Prompt text is allowed here (local-only); only counts ever leave the log as summaries. |
+
+This is the Level-1 "recipe log" tier: decoded slices are **counted**
+for the summary but never hashed — audio-slice hashing and its
+cross-checking belong to the follow-up cryptographic tier.
+
+Wiring: :func:`attach_session` subscribes a :class:`SessionLogTap` to
+the session's typed event bus (:mod:`acestep.streaming.events`). The
+session registry (:mod:`acestep.streaming.registry`) calls attach/detach
+when a handle carrying a ``bus`` is registered/unregistered, so transport
+adapters only have to hand the bus over. Torch-free, like the registry.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+from loguru import logger
+
+from acestep.provenance import session_logs_dir
+from acestep.provenance.ledger_client import LedgerClient
+from acestep.streaming.events import (
+    AudioReady,
+    AudioWriteFailed,
+    AudioWritten,
+    CommandFailed,
+    DepthApplied,
+    LoraCatalogUpdate,
+    ParamsEcho,
+    ParamsUpdate,
+    PromptApplied,
+    PromptBlendEcho,
+    SessionError,
+    SessionReady,
+    StemAssets,
+    StemFailed,
+    StructureCleared,
+    StructureFailed,
+    StructureSet,
+    SubscriberDropped,
+    SwapFailed,
+    SwapReady,
+    TimbreCleared,
+    TimbreFailed,
+    TimbreSet,
+)
+
+__all__ = [
+    "LOCAL_STREAM",
+    "SessionLogWriter",
+    "SessionLogTap",
+    "attach_session",
+    "detach_session",
+    "get_tap",
+    "record_user_action",
+]
+
+# File-envelope stream label for local logs.
+LOCAL_STREAM = "local"
+
+# Params messages arrive at ~125 Hz; action.param records for them are
+# diffed against the last logged values and rate-limited.
+_PARAMS_ACTION_MIN_INTERVAL_S = 1.0
+
+# Telemetry fields of the wire "params" message that are not user
+# actions (playhead/flow-control reporting).
+_PARAMS_TELEMETRY_KEYS = frozenset(
+    {"type", "playback_pos", "client_time", "slice_lead_s", "slice_bytes_rx"},
+)
+
+_MAX_SUMMARY_STR = 300
+_MAX_SUMMARY_LIST = 24
+
+
+def _now_ms() -> int:
+    """Wall-clock ms since epoch."""
+    return int(time.time() * 1000)
+
+
+def buffer_fingerprint(arr: np.ndarray) -> str:
+    """Numpy analogue of :func:`acestep.track_assets.waveform_fingerprint`
+    for ``[N, C]`` / ``[N]`` float buffers carried on bus events: mono
+    mix, fixed 4096-point decimation grid, quantize, sha256. Same
+    robustness intent (stable across benign decode round-trips); kept
+    torch-free because the tap runs on pods and local CPUs alike.
+    """
+    a = np.asarray(arr, dtype=np.float32)
+    mono = a.mean(axis=1) if a.ndim == 2 else a.reshape(-1)
+    n = int(mono.shape[-1])
+    if n == 0:
+        return "empty"
+    grid = 4096
+    if n > grid:
+        idx = np.round(np.linspace(0, n - 1, grid)).astype(np.int64)
+        mono = mono[idx]
+    quantized = np.round(np.ascontiguousarray(mono) * 10_000.0).astype(np.int32)
+    return hashlib.sha256(quantized.tobytes()).hexdigest()
+
+
+def _summarize(value: Any) -> Any:
+    """Shrink a payload value: bounded strings and lists, no binary.
+    Prompt text stays intact up to the cap — the log is local-only, so
+    prompt content is allowed here even though only counts ever leave
+    the log as summaries."""
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return {"bytes": len(value)}
+    if isinstance(value, str):
+        return value if len(value) <= _MAX_SUMMARY_STR else value[:_MAX_SUMMARY_STR] + "…"
+    if isinstance(value, dict):
+        return {str(k): _summarize(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        if len(value) > _MAX_SUMMARY_LIST:
+            return {"items": len(value)}
+        return [_summarize(v) for v in value]
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    return repr(value)[:_MAX_SUMMARY_STR]
+
+
+class SessionLogWriter:
+    """Append-only JSONL writer for the shared event envelope. Owns the
+    local stream's contiguous ``seq`` counter. Thread-safe; one flush per
+    event so a crash loses at most the in-flight line. Never raises out
+    of :meth:`record` — a broken log must not take down the session."""
+
+    def __init__(self, path: Path, session_id: str) -> None:
+        self.path = path
+        self.session_id = session_id
+        self._lock = threading.Lock()
+        self._seq = 0
+        self._failed = False
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = open(path, "a", encoding="utf-8")
+
+    def record(
+        self,
+        type: str,
+        payload: dict,
+        *,
+        ts: int | None = None,
+        ppq: float | None = None,
+    ) -> None:
+        try:
+            with self._lock:
+                if self._fh.closed:
+                    return
+                line = {
+                    "stream": LOCAL_STREAM,
+                    "seq": self._seq,
+                    "type": type,
+                    "ts": _now_ms() if ts is None else int(ts),
+                    "payload": payload,
+                }
+                if ppq is not None:
+                    line["ppq"] = float(ppq)
+                payload_str = json.dumps(
+                    line, default=str, separators=(",", ":"),
+                )
+                self._fh.write(payload_str + "\n")
+                self._fh.flush()
+                self._seq += 1
+        except Exception as exc:  # noqa: BLE001
+            if not self._failed:
+                self._failed = True
+                logger.warning(
+                    "session log write failed path={} error={}",
+                    self.path, exc,
+                )
+
+    def file_sha256(self) -> str | None:
+        try:
+            with self._lock:
+                if not self._fh.closed:
+                    self._fh.flush()
+            return hashlib.sha256(self.path.read_bytes()).hexdigest()
+        except Exception:  # noqa: BLE001
+            return None
+
+    def close(self) -> None:
+        with self._lock:
+            try:
+                self._fh.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+class SessionLogTap:
+    """Event-bus subscriber that serializes session events to the local
+    log in the shared schema (and forwards them to the ledger client
+    when one is configured).
+
+    Counts decoded output slices for the summary but does not hash them
+    (see the module docstring). Runs on the subscription's drainer
+    thread plus whichever thread calls :meth:`record_user_action`;
+    shared counters sit behind one lock.
+    """
+
+    def __init__(
+        self,
+        bus: Any,
+        session_id: str,
+        *,
+        meta: dict | None = None,
+        snapshot: Any = None,
+        log_dir: Path | None = None,
+    ) -> None:
+        self.session_id = session_id
+        d = Path(log_dir) if log_dir is not None else session_logs_dir()
+        self.writer = SessionLogWriter(d / f"{session_id}.jsonl", session_id)
+        self.ledger = LedgerClient(session_id=session_id)
+
+        self._lock = threading.Lock()
+        self._started_wall = time.time()
+        self._slices = 0            # decoded slices seen on the bus
+        self._counts = {
+            "events": 0,
+            "prompt_changes": 0,
+            "param_changes": 0,
+            "user_actions": 0,
+        }
+        self._prompts_seen: set[str] = set()
+        self._input_sources_seen: set[str] = set()
+        self._last_params: dict = {}
+        # None until the first logged change: time.monotonic() has an
+        # arbitrary epoch (near zero on some platforms), so "0.0" would
+        # silently rate-limit the session's first knob change away.
+        self._last_params_wall: float | None = None
+        self._closed = False
+
+        snap: dict = {}
+        if callable(snapshot):
+            try:
+                snap = snapshot() or {}
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "session snapshot failed for provenance log: {}", exc,
+                )
+        meta = dict(meta or {})
+        loras = [
+            e.get("id")
+            for e in snap.get("lora_catalog") or []
+            if isinstance(e, dict) and e.get("state") == "enabled"
+        ]
+        self._model = meta.get("checkpoint") or snap.get("checkpoint")
+        self._loras = loras
+        # session.config: model + LoRA identifiers + initial config,
+        # mirroring the WS config handshake.
+        self._record(
+            "session.config",
+            {
+                "model": self._model,
+                "loras": loras,
+                "fixture_name": meta.get("fixture_name")
+                or snap.get("fixture_name"),
+                "prompt": snap.get("prompt"),
+                "bpm": snap.get("bpm"),
+                "key": snap.get("key"),
+                "time_signature": snap.get("time_signature"),
+                "extra": {
+                    k: v for k, v in meta.items()
+                    # fixture_path is a server filesystem path — consumed
+                    # below for the input hash, never recorded verbatim;
+                    # initial_source_sha256 lands as an input.source event.
+                    if k not in ("checkpoint", "fixture_name",
+                                 "fixture_path", "initial_source_sha256")
+                },
+            },
+        )
+        if isinstance(snap.get("prompt"), str) and snap["prompt"]:
+            self._prompts_seen.add(snap["prompt"])
+
+        # Initial input source, two commitments: the adapter-computed
+        # fingerprint of the waveform actually consumed (covers client
+        # uploads that never exist as pod files — recorded synchronously),
+        # and the source FILE's sha256 when a cached file exists (hashed
+        # off-thread; a ~10 MB read must not sit in the
+        # session-registration path). Later user-provided sources are
+        # recorded via their buffer fingerprints as SessionReady/SwapReady
+        # arrive on the bus.
+        initial_fp = meta.get("initial_source_sha256")
+        if initial_fp:
+            self._record_input_source(
+                initial_fp, "initial_source",
+                {"algo": "sha256:buffer_fingerprint",
+                 "fixture_name": meta.get("fixture_name")
+                 or snap.get("fixture_name")},
+            )
+        fixture_path = meta.get("fixture_path")
+        if fixture_path:
+            threading.Thread(
+                target=self._hash_initial_source,
+                args=(Path(fixture_path),
+                      meta.get("fixture_name") or snap.get("fixture_name")),
+                name="provenance-input-hash",
+                daemon=True,
+            ).start()
+
+        self._sub = bus.subscribe(self._on_event, name="provenance")
+        self._bus = bus
+
+    # ---- input-source commitments -----------------------------------------
+
+    def _hash_initial_source(self, path: Path, fixture_name: str | None) -> None:
+        """SHA-256 the initial source file and record it as an input
+        source. Runs on its own daemon thread; fail-open like everything
+        else here — an unreadable file logs one warning and that's it."""
+        try:
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        except OSError as exc:
+            logger.warning(
+                "input source hash failed for session={} path={}: {}",
+                self.session_id, path, exc,
+            )
+            return
+        if self._closed:
+            return
+        self._record_input_source(
+            digest, "initial_source",
+            {"algo": "sha256:file", "fixture_name": fixture_name},
+        )
+
+    def _record_input_source(
+        self, input_sha256: str, label: str, extra: dict | None = None,
+    ) -> None:
+        """Record one consumed input source (``input.source``): the
+        input's hash plus how it was computed. A file hash stays directly
+        comparable to ``shasum -a 256 <file>``."""
+        with self._lock:
+            self._input_sources_seen.add(input_sha256)
+        payload: dict = {"sha256": input_sha256, "label": label}
+        if extra:
+            payload.update({k: v for k, v in extra.items() if v is not None})
+        self._record("input.source", payload)
+
+    # ---- recording -------------------------------------------------------
+
+    def _record(self, type: str, payload: dict, *, ppq: float | None = None) -> None:
+        ts = _now_ms()
+        with self._lock:
+            self._counts["events"] += 1
+        self.writer.record(type, payload, ts=ts, ppq=ppq)
+        self.ledger.post_event(type, payload, ts=ts, ppq=ppq)
+
+    def record_user_action(
+        self, action: str, payload: dict, *, source: str = "ws",
+    ) -> None:
+        """One authorship-action record in the shared schema. ``params``
+        actions map to ``action.param`` and are diffed against the last
+        logged knob values and rate-limited so the ~125 Hz knob channel
+        doesn't flood the log."""
+        if self._closed:
+            return
+        if action == "params":
+            values = {
+                k: v for k, v in payload.items()
+                if k not in _PARAMS_TELEMETRY_KEYS
+            }
+            with self._lock:
+                changed = {
+                    k: v for k, v in values.items()
+                    if self._last_params.get(k) != v
+                }
+                now = time.monotonic()
+                if not changed or (
+                    self._last_params_wall is not None
+                    and now - self._last_params_wall
+                    < _PARAMS_ACTION_MIN_INTERVAL_S
+                ):
+                    return
+                self._last_params.update(values)
+                self._last_params_wall = now
+                self._counts["user_actions"] += 1
+                self._counts["param_changes"] += 1
+            self._record(
+                "action.param",
+                {"source": source, "changed": _summarize(changed)},
+            )
+            return
+        with self._lock:
+            self._counts["user_actions"] += 1
+            if action == "prompt":
+                self._counts["prompt_changes"] += 1
+                tags = payload.get("tags")
+                if isinstance(tags, str) and tags:
+                    self._prompts_seen.add(tags)
+        summary = _summarize({
+            k: v for k, v in payload.items() if k != "type"
+        })
+        body = {"source": source}
+        if isinstance(summary, dict):
+            body.update(summary)
+        else:
+            body["value"] = summary
+        if action == "prompt":
+            self._record("action.prompt", body)
+        else:
+            body["action"] = action
+            self._record("session.note", {"note": "user_action", **body})
+
+    # ---- bus tap ---------------------------------------------------------
+
+    def _on_event(self, event: Any) -> None:
+        try:
+            self._dispatch_event(event)
+        except Exception as exc:  # noqa: BLE001 — tap must never wedge the drainer
+            logger.warning("provenance tap event failed: {}", exc)
+
+    def _dispatch_event(self, event: Any) -> None:
+        if isinstance(event, AudioReady):
+            self._on_slice(event)
+        elif isinstance(event, ParamsUpdate):
+            # Per-slice telemetry snapshot; authorship-irrelevant.
+            return
+        elif isinstance(event, PromptApplied):
+            with self._lock:
+                self._counts["prompt_changes"] += 1
+                if event.tags:
+                    self._prompts_seen.add(event.tags)
+            self._record("action.prompt", {"prompt": _summarize(event.tags)})
+        elif isinstance(event, PromptBlendEcho):
+            self._record(
+                "action.param", {"name": "prompt_blend", "value": event.value},
+            )
+        elif isinstance(event, ParamsEcho):
+            if getattr(event, "origin", "external") == "external":
+                # Deliberate MCP/control-bus action: record verbatim.
+                with self._lock:
+                    self._counts["param_changes"] += 1
+                self._record("action.param", {"raw": _summarize(event.raw)})
+            else:
+                # The performer's own knob stream (up to 125 Hz during a
+                # drag): reuse the diff + rate-limit path so the log gets
+                # "what changed", not a firehose.
+                self.record_user_action(
+                    "params", dict(event.raw), source="primary",
+                )
+        elif isinstance(event, DepthApplied):
+            self._record(
+                "action.param", {"name": "depth", "value": event.value},
+            )
+        elif isinstance(event, LoraCatalogUpdate):
+            loras = [
+                e.get("id")
+                for e in event.catalog or []
+                if isinstance(e, dict) and e.get("state") == "enabled"
+            ]
+            with self._lock:
+                self._loras = loras
+            self._record("action.lora", {"loras": loras})
+        elif isinstance(event, SessionReady):
+            fp = buffer_fingerprint(event.initial_buffer)
+            self._record(
+                "action.seed_audio",
+                {
+                    "sha256": fp,
+                    "label": "initial_source",
+                    "duration_sec": event.duration,
+                    "sample_rate": event.sample_rate,
+                    "bpm": event.bpm,
+                    "key": event.key,
+                    "time_signature": event.time_signature,
+                    "pipeline_depth": event.pipeline_depth,
+                },
+            )
+            self._record_input_source(
+                fp, "initial_source", {"algo": "sha256:buffer_fingerprint"},
+            )
+        elif isinstance(event, SwapReady):
+            fp = buffer_fingerprint(event.initial_buffer)
+            self._record(
+                "action.seed_audio",
+                {
+                    "sha256": fp,
+                    "label": "source_swap",
+                    "fixture_name": event.fixture_name,
+                    "duration_sec": event.duration,
+                    "bpm": event.bpm,
+                    "key": event.key,
+                    "source_epoch": event.source_epoch,
+                },
+            )
+            self._record_input_source(
+                fp, "source_swap",
+                {"algo": "sha256:buffer_fingerprint",
+                 "fixture_name": event.fixture_name},
+            )
+        elif isinstance(event, TimbreSet):
+            self._record(
+                "action.param",
+                {"name": "timbre", "op": "set",
+                 "timbre": event.name, "duration": event.duration},
+            )
+        elif isinstance(event, TimbreCleared):
+            self._record("action.param", {"name": "timbre", "op": "clear"})
+        elif isinstance(event, StructureSet):
+            self._record(
+                "action.param",
+                {"name": "structure", "op": "set",
+                 "structure": event.name, "duration": event.duration},
+            )
+        elif isinstance(event, StructureCleared):
+            self._record("action.param", {"name": "structure", "op": "clear"})
+        elif isinstance(event, AudioWritten):
+            self._record(
+                "action.transport",
+                {"op": "write_audio", "start_s": event.start_s,
+                 "end_s": event.end_s, "source_epoch": event.source_epoch},
+            )
+        elif isinstance(event, StemAssets):
+            self._record(
+                "session.note",
+                {"note": "stem_assets", "fixture_name": event.fixture_name,
+                 "source_mode": event.source_mode, "frames": event.frames},
+            )
+        elif isinstance(event, (
+            CommandFailed, SwapFailed, StemFailed, TimbreFailed,
+            StructureFailed, AudioWriteFailed, SessionError,
+        )):
+            self._record(
+                "session.note",
+                {"note": "error", "kind": type(event).__name__,
+                 "error": _summarize(getattr(event, "error", None)
+                                     or getattr(event, "message", ""))},
+            )
+        elif isinstance(event, SubscriberDropped):
+            # Our own queue overflowed: the log has a gap from here on.
+            self._record(
+                "session.note",
+                {"note": "log_tap_dropped", "reason": event.reason},
+            )
+
+    def _on_slice(self, event: AudioReady) -> None:
+        # Count decoded slices for the summary — Level 1 never hashes
+        # audio; slice hashing belongs to the follow-up cryptographic
+        # tier.
+        with self._lock:
+            self._slices += 1
+
+    # ---- summary / lifecycle ---------------------------------------------
+
+    def timeline_summary(self) -> dict:
+        """Counts-only view of the timeline — never prompt content."""
+        with self._lock:
+            elapsed = time.time() - self._started_wall
+            return {
+                **self._counts,
+                "distinct_prompts": len(self._prompts_seen),
+                "distinct_input_sources": len(self._input_sources_seen),
+                "slices": self._slices,
+                "duration_s": round(elapsed, 3),
+            }
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._bus.unsubscribe(self._sub)
+            self._sub.join(timeout=5)
+        except Exception:  # noqa: BLE001
+            pass
+        with self._lock:
+            n = self._slices
+        self._record(
+            "session.note",
+            {
+                "note": "session_end",
+                "slices": n,
+                "timeline_summary": self.timeline_summary(),
+            },
+        )
+        self.ledger.close()
+        self.writer.close()
+
+
+# ---------------------------------------------------------------------------
+# Process-global tap registry, driven by acestep.streaming.registry
+# ---------------------------------------------------------------------------
+
+_taps: dict[str, SessionLogTap] = {}
+_taps_lock = threading.Lock()
+
+
+def attach_session(handle: Any, *, log_dir: Path | None = None) -> Optional[SessionLogTap]:
+    """Attach a log tap for a registered session handle (must carry a
+    ``bus``; ``snapshot`` and ``provenance_meta`` are optional). Returns
+    ``None`` — after one warning — if the tap could not be created."""
+    bus = getattr(handle, "bus", None)
+    if bus is None:
+        return None
+    try:
+        tap = SessionLogTap(
+            bus,
+            handle.id,
+            meta=getattr(handle, "provenance_meta", None),
+            snapshot=getattr(handle, "snapshot", None),
+            log_dir=log_dir,
+        )
+    except Exception as exc:  # noqa: BLE001 — never block session registration
+        logger.warning(
+            "session log attach failed session_id={} error={}",
+            getattr(handle, "id", "?"), exc,
+        )
+        return None
+    with _taps_lock:
+        _taps[handle.id] = tap
+    logger.info("session_log_attached path={}", tap.writer.path)
+    return tap
+
+
+def detach_session(session_id: str) -> None:
+    with _taps_lock:
+        tap = _taps.pop(session_id, None)
+    if tap is not None:
+        tap.close()
+
+
+def get_tap(session_id: str) -> Optional[SessionLogTap]:
+    with _taps_lock:
+        return _taps.get(session_id)
+
+
+def record_user_action(
+    session_id: str, action: str, payload: dict, *, source: str = "ws",
+) -> None:
+    """Module-level convenience for transport adapters: no-op when the
+    session has no attached tap (e.g. the brief window before the
+    registry registers the handle)."""
+    tap = get_tap(session_id)
+    if tap is not None:
+        tap.record_user_action(action, payload, source=source)

--- a/acestep/streaming/events.py
+++ b/acestep/streaming/events.py
@@ -134,17 +134,24 @@ class ParamsUpdate:
 
 @dataclass(frozen=True)
 class ParamsEcho:
-    """Echo of a knob update that came from a non-primary origin.
+    """Echo of a knob update, tagged with where it came from.
 
-    Emitted ONLY when ``set_knobs(origin=CommandOrigin.EXTERNAL)``.
-    The primary transport's UI layer (today: the browser's smoothing
+    ``origin == "external"`` (``set_knobs(origin=CommandOrigin.EXTERNAL)``):
+    the primary transport's UI layer (today: the browser's smoothing
     tween) listens for this so it can ease toward the target and
     re-send the tweened sequence as a ``PRIMARY`` ``set_knobs``.
+    Transports forward ONLY these to the client.
+
+    ``origin == "primary"``: the player's own knob change (published only
+    when the raw dict actually changed). Consumed by the provenance tap —
+    the authorship record must capture the performer's moves — and NEVER
+    echoed back to the client, which would fight its own UI.
 
     Carries the raw dict as posted, NOT the per-knob clamped value.
     """
 
     raw: dict
+    origin: str = "external"
 
 
 @dataclass(frozen=True)

--- a/acestep/streaming/registry.py
+++ b/acestep/streaming/registry.py
@@ -39,6 +39,13 @@ class SessionHandle:
     started_at: float
     inject: InjectFn
     snapshot: SnapshotFn
+    # Optional provenance surface. When ``bus`` (the session's typed
+    # EventBus) is present, register() attaches a local session-log tap
+    # (acestep.provenance.session_log) and unregister() closes it.
+    # ``provenance_meta`` carries adapter-known identifiers the snapshot
+    # doesn't expose (checkpoint, fixture name).
+    bus: Optional[Any] = None
+    provenance_meta: Optional[dict] = None
 
 
 _sessions: dict[str, SessionHandle] = {}
@@ -53,11 +60,25 @@ def new_session_id() -> str:
 def register(handle: SessionHandle) -> None:
     with _lock:
         _sessions[handle.id] = handle
+    if handle.bus is not None:
+        # Lazy + guarded: provenance logging must never block session
+        # registration, and this module stays importable (torch-free,
+        # provenance-free) under --no-backend.
+        try:
+            from acestep.provenance.session_log import attach_session
+            attach_session(handle)
+        except Exception:
+            pass
 
 
 def unregister(session_id: str) -> None:
     with _lock:
         _sessions.pop(session_id, None)
+    try:
+        from acestep.provenance.session_log import detach_session
+        detach_session(session_id)
+    except Exception:
+        pass
 
 
 def get(session_id: str) -> Optional[SessionHandle]:

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -1780,7 +1780,8 @@ class StreamingSession:
         # Activity gating: only bump on a real change. ``playback_pos``
         # advances every tick but is excluded from the diff because
         # it's a clock, not user input.
-        if raw != state.last_params_raw:
+        params_changed = raw != state.last_params_raw
+        if params_changed:
             state.last_activity_ts = time.monotonic()
             # Knob→ear latency marker: log the denoise value + the playhead
             # at the instant a real knob change lands, so the lat_decode
@@ -1807,6 +1808,11 @@ class StreamingSession:
         if origin is CommandOrigin.EXTERNAL:
             self.bus.publish(ParamsEcho(raw=dict(raw)))
             return
+        if params_changed:
+            # PRIMARY knob change: surface it on the bus for the provenance
+            # tap (the performer's moves ARE the authorship record, 06 §2.2).
+            # Origin-tagged so transports never echo it back to the client.
+            self.bus.publish(ParamsEcho(raw=dict(raw), origin="primary"))
         # Enforce the knob contract on the load-bearing path: clamp numerics
         # to [min,max], coerce ints, drop invalid enum/bool values. Unknown
         # keys (curve specs, the playback clock) pass through untouched.

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -367,6 +367,34 @@ except ValueError:
     _BINARY_PAYLOAD_TIMEOUT_S = 120.0
 
 
+def _known_fixture_local_path(fixture_name) -> str | None:
+    """Local path of a known fixture IF it is already cached — never
+    downloads (this feeds the provenance input hash; provenance must not
+    add network work to session registration). None for user uploads,
+    unknown names, or a cache miss."""
+    if not fixture_name or fixture_name not in KNOWN_FIXTURES:
+        return None
+    try:
+        from acestep.paths import fixtures_dir
+        from acestep.track_assets import source_audio_path
+        local = source_audio_path(fixtures_dir(), fixture_name)
+        return str(local) if local.is_file() else None
+    except Exception:  # noqa: BLE001 — fail-open, hash is best-effort
+        return None
+
+
+def _waveform_fingerprint_or_none(waveform) -> str | None:
+    """Provenance fingerprint of the initial source as ACTUALLY consumed
+    ([C, N] torch tensor → the tap's np fingerprint). Covers the client-
+    upload path where no source file ever exists on the pod. Fail-open:
+    any error returns None and costs the session nothing."""
+    try:
+        from acestep.provenance.session_log import buffer_fingerprint
+        return buffer_fingerprint(waveform.detach().cpu().numpy().T)
+    except Exception:  # noqa: BLE001 — provenance is best-effort
+        return None
+
+
 def _socket_send_backlog(sock) -> int | None:
     """Bytes queued in the kernel send buffer (unsent + unacked) for
     ``sock``, or ``None`` if the FD can't be queried (closed / errored /
@@ -1468,7 +1496,12 @@ def _handle_client_body(
                 payload["build_command"] = event.build_command
             _send_json(payload)
         elif isinstance(event, ParamsEcho):
-            _send_json({"type": "params_echo", "raw": event.raw})
+            # Only EXTERNAL (MCP/control-bus) changes are echoed to the
+            # client; a "primary" echo is the client's own knob move,
+            # published for the provenance tap — bouncing it back would
+            # fight the client's UI tween.
+            if event.origin == "external":
+                _send_json({"type": "params_echo", "raw": event.raw})
         elif isinstance(event, PromptBlendEcho):
             _send_json({"type": "prompt_blend_echo", "value": event.value})
         elif isinstance(event, PromptApplied):
@@ -2188,9 +2221,28 @@ def _handle_client_body(
         started_at=time.time(),
         inject=inject_control,
         snapshot=snapshot_session,
+        # Carrying the session EventBus makes register() attach the local
+        # provenance session-log tap (spec 06 §2.2); everything downstream
+        # is fail-open and degrades to a no-op without the provenance
+        # extra installed. provenance_meta supplies the adapter-known
+        # identifiers the snapshot doesn't expose.
+        bus=streaming.bus,
+        provenance_meta={
+            "checkpoint": checkpoint,
+            "fixture_name": fixture_name,
+            "decoder_backend": decoder_backend,
+            # Input-source commitments: fingerprint of the waveform
+            # actually consumed (works for client uploads that never exist
+            # as pod files), plus the source file's local path when it is
+            # already cached (never triggers a download) so the tap can
+            # record the file sha256 too.
+            "initial_source_sha256": _waveform_fingerprint_or_none(waveform),
+            "fixture_path": _known_fixture_local_path(fixture_name),
+        },
     ))
     session_registered = True
     logger.info("session_registered")
+
 
     # Stage the initial enable set so they get applied on the runner
     # thread before the first tick. Each entry carries its target

--- a/tests/unit/test_provenance_session_log.py
+++ b/tests/unit/test_provenance_session_log.py
@@ -1,0 +1,506 @@
+"""Local JSONL session log: bus tap wiring, envelope schema, slice
+counting, and the batched ledger client (Level-1 action log).
+
+Pure Python — no GPU, no crypto. Drives a real
+:class:`acestep.streaming.events.EventBus` through the registry hook
+(:func:`acestep.streaming.registry.register` attaches the tap when the
+handle carries a ``bus``) and asserts the on-disk JSONL record uses the
+shared ledger schema: ``{stream:"local", seq, type, ts(ms), payload}``
+envelopes with namespaced type names, a ``session.config`` opener, and a
+``session.note`` seal.
+
+Determinism: :meth:`SessionLogTap.close` (via ``unregister``)
+unsubscribes and joins the drainer, and the drainer delivers all
+already-queued events before exiting — so once ``unregister`` returns,
+every published event is on disk and the seal is the last line.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import acestep.provenance.session_log as session_log_mod
+from acestep.provenance.ledger_client import LedgerClient
+from acestep.provenance.session_log import (
+    LOCAL_STREAM,
+    buffer_fingerprint,
+    get_tap,
+    record_user_action,
+)
+from acestep.streaming import registry
+from acestep.streaming.events import (
+    AudioReady,
+    EventBus,
+    PromptApplied,
+    SwapFailed,
+    SwapReady,
+)
+
+
+def _slice(tag: int) -> AudioReady:
+    audio = np.full((16, 2), float(tag), dtype=np.float32)
+    return AudioReady(
+        audio=audio, start_sample=tag * 16, num_samples=16, channels=2,
+        tick_ms=0.0, dec_ms=0.0, num_gens=tag, params={},
+    )
+
+
+def _register(bus: EventBus, session_id: str, **kwargs) -> registry.SessionHandle:
+    handle = registry.SessionHandle(
+        id=session_id,
+        started_at=time.time(),
+        inject=lambda data, audio: None,
+        snapshot=kwargs.pop("snapshot", lambda: {}),
+        bus=bus,
+        provenance_meta=kwargs.pop("provenance_meta", None),
+    )
+    assert not kwargs
+    registry.register(handle)
+    return handle
+
+
+def _read_log(tmp_path: Path, session_id: str) -> list[dict]:
+    p = tmp_path / "provenance" / "sessions" / f"{session_id}.jsonl"
+    assert p.is_file(), f"missing session log at {p}"
+    return [json.loads(line) for line in p.read_text(encoding="utf-8").splitlines()]
+
+
+def _by_type(lines: list[dict], type_: str) -> list[dict]:
+    return [l for l in lines if l["type"] == type_]
+
+
+def _notes(lines: list[dict], note: str) -> list[dict]:
+    return [l for l in lines
+            if l["type"] == "session.note" and l["payload"].get("note") == note]
+
+
+def test_session_log_schema_and_lifecycle(tmp_path, monkeypatch):
+    monkeypatch.setenv("ACESTEP_PROVENANCE_DIR", str(tmp_path / "provenance"))
+    bus = EventBus()
+    snapshot = lambda: {  # noqa: E731 — mirrors adapter snapshot shape
+        "lora_catalog": [
+            {"id": "lead-guitar", "state": "enabled"},
+            {"id": "muted", "state": "disabled"},
+        ],
+        "prompt": "warm analog dub",
+        "bpm": 120,
+        "key": "C minor",
+        "time_signature": "4",
+    }
+    _register(
+        bus, "sess-schema",
+        snapshot=snapshot,
+        provenance_meta={"checkpoint": "ace_step_v1", "fixture_name": "loop60"},
+    )
+
+    bus.publish(PromptApplied(tags="dark techno"))
+    bus.publish(SwapFailed(error="no such fixture"))
+    record_user_action("sess-schema", "prompt", {"type": "prompt", "tags": "dub 2"})
+    registry.unregister("sess-schema")
+
+    lines = _read_log(tmp_path, "sess-schema")
+
+    # Every line carries the shared envelope: a "local" stream label, a
+    # contiguous-from-0 seq, a namespaced string type, an integer
+    # epoch-ms ts (never an ISO string), and a payload object.
+    for i, line in enumerate(lines):
+        assert line["stream"] == LOCAL_STREAM
+        assert line["seq"] == i
+        assert isinstance(line["type"], str) and "." in line["type"]
+        assert isinstance(line["ts"], int)
+        assert line["ts"] > 1_600_000_000_000  # plausibly ms, not seconds
+        assert isinstance(line["payload"], dict)
+
+    # session.config is first and carries the identity fields in payload.
+    start = lines[0]
+    assert start["type"] == "session.config"
+    cfg = start["payload"]
+    assert cfg["model"] == "ace_step_v1"
+    assert cfg["loras"] == ["lead-guitar"]
+    assert cfg["fixture_name"] == "loop60"
+    assert cfg["prompt"] == "warm analog dub"
+    assert cfg["bpm"] == 120
+
+    # Prompts (bus PromptApplied + user action) both map to action.prompt.
+    prompts = _by_type(lines, "action.prompt")
+    assert {p["payload"].get("prompt") for p in prompts} >= {"dark techno"}
+    user_prompt = [p for p in prompts if p["payload"].get("tags") == "dub 2"]
+    assert len(user_prompt) == 1
+    assert user_prompt[0]["payload"]["source"] == "ws"
+
+    # A failure lands as a session.note error with the kind + message.
+    errors = _notes(lines, "error")
+    assert len(errors) == 1
+    assert errors[0]["payload"]["kind"] == "SwapFailed"
+    assert errors[0]["payload"]["error"] == "no such fixture"
+
+    # session_end seals the log with counts (never prompt content).
+    end = lines[-1]
+    assert end["type"] == "session.note"
+    assert end["payload"]["note"] == "session_end"
+    assert end["payload"]["slices"] == 0
+    summary = end["payload"]["timeline_summary"]
+    assert summary["prompt_changes"] == 2  # bus PromptApplied + user action
+    assert summary["user_actions"] == 1
+    assert summary["distinct_prompts"] == 3  # snapshot + applied + user action
+    # The seal's summary is computed before the session_end line itself
+    # is counted.
+    assert summary["events"] == len(lines) - 1
+    assert summary["duration_s"] >= 0.0
+
+    # Level 1 records no audio hashes anywhere in the log.
+    assert not _by_type(lines, "slice.pod_hash")
+    assert all("chain_head" not in l["payload"] for l in lines)
+
+    # Detach removed the tap from the process-global registry.
+    assert get_tap("sess-schema") is None
+
+
+def test_input_sources_are_recorded(tmp_path, monkeypatch):
+    monkeypatch.setenv("ACESTEP_PROVENANCE_DIR", str(tmp_path / "provenance"))
+    src = tmp_path / "low_fi_test_fixture.wav"
+    src.write_bytes(b"RIFF" + bytes(range(256)) * 8)
+    file_sha = hashlib.sha256(src.read_bytes()).hexdigest()
+
+    consumed_fp = "ab" * 32  # adapter-computed waveform fingerprint
+
+    bus = EventBus()
+    _register(
+        bus, "sess-input",
+        provenance_meta={
+            "checkpoint": "ace_step_v1",
+            "fixture_name": "low_fi_test_fixture.wav",
+            "initial_source_sha256": consumed_fp,
+            "fixture_path": str(src),
+        },
+    )
+
+    # The file hash is recorded from a background thread — wait for it
+    # before publishing the swap so the event order is deterministic.
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        p = tmp_path / "provenance" / "sessions" / "sess-input.jsonl"
+        if p.is_file() and any(
+            json.loads(l)["type"] == "input.source"
+            and json.loads(l)["payload"].get("algo") == "sha256:file"
+            for l in p.read_text(encoding="utf-8").splitlines()
+        ):
+            break
+        time.sleep(0.05)
+
+    buf = np.linspace(-1.0, 1.0, 4096, dtype=np.float32).reshape(-1, 1)
+    bus.publish(SwapReady(
+        duration=1.0, sample_rate=48_000, channels=1, bpm=120,
+        key="C minor", time_signature="4", fixture_name=None,
+        initial_buffer=buf,
+    ))
+    registry.unregister("sess-input")
+
+    lines = _read_log(tmp_path, "sess-input")
+
+    # Neither the server filesystem path nor the pre-computed fingerprint
+    # may leak into session.config's extra.
+    cfg = lines[0]["payload"]
+    assert cfg["fixture_name"] == "low_fi_test_fixture.wav"
+    assert "fixture_path" not in cfg.get("extra", {})
+    assert "initial_source_sha256" not in cfg.get("extra", {})
+
+    sources = _by_type(lines, "input.source")
+    assert len(sources) == 3, "one event per consumed input"
+
+    first = sources[0]["payload"]
+    # The consumed-waveform fingerprint is recorded synchronously.
+    assert first["sha256"] == consumed_fp
+    assert first["algo"] == "sha256:buffer_fingerprint"
+    assert first["label"] == "initial_source"
+
+    second = sources[1]["payload"]
+    # The file hash stays comparable to `shasum -a 256 <file>`.
+    assert second["sha256"] == file_sha
+    assert second["algo"] == "sha256:file"
+    assert second["label"] == "initial_source"
+
+    third = sources[2]["payload"]
+    fp = buffer_fingerprint(buf)
+    assert third["sha256"] == fp
+    assert third["algo"] == "sha256:buffer_fingerprint"
+    assert third["label"] == "source_swap"
+
+    # The swap also still records its action.seed_audio fingerprint.
+    seeds = _by_type(lines, "action.seed_audio")
+    assert seeds and seeds[-1]["payload"]["sha256"] == fp
+
+    # The seal's summary counts distinct input sources.
+    end = lines[-1]
+    assert end["payload"]["timeline_summary"]["distinct_input_sources"] == 3
+
+
+def test_slices_are_counted_never_hashed(tmp_path, monkeypatch):
+    monkeypatch.setenv("ACESTEP_PROVENANCE_DIR", str(tmp_path / "provenance"))
+    bus = EventBus()
+    _register(bus, "sess-slice")
+
+    # Decoded slices on the bus are counted, not hashed — Level 1 makes
+    # no per-slice cryptographic claims.
+    for i in range(6):
+        bus.publish(_slice(i))
+    registry.unregister("sess-slice")
+
+    lines = _read_log(tmp_path, "sess-slice")
+    assert not _by_type(lines, "slice.pod_hash")
+
+    end = lines[-1]
+    assert end["payload"]["note"] == "session_end"
+    assert end["payload"]["slices"] == 6
+    assert end["payload"]["timeline_summary"]["slices"] == 6
+
+
+def test_params_actions_are_diffed_and_rate_limited(tmp_path, monkeypatch):
+    monkeypatch.setenv("ACESTEP_PROVENANCE_DIR", str(tmp_path / "provenance"))
+    bus = EventBus()
+    _register(bus, "sess-params")
+    tap = get_tap("sess-params")
+    assert tap is not None
+
+    # First params action logs only the changed knobs; telemetry keys
+    # are stripped.
+    record_user_action(
+        "sess-params", "params",
+        {"type": "params", "steer": 0.5, "flow": 0.1, "playback_pos": 12.5},
+    )
+    # Inside the rate-limit window: suppressed even though a knob moved.
+    record_user_action("sess-params", "params", {"steer": 0.9})
+    # Identical values are suppressed regardless of the window.
+    monkeypatch.setattr(session_log_mod.time, "monotonic", lambda: 1e9)
+    record_user_action(
+        "sess-params", "params", {"steer": 0.5, "flow": 0.1},
+    )
+    # Outside the window with a real change: logs the diff only.
+    record_user_action("sess-params", "params", {"steer": 0.7, "flow": 0.1})
+
+    registry.unregister("sess-params")
+    lines = _read_log(tmp_path, "sess-params")
+    actions = _by_type(lines, "action.param")
+    assert [a["payload"]["changed"] for a in actions] == [
+        {"steer": 0.5, "flow": 0.1},
+        {"steer": 0.7},
+    ]
+    assert all(a["payload"]["source"] == "ws" for a in actions)
+    assert lines[-1]["payload"]["timeline_summary"]["param_changes"] == 2
+
+
+def test_primary_params_echo_records_knob_changes(tmp_path, monkeypatch):
+    # The performer's own knob moves (ParamsEcho origin="primary") must land
+    # in the log — diffed and rate-limited — while EXTERNAL echoes keep the
+    # verbatim-raw behaviour. This is the authorship record.
+    from acestep.streaming.events import ParamsEcho
+
+    monkeypatch.setenv("ACESTEP_PROVENANCE_DIR", str(tmp_path / "provenance"))
+    bus = EventBus()
+    _register(bus, "sess-knobs", provenance_meta={"checkpoint": "m"})
+
+    # ParamsEcho carries the COALESCE backpressure policy (newest wins in a
+    # burst), so let the drainer consume the first primary before publishing
+    # more. The second primary then lands inside the 1 s rate-limit window
+    # and is dropped by the tap — exactly one primary record, deterministic.
+    bus.publish(ParamsEcho(raw={"denoise": 0.4, "playback_pos": 1.0},
+                           origin="primary"))
+    log_path = tmp_path / "provenance" / "sessions" / "sess-knobs.jsonl"
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        if log_path.is_file() and "action.param" in log_path.read_text():
+            break
+        time.sleep(0.02)
+    bus.publish(ParamsEcho(raw={"denoise": 0.9, "playback_pos": 2.0},
+                           origin="primary"))
+    bus.publish(ParamsEcho(raw={"denoise": 0.5}))  # external, verbatim
+    registry.unregister("sess-knobs")
+
+    lines = _read_log(tmp_path, "sess-knobs")
+    params = _by_type(lines, "action.param")
+    primary = [p for p in params if p["payload"].get("source") == "primary"]
+    assert len(primary) == 1, "diffed + rate-limited, not a firehose"
+    assert primary[0]["payload"]["changed"]["denoise"] == 0.4
+    # The playback clock is telemetry, never an authorship change.
+    assert "playback_pos" not in primary[0]["payload"]["changed"]
+    external = [p for p in params if "raw" in p["payload"]]
+    assert external and external[-1]["payload"]["raw"] == {"denoise": 0.5}
+
+
+def test_registry_hook_is_inert_without_bus(tmp_path, monkeypatch):
+    monkeypatch.setenv("ACESTEP_PROVENANCE_DIR", str(tmp_path / "provenance"))
+    handle = registry.SessionHandle(
+        id="sess-no-bus",
+        started_at=time.time(),
+        inject=lambda data, audio: None,
+        snapshot=lambda: {},
+    )
+    registry.register(handle)
+    registry.unregister("sess-no-bus")
+
+    assert get_tap("sess-no-bus") is None
+    assert not (tmp_path / "provenance" / "sessions").exists()
+
+
+# ---------------------------------------------------------------------------
+# Batched ledger client: wire shape, auth, contiguous seq, dev bootstrap
+# ---------------------------------------------------------------------------
+
+
+class _CapturingLedger:
+    """A throwaway HTTP server that captures ingestion requests and
+    answers with the action-log's plain ``{event_count}`` ack."""
+
+    def __init__(self):
+        self.requests: list[dict] = []
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *a):  # silence
+                pass
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(length) or b"{}")
+                outer.requests.append({
+                    "path": self.path,
+                    "auth": self.headers.get("Authorization"),
+                    "content_type": self.headers.get("Content-Type"),
+                    "body": body,
+                })
+                if self.path.endswith("/internal/v1/sessions"):
+                    # Broker bootstrap surface, used by the client's dev
+                    # broker emulation.
+                    resp = json.dumps({
+                        "pod_ledger_token": "dlt_pod_minted",
+                        "ledger_base_url": outer.base_url,
+                    }).encode("utf-8")
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(resp)))
+                    self.end_headers()
+                    self.wfile.write(resp)
+                    return
+                last_seq = body["events"][-1]["seq"]
+                resp = json.dumps({
+                    "event_count": last_seq + 1,
+                }).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(resp)))
+                self.end_headers()
+                self.wfile.write(resp)
+
+        self._server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(
+            target=self._server.serve_forever, daemon=True,
+        )
+        self._thread.start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/v1"
+
+    def close(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+
+def test_ledger_client_noop_without_url_or_token():
+    # No config at all → disabled, no thread, no crash.
+    c = LedgerClient(base_url="", session_id="s", token="")
+    assert not c.enabled
+    c.post_event("action.prompt", {"prompt": "x"})
+    c.close()
+    assert c._worker is None
+    # URL but no token is still a no-op (the pod token is mandatory).
+    c2 = LedgerClient(base_url="http://x/v1", session_id="s", token=None)
+    assert not c2.enabled
+
+
+def test_ledger_client_batches_events_with_auth_and_contiguous_seq():
+    server = _CapturingLedger()
+    try:
+        client = LedgerClient(
+            base_url=server.base_url, session_id="sess_9f2c", token="dlt_pod_abc",
+        )
+        assert client.enabled
+        client.post_event("session.config", {"model": "acestep-1.5"}, ts=1000)
+        client.post_event("action.prompt", {"prompt": "warm keys"}, ts=1001)
+        client.post_event(
+            "input.source",
+            {"sha256": "cd" * 32, "label": "initial_source"},
+            ts=1002,
+        )
+        client.close(timeout=5.0)
+    finally:
+        server.close()
+
+    assert len(server.requests) >= 1
+    req = server.requests[0]
+    # Path + auth shape.
+    assert req["path"] == "/v1/sessions/sess_9f2c/events"
+    assert req["auth"] == "Bearer dlt_pod_abc"
+    assert req["content_type"] == "application/json"
+    # Batched envelope with contiguous seq from 0.
+    events = req["body"]["events"]
+    assert [e["seq"] for e in events] == list(range(len(events)))
+    types = [e["type"] for e in events]
+    assert types[:2] == ["session.config", "action.prompt"]
+    # Every event uses integer epoch-ms ts.
+    assert all(isinstance(e["ts"], int) for e in events)
+    # The server ack was adopted.
+    assert client.acked_count == len(events)
+
+
+def test_ledger_client_dev_bootstrap_mints_pod_token(monkeypatch):
+    # No token delivered, but the internal secret is set: the worker mints
+    # the session itself (broker emulation) before its first flush.
+    server = _CapturingLedger()
+    try:
+        monkeypatch.delenv("DEMON_LEDGER_TOKEN", raising=False)
+        monkeypatch.setenv("DEMON_LEDGER_INTERNAL_SECRET", "int_sec_1")
+        monkeypatch.setenv("DEMON_LEDGER_USER_ID", "user_dev_1")
+        client = LedgerClient(base_url=server.base_url, session_id="sess_bs")
+        assert client.enabled, "the internal secret arms the client"
+        client.post_event("action.prompt", {"prompt": "warm keys"})
+        client.close(timeout=5.0)
+    finally:
+        server.close()
+
+    assert len(server.requests) == 2
+    mint = server.requests[0]
+    assert mint["path"] == "/internal/v1/sessions"
+    assert mint["auth"] == "Bearer int_sec_1"
+    assert mint["body"] == {"session_id": "sess_bs", "user_id": "user_dev_1"}
+    ingest = server.requests[1]
+    assert ingest["path"] == "/v1/sessions/sess_bs/events"
+    assert ingest["auth"] == "Bearer dlt_pod_minted", (
+        "events must be reported with the minted pod token"
+    )
+
+
+def test_ledger_client_dev_bootstrap_failure_is_fail_open(monkeypatch):
+    # Secret set but no server listening: the mint fails, reporting stays
+    # off, and nothing raises into the caller.
+    monkeypatch.delenv("DEMON_LEDGER_TOKEN", raising=False)
+    monkeypatch.setenv("DEMON_LEDGER_INTERNAL_SECRET", "int_sec_1")
+    client = LedgerClient(
+        base_url="http://127.0.0.1:1/v1", session_id="sess_bs_fail",
+    )
+    assert client.enabled
+    client.post_event("action.prompt", {"prompt": "x"})
+    client.close(timeout=5.0)
+    assert client.token == "", "a failed mint must not fabricate a token"
+    assert client.acked_count is None


### PR DESCRIPTION
## What

The **Level 1 "Log Actions"** cut of the provenance work ([design doc](https://app.notion.com/p/livepeer/Daydream-Provenance-3c30a34856878025b56fc1d04f69e116), per the team discussion to start light): record every user operation of a live session — actions, parameter changes, prompts, input-source hashes, models used — to a local JSONL log and, when configured, to the cloud action log.

This is the lightweight **alternative** to the full provenance branch (#305). Compared to it, this PR deliberately drops: audio slice hashing + canvas fingerprints, receipt verification, C2PA manifests on written WAVs, and local signing keys. The pod makes **no cryptographic claims** at this tier — the log answers "what happened in this session", not "prove this WAV came from it".

Pairs with livepeer/pipelines#2758 (the Level-1 ledger service). No rtmg-vst changes are needed at this tier — the log is entirely server-side.

## What ships

- **`acestep/provenance/session_log.py`** — event-bus tap writing the shared `{stream, seq, type, ts, payload}` envelope per session (`session.config` opener, `action.prompt` / `action.param` / `action.lora` / `action.seed_audio` / `action.transport`, `input.source`, `session.note` seal). Params are diffed + rate-limited so the ~125 Hz knob stream never floods the log. Input sources are recorded as `input.source` events: the buffer fingerprint of what was actually consumed (covers client uploads that never exist as pod files) plus, when a cached source file exists, its plain `sha256` (comparable to `shasum -a 256 <file>`). Decoded slices are counted, never hashed.
- **`acestep/provenance/ledger_client.py`** — batched fire-and-forget POST client for the pod event stream. Contiguous `seq` assigned at flush time, so best-effort queue drops never trip the server's gap check. Dev-only broker emulation (`DEMON_LEDGER_INTERNAL_SECRET`) mints the session via the internal endpoint for E2E testing; production pods receive the `dlt_pod_…` token from the broker.
- **`ParamsEcho.origin`** (`"external"` / `"primary"`): PRIMARY knob changes are now published on the bus for the provenance tap — the performer's moves are the authorship record — and never echoed back to the client (which would fight its own UI tween). Transports forward only external echoes; additive, default keeps today's behavior.
- **registry / ws_adapter wiring** — `SessionHandle` gains optional `bus` + `provenance_meta`; `register()`/`unregister()` attach/detach the tap. The adapter hands over the checkpoint, fixture name, and input fingerprints — never raw server filesystem paths.
- **Fix**: the first knob change of a session could be silently rate-limited away on platforms where `time.monotonic()` starts near zero (the window was compared against an initial `0.0`).

Everything is fail-open: provenance can never block session registration, the bus drainer, or the downlink.

## Tests

10 unit tests (pure Python, no GPU, no new deps): envelope schema + lifecycle, input-source recording, params diff + rate-limit, primary-echo handling, registry inertness without a bus, ledger client wire shape / auth / contiguous seq / dev bootstrap / fail-open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
