### PR TITLE
feat(sa3): run the sa3-small path locally on macOS (Apple Silicon / MPS)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,9 @@ Hard rules:
 - The demo's default `--accel tensorrt` requires built engines; the
   server preflight at boot prints the exact fix when they're missing.
   The no-engines fallback is `-- --accel compile`, not eager hacks.
+- **macOS (Apple Silicon) runs the SA3 small model only**, eager on
+  MPS (`--accel` defaults to eager there; skip `demon-setup`). Setup:
+  "Running on macOS" in [docs/INSTALL.md](docs/INSTALL.md).
 - Full walkthrough + troubleshooting table: [docs/INSTALL.md](docs/INSTALL.md).
 
 ## Where to go by task

--- a/acestep/engine/sa3_context.py
+++ b/acestep/engine/sa3_context.py
@@ -24,6 +24,7 @@ when it is absent.
 
 from __future__ import annotations
 
+import os
 from typing import Callable
 
 import torch
@@ -34,6 +35,32 @@ from acestep.engine.sa3_helpers import (
     import_stream_helpers,
     require_sa3_vendor,
 )
+
+
+def resolve_sa3_device() -> str:
+    """Best available torch device for the SA3 eager path: cuda > mps >
+    cpu, the same order upstream ``StableAudioModel.from_pretrained``
+    uses. ``DEMON_SA3_DEVICE`` overrides for debugging (e.g. forcing
+    ``cpu`` on an Apple Silicon machine to bisect an MPS kernel issue)."""
+    override = os.environ.get("DEMON_SA3_DEVICE", "").strip()
+    if override:
+        return override
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _resolve_model_half(device: str) -> bool:
+    """fp16 on CUDA, fp32 elsewhere — upstream forces fp32 off-CUDA
+    (``model.py`` sets ``model_half = False`` without CUDA), and MPS
+    fp16 is unproven for this stack. ``DEMON_SA3_HALF=1|0`` overrides
+    to experiment (e.g. fp16 on MPS for the ~2x memory/throughput win)."""
+    override = os.environ.get("DEMON_SA3_HALF", "").strip()
+    if override:
+        return override not in ("0", "false", "no")
+    return device == "cuda"
 
 # Models whose SAME decoder is too slow to full-decode per render tick
 # (SAME-L: ~80 ms eager full at 60 s) and therefore use the windowed
@@ -49,16 +76,24 @@ class SA3Context:
         self,
         model_id: str = "small-music",
         *,
-        device: str = "cuda",
-        model_half: bool = True,
+        device: str | None = None,
+        model_half: bool | None = None,
     ):
         require_sa3_vendor()
         loader = import_loader_helpers()
         self._helpers = import_stream_helpers()
 
+        if device is None:
+            device = resolve_sa3_device()
+        if model_half is None:
+            model_half = _resolve_model_half(device)
+
         self.model_id = model_id
         ckpt = loader.checkpoint_dir(model_id)
-        logger.info("sa3_model_load_start model_id={} dir={}", model_id, ckpt)
+        logger.info(
+            "sa3_model_load_start model_id={} dir={} device={} model_half={}",
+            model_id, ckpt, device, model_half,
+        )
         self.sam = loader.load_local_model(ckpt, device=device, model_half=model_half)
         self.device = torch.device(self.sam.device)
         self.dtype = next(self.sam.model.model.parameters()).dtype

--- a/acestep/engine/sa3_context.py
+++ b/acestep/engine/sa3_context.py
@@ -24,7 +24,9 @@ when it is absent.
 
 from __future__ import annotations
 
+import contextlib
 import os
+import threading
 from typing import Callable
 
 import torch
@@ -50,6 +52,27 @@ def resolve_sa3_device() -> str:
     if torch.backends.mps.is_available():
         return "mps"
     return "cpu"
+
+
+def make_device_lock(device) -> "contextlib.AbstractContextManager":
+    """Serializer for GPU submissions from more than one thread.
+
+    PyTorch's **MPS** backend drives a single shared Metal command
+    queue that is NOT thread-safe: two threads encoding at once abort
+    the whole process inside Metal ("failed assertion
+    `_status < MTLCommandBufferStatusCommitted`" /
+    "Scheduled handler provided after commit call"). DEMON hits this
+    because conditioning runs on the COMMAND thread (``set_prompt``
+    -> T5Gemma) while the runner thread is mid-DiT.
+
+    CUDA is thread-safe (per-thread default streams), so there the
+    lock is a no-op context manager and the fleet path is untouched.
+    Reentrant so a wrapped entry point may nest inside another on the
+    same thread without deadlocking.
+    """
+    if torch.device(device).type == "cuda":
+        return contextlib.nullcontext()
+    return threading.RLock()
 
 
 def _resolve_model_half(device: str) -> bool:
@@ -103,6 +126,10 @@ class SA3Context:
         )
         self.sam = loader.load_local_model(ckpt, device=device, model_half=model_half)
         self.device = torch.device(self.sam.device)
+        #: Held across every GPU submission that can race another
+        #: thread — see :func:`make_device_lock`. Threaded into the
+        #: backend by ``SA3Backend.from_context``.
+        self.device_lock = make_device_lock(self.device)
         self.dtype = next(self.sam.model.model.parameters()).dtype
         self.sample_rate = int(self.sam.model.sample_rate)          # 44100
         self.downsampling_ratio = int(

--- a/acestep/engine/sa3_context.py
+++ b/acestep/engine/sa3_context.py
@@ -68,6 +68,13 @@ def _resolve_model_half(device: str) -> bool:
 # would only add seam surface there.
 WINDOWED_DECODE_MODELS = {"medium"}
 
+# Session-geometry ceilings applied on non-CUDA devices (MPS / CPU),
+# where the eager path runs ~20-50x slower than the fleet GPUs. See
+# clamp_duration_for_device / max_depth_for_device for the measured
+# numbers behind these values; both have env overrides.
+NONCUDA_MAX_DURATION_S = 24.0
+NONCUDA_MAX_DEPTH = 1
+
 
 class SA3Context:
     """Loaded SA3 model + family-private operations. See module docstring."""
@@ -197,6 +204,44 @@ class SA3Context:
             self.model_id, duration_s, cap,
         )
         return cap
+
+    def clamp_duration_for_device(self, duration_s: float) -> float:
+        """Cap the diffusion window on non-CUDA devices so ticks stay
+        interactive. The eager DiT tick scales linearly with the latent
+        window; measured on an M1 Pro (fp32/MPS, depth 1): 57.6 s window
+        = 416 ms/tick + 1.05 s per full decode (a fresh generation lands
+        every ~14 s — the playhead outruns it and the client keeps
+        playing the raw source), 24 s = 227 ms/tick + 0.6 s decode
+        (~2.5 s knob-to-new-audio at 8 steps). No-op on CUDA.
+        ``DEMON_SA3_MAX_DURATION_S`` overrides; 0 disables the cap."""
+        if self.device.type == "cuda":
+            return duration_s
+        cap = float(
+            os.environ.get("DEMON_SA3_MAX_DURATION_S", "")
+            or NONCUDA_MAX_DURATION_S
+        )
+        if cap <= 0 or duration_s <= cap:
+            return duration_s
+        logger.warning(
+            "sa3_duration_clamped_for_device device={} requested_s={:.1f} "
+            "cap_s={:.1f} (override: DEMON_SA3_MAX_DURATION_S)",
+            self.device.type, duration_s, cap,
+        )
+        return cap
+
+    def max_depth_for_device(self) -> int | None:
+        """Pipeline-depth ceiling for this device, or None for no extra
+        cap (CUDA). On a saturated MPS/CPU device the batched tick cost
+        is LINEAR in depth (measured M1 Pro: depth 4 = 4.2x depth 1 at
+        57.6 s), so extra slots buy no throughput and multiply the
+        knob-to-audio latency — depth 1 is strictly better there.
+        ``DEMON_SA3_MAX_DEPTH`` overrides."""
+        if self.device.type == "cuda":
+            return None
+        return max(1, int(
+            os.environ.get("DEMON_SA3_MAX_DEPTH", "")
+            or NONCUDA_MAX_DEPTH
+        ))
 
     # ---- per-prompt (outside the hot loop) ---------------------------------
 

--- a/acestep/streaming/diffusion_backend.py
+++ b/acestep/streaming/diffusion_backend.py
@@ -151,6 +151,8 @@ class DiffusionBackend:
 
         if torch.cuda.is_available():
             torch.cuda.synchronize()
+        elif torch.backends.mps.is_available():
+            torch.mps.synchronize()
         t0 = time.perf_counter()
 
         if mode == "reuse":
@@ -167,6 +169,8 @@ class DiffusionBackend:
 
         if torch.cuda.is_available():
             torch.cuda.synchronize()
+        elif torch.backends.mps.is_available():
+            torch.mps.synchronize()
         self.last_tick_ms = (time.perf_counter() - t0) * 1000
         self.last_dec_ms = 0.0
 

--- a/acestep/streaming/sa3_backend.py
+++ b/acestep/streaming/sa3_backend.py
@@ -1160,6 +1160,8 @@ class SA3Backend(DiffusionBackend):
         )
         if torch.cuda.is_available():
             torch.cuda.synchronize()
+        elif torch.backends.mps.is_available():
+            torch.mps.synchronize()
         self.last_dec_ms += (time.perf_counter() - t0) * 1000
         self._rendered_48k = audio_48.clamp(-1, 1).cpu().numpy().T  # [N, C]
         self._rendered_for = latent_btc
@@ -1214,6 +1216,8 @@ class SA3Backend(DiffusionBackend):
         )
         if torch.cuda.is_available():
             torch.cuda.synchronize()
+        elif torch.backends.mps.is_available():
+            torch.mps.synchronize()
         self.last_dec_ms += (time.perf_counter() - t0) * 1000
 
         lead48 = (lead44 * DELIVERY_SAMPLE_RATE) // SA3_SAMPLE_RATE

--- a/acestep/streaming/sa3_backend.py
+++ b/acestep/streaming/sa3_backend.py
@@ -53,6 +53,7 @@ plan Phase 5).
 
 from __future__ import annotations
 
+import contextlib
 import threading
 import time
 from collections import deque
@@ -238,8 +239,18 @@ class SA3Backend(DiffusionBackend):
         # knob-driven strength changes route through the pending stash
         # (D6b.5) so the refit stall is always announced.
         refit_mirror=None,
+        # Serializes GPU submissions between the runner thread (tick /
+        # render) and the command thread (prompt swap / blend / source
+        # re-anchor). Required on MPS, whose single Metal command queue
+        # aborts the process when two threads encode at once; a no-op
+        # nullcontext on CUDA. Supplied by :meth:`from_context`; a
+        # directly-constructed test backend defaults to no-op.
+        device_lock=None,
     ):
         super().__init__(adapter=adapter, codec=codec)
+        self._device_lock = (
+            device_lock if device_lock is not None else contextlib.nullcontext()
+        )
         self._cond = cond
         self._cond_b = cond_b if cond_b is not None else cond
         # Live A↔B crossfade value and the bundle the next submit
@@ -498,6 +509,7 @@ class SA3Backend(DiffusionBackend):
             eager_dit=context.dit,
             model_id=str(context.model_id),
             refit_mirror=refit_mirror,
+            device_lock=getattr(context, "device_lock", None),
             **kwargs,
         )
 
@@ -774,6 +786,17 @@ class SA3Backend(DiffusionBackend):
     # ---- control (universal): per-prompt re-conditioning ------------------------
 
     def handle_set_prompt(self, tags: str, *, tags_b: Optional[str] = None) -> None:
+        # Device lock OUTSIDE _control_lock (the invariant every
+        # wrapped entry point keeps, so the two locks can never be
+        # taken in opposite orders): the T5Gemma capture below runs on
+        # the command thread and would otherwise encode Metal work
+        # concurrently with the runner's DiT.
+        with self._device_lock:
+            self._handle_set_prompt_locked(tags, tags_b=tags_b)
+
+    def _handle_set_prompt_locked(
+        self, tags: str, *, tags_b: Optional[str] = None,
+    ) -> None:
         """Re-run ``prepare_cond`` for ``tags`` (and ``tags_b`` when it
         differs) and swap the conditioning captures (the session's
         backend control hook — plan §2: prompt is the universal
@@ -847,6 +870,13 @@ class SA3Backend(DiffusionBackend):
         )
 
     def handle_swap_source(self, waveform, sample_rate) -> None:
+        # Runner-thread dispatched today (via _apply_swap_if_pending),
+        # so this is defense in depth — the SAME-encode is GPU work and
+        # must serialize if the dispatch ever moves off that thread.
+        with self._device_lock:
+            self._handle_swap_source_locked(waveform, sample_rate)
+
+    def _handle_swap_source_locked(self, waveform, sample_rate) -> None:
         """Re-anchor the session on a new source (the session's
         backend-owned ``swap_source`` hook, dispatched from
         ``_apply_swap_if_pending`` on the runner thread). SAME-encodes
@@ -887,6 +917,13 @@ class SA3Backend(DiffusionBackend):
         )
 
     def handle_set_prompt_blend(self, value: float) -> None:
+        # Device lock OUTSIDE _control_lock: the per-token slerp below
+        # is real tensor math on the command thread (see
+        # :func:`~acestep.engine.sa3_context.make_device_lock`).
+        with self._device_lock:
+            self._handle_set_prompt_blend_locked(value)
+
+    def _handle_set_prompt_blend_locked(self, value: float) -> None:
         """Crossfade the live conditioning between the A and B captures
         (the session's ``set_prompt_blend`` backend hook). Per-token
         slerp of the T5Gemma cross-attn conditioning — cheap tensor
@@ -1140,6 +1177,17 @@ class SA3Backend(DiffusionBackend):
                 p["gen_sa3_denoise"], epoch, tags,
             )
 
+    # ---- runner-thread GPU entry points ----------------------------------------
+
+    def produce(self, knobs: dict, ctx, mode) -> bool:
+        """The runner's tick. Held under the device lock so a prompt
+        swap / blend arriving on the command thread waits for the DiT
+        rather than encoding Metal work beside it (the lock is a no-op
+        on CUDA — see
+        :func:`~acestep.engine.sa3_context.make_device_lock`)."""
+        with self._device_lock:
+            return super().produce(knobs, ctx, mode)
+
     # ---- rendering -------------------------------------------------------------
 
     def _rendered_audio(self, latent_btc: torch.Tensor):
@@ -1168,6 +1216,12 @@ class SA3Backend(DiffusionBackend):
         return self._rendered_48k
 
     def render_window(self, t_start_s: float):
+        # Decode is GPU work on the runner thread; same serialization
+        # requirement as produce().
+        with self._device_lock:
+            return self._render_window_locked(t_start_s)
+
+    def _render_window_locked(self, t_start_s: float):
         decode_src = (
             self._current_result if self._current_result is not None
             else self._last_result_latent
@@ -1228,11 +1282,12 @@ class SA3Backend(DiffusionBackend):
         return AudioChunk(pcm=pcm, start_sample=start48)
 
     def render_full(self):
-        if self._current_result is None:
-            return None
-        return AudioChunk(
-            pcm=self._rendered_audio(self._current_result), start_sample=0,
-        )
+        with self._device_lock:
+            if self._current_result is None:
+                return None
+            return AudioChunk(
+                pcm=self._rendered_audio(self._current_result), start_sample=0,
+            )
 
     # ---- teardown ----------------------------------------------------------------
 

--- a/acestep/streaming/sa3_session.py
+++ b/acestep/streaming/sa3_session.py
@@ -145,12 +145,25 @@ def create_sa3_session(
     # a duration whose padded latent window exceeds every engine
     # profile would silently fall back to the ~5x-slower eager DiT.
     duration_s = context.clamp_duration_for_trt(duration_s, backend=dit_backend)
+    # On MPS/CPU, additionally cap the window so eager ticks stay
+    # interactive (see SA3Context.clamp_duration_for_device).
+    duration_s = context.clamp_duration_for_device(duration_s)
     waveform = waveform[:, : int(duration_s * SAMPLE_RATE)]
 
     prompt = config.prompt
     prompt_b = config.prompt_b if config.prompt_b not in (None, "") else prompt
     steps = int(config.steps)
     depth = max(1, min(int(config.depth), SA3_MAX_PIPELINE_DEPTH))
+    # Non-CUDA: batched tick cost is linear in depth, so extra slots
+    # only multiply knob-to-audio latency (SA3Context.max_depth_for_device).
+    device_depth_cap = context.max_depth_for_device()
+    if device_depth_cap is not None and depth > device_depth_cap:
+        logger.warning(
+            "sa3_depth_clamped_for_device device={} requested={} cap={} "
+            "(override: DEMON_SA3_MAX_DEPTH)",
+            context.device.type, depth, device_depth_cap,
+        )
+        depth = device_depth_cap
 
     logger.info(
         "sa3_session_create model_id={} duration_s={:.1f} "

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -743,6 +743,12 @@ def main():
     if "--accel" in args:
         idx = args.index("--accel")
         accel = args[idx + 1]
+    elif sys.platform == "darwin":
+        # No TensorRT on macOS: default to the eager path (SA3 runs it on
+        # MPS) instead of exiting at the engine preflight. An explicit
+        # --accel still wins.
+        accel = "eager"
+        print("[Server] macOS: defaulting --accel to eager (no TensorRT)")
     _VALID_ACCEL = ("tensorrt", "compile", "eager")
     if accel not in _VALID_ACCEL:
         raise SystemExit(

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -14,7 +14,7 @@ to fix the failures you might hit along the way.
 | [uv](https://docs.astral.sh/uv/) | Manages Python 3.11 and all dependencies; you do not need a system Python. |
 | Node.js 20+ | Only for the bundled web demo. [nodejs.org](https://nodejs.org). |
 | Disk | ~40 GB free: ~18 GB checkpoints, ~10 GB ONNX + engines, headroom. |
-| OS | Windows 11 and Linux are exercised regularly. |
+| OS | Windows 11 and Linux are exercised regularly. macOS (Apple Silicon) runs the SA3 small model on the eager/MPS path — see [Running on macOS](#running-on-macos-apple-silicon). |
 
 ## The quick path
 
@@ -43,6 +43,51 @@ uv run python -u -m demos.realtime_motion_graph_web.run -- --checkpoint sa3-medi
 
 The `/sa3/` UI sends `backend: "sa3"`, but it does not switch the
 server's loaded model after boot.
+
+## Running on macOS (Apple Silicon)
+
+DEMON's **SA3 small-music** path runs locally on Apple Silicon — no
+NVIDIA GPU, no TensorRT. The DiT + SAME codec + T5Gemma conditioner run
+eager on PyTorch **MPS** in fp32 (measured on an M1 Pro / 32 GB: model
+load ~10 s warm, ~275 ms per DiT tick and ~300 ms per full decode for a
+10 s window at 8 steps; the reference generator does 10 s of audio in
+~7.6 s end-to-end). ACE-Step checkpoints and `sa3-medium` are NOT
+supported on macOS — the ACE stack and the SAME-L windowed decoder are
+CUDA-sized; only `sa3-small` is practical.
+
+Setup (no `demon-setup` — that flow is CUDA/TensorRT-shaped):
+
+```bash
+uv sync                      # resolves the macOS (MPS) torch build automatically
+# SA3 weights are a manual, license-gated download (~3.5 GB):
+huggingface-cli download stabilityai/stable-audio-3-small-music \
+  --local-dir ~/.daydream-scope/models/demon/sa3/checkpoints/stable-audio-3-small-music
+```
+
+The pinned Stable Audio 3 source checkout is fetched automatically on
+first model load (or run `uv run python scripts/sa3/vendor_sa3.py`).
+
+Launch (on macOS `--accel` defaults to `eager`, so no extra flags):
+
+```bash
+uv run python -u -m demos.realtime_motion_graph_web.run -- --checkpoint sa3-small
+# open http://localhost:6660/sa3/  (or http://localhost:1318/sa3/)
+```
+
+Practical notes:
+
+- Keep sessions short (`duration` ≤ ~30 s) and pipeline depth low
+  (1–2): the eager DiT tick scales with the latent window, and an M1
+  is ~20-50x slower than the 5090 the defaults were tuned on.
+- Device/precision overrides for debugging: `DEMON_SA3_DEVICE=cpu|mps`
+  and `DEMON_SA3_HALF=1` (fp16 on MPS is unproven upstream; fp32 is
+  the default off-CUDA, matching the upstream loader).
+- Smoke test without the server:
+  `uv run python scripts/sa3/sa3_reference_generate.py --duration 10`
+  (auto-selects MPS, writes a wav under the models dir).
+- The VST / DreamSampler connects to a local Mac backend exactly like
+  a pod: put `ws://localhost:1318` in the SERVER box, pick the SOLO
+  INSTRUMENT (sa3) workflow, press CONNECT.
 
 ### What `demon-setup` does
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -76,9 +76,12 @@ uv run python -u -m demos.realtime_motion_graph_web.run -- --checkpoint sa3-smal
 
 Practical notes:
 
-- Keep sessions short (`duration` ≤ ~30 s) and pipeline depth low
-  (1–2): the eager DiT tick scales with the latent window, and an M1
-  is ~20-50x slower than the 5090 the defaults were tuned on.
+- Session geometry is auto-capped off-CUDA: the diffusion window
+  clamps to 24 s (`DEMON_SA3_MAX_DURATION_S`, 0 disables) and pipeline
+  depth to 1 (`DEMON_SA3_MAX_DEPTH`). Measured on an M1 Pro, the eager
+  tick is linear in both, so the fleet defaults (60 s+, depth 4-8)
+  make generation lag the playhead by design — the caps keep
+  knob-to-new-audio at ~2.5 s (8 steps; fewer steps respond faster).
 - Device/precision overrides for debugging: `DEMON_SA3_DEVICE=cpu|mps`
   and `DEMON_SA3_HALF=1` (fp16 on MPS is unproven upstream; fp32 is
   the default off-CUDA, matching the upstream loader).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,15 @@ maintainers = [
     {name = "Daydream Live"}
 ]
 dependencies = [
-    # PyTorch with CUDA 12.8 - pinned to match ComfyUI
-    "torch==2.9.1+cu128",
-    "torchvision==0.24.1+cu128",
-    "torchaudio==2.9.1+cu128",
+    # PyTorch with CUDA 12.8 - pinned to match ComfyUI.
+    # macOS (Apple Silicon) has no CUDA builds: same versions from PyPI,
+    # which ship the MPS backend used by the SA3 eager path.
+    "torch==2.9.1+cu128; sys_platform != 'darwin'",
+    "torchvision==0.24.1+cu128; sys_platform != 'darwin'",
+    "torchaudio==2.9.1+cu128; sys_platform != 'darwin'",
+    "torch==2.9.1; sys_platform == 'darwin'",
+    "torchvision==0.24.1; sys_platform == 'darwin'",
+    "torchaudio==2.9.1; sys_platform == 'darwin'",
     # Common dependencies
     "transformers>=4.51.0,<4.58.0",
     "diffusers",
@@ -52,14 +57,16 @@ dependencies = [
     # ran for months before this was pinned at all. Unpinned, a venv rebuild
     # resolves to newest and breaks inference; pinned too low it breaks
     # training. Change either bound only with both paths retested.
-    "torchao==0.17.0",
+    # Skipped on macOS: no arm64 wheels for this pin, and diffusers only
+    # imports torchao when it is installed — absence is the safe state.
+    "torchao==0.17.0; sys_platform != 'darwin'",
     # Training dependencies
     "peft>=0.7.0",
     "lightning>=2.0.0",
     "tensorboard>=2.0.0",
     # Attention / inference dependencies
     "triton-windows>=3.0.0,<3.4; sys_platform == 'win32'",
-    "triton>=3.0.0; sys_platform != 'win32'",
+    "triton>=3.0.0; sys_platform == 'linux'",
     "flash-attn @ https://github.com/kingbri1/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu128torch2.9.0cxx11abiFALSE-cp311-cp311-win_amd64.whl ; sys_platform == 'win32' and python_version == '3.11' and platform_machine == 'AMD64'",
     "flash-attn @ https://github.com/kingbri1/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu128torch2.9.0cxx11abiFALSE-cp311-cp311-linux_x86_64.whl ; sys_platform == 'linux' and python_version == '3.11' and platform_machine == 'x86_64'",
     "websockets>=13.0",
@@ -78,10 +85,14 @@ dependencies = [
     ###
     ###
     ### 10.16
+    # TensorRT stack is CUDA-only; on macOS the SA3/ACE eager paths run
+    # without it (all acestep imports of tensorrt/polygraphy are lazy).
+    # onnx stays everywhere: portable wheels, and the onnx-staleness unit
+    # tests import it.
     "onnx>=1.20,<1.22",
-    "tensorrt>=10.16,<10.17",
-    "polygraphy>=0.49.26",
-    "cuda-python>=13.2,<13.3",
+    "tensorrt>=10.16,<10.17; sys_platform != 'darwin'",
+    "polygraphy>=0.49.26; sys_platform != 'darwin'",
+    "cuda-python>=13.2,<13.3; sys_platform != 'darwin'",
     ###
     ###
     "modelscope",
@@ -106,12 +117,53 @@ name = "pypi"
 url = "https://pypi.org/simple"
 
 [tool.uv.sources]
-torch = { index = "pytorch-cu128" }
-torchvision = { index = "pytorch-cu128" }
-torchaudio = { index = "pytorch-cu128" }
+# The CUDA index only applies off-macOS; darwin resolves the plain
+# (MPS-enabled) builds from PyPI.
+torch = [
+    { index = "pytorch-cu128", marker = "sys_platform != 'darwin'" },
+    { index = "pypi", marker = "sys_platform == 'darwin'" },
+]
+torchvision = [
+    { index = "pytorch-cu128", marker = "sys_platform != 'darwin'" },
+    { index = "pypi", marker = "sys_platform == 'darwin'" },
+]
+torchaudio = [
+    { index = "pytorch-cu128", marker = "sys_platform != 'darwin'" },
+    { index = "pypi", marker = "sys_platform == 'darwin'" },
+]
 torchao = { index = "pypi" }
 torchcodec = { index = "pypi" }
 tensorrt = { index = "pypi" }
+
+# The tensorrt PyPI packages are wheel_stub sdists whose build downloads
+# the real wheel from pypi.nvidia.com — a build that FAILS on machines
+# without NVIDIA drivers (e.g. macOS), yet uv's universal resolution must
+# build it just to read its metadata even though the darwin install never
+# uses it. Declaring the (verified, from PyPI) metadata statically lets
+# resolution skip those sdist builds everywhere; actual installs on
+# CUDA machines still build/download the real wheels as before.
+[[tool.uv.dependency-metadata]]
+name = "tensorrt"
+version = "10.16.1.11"
+requires-dist = ["tensorrt_cu13==10.16.1.11"]
+
+[[tool.uv.dependency-metadata]]
+name = "tensorrt-cu13"
+version = "10.16.1.11"
+requires-dist = [
+    "tensorrt_cu13_libs==10.16.1.11",
+    "tensorrt_cu13_bindings==10.16.1.11",
+]
+
+[[tool.uv.dependency-metadata]]
+name = "tensorrt-cu13-libs"
+version = "10.16.1.11"
+requires-dist = []
+
+[[tool.uv.dependency-metadata]]
+name = "tensorrt-cu13-bindings"
+version = "10.16.1.11"
+requires-dist = []
 
 [project.scripts]
 acestep-download = "acestep.model_downloader:main"

--- a/scripts/sa3/sa3_reference_generate.py
+++ b/scripts/sa3/sa3_reference_generate.py
@@ -124,7 +124,7 @@ def main() -> int:
     ap.add_argument("--steps", type=int, default=8)
     ap.add_argument("--seed", type=int, default=42)
     ap.add_argument("--cfg-scale", type=float, default=1.0)
-    ap.add_argument("--device", default=None, help="cuda|cpu (auto if omitted)")
+    ap.add_argument("--device", default=None, help="cuda|mps|cpu (auto if omitted)")
     ap.add_argument(
         "--out",
         default=None,
@@ -143,7 +143,11 @@ def main() -> int:
         os.environ["HF_HUB_OFFLINE"] = "1"
         os.environ["TRANSFORMERS_OFFLINE"] = "1"
 
-    device = args.device or ("cuda" if torch.cuda.is_available() else "cpu")
+    device = args.device or (
+        "cuda" if torch.cuda.is_available()
+        else "mps" if torch.backends.mps.is_available()
+        else "cpu"
+    )
     model_half = device == "cuda"
 
     dest = checkpoint_dir()


### PR DESCRIPTION
## What

Makes DEMON's **SA3 small-music** path run locally on Apple Silicon — no NVIDIA GPU, no TensorRT — and makes it hold up under real interactive use. Verified end-to-end on an M1 Pro / 32 GB, driving it from both the `/sa3/` web UI and DreamSampler.

Three commits, each independently reviewable.

### 1. `feat` — run sa3-small on macOS (MPS)

The DiT + SAME codec + T5Gemma conditioner run eager on PyTorch MPS in fp32, matching upstream's own off-CUDA behavior (`StableAudioModel.from_pretrained` picks cuda → mps → cpu and forces fp32 off-CUDA; small models need no flash-attn thanks to the SDPA fallback cascade).

- **`pyproject.toml`** — platform markers: plain MPS-enabled torch 2.9.1 from PyPI on darwin (CUDA index unchanged elsewhere); TensorRT stack, triton, torchao gated off darwin. Static `[[tool.uv.dependency-metadata]]` for the tensorrt wheel-stub chain so uv's universal resolution stops building NVIDIA's sdist (which fails on any machine without drivers); CUDA installs still fetch the real wheels.
- **`SA3Context`** — `device`/`model_half` auto-resolve (cuda > mps > cpu; fp16 only on CUDA), with `DEMON_SA3_DEVICE` / `DEMON_SA3_HALF` overrides.
- **`server.py`** — `--accel` defaults to `eager` on darwin instead of exiting at the TensorRT preflight.
- Docs: "Running on macOS (Apple Silicon)" in INSTALL.md. Scope is deliberate: **sa3-small only** — ACE checkpoints and sa3-medium stay CUDA.

### 2. `perf` — cap session geometry off-CUDA

The eager tick is linear in both window length and pipeline depth. Measured on an M1 Pro (fp32): 57.6 s window × depth 4 = **1.74 s/tick + 1.05 s/decode**, so a fresh generation landed only every ~14 s — the playhead outran generation and the client just kept playing the raw source. Batching buys nothing on a saturated device, so extra depth only multiplies knob-to-audio latency.

Window now clamps to 24 s and depth to 1 off-CUDA (`DEMON_SA3_MAX_DURATION_S` / `DEMON_SA3_MAX_DEPTH`; CUDA untouched). Verified headless against the 60 s fixture at requested depth 4: tick drops to **231 ms**, and the stream holds positive slice lead with zero stale ticks.

fp16 was benchmarked and rejected: ≤10% faster on MPS for these shapes (velocity cos 0.99999 vs fp32) — not worth the dtype seams.

### 3. `fix` — serialize GPU submissions on MPS (process abort)

PyTorch's MPS backend drives a single shared Metal command queue that is **not thread-safe**. DEMON runs conditioning on the COMMAND thread (`set_prompt` → T5Gemma; `set_prompt_blend` → per-token slerp) while the runner thread is mid-DiT, so the two encode concurrently and Metal aborts the process:

```
failed assertion `_status < MTLCommandBufferStatusCommitted'
    in -[IOGPUMetalCommandBuffer setCurrentCommandEncoder:]
-[_MTLCommandBuffer addScheduledHandler:] Scheduled handler provided after commit call
```

This killed live VST sessions after ~1 minute of normal knob/prompt use. Reproduced deterministically: a headless session aborted after **7 prompt swaps**.

`SA3Context` now owns a device lock (`make_device_lock`: an `RLock` off-CUDA, `nullcontext` on CUDA so the fleet path is untouched), threaded into `SA3Backend` by `from_context`. Every GPU-submitting entry point holds it: `produce` / `render_window` / `render_full` (runner thread) and `handle_set_prompt` / `handle_set_prompt_blend` / `handle_swap_source` (command thread). Always taken **outside** `_control_lock`, so the two can't be acquired in opposite orders.

After the fix the same repro survives **40 prompt swaps**, and a combined stress (30 swaps + ~200 interleaved blends) runs clean. Cost is bounded by one tick (~230 ms): a prompt swap waits for the in-flight DiT instead of racing it.

## Verification

- `uv sync` resolves and installs clean on macOS; Linux/Windows resolution unchanged.
- `scripts/sa3/sa3_reference_generate.py`: 10 s of audio in 7.6 s, healthy spectrum, no NaNs.
- `/sa3/` web UI: live session, knob-drag re-generation.
- **DreamSampler** direct-connected via `ws://localhost:1318`: a ~4-minute interactive session produced **170 generations** and disconnected cleanly, with no Metal assertions. No rtmg-vst changes were needed — the `ws://` SERVER-box direct connect already exists.
- `tests/unit`: 556 passed, 4 skipped (the `test_lora_facade_session` failure pre-exists on main).

## Known, not addressed here

Two findings from the M1 logs, both out of scope for this PR:

1. **Slice backpressure on SA3.** The flow-control window is 256 KB (tuned for ACE's 0.36 s / ~35 KB slices), but an SA3 slice is a 3 s float16 window — roughly 280–300 KB compressed — so a single slice exceeds the window and the next is shed until an ack returns (~106 sheds in the session above, even on localhost). Shed slices are redundant re-renders, so no audio is lost, but the delivery is chunkier than it needs to be.
2. **`user_lora_unregister_failed` at SA3 session teardown.** `_drop_fetched_loras` calls `self.engine_obj.remove_lora()`, but SA3 sessions construct with `engine_obj=None` (their catalog lives on `SA3LoRAManager`). Pre-existing on main and not macOS-specific — it fires on the fleet too for any SA3 session with user LoRAs. The next line still unlinks the file, so user LoRAs re-download every session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
