### PR TITLE
feat(plugins): out-of-tree model extensions for the sa3 family

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -281,3 +281,7 @@ PortableGit/
 # golden-harness scratch (bundles live on the HF dataset, see tests/golden)
 runs/
 refs-out/
+
+# ad-hoc script/benchmark output (audio is covered by the media rules above,
+# but the JSON/log siblings were not)
+out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Hard rules:
 | Drive a live session from an agent (no browser) | The MCP server (`demos/realtime_motion_graph_web/mcp_server.py`): `describe_protocol` / `list_knobs` return the same manifests the HTTP API serves; `set_knob(s)` / `set_prompt` / `swap_to_fixture` / etc. control a running session. |
 | Reproduce frontend/realtime bugs headlessly (e.g. generation lagging the playhead) | `headless_start` on the same MCP server spawns a full PRIMARY client (`demos/realtime_motion_graph_web/headless_client.py`) with a simulated audio clock — no browser needed. `headless_lag_report` (and the snapshot in `headless_status`) measure slice lead vs the playhead and audio staleness. Preempts any live browser session (one session per pod). |
 | Engine / pipeline / nodes work | [README.md](./README.md) — Session API (`acestep/engine/session.py`), StreamPipeline (`acestep/engine/stream.py`), typed node graph (`acestep/nodes/`). |
+| Extend DEMON from an out-of-tree package | [`docs/PLUGINS.md`](docs/PLUGINS.md) — the `acestep.plugins` Tier-1 API: entry-point discovery, model-extension lifecycle, namespaced knobs, and the operator flags (`--model-extension`). Extensions that must reach model internals use the Tier-2 `acestep/engine/sa3_internals.py` contract, never the vendored package directly. |
 
 ## Repo-wide rules
 
@@ -52,7 +53,12 @@ Hard rules:
   (WS commands/events/config, served at `GET /api/protocol`). Never
   hand-declare a knob, command shape, or enum option list anywhere else
   — clients build from the manifests, and adding a control is an edit to
-  exactly one registry.
+  exactly one registry. Out-of-tree plugins contribute knobs through the
+  same machinery (`KnobSpec` → the backend's `knob_specs()` → the session
+  manifest), namespaced and validated at registration; see
+  [`docs/PLUGINS.md`](docs/PLUGINS.md). Note that `GET /api/knobs` is the
+  static pre-session catalog — the live truth is the per-session
+  `knob_manifest` on the WS `ready` frame.
 - **After any registry change, regenerate the TS types:**
   `python demos/realtime_motion_graph_web/scripts/gen_wire_types.py`
   (output: `packages/demon-client/types/wireContract.gen.ts`). A stale

--- a/acestep/engine/sa3_context.py
+++ b/acestep/engine/sa3_context.py
@@ -24,6 +24,7 @@ when it is absent.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Callable
 
 import torch
@@ -42,6 +43,22 @@ from acestep.engine.sa3_helpers import (
 WINDOWED_DECODE_MODELS = {"medium"}
 
 
+def _read_model_config(checkpoint_dir: Path) -> dict:
+    """The checkpoint's ``model_config.json``, or ``{}`` if unreadable.
+
+    Read before the weights so an extension can be offered a veto cheaply.
+    A missing/!malformed config is not fatal on its own — the loader gives
+    a better error than a JSON traceback would.
+    """
+    import json
+
+    path = Path(checkpoint_dir) / "model_config.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
 class SA3Context:
     """Loaded SA3 model + family-private operations. See module docstring."""
 
@@ -51,13 +68,53 @@ class SA3Context:
         *,
         device: str = "cuda",
         model_half: bool = True,
+        checkpoint_dir: str | Path | None = None,
+        extension=None,
     ):
+        """``checkpoint_dir`` overrides the catalog location for
+        ``model_id`` with an operator-supplied directory in the same
+        layout (``model_config.json`` + ``model.safetensors``). It exists
+        so a non-catalog SA3 checkpoint can be evaluated without being
+        installed into the managed models tree; ``model_id`` still selects
+        the family behaviors (decode geometry, engine lookup).
+
+        ``extension`` is an optional
+        :class:`~acestep.plugins.selection.SelectedExtension` the operator
+        chose at startup. It is offered a veto BEFORE the weights load,
+        and installed onto the model AFTER they do. Installation failure
+        is fatal: the operator asked for this extension, so running the
+        stock trunk instead would silently generate with a different model
+        than the one requested."""
         require_sa3_vendor()
         loader = import_loader_helpers()
         self._helpers = import_stream_helpers()
 
         self.model_id = model_id
-        ckpt = loader.checkpoint_dir(model_id)
+        ckpt = (
+            Path(checkpoint_dir).expanduser().resolve()
+            if checkpoint_dir is not None
+            else loader.checkpoint_dir(model_id)
+        )
+        self.checkpoint_dir = Path(ckpt)
+        self.model_config = _read_model_config(self.checkpoint_dir)
+        self.extension = extension
+        self.extension_runtime = None
+
+        # Veto before the expensive load: an extension that cannot run
+        # against this base model should say so in the time it takes to
+        # read a JSON file, not after several seconds of weight loading.
+        if extension is not None:
+            from acestep.plugins.model_extensions import ModelDescriptor
+
+            extension.validate_base_model(
+                ModelDescriptor(
+                    family="sa3",
+                    model_id=model_id,
+                    checkpoint_dir=str(self.checkpoint_dir),
+                    model_config=self.model_config,
+                )
+            )
+
         logger.info("sa3_model_load_start model_id={} dir={}", model_id, ckpt)
         self.sam = loader.load_local_model(ckpt, device=device, model_half=model_half)
         self.device = torch.device(self.sam.device)
@@ -67,10 +124,27 @@ class SA3Context:
             self.sam.model.pretransform.downsampling_ratio          # 4096
         )
         self.latent_channels = int(self.sam.model.io_channels)      # 256
+        # The loaded checkpoint's training objective. Post-trained SA3
+        # releases are "rf_denoiser"; the plain rectified-flow bases are
+        # "rectified_flow". They want different samplers, so the backend
+        # reads this rather than assuming every SA3 checkpoint is
+        # post-trained (see SA3Backend.from_context).
+        self.diffusion_objective = str(self.sam.model.diffusion_objective)
         logger.info(
-            "sa3_model_loaded model_id={} latent_rate_hz={:.4f} dtype={}",
+            "sa3_model_loaded model_id={} latent_rate_hz={:.4f} dtype={} "
+            "objective={}",
             model_id, self.sample_rate / self.downsampling_ratio, self.dtype,
+            self.diffusion_objective,
         )
+
+        # Install last, so every derived attribute above describes the
+        # stock model and the extension sees a fully-formed context.
+        if extension is not None:
+            self.extension_runtime = extension.install(self.sam, self.model_config)
+            logger.info(
+                "sa3_extension_installed id={} model_id={}",
+                extension.qualified_id, model_id,
+            )
 
     @property
     def dit(self):
@@ -80,6 +154,55 @@ class SA3Context:
     @property
     def latent_rate_hz(self) -> float:
         return self.sample_rate / self.downsampling_ratio
+
+    # ---- model extension ---------------------------------------------------
+
+    def effective_dit_backend(self, requested: str) -> tuple[str, str]:
+        """``(backend, reason)`` after consulting the installed extension.
+
+        An extension that augments the transformer generally cannot run
+        under a prebuilt acceleration plan, because the plan contains only
+        the stock graph — running it would silently drop the extension.
+        SA3's established contract is to fall back to eager rather than
+        refuse to boot, so that is preserved.
+
+        The downgrade is reported at SESSION CREATE, not at boot. Boot
+        cannot report it: the verdict comes from the installed runtime,
+        and installation requires the loaded weights, which the preflight
+        deliberately does not pay for. The caller logs it at WARNING so it
+        is visible in a default-level log rather than only under debug.
+        """
+        if self.extension_runtime is None or requested != "tensorrt":
+            return requested, ""
+        verdict = self.extension_runtime.supports_dit_backend(requested)
+        if verdict.ok:
+            return requested, ""
+        return "eager", verdict.reason or "extension does not support tensorrt"
+
+    def effective_codec_backend(self, requested: str) -> tuple[str, str]:
+        """``(backend, reason)`` for the codec. See :meth:`effective_dit_backend`."""
+        if self.extension_runtime is None or requested != "tensorrt":
+            return requested, ""
+        verdict = self.extension_runtime.supports_codec_backend(requested)
+        if verdict.ok:
+            return requested, ""
+        return "eager", verdict.reason or "extension does not support tensorrt"
+
+    def close(self) -> None:
+        """Release the installed extension. Idempotent.
+
+        The loaded model is process-cached and shared, so an extension
+        that attached itself to the trunk has to detach here or every
+        later session keeps running its graph.
+        """
+        if self.extension_runtime is None:
+            return
+        runtime = self.extension_runtime
+        self.extension_runtime = None
+        try:
+            runtime.close()
+        except Exception as exc:  # noqa: BLE001 - teardown must not raise
+            logger.error("sa3_extension_close_failed error={}", exc)
 
     # ---- TRT-or-eager component selection ----------------------------------
 

--- a/acestep/engine/sa3_helpers.py
+++ b/acestep/engine/sa3_helpers.py
@@ -64,6 +64,65 @@ def sa3_vendor_present() -> bool:
     return (sa3_vendor_dir() / "stable_audio_3").is_dir()
 
 
+def sa3_checkpoint_files(checkpoint_dir) -> tuple[Path, Path]:
+    """The two files that make a directory a usable SA3 checkpoint."""
+    base = Path(checkpoint_dir)
+    return base / "model_config.json", base / "model.safetensors"
+
+
+def sa3_custom_checkpoint_status(checkpoint_dir) -> tuple[bool, str]:
+    """``(ok, message)`` for an operator-supplied SA3 checkpoint directory.
+
+    The catalog path (:func:`sa3_checkpoint_status`) resolves a known
+    ``model_id`` under the managed models dir; this one validates a
+    directory the operator named explicitly, so it checks layout rather
+    than offering a download remedy."""
+    base = Path(checkpoint_dir).expanduser().resolve()
+    if not base.is_dir():
+        return False, f"SA3 checkpoint directory not found: {base}"
+    missing = [str(p) for p in sa3_checkpoint_files(base) if not p.is_file()]
+    if missing:
+        return False, (
+            f"SA3 checkpoint directory {base} is missing required files: "
+            f"{', '.join(missing)}"
+        )
+    if not sa3_vendor_present():
+        return False, (
+            f"SA3 source not found at {sa3_vendor_dir()} "
+            "(required to import stable_audio_3). Run `uv run demon-setup` "
+            "to fetch it."
+        )
+    return True, f"SA3 checkpoint ready: {base}"
+
+
+def sa3_checkpoint_identity(path) -> tuple:
+    """A cheap content-identity fingerprint for a checkpoint path.
+
+    Returns ``(resolved_path, size, mtime_ns)`` per file, so a checkpoint
+    that is REWRITTEN IN PLACE (a training run that keeps overwriting the
+    same file as it improves) does not collide with the previous one in a
+    path-keyed cache. Path identity alone is not content identity for a
+    file the producer keeps updating.
+
+    Missing files contribute ``None`` rather than raising: callers use this
+    for cache keys, and a genuinely missing file is reported by the
+    preflight with a better message than a stat error.
+    """
+    base = Path(path).expanduser().resolve()
+    targets = (
+        sorted(p for p in sa3_checkpoint_files(base)) if base.is_dir() else [base]
+    )
+    parts: list = [str(base)]
+    for target in targets:
+        try:
+            st = target.stat()
+        except OSError:
+            parts.append((str(target), None, None))
+        else:
+            parts.append((str(target), int(st.st_size), int(st.st_mtime_ns)))
+    return tuple(parts)
+
+
 def sa3_checkpoint_status(model_id: str) -> tuple[bool, str]:
     """``(ok, message)`` for an SA3 ``model_id``'s boot readiness — the SA3
     analog of ``model_downloader.ensure_dit_model``'s contract, but a

--- a/acestep/engine/sa3_internals.py
+++ b/acestep/engine/sa3_internals.py
@@ -1,0 +1,192 @@
+"""Tier-2 SA3 model internals: the extension-reachable surface.
+
+DEMON's plugin API (:mod:`acestep.plugins`) is Tier 1 — stable, versioned,
+and sufficient for registration and lifecycle. It is NOT sufficient for a
+model extension that has to participate in the transformer itself: such an
+extension must construct modules against the vendored ``stable_audio_3``
+architecture, read the loaded model's object graph, and attach itself to
+the trunk. There is no way to abstract that away, because the shapes it
+depends on belong to a vendored third-party package rather than to DEMON.
+
+This module is the response to that reality. It does not remove the
+coupling; it gives the coupling ONE address. Extensions traverse the
+loaded model through the accessors here instead of hard-coding attribute
+chains like ``sam.model.model.model.transformer.layers``, so a vendored
+SA3 bump breaks one public, tested file with a clear message rather than
+failing somewhere inside an out-of-tree package — where the failure mode
+is not an ImportError but a silently wrong model.
+
+Contract for extension authors:
+
+* Import from here, never from ``stable_audio_3`` or the private helpers
+  directly.
+* Assert :data:`API_VERSION` at install time and fail closed on mismatch.
+* Treat :data:`VENDOR_SHA` as the architecture revision you were built
+  against; a change means re-validating, not just re-pinning.
+
+Bump :data:`API_VERSION` whenever anything exported here changes shape.
+The structural canary in ``tests/unit/test_sa3_internals.py`` fails in
+public CI when the vendored layout drifts out from under these accessors.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from acestep.engine.sa3_helpers import (
+    SA3_VENDOR_SHA,
+    ensure_sa3_paths,
+    skip_param_init,
+)
+
+#: Shape version for everything this module exports. Extensions assert it.
+API_VERSION = 1
+
+#: The vendored stable_audio_3 revision these accessors were written for.
+VENDOR_SHA = SA3_VENDOR_SHA
+
+#: Attribute chains this module encapsulates, for diagnostics and for the
+#: canary test. Documented rather than repeated at each call site.
+TRUNK_WRAPPER_PATH = "sam.model.model"
+TRUNK_MODULE_PATH = "sam.model.model.model"
+TRUNK_BLOCKS_PATH = "sam.model.model.model.transformer.layers"
+
+__all__ = [
+    "API_VERSION",
+    "VENDOR_SHA",
+    "TRUNK_WRAPPER_PATH",
+    "TRUNK_MODULE_PATH",
+    "TRUNK_BLOCKS_PATH",
+    "LayoutError",
+    "ensure_sa3_paths",
+    "skip_param_init",
+    "dit_class",
+    "dit_architecture_config",
+    "trunk_wrapper",
+    "trunk_module",
+    "trunk_blocks",
+    "replace_trunk",
+    "check_layout",
+]
+
+
+class LayoutError(RuntimeError):
+    """The loaded SA3 model does not match the expected vendored layout.
+
+    Raised instead of an AttributeError from halfway down an attribute
+    chain, so the message names the accessor, the expected path, and the
+    vendor revision the accessor was written for.
+    """
+
+
+def _walk(root: Any, path: str, accessor: str):
+    """Traverse a dotted path, reporting the exact hop that failed."""
+    node = root
+    walked = path.split(".")[0]
+    for attr in path.split(".")[1:]:
+        if not hasattr(node, attr):
+            raise LayoutError(
+                f"{accessor}: expected {path!r} on the loaded SA3 model, but "
+                f"{walked!r} has no attribute {attr!r}. The vendored "
+                f"stable_audio_3 layout changed (accessors written for "
+                f"{VENDOR_SHA}); update acestep.engine.sa3_internals."
+            )
+        node = getattr(node, attr)
+        walked = f"{walked}.{attr}"
+    return node
+
+
+def dit_class():
+    """The vendored diffusion-transformer class.
+
+    Extensions that build a parallel/derived branch subclass this so their
+    module matches the trunk architecture exactly.
+    """
+    ensure_sa3_paths()
+    from stable_audio_3.models.dit import DiffusionTransformer
+
+    return DiffusionTransformer
+
+
+def dit_architecture_config(model_config: dict) -> tuple[str, dict]:
+    """``(diffusion_objective, dit_kwargs)`` from a parsed model config.
+
+    The vendored ``model_config.json`` nests the transformer's constructor
+    arguments; this normalizes that lookup so extensions do not re-derive
+    the config layout. The returned kwargs are a copy and safe to mutate
+    (e.g. to build a shallower branch).
+    """
+    try:
+        diffusion = model_config["model"]["diffusion"]
+        dit_kwargs = dict(diffusion["config"])
+    except (KeyError, TypeError) as exc:
+        raise LayoutError(
+            "dit_architecture_config: model_config is missing "
+            "model.diffusion.config; not an SA3 model config?"
+        ) from exc
+    objective = str(diffusion.get("diffusion_objective", "v"))
+    return objective, dit_kwargs
+
+
+def trunk_wrapper(sam):
+    """The per-step callable wrapping the DiT (``dit(x_bct, t, **cond)``).
+
+    This is the object an extension REPLACES to interpose itself; see
+    :func:`replace_trunk`.
+    """
+    return _walk(sam, TRUNK_WRAPPER_PATH, "trunk_wrapper")
+
+
+def trunk_module(sam):
+    """The diffusion transformer itself, inside the wrapper."""
+    return _walk(sam, TRUNK_MODULE_PATH, "trunk_module")
+
+
+def trunk_blocks(sam) -> Sequence:
+    """The trunk's ordered transformer blocks.
+
+    Indexable and len()-able. Extensions that inject per-block residuals
+    attach hooks to these; they must remove every hook they attach when
+    their runtime closes, because the model object is process-cached and
+    shared across sessions.
+    """
+    blocks = _walk(sam, TRUNK_BLOCKS_PATH, "trunk_blocks")
+    try:
+        len(blocks)
+    except TypeError as exc:
+        raise LayoutError(
+            f"trunk_blocks: {TRUNK_BLOCKS_PATH} is not a sized sequence "
+            f"(got {type(blocks).__name__}); accessors written for "
+            f"{VENDOR_SHA}."
+        ) from exc
+    return blocks
+
+
+def replace_trunk(sam, wrapper) -> Any:
+    """Install ``wrapper`` as the per-step callable; return the old one.
+
+    The caller owns restoration: keep the returned object and pass it back
+    through this function on close. Nothing here is reference-counted, and
+    the loaded model is shared, so an extension that fails to restore
+    leaves every later session running its graph.
+    """
+    previous = trunk_wrapper(sam)
+    sam.model.model = wrapper
+    return previous
+
+
+def check_layout(sam) -> None:
+    """Validate the loaded model against every accessor above.
+
+    Extensions call this once at install, before building anything, so a
+    vendor drift surfaces as a clear LayoutError at boot rather than as a
+    wrong-shaped tensor mid-generation.
+    """
+    trunk_wrapper(sam)
+    trunk_module(sam)
+    blocks = trunk_blocks(sam)
+    if len(blocks) < 1:
+        raise LayoutError(
+            f"check_layout: {TRUNK_BLOCKS_PATH} is empty; the loaded model "
+            "has no transformer blocks to extend."
+        )

--- a/acestep/plugins/__init__.py
+++ b/acestep/plugins/__init__.py
@@ -1,0 +1,91 @@
+"""DEMON plugin API (Tier 1).
+
+The supported surface for out-of-tree extensions. Everything exported
+here is versioned by :data:`PLUGIN_API_VERSION` and changes only with a
+version bump. Anything else under ``acestep.*`` is internal and may move
+without notice.
+
+Import tiers, for extension authors:
+
+* **Tier 1** — this module. Registration, configuration, lifecycle.
+  Sufficient for any extension that does not have to participate in the
+  model's internal computation.
+* **Tier 2** — ``acestep.engine.sa3_internals``. The documented, tested
+  subset of vendored SA3 model internals an extension may traverse when
+  it genuinely must build modules against the trunk architecture. Assert
+  its ``API_VERSION`` at install and fail closed on mismatch.
+* **Tier 0** — everything else. Importing it is a bug in your plugin.
+
+A plugin is an installed distribution advertising a ``demon.plugins``
+entry point::
+
+    [project.entry-points."demon.plugins"]
+    my_extension = "my_extension.plugin:register"
+
+whose module defines ``PLUGIN_API`` and ``register(registry)``. See
+:mod:`acestep.plugins.discovery`.
+
+Plugins are trusted, in-process Python. This is an extensibility
+boundary, not a security sandbox: plugins load only from operator-
+controlled startup configuration, never at the request of a client.
+"""
+
+from __future__ import annotations
+
+from acestep.plugins.api import (
+    PLUGIN_API_VERSION,
+    LoadedPlugin,
+    PluginManifest,
+    PluginRegistry,
+    validate_extension_config,
+)
+from acestep.plugins.errors import (
+    ExtensionConfigError,
+    PluginError,
+    PluginIncompatibleError,
+    PluginLoadError,
+    PluginNotFoundError,
+    PluginRegistrationError,
+)
+from acestep.plugins.model_extensions import (
+    CONFIG_FIELD_TYPES,
+    EXTENSION_KNOB_TYPES,
+    BackendVerdict,
+    ConfigField,
+    ExtensionContext,
+    ModelDescriptor,
+    ModelExtension,
+    ModelExtensionRuntime,
+    ModelExtensionSpec,
+    Rejection,
+)
+# Re-exported, not re-declared: extension controls ARE core knobs, and
+# routing them through a parallel type would be the second schema this
+# design exists to avoid. It lives here so declaring a control never
+# requires an import from outside the Tier-1 surface.
+from acestep.streaming.knobs import KnobSpec
+
+__all__ = [
+    "PLUGIN_API_VERSION",
+    "CONFIG_FIELD_TYPES",
+    "EXTENSION_KNOB_TYPES",
+    "BackendVerdict",
+    "ConfigField",
+    "ExtensionContext",
+    "KnobSpec",
+    "LoadedPlugin",
+    "ModelDescriptor",
+    "ModelExtension",
+    "ModelExtensionRuntime",
+    "ModelExtensionSpec",
+    "PluginManifest",
+    "PluginRegistry",
+    "Rejection",
+    "PluginError",
+    "PluginIncompatibleError",
+    "PluginLoadError",
+    "PluginNotFoundError",
+    "PluginRegistrationError",
+    "ExtensionConfigError",
+    "validate_extension_config",
+]

--- a/acestep/plugins/__init__.py
+++ b/acestep/plugins/__init__.py
@@ -58,6 +58,7 @@ from acestep.plugins.model_extensions import (
     ModelExtensionRuntime,
     ModelExtensionSpec,
     Rejection,
+    SourceView,
 )
 # Re-exported, not re-declared: extension controls ARE core knobs, and
 # routing them through a parallel type would be the second schema this
@@ -81,6 +82,7 @@ __all__ = [
     "PluginManifest",
     "PluginRegistry",
     "Rejection",
+    "SourceView",
     "PluginError",
     "PluginIncompatibleError",
     "PluginLoadError",

--- a/acestep/plugins/api.py
+++ b/acestep/plugins/api.py
@@ -1,0 +1,302 @@
+"""Plugin manifest, registry, and capability validation.
+
+The registry is where a plugin's declarations become part of DEMON, so it
+is where they are checked. Everything validated here fails at BOOT, for
+the whole process, rather than per connection — a control that shadows a
+core knob or escapes coercion is a silent-wrongness bug, and the cheapest
+place to make it loud is registration.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from acestep.plugins.errors import PluginRegistrationError
+from acestep.plugins.model_extensions import (
+    EXTENSION_KNOB_TYPES,
+    ConfigField,
+    ModelExtensionSpec,
+)
+
+#: Shape version of the plugin API. A plugin declares the version it was
+#: built against; DEMON serves exactly one.
+PLUGIN_API_VERSION = 1
+
+_PLUGIN_ID_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_CAPABILITY_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,47}$")
+
+
+def _knob_name_pattern(plugin_id: str) -> re.Pattern:
+    return re.compile(rf"^plugin_{re.escape(plugin_id)}_[a-z0-9_]+$")
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    """Identity and compatibility declaration for one plugin."""
+
+    id: str
+    version: str
+    plugin_api: int
+    requires_demon: str | None = None
+    description: str = ""
+    source: str = "entry_point"
+
+
+@dataclass
+class LoadedPlugin:
+    """A plugin whose entry callable ran successfully."""
+
+    manifest: PluginManifest
+    model_extensions: dict = field(default_factory=dict)
+
+    @property
+    def capability_ids(self) -> list[str]:
+        return sorted(self.model_extensions)
+
+
+class PluginRegistry:
+    """What a plugin's ``register()`` callable is handed.
+
+    Scoped to one plugin: every capability it adds is namespaced under
+    that plugin's id automatically, and it cannot see or disturb another
+    plugin's registrations. ``seen`` catches a plugin registering the
+    same capability name twice — the reachable duplicate, since two
+    different plugins cannot collide once the id is qualified, and
+    ``discover_plugins`` already rejects a duplicate plugin id.
+    """
+
+    #: Exposed so a plugin can assert compatibility from inside register().
+    api_version = PLUGIN_API_VERSION
+
+    def __init__(self, manifest: PluginManifest, seen: set[str] | None = None):
+        self.manifest = manifest
+        self._seen = seen if seen is not None else set()
+        self._model_extensions: dict[str, ModelExtensionSpec] = {}
+
+    @property
+    def plugin_id(self) -> str:
+        return self.manifest.id
+
+    @property
+    def model_extensions(self) -> dict[str, ModelExtensionSpec]:
+        return dict(self._model_extensions)
+
+    def qualified_id(self, capability_name: str) -> str:
+        return f"{self.manifest.id}.{capability_name}"
+
+    def add_model_extension(self, spec: ModelExtensionSpec) -> str:
+        """Validate and register a model extension. Returns its qualified id."""
+        plugin_id = self.manifest.id
+        self._check_capability_name(spec.name)
+        qualified = self.qualified_id(spec.name)
+
+        if qualified in self._seen:
+            raise PluginRegistrationError(
+                f"duplicate capability id {qualified!r}: a capability id must "
+                "resolve to exactly one provider"
+            )
+        if not callable(spec.create):
+            raise PluginRegistrationError(
+                f"{qualified}: create must be callable"
+            )
+        self._check_family(qualified, spec.family)
+        self._check_config_schema(qualified, spec.config_schema)
+        self._check_knob_specs(qualified, plugin_id, spec.knob_specs)
+
+        self._model_extensions[spec.name] = spec
+        self._seen.add(qualified)
+        return qualified
+
+    # ---- validation ------------------------------------------------------
+
+    def _check_capability_name(self, name: str) -> None:
+        if not isinstance(name, str) or not _CAPABILITY_NAME_RE.match(name):
+            raise PluginRegistrationError(
+                f"invalid capability name {name!r}: expected "
+                f"{_CAPABILITY_NAME_RE.pattern}"
+            )
+
+    def _check_family(self, qualified: str, family: str) -> None:
+        from acestep.streaming.families import FAMILIES
+
+        if family not in FAMILIES:
+            raise PluginRegistrationError(
+                f"{qualified}: unknown backend family {family!r} "
+                f"(known: {sorted(FAMILIES)})"
+            )
+
+    def _check_config_schema(
+        self, qualified: str, schema: Mapping[str, ConfigField],
+    ) -> None:
+        for key, spec in (schema or {}).items():
+            if not isinstance(key, str) or not key:
+                raise PluginRegistrationError(
+                    f"{qualified}: config field names must be non-empty strings"
+                )
+            if not isinstance(spec, ConfigField):
+                raise PluginRegistrationError(
+                    f"{qualified}: config field {key!r} must be a ConfigField, "
+                    f"got {type(spec).__name__}"
+                )
+            # An optional field's default bypasses _coerce_config_value
+            # entirely, so a default of the wrong type would reach the
+            # extension unconverted — the one way a declared schema can
+            # still hand over a value it does not describe.
+            if not spec.required and spec.default is not None:
+                try:
+                    _coerce_config_value(qualified, key, spec, spec.default)
+                except Exception as exc:
+                    raise PluginRegistrationError(
+                        f"{qualified}: config field {key!r} declares type "
+                        f"{spec.type!r} but its default {spec.default!r} is "
+                        f"not a valid {spec.type} ({exc})"
+                    ) from exc
+
+    def _check_knob_specs(
+        self, qualified: str, plugin_id: str, specs,
+    ) -> None:
+        pattern = _knob_name_pattern(plugin_id)
+        seen: set[str] = set()
+
+        for spec in specs or ():
+            name = getattr(spec, "name", None)
+            if not isinstance(name, str):
+                raise PluginRegistrationError(
+                    f"{qualified}: knob specs must be KnobSpec instances"
+                )
+            if name in seen:
+                raise PluginRegistrationError(
+                    f"{qualified}: duplicate knob {name!r}"
+                )
+            seen.add(name)
+
+            if not pattern.match(name):
+                # This is the whole shadowing defense, and it is
+                # deliberately the only one: no core or family knob is
+                # named plugin_*, so a name matching this pattern cannot
+                # collide with one. A blocklist of existing core names
+                # would be strictly weaker — it goes stale as knobs are
+                # added, and it cannot enumerate the dynamically named
+                # ones (lora_str_<id>, man_alpha_<N>) at all.
+                raise PluginRegistrationError(
+                    f"{qualified}: knob {name!r} must be namespaced as "
+                    f"plugin_{plugin_id}_<control>. The namespace is what "
+                    "keeps plugin controls from shadowing a core knob and "
+                    "from colliding across plugins; a shadowed control is "
+                    "silently swallowed by whichever spec map wins and "
+                    "stops being coerced."
+                )
+
+            knob_type = getattr(spec, "type", "float")
+            if knob_type not in EXTENSION_KNOB_TYPES:
+                raise PluginRegistrationError(
+                    f"{qualified}: knob {name!r} has type {knob_type!r}; "
+                    f"extension knobs must be one of {EXTENSION_KNOB_TYPES} "
+                    "(the browser panel has no generic binding for the rest)"
+                )
+            self._check_knob_bounds(qualified, spec)
+
+    def _check_knob_bounds(self, qualified: str, spec) -> None:
+        name = spec.name
+        low = getattr(spec, "min_val", None)
+        # Absent min floors at 0 — the same convention coerce_knob_values
+        # applies, so this check and the runtime clamp agree.
+        low = 0.0 if low is None else float(low)
+        try:
+            high = float(getattr(spec, "max_val", 1.0))
+        except (TypeError, ValueError) as exc:
+            raise PluginRegistrationError(
+                f"{qualified}: knob {name!r} has a non-numeric max_val "
+                f"{getattr(spec, 'max_val', None)!r}; an extension knob must "
+                "declare a finite upper bound to be clampable"
+            ) from exc
+        if high < low:
+            raise PluginRegistrationError(
+                f"{qualified}: knob {name!r} has max_val {high} below "
+                f"min_val {low}"
+            )
+        try:
+            default = float(getattr(spec, "default", 0.0))
+        except (TypeError, ValueError) as exc:
+            raise PluginRegistrationError(
+                f"{qualified}: knob {name!r} default is not numeric"
+            ) from exc
+        if not (low <= default <= high):
+            # Coercion clamps to bounds, so an out-of-range default would
+            # silently become a different value than the one declared.
+            raise PluginRegistrationError(
+                f"{qualified}: knob {name!r} default {default} is outside "
+                f"its own bounds [{low}, {high}]"
+            )
+
+
+def validate_extension_config(
+    qualified_id: str,
+    schema: Mapping[str, ConfigField],
+    raw: Mapping[str, Any] | None,
+) -> dict:
+    """Coerce operator configuration against an extension's schema.
+
+    Unknown keys are rejected rather than ignored: a typo in an operator's
+    config file must not silently mean "default".
+    """
+    from acestep.plugins.errors import ExtensionConfigError
+
+    schema = schema or {}
+    raw = dict(raw or {})
+
+    unknown = sorted(set(raw) - set(schema))
+    if unknown:
+        raise ExtensionConfigError(
+            f"{qualified_id}: unknown configuration key(s): "
+            f"{', '.join(unknown)}"
+        )
+
+    out: dict[str, Any] = {}
+    for key, field_spec in schema.items():
+        if key not in raw:
+            if field_spec.required:
+                raise ExtensionConfigError(
+                    f"{qualified_id}: missing required configuration key "
+                    f"{key!r} ({field_spec.description or field_spec.type})"
+                )
+            out[key] = field_spec.default
+            continue
+        out[key] = _coerce_config_value(qualified_id, key, field_spec, raw[key])
+    return out
+
+
+def _coerce_config_value(qualified_id: str, key: str, field_spec, value):
+    from acestep.plugins.errors import ExtensionConfigError
+
+    kind = field_spec.type
+    try:
+        if kind == "bool":
+            if not isinstance(value, bool):
+                raise TypeError("expected a JSON boolean")
+            return value
+        if kind == "int":
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError("expected a number")
+            if isinstance(value, float) and not value.is_integer():
+                raise TypeError("expected an integer")
+            return int(value)
+        if kind == "float":
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError("expected a number")
+            return float(value)
+        if kind in ("str", "path"):
+            if not isinstance(value, str):
+                raise TypeError("expected a string")
+            return value
+    except TypeError as exc:
+        raise ExtensionConfigError(
+            f"{qualified_id}: configuration key {key!r} has the wrong type "
+            f"({exc}; got {type(value).__name__})"
+        ) from exc
+    raise ExtensionConfigError(
+        f"{qualified_id}: configuration key {key!r} has unsupported type "
+        f"{kind!r}"
+    )

--- a/acestep/plugins/api.py
+++ b/acestep/plugins/api.py
@@ -22,7 +22,12 @@ from acestep.plugins.model_extensions import (
 
 #: Shape version of the plugin API. A plugin declares the version it was
 #: built against; DEMON serves exactly one.
-PLUGIN_API_VERSION = 1
+#:
+#: 2 — ``decorate_conditioning`` receives a :class:`SourceView` instead of
+#:     the source latent alone. Breaking: a version-1 runtime's hook would
+#:     bind the view where it expected a latent, so the mismatch is
+#:     refused at load rather than surfacing as wrong conditioning.
+PLUGIN_API_VERSION = 2
 
 _PLUGIN_ID_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 _CAPABILITY_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,47}$")

--- a/acestep/plugins/compatibility.py
+++ b/acestep/plugins/compatibility.py
@@ -1,0 +1,65 @@
+"""Plugin/DEMON compatibility checks.
+
+Two axes, deliberately separated:
+
+* **Plugin API version** — the real gate. A plugin declares the API shape
+  it was built against and DEMON serves exactly one; a mismatch is fatal.
+* **``requires_demon``** — advisory only, for now, and honestly labelled
+  as such. DEMON's distribution version tracks the ACE-Step *model*
+  generation rather than an API contract, so enforcing a specifier
+  against it would look like a guarantee while promising nothing. It is
+  recorded in logs and diagnostics until the two are decoupled.
+
+Extensions that reach into model internals have a third axis
+(``acestep.engine.sa3_internals.API_VERSION``) which they assert
+themselves at install time.
+"""
+
+from __future__ import annotations
+
+from acestep.engine.obs import logger
+from acestep.plugins.api import PLUGIN_API_VERSION
+from acestep.plugins.errors import PluginIncompatibleError
+
+
+def demon_version() -> str:
+    """The installed distribution version, or ``"0+unknown"``.
+
+    Not importable as ``acestep.__version__``; read from distribution
+    metadata so a source checkout without an install still boots.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+    except ImportError:  # pragma: no cover - stdlib since 3.8
+        return "0+unknown"
+    try:
+        return version("demon")
+    except PackageNotFoundError:
+        return "0+unknown"
+
+
+def check_plugin_api(declared, plugin_id: str) -> int:
+    """Validate a plugin's declared API version. Fatal on mismatch."""
+    if not isinstance(declared, int) or isinstance(declared, bool):
+        raise PluginIncompatibleError(
+            f"plugin {plugin_id!r} declares PLUGIN_API={declared!r}; "
+            "expected an integer"
+        )
+    if declared != PLUGIN_API_VERSION:
+        raise PluginIncompatibleError(
+            f"plugin {plugin_id!r} was built against plugin API {declared} "
+            f"but this DEMON serves plugin API {PLUGIN_API_VERSION}. "
+            "Rebuild or reinstall the plugin against this DEMON version."
+        )
+    return declared
+
+
+def note_requires_demon(requires: str | None, plugin_id: str) -> None:
+    """Record a plugin's DEMON constraint. Advisory — see module docstring."""
+    if not requires:
+        return
+    logger.info(
+        "plugin_requires_demon plugin_id={} requires={} running={} "
+        "enforced=false",
+        plugin_id, requires, demon_version(),
+    )

--- a/acestep/plugins/discovery.py
+++ b/acestep/plugins/discovery.py
@@ -1,0 +1,173 @@
+"""Plugin discovery through installed entry points.
+
+One source, on purpose. A private extension is installed into DEMON's
+environment (editable or from a private index), which means the standard
+``demon.plugins`` entry-point group already answers "what is installed"
+without DEMON inventing a search path, mutating ``sys.path``, resolving
+root precedence, or creating directories as a side effect of looking.
+
+A distribution advertises itself as::
+
+    [project.entry-points."demon.plugins"]
+    my_extension = "my_extension.plugin:register"
+
+The referenced module must define, at module scope:
+
+* ``PLUGIN_API`` — the integer plugin API version it was built against.
+* ``register(registry)`` — called with a :class:`PluginRegistry` scoped to
+  this plugin. Optionally ``REQUIRES_DEMON`` and ``DESCRIPTION``.
+
+Compatibility is checked after importing the module but BEFORE calling
+``register``, so an incompatible plugin never gets to run registration
+code against an API it does not understand.
+
+Discovery order is deterministic (sorted by entry-point name) and a
+capability id resolves to exactly one provider; a collision is an error,
+not a last-writer-wins race.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from acestep.engine.obs import logger
+from acestep.plugins.api import LoadedPlugin, PluginManifest, PluginRegistry
+from acestep.plugins.compatibility import check_plugin_api, note_requires_demon
+from acestep.plugins.errors import PluginError, PluginLoadError
+
+ENTRY_POINT_GROUP = "demon.plugins"
+
+
+def _iter_entry_points(group: str):
+    from importlib.metadata import entry_points
+
+    try:
+        found = entry_points(group=group)
+    except TypeError:  # pragma: no cover - Python < 3.10 shape
+        found = entry_points().get(group, [])
+    return sorted(found, key=lambda ep: ep.name)
+
+
+def _manifest_for(entry_point, module) -> PluginManifest:
+    plugin_id = entry_point.name
+    declared = getattr(module, "PLUGIN_API", None)
+    if declared is None:
+        raise PluginLoadError(
+            f"plugin {plugin_id!r} ({entry_point.value}) does not define "
+            "PLUGIN_API at module scope"
+        )
+    check_plugin_api(declared, plugin_id)
+
+    version = "0+unknown"
+    dist = getattr(entry_point, "dist", None)
+    if dist is not None and getattr(dist, "version", None):
+        version = str(dist.version)
+
+    return PluginManifest(
+        id=plugin_id,
+        version=version,
+        plugin_api=int(declared),
+        requires_demon=getattr(module, "REQUIRES_DEMON", None),
+        description=str(getattr(module, "DESCRIPTION", "") or ""),
+        source="entry_point",
+    )
+
+
+def _import_entry_module(entry_point):
+    """Import the entry point's MODULE, not its target attribute.
+
+    ``EntryPoint.load()`` resolves all the way to the callable, which
+    would give us no way to read the module-scope compatibility
+    declaration before deciding whether to run the plugin's code.
+    """
+    import importlib
+
+    return importlib.import_module(entry_point.module)
+
+
+def _load_one(entry_point, seen: set[str]) -> LoadedPlugin:
+    plugin_id = entry_point.name
+    try:
+        module = _import_entry_module(entry_point)
+    except Exception as exc:  # noqa: BLE001 - any import failure is a load failure
+        raise PluginLoadError(
+            f"plugin {plugin_id!r} ({entry_point.value}) failed to import: {exc}"
+        ) from exc
+
+    # Compatibility is checked against the imported module BEFORE the
+    # entry callable is resolved or run, so an incompatible plugin never
+    # executes registration code against an API it does not understand.
+    manifest = _manifest_for(entry_point, module)
+    note_requires_demon(manifest.requires_demon, plugin_id)
+
+    register = getattr(module, entry_point.attr or "register", None)
+    if not callable(register):
+        raise PluginLoadError(
+            f"plugin {plugin_id!r} ({entry_point.value}) has no callable "
+            f"{entry_point.attr or 'register'}(registry)"
+        )
+
+    registry = PluginRegistry(manifest, seen=seen)
+    try:
+        register(registry)
+    except PluginError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - plugin code is arbitrary
+        raise PluginLoadError(
+            f"plugin {plugin_id!r} register() failed: {exc}"
+        ) from exc
+
+    plugin = LoadedPlugin(
+        manifest=manifest, model_extensions=registry.model_extensions,
+    )
+    logger.info(
+        "plugin_loaded plugin_id={} version={} plugin_api={} capabilities={}",
+        manifest.id, manifest.version, manifest.plugin_api,
+        plugin.capability_ids,
+    )
+    return plugin
+
+
+def discover_plugins(
+    *, required: Iterable[str] = (), group: str = ENTRY_POINT_GROUP,
+) -> dict[str, LoadedPlugin]:
+    """Load every installed plugin. Returns ``{plugin_id: LoadedPlugin}``.
+
+    A plugin named in ``required`` (because the operator selected it, or a
+    capability of it) fails the process on any error. A plugin nobody asked
+    for is isolated: logged and skipped, so one broken optional plugin
+    cannot take the server down.
+
+    This asymmetry is the whole safety story. Silently dropping a model
+    extension the operator explicitly selected would produce output that
+    looks fine and is not the model they asked for.
+    """
+    required = set(required)
+    plugins: dict[str, LoadedPlugin] = {}
+    seen: set[str] = set()
+
+    for entry_point in _iter_entry_points(group):
+        plugin_id = entry_point.name
+        if plugin_id in plugins:
+            raise PluginLoadError(
+                f"duplicate plugin id {plugin_id!r}: a plugin id must resolve "
+                "to exactly one provider"
+            )
+        try:
+            plugins[plugin_id] = _load_one(entry_point, seen)
+        except PluginError as exc:
+            if plugin_id in required:
+                raise
+            logger.warning(
+                "plugin_skipped plugin_id={} reason={}", plugin_id, exc,
+            )
+
+    missing = sorted(required - set(plugins))
+    if missing:
+        from acestep.plugins.errors import PluginNotFoundError
+
+        raise PluginNotFoundError(
+            f"selected plugin(s) not installed: {', '.join(missing)}. "
+            f"Install the distribution providing the {group!r} entry point."
+        )
+    return plugins

--- a/acestep/plugins/errors.py
+++ b/acestep/plugins/errors.py
@@ -1,0 +1,34 @@
+"""Plugin failure taxonomy.
+
+Every one of these is fatal for an EXPLICITLY selected plugin. That is
+the central safety property of the plugin system: a model extension the
+operator asked for is part of the model, so dropping it silently would
+produce output that is plausible and wrong. Auto-discovered plugins that
+nobody selected may be isolated and reported instead.
+"""
+
+from __future__ import annotations
+
+
+class PluginError(Exception):
+    """Base for every plugin-system failure."""
+
+
+class PluginLoadError(PluginError):
+    """A plugin could not be imported or its entry callable failed."""
+
+
+class PluginIncompatibleError(PluginError):
+    """A plugin declares an API version this DEMON build does not serve."""
+
+
+class PluginRegistrationError(PluginError):
+    """A plugin registered a capability that failed validation."""
+
+
+class PluginNotFoundError(PluginError):
+    """An explicitly selected plugin or capability was not discovered."""
+
+
+class ExtensionConfigError(PluginError):
+    """Operator configuration did not satisfy an extension's schema."""

--- a/acestep/plugins/model_extensions.py
+++ b/acestep/plugins/model_extensions.py
@@ -1,0 +1,268 @@
+"""Generic model-extension contracts.
+
+A *model extension* is a persistent, startup-selected participant in a
+loaded model: it may inspect the base checkpoint before it loads, wrap or
+augment the model after it loads, decorate conditioning, contribute
+controls, and report telemetry. It is not a job or a recipe — it is part
+of the model for the lifetime of the process.
+
+Nothing here names any concrete extension. The core treats an extension's
+configuration, controls, and metrics as opaque, and never branches on its
+type.
+
+Lifecycle, in order:
+
+1. ``spec.create(ExtensionContext)`` -> a :class:`ModelExtension`.
+   Configuration is already validated against ``spec.config_schema``.
+2. ``extension.validate_base_model(descriptor)`` -> ``None`` to accept, or
+   a :class:`Rejection` to abort boot. The extension may VETO a base model
+   but never substitutes one: which weights load is the operator's call.
+3. ``extension.config_fingerprint()`` -> a stable, non-secret string that
+   is folded into the model cache key, so two differently configured
+   graphs can never share a cached context.
+4. ``extension.install(model, model_config)`` -> a
+   :class:`ModelExtensionRuntime`. The core loads the model; the extension
+   only ever receives one that loaded successfully.
+5. Per-session: ``supports_dit_backend`` / ``supports_codec_backend``,
+   ``decorate_conditioning``, ``apply_controls``, ``status`` / ``metrics``.
+6. ``runtime.close()`` at teardown — idempotent, and responsible for
+   removing anything the runtime attached to the shared model.
+
+Installation is wrapped by the core: if ``install`` raises after it has
+already mutated the model, ``close()`` is still called on whatever was
+produced, and boot aborts. A half-hooked model must never serve traffic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping
+
+#: Config field types an extension may declare. Deliberately small: these
+#: values come from an operator-authored JSON file, and every one of them
+#: has an unambiguous coercion.
+#:
+#: ``path`` is a coercion type, not a filesystem assertion: it validates
+#: as a string and nothing is stat'd. Only the extension knows whether a
+#: configured path is one it READS (must already exist) or one it WRITES
+#: (must not have to), so existence, readability, and format checks
+#: belong in the extension's ``create`` callable — which runs at
+#: selection, before any model work at all. See :class:`ModelExtension`.
+CONFIG_FIELD_TYPES = ("str", "int", "float", "bool", "path")
+
+#: Knob value types an extension may contribute. Restricted to numeric on
+#: purpose: the browser control panel renders float/int knobs generically
+#: from manifest bounds, but binds enum/bool knobs by name and renders
+#: unknown ones disabled. An extension enum knob would therefore appear in
+#: the manifest and be unusable. Revisit when the panel grows a generic
+#: binding.
+EXTENSION_KNOB_TYPES = ("float", "int")
+
+
+@dataclass(frozen=True)
+class ConfigField:
+    """One operator-supplied configuration value."""
+
+    type: str = "str"
+    required: bool = True
+    default: Any = None
+    description: str = ""
+
+    def __post_init__(self):
+        if self.type not in CONFIG_FIELD_TYPES:
+            raise ValueError(
+                f"config field type {self.type!r} is not one of "
+                f"{CONFIG_FIELD_TYPES}"
+            )
+
+
+@dataclass(frozen=True)
+class Rejection:
+    """An extension's refusal to run against a base model."""
+
+    reason: str
+
+
+@dataclass(frozen=True)
+class BackendVerdict:
+    """Whether an extension can run under a given acceleration backend.
+
+    ``reason`` is operator-facing and must not leak private architecture
+    detail; it is printed at boot when a downgrade happens.
+    """
+
+    ok: bool
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class ModelDescriptor:
+    """What the core is about to load, offered for veto and fingerprinting."""
+
+    family: str
+    model_id: str
+    checkpoint_dir: str
+    model_config: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExtensionContext:
+    """What an extension receives at construction time."""
+
+    qualified_id: str
+    plugin_id: str
+    plugin_version: str
+    config: Mapping[str, Any]
+
+
+class ModelExtensionRuntime:
+    """An installed extension. Subclass and override what you need.
+
+    Every method has a safe default, so an extension implements only the
+    hooks it actually uses. The core calls these through the module-level
+    helpers below, which tolerate a runtime that is not a subclass.
+    """
+
+    def supports_dit_backend(self, backend: str) -> BackendVerdict:
+        return BackendVerdict(True)
+
+    def supports_codec_backend(self, backend: str) -> BackendVerdict:
+        return BackendVerdict(True)
+
+    def decorate_conditioning(
+        self, bundle: Mapping[str, Any], source_latent_bct: Any = None,
+    ) -> Mapping[str, Any]:
+        """Return conditioning for the extension's own use.
+
+        MUST return a fresh mapping rather than mutating ``bundle``: the
+        bundle passed in may already be referenced by in-flight requests,
+        which have to keep seeing the conditioning they were submitted
+        with. The core always hands over a mapping it just built, and
+        never reads back through the one it gave you.
+
+        MUST be idempotent in its own keys. On a source swap the core
+        re-decorates the CURRENT conditioning, so ``bundle`` will already
+        carry the keys you added last time. Assign your keys; never append
+        to or accumulate on a value you find already present, or a second
+        swap will compound the first.
+
+        Called on the COMMAND thread (a prompt or source swap), not the
+        streaming runner. See ``apply_controls`` for what that means if
+        the two share state.
+        """
+        return bundle
+
+    def apply_controls(self, values: Mapping[str, float]) -> None:
+        """Apply this extension's namespaced knob values.
+
+        Called once per tick on the STREAMING RUNNER, unlocked — the
+        same thread that then runs your model code, so a value written
+        here is read by that tick with no synchronization needed. Do not
+        block.
+
+        ``decorate_conditioning``, by contrast, is called on the COMMAND
+        thread. If this method and that one touch the same state, that
+        is the one race the core does not serialize for you, and you own
+        it. Keeping controls to plain scalar rebinds avoids the question
+        entirely.
+        """
+
+    def status(self) -> Mapping[str, Any]:
+        """Operator-visible state. Must not contain paths or secrets."""
+        return {}
+
+    def metrics(self) -> Mapping[str, Any]:
+        """Operator-only telemetry.
+
+        Not called on the per-generation path — the core polls this on
+        demand or on a slow cadence, so it may be more expensive than a
+        hot-path accessor.
+        """
+        return {}
+
+    def close(self) -> None:
+        """Release everything, idempotently.
+
+        The loaded model is process-cached and shared across sessions, so
+        anything attached to it (wrappers, hooks, buffers) must be removed
+        here. Being called twice, or after a failed install, is normal.
+        """
+
+
+class ModelExtension:
+    """A configured, not-yet-installed extension. Subclass to implement.
+
+    ``spec.create(context)`` runs this class's constructor at SELECTION
+    time — before the model cache key is computed and long before any
+    weights load. That is the right place to validate configuration the
+    core cannot: that a configured input path exists and is readable,
+    that a numeric value is in a range only this extension knows. Raise
+    :class:`~acestep.plugins.errors.ExtensionConfigError` there and the
+    operator learns immediately, rather than after a multi-second load.
+    """
+
+    def validate_base_model(self, descriptor: ModelDescriptor):
+        """``None`` to accept, or a :class:`Rejection` to abort boot.
+
+        For facts about the BASE MODEL only — its objective, geometry,
+        or size. Configuration this extension owns is validated in the
+        constructor, which runs earlier.
+        """
+        return None
+
+    def config_fingerprint(self) -> str:
+        """Stable, non-secret identity of this extension's configuration.
+
+        Folded into the model cache key. Include the CONTENT identity of
+        any file you load (size and mtime, or a hash) — not just its path.
+        A file that a producer rewrites in place has a stable path and
+        different contents, and a path-only fingerprint would serve the
+        previously loaded model forever.
+        """
+        return ""
+
+    def install(self, model: Any, model_config: Mapping[str, Any]) -> ModelExtensionRuntime:
+        """Attach to the freshly loaded model and return the runtime."""
+        return ModelExtensionRuntime()
+
+    def close(self) -> None:
+        """Unwind an ``install()`` that raised part-way. Idempotent.
+
+        ``install`` can fail after it has already mutated the shared,
+        process-cached model. When it does, the core has no runtime to
+        close, so it calls this instead — the extension is the only
+        thing that knows what it had attached. A no-op is correct for an
+        extension whose ``install`` cannot fail dirty.
+        """
+
+
+@dataclass(frozen=True)
+class ModelExtensionSpec:
+    """Registration-time declaration of a model extension.
+
+    ``knob_specs`` are plain :class:`~acestep.streaming.knobs.KnobSpec`
+    values, so extension controls flow through exactly the same catalog
+    projection and coercion as core knobs. Their names must be namespaced
+    (``plugin_<plugin_id>_<control>``); the registry enforces that, along
+    with shadowing, type and bounds checks, at registration time so a bad
+    declaration fails at boot rather than per connection.
+    """
+
+    name: str
+    family: str
+    create: Callable[[ExtensionContext], ModelExtension]
+    config_schema: Mapping[str, ConfigField] = field(default_factory=dict)
+    knob_specs: tuple = ()
+    description: str = ""
+
+
+def decorate_conditioning(runtime, bundle, source_latent_bct=None):
+    """Call the runtime's conditioning hook, normalizing a ``None`` return.
+
+    The one contract detail a subclass can still get wrong: returning
+    nothing from ``decorate_conditioning`` reads as "I made no changes",
+    not as "the conditioning is now None". Every other hook has a total
+    default on the base class, so the core calls those directly.
+    """
+    decorated = runtime.decorate_conditioning(bundle, source_latent_bct)
+    return bundle if decorated is None else decorated

--- a/acestep/plugins/model_extensions.py
+++ b/acestep/plugins/model_extensions.py
@@ -106,6 +106,36 @@ class ModelDescriptor:
 
 
 @dataclass(frozen=True)
+class SourceView:
+    """The session's current source, in every form the core already holds.
+
+    ``latent`` is the encoded anchor in the model's own native layout —
+    for the sa3 family, ``[1, C, T]``. It is what most conditioning
+    extensions want, and it is what DEMON's own denoising path uses.
+
+    ``waveform`` and ``sample_rate`` are the audio that latent was encoded
+    FROM, carried because the core already holds it. An extension whose
+    condition derives from the audio itself rather than from its latent
+    cannot recover the audio here without a decode round-trip that costs
+    real time and cannot return what the encoder discarded. Handing over a
+    tensor the core is keeping anyway is strictly cheaper than making
+    every such extension pay for that.
+
+    Every field is optional and any of them may be ``None``: a session
+    created without a source has no latent, and a source re-anchored from
+    a latent DEMON did not encode itself has no waveform. Check before you
+    use; do not assume the shape of a session you did not create.
+
+    Treat the tensors as READ-ONLY. They are the live session anchor
+    itself, not copies, and the streaming runner reads them concurrently.
+    """
+
+    latent: Any = None
+    waveform: Any = None
+    sample_rate: int | None = None
+
+
+@dataclass(frozen=True)
 class ExtensionContext:
     """What an extension receives at construction time."""
 
@@ -130,9 +160,14 @@ class ModelExtensionRuntime:
         return BackendVerdict(True)
 
     def decorate_conditioning(
-        self, bundle: Mapping[str, Any], source_latent_bct: Any = None,
+        self, bundle: Mapping[str, Any], source: "SourceView | None" = None,
     ) -> Mapping[str, Any]:
         """Return conditioning for the extension's own use.
+
+        ``source`` is a :class:`SourceView` over the session's current
+        anchor, or ``None`` when the session has no source at all. Its
+        fields are individually optional — read
+        :class:`SourceView` before depending on any of them.
 
         MUST return a fresh mapping rather than mutating ``bundle``: the
         bundle passed in may already be referenced by in-flight requests,
@@ -256,7 +291,7 @@ class ModelExtensionSpec:
     description: str = ""
 
 
-def decorate_conditioning(runtime, bundle, source_latent_bct=None):
+def decorate_conditioning(runtime, bundle, source=None):
     """Call the runtime's conditioning hook, normalizing a ``None`` return.
 
     The one contract detail a subclass can still get wrong: returning
@@ -264,5 +299,5 @@ def decorate_conditioning(runtime, bundle, source_latent_bct=None):
     not as "the conditioning is now None". Every other hook has a total
     default on the base class, so the core calls those directly.
     """
-    decorated = runtime.decorate_conditioning(bundle, source_latent_bct)
+    decorated = runtime.decorate_conditioning(bundle, source)
     return bundle if decorated is None else decorated

--- a/acestep/plugins/selection.py
+++ b/acestep/plugins/selection.py
@@ -1,0 +1,249 @@
+"""Startup selection and installation of a model extension.
+
+Selection is startup-only and operator-controlled. That is both a safety
+property (a browser client can never name a module, checkpoint, or config
+path) and a mechanical necessity: the per-session knob manifest is sent
+once on the ``ready`` frame, so an extension's controls have to exist
+before any session is accepted for a client to ever see them.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from acestep.engine.obs import logger
+from acestep.plugins.api import (
+    LoadedPlugin,
+    PluginManifest,
+    validate_extension_config,
+)
+from acestep.plugins.discovery import discover_plugins
+from acestep.plugins.errors import (
+    ExtensionConfigError,
+    PluginNotFoundError,
+)
+from acestep.plugins.model_extensions import (
+    ExtensionContext,
+    ModelDescriptor,
+    ModelExtensionRuntime,
+    ModelExtensionSpec,
+    Rejection,
+)
+
+
+@dataclass
+class SelectedExtension:
+    """A configured extension, constructed but not yet installed."""
+
+    qualified_id: str
+    manifest: PluginManifest
+    spec: ModelExtensionSpec
+    extension: Any
+    config: Mapping[str, Any]
+
+    @property
+    def knob_specs(self) -> tuple:
+        return tuple(self.spec.knob_specs or ())
+
+    def public_status(self) -> dict:
+        """Safe-to-publish identity. Never the configuration values."""
+        return {
+            "id": self.qualified_id,
+            "plugin": self.manifest.id,
+            "version": self.manifest.version,
+        }
+
+    # ---- lifecycle -------------------------------------------------------
+
+    def validate_base_model(self, descriptor: ModelDescriptor) -> None:
+        """Give the extension a veto over the base model. Raises on refusal."""
+        hook = getattr(self.extension, "validate_base_model", None)
+        if hook is None:
+            return
+        verdict = hook(descriptor)
+        if isinstance(verdict, Rejection):
+            raise ExtensionConfigError(
+                f"{self.qualified_id} refused the selected base model: "
+                f"{verdict.reason}"
+            )
+
+    def config_fingerprint(self) -> str:
+        hook = getattr(self.extension, "config_fingerprint", None)
+        return str(hook() or "") if hook is not None else ""
+
+    def cache_key(self) -> tuple:
+        """Identity folded into the model cache key by the caller."""
+        return (
+            self.qualified_id, self.manifest.version, self.config_fingerprint(),
+        )
+
+    def install(self, model: Any, model_config: Mapping[str, Any]):
+        """Install onto a freshly loaded model, unwinding a partial failure.
+
+        If ``install`` raises after it has already mutated the model, the
+        partially-built runtime still gets ``close()`` before the error
+        propagates. A half-hooked model must never be cached or served:
+        the operator explicitly asked for this extension, so the stock
+        trunk is not an acceptable fallback.
+
+        The runtime must subclass :class:`ModelExtensionRuntime`. That is
+        checked HERE, at boot, because the alternative is discovering a
+        missing hook at a tick boundary as an ``AttributeError`` in the
+        streaming runner. The base class defines a total, neutral default
+        for every hook, so subclassing costs an extension nothing.
+        """
+        runtime = None
+        try:
+            runtime = self.extension.install(model, model_config)
+            if runtime is None:
+                raise ExtensionConfigError(
+                    f"{self.qualified_id}: install() returned None; it must "
+                    "return a runtime"
+                )
+            if not isinstance(runtime, ModelExtensionRuntime):
+                raise ExtensionConfigError(
+                    f"{self.qualified_id}: install() returned "
+                    f"{type(runtime).__name__}, which does not subclass "
+                    "ModelExtensionRuntime. Subclass it so every lifecycle "
+                    "hook has a defined default."
+                )
+            return runtime
+        except Exception:
+            if runtime is not None:
+                _close_quietly(runtime, self.qualified_id)
+            else:
+                # install() may have mutated the model before raising, so
+                # give the extension itself a chance to unwind.
+                _close_quietly(self.extension, self.qualified_id)
+            raise
+
+
+def _close_quietly(target, qualified_id: str) -> None:
+    try:
+        target.close()
+    except Exception as exc:  # noqa: BLE001 - unwinding must not mask the cause
+        logger.error(
+            "extension_unwind_failed id={} error={}", qualified_id, exc,
+        )
+
+
+def load_extension_config(path, qualified_id: str) -> dict:
+    """Read the operator's local JSON config for one extension.
+
+    The file is keyed by qualified extension id so one file can configure
+    several extensions and so a config can never be applied to the wrong
+    one by accident.
+    """
+    if path is None:
+        return {}
+    config_path = Path(path).expanduser().resolve()
+    try:
+        raw = json.loads(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ExtensionConfigError(
+            f"model extension config not found: {config_path}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise ExtensionConfigError(
+            f"model extension config {config_path} is not valid JSON: {exc}"
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise ExtensionConfigError(
+            f"model extension config {config_path} must be a JSON object "
+            f"keyed by extension id (e.g. {{{qualified_id!r}: {{...}}}})"
+        )
+    if qualified_id not in raw:
+        raise ExtensionConfigError(
+            f"model extension config {config_path} has no entry for "
+            f"{qualified_id!r} (found: {', '.join(sorted(raw)) or 'nothing'})"
+        )
+    section = raw[qualified_id]
+    if not isinstance(section, dict):
+        raise ExtensionConfigError(
+            f"model extension config {config_path}: entry {qualified_id!r} "
+            "must be a JSON object"
+        )
+    return section
+
+
+def split_qualified_id(qualified_id: str) -> tuple[str, str]:
+    plugin_id, sep, capability = str(qualified_id).partition(".")
+    if not sep or not plugin_id or not capability:
+        raise PluginNotFoundError(
+            f"invalid model extension id {qualified_id!r}: expected "
+            "<plugin-id>.<extension-name>"
+        )
+    return plugin_id, capability
+
+
+def select_model_extension(
+    qualified_id: str | None,
+    *,
+    family: str,
+    config_path=None,
+    plugins: Mapping[str, LoadedPlugin] | None = None,
+) -> SelectedExtension | None:
+    """Resolve, configure, and construct the selected model extension.
+
+    Returns ``None`` when nothing is selected — the stock path, which must
+    behave exactly as if the plugin system did not exist. Every failure
+    after a selection is made is fatal.
+    """
+    if not qualified_id:
+        return None
+
+    plugin_id, capability = split_qualified_id(qualified_id)
+    if plugins is None:
+        plugins = discover_plugins(required=[plugin_id])
+
+    plugin = plugins.get(plugin_id)
+    if plugin is None:
+        raise PluginNotFoundError(
+            f"plugin {plugin_id!r} is not installed (selected via "
+            f"{qualified_id!r})"
+        )
+    spec = plugin.model_extensions.get(capability)
+    if spec is None:
+        available = ", ".join(plugin.capability_ids) or "none"
+        raise PluginNotFoundError(
+            f"plugin {plugin_id!r} provides no model extension "
+            f"{capability!r} (available: {available})"
+        )
+    if spec.family != family:
+        raise ExtensionConfigError(
+            f"{qualified_id} extends the {spec.family!r} backend family, but "
+            f"this server is running {family!r}"
+        )
+
+    raw_config = load_extension_config(config_path, qualified_id)
+    config = validate_extension_config(qualified_id, spec.config_schema, raw_config)
+
+    context = ExtensionContext(
+        qualified_id=qualified_id,
+        plugin_id=plugin_id,
+        plugin_version=plugin.manifest.version,
+        config=config,
+    )
+    extension = spec.create(context)
+    if extension is None:
+        raise ExtensionConfigError(
+            f"{qualified_id}: create() returned None"
+        )
+
+    logger.info(
+        "model_extension_selected id={} plugin_version={} family={} "
+        "knobs={} config_keys={}",
+        qualified_id, plugin.manifest.version, spec.family,
+        [s.name for s in spec.knob_specs or ()], sorted(config),
+    )
+    return SelectedExtension(
+        qualified_id=qualified_id,
+        manifest=plugin.manifest,
+        spec=spec,
+        extension=extension,
+        config=config,
+    )

--- a/acestep/streaming/families.py
+++ b/acestep/streaming/families.py
@@ -78,6 +78,11 @@ def _make_sa3(ss):
         # payload predating the blend surface stays blend-neutral.
         cond_b=init.get("cond_b"),
         source_latent_bct=init["source_latent_bct"],
+        # The pre-encode audio behind that anchor, for the extension
+        # conditioning hook. .get so an in-process payload predating it
+        # still assembles, with the waveform half of the source view
+        # simply absent.
+        source_audio=init.get("source_audio"),
         # Resolved accel values (compile already normalized to eager by
         # the create path); .get so an in-process payload without them
         # stays on the eager default.

--- a/acestep/streaming/families.py
+++ b/acestep/streaming/families.py
@@ -83,6 +83,8 @@ def _make_sa3(ss):
         # stays on the eager default.
         dit_backend=init.get("dit_backend", "eager"),
         codec_backend=init.get("codec_backend", "eager"),
+        # Startup-selected model extension, absent on stock sessions.
+        model_extension=init.get("model_extension"),
         steps=int(ss.config.steps),
         depth=int(ss.state.current_depth),
         vae_window_s=float(ss.vae_window),

--- a/acestep/streaming/sa3_backend.py
+++ b/acestep/streaming/sa3_backend.py
@@ -247,6 +247,12 @@ class SA3Backend(DiffusionBackend):
         # knob-driven strength changes route through the pending stash
         # (D6b.5) so the refit stall is always announced.
         refit_mirror=None,
+        # ``(sample_rate, waveform)`` for the audio ``source_latent_bct``
+        # was encoded from. Retained ONLY so an extension's conditioning
+        # hook can see it (``acestep.plugins.SourceView``); nothing on the
+        # denoising path reads it. None when the caller did not supply it,
+        # which is a supported shape rather than an error.
+        source_audio=None,
         # Startup-selected model extension (a SelectedExtension) and its
         # installed runtime. Both None on stock sessions, which must
         # behave exactly as if the plugin system did not exist.
@@ -261,8 +267,19 @@ class SA3Backend(DiffusionBackend):
                 model_extension.knob_specs if model_extension is not None else ()
             )
         )
-        cond = self._decorate(cond, source_latent_bct)
-        cond_b = self._decorate(cond_b, source_latent_bct)
+        # Source anchor for audio-to-audio: engine layout [1, T, 256].
+        # Assigned BEFORE the decorate calls below, which read it back
+        # out through _source_view().
+        self._source_latent_btc = (
+            source_latent_bct.movedim(1, 2).contiguous()
+            if source_latent_bct is not None else None
+        )
+        self._source_sample_rate, self._source_waveform = (
+            (int(source_audio[0]), source_audio[1])
+            if source_audio is not None else (None, None)
+        )
+        cond = self._decorate(cond, self._source_view())
+        cond_b = self._decorate(cond_b, self._source_view())
         self._cond = cond
         self._cond_b = cond_b if cond_b is not None else cond
         # Live A↔B crossfade value and the bundle the next submit
@@ -293,11 +310,8 @@ class SA3Backend(DiffusionBackend):
         # renoise) | "ode" (euler; off-objective for SA3, debug only)
         self._sampler = sampler
 
-        # Source anchor for audio-to-audio: engine layout [1, T, 256].
-        self._source_latent_btc = (
-            source_latent_bct.movedim(1, 2).contiguous()
-            if source_latent_bct is not None else None
-        )
+        # (The source anchor is assigned near the top of __init__, ahead
+        # of the conditioning decoration that reads it.)
 
         # Emerged-generation observability. SA3 knob/prompt changes ride
         # the NEXT SlotRequest only (no shared-curve writes onto
@@ -527,6 +541,10 @@ class SA3Backend(DiffusionBackend):
             knob_state=knob_state,
             state=state,
             source_latent_bct=source_latent,
+            # Carried for the extension conditioning hook only; see the
+            # ctor arg. ``source_audio`` is already the ``(sample_rate,
+            # waveform)`` pair ``context.encode_source`` consumes.
+            source_audio=source_audio,
             prompt_rebuilder=_prompt_rebuilder,
             prompt_tags=prompt,
             source_encoder=_source_encoder,
@@ -541,17 +559,31 @@ class SA3Backend(DiffusionBackend):
             **kwargs,
         )
 
-    def _source_latent_bct(self):
-        """The source anchor in SA3-native ``[1, 256, T]`` layout, or None.
+    def _source_view(self, latent_bct=None, audio=None):
+        """The session source as an extension sees it, or None if absent.
 
-        Stored internally as engine-layout ``[1, T, 256]``; extensions are
-        handed the native layout their model actually consumes.
+        The latent is handed over in SA3-native ``[1, 256, T]``: it is
+        stored engine-layout ``[1, T, 256]``, and extensions get the
+        native layout their model actually consumes.
+
+        ``latent_bct`` / ``audio`` override the stored anchor, for a swap
+        that has already computed the new one but not yet published it.
         """
-        if self._source_latent_btc is None:
+        if latent_bct is None and self._source_latent_btc is not None:
+            latent_bct = self._source_latent_btc.movedim(1, 2)
+        sample_rate, waveform = (
+            (int(audio[0]), audio[1]) if audio is not None
+            else (self._source_sample_rate, self._source_waveform)
+        )
+        if latent_bct is None and waveform is None:
             return None
-        return self._source_latent_btc.movedim(1, 2)
+        from acestep.plugins.model_extensions import SourceView
 
-    def _decorate(self, cond, source_latent_bct):
+        return SourceView(
+            latent=latent_bct, waveform=waveform, sample_rate=sample_rate,
+        )
+
+    def _decorate(self, cond, source):
         """Apply the extension's conditioning contribution to a capture.
 
         Always builds a FRESH bundle: an in-flight SlotRequest holds a
@@ -565,7 +597,7 @@ class SA3Backend(DiffusionBackend):
         from acestep.plugins.model_extensions import decorate_conditioning
 
         decorated = decorate_conditioning(
-            self._extension_runtime, dict(cond.cond_bundle), source_latent_bct,
+            self._extension_runtime, dict(cond.cond_bundle), source,
         )
         return replace(cond, cond_bundle=dict(decorated))
 
@@ -892,7 +924,7 @@ class SA3Backend(DiffusionBackend):
         # decoration is NOT conditioner execution and stays outside it.
         with self._conditioner_lock:
             cond, sched_factory = self._prompt_rebuilder(tags, self._steps)
-        cond = self._decorate(cond, self._source_latent_bct())
+        cond = self._decorate(cond, self._source_view())
         rebuild_ms = (time.perf_counter() - t0) * 1000
         if int(cond.latent_frames) != int(self._cond.latent_frames):
             # Duration is fixed for the session lifetime, so the latent
@@ -906,7 +938,7 @@ class SA3Backend(DiffusionBackend):
         if tags_b and tags_b != tags:
             with self._conditioner_lock:
                 cond_b, _ = self._prompt_rebuilder(tags_b, self._steps)
-            cond_b = self._decorate(cond_b, self._source_latent_bct())
+            cond_b = self._decorate(cond_b, self._source_view())
             if int(cond_b.latent_frames) != int(cond.latent_frames):
                 raise ValueError(
                     f"sa3 prompt-B swap changed latent_frames "
@@ -979,17 +1011,26 @@ class SA3Backend(DiffusionBackend):
         # calling this hook.
         with self._control_lock:
             self._source_latent_btc = latent_btc
+            # The waveform is retained alongside the latent so an
+            # extension's next re-decoration sees a source view whose two
+            # halves describe the same audio. Dropping it here would leave
+            # the previous upload's waveform paired with the new anchor.
+            self._source_waveform = waveform
+            self._source_sample_rate = int(sample_rate)
             self._latent_history.clear()
             if self._extension_runtime is not None:
                 # An extension may condition on the source, so re-decorate
                 # against the new anchor. Rebuilding both captures (rather
                 # than editing their bundles) is what keeps in-flight slots
                 # finishing on the conditioning they were submitted with.
+                view = self._source_view(
+                    latent_bct=latent_bct, audio=(int(sample_rate), waveform),
+                )
                 old_a, old_b = self._cond, self._cond_b
-                self._cond = self._decorate(old_a, latent_bct)
+                self._cond = self._decorate(old_a, view)
                 self._cond_b = (
                     self._cond if old_b is old_a
-                    else self._decorate(old_b, latent_bct)
+                    else self._decorate(old_b, view)
                 )
                 self._active_bundle = self._blend_bundles(self._blend)
                 self._cond_epoch += 1

--- a/acestep/streaming/sa3_backend.py
+++ b/acestep/streaming/sa3_backend.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 import threading
 import time
 from collections import deque
+from dataclasses import replace
 from typing import Callable, Optional
 
 import torch
@@ -121,7 +122,7 @@ def sa3_lora_compatible(metadata: dict, model_id: str) -> bool:
     return lineage == model_id
 
 
-def sa3_knob_specs(loras: tuple | list = ()) -> list:
+def sa3_knob_specs(loras: tuple | list = (), *, extension_specs=()) -> list:
     """The SA3 family knob manifest (backend-owned, plan §3.3).
 
     ``seed``, ``steps_override``, ``x0_target``, ``feedback`` and
@@ -137,6 +138,14 @@ def sa3_knob_specs(loras: tuple | list = ()) -> list:
     the shared ``lora_str_<id>`` strength spec — the same registry
     factory ACE uses, so the knob's shape (and therefore its wire
     semantics) cannot fork across families.
+
+    ``extension_specs`` appends the controls contributed by a
+    startup-selected model extension. They are already namespaced and
+    validated at plugin-registration time, and they join the manifest
+    HERE so they reach the session's spec map — and therefore
+    ``coerce_knob_values`` — by the same route as every core knob. A knob
+    that reached the client but not that map would be accepted from the
+    wire unvalidated and unclamped, with no error.
     """
     shared = {s.name: s for s in registry_knob_specs(False)}
     return [
@@ -165,7 +174,7 @@ def sa3_knob_specs(loras: tuple | list = ()) -> list:
         shared["feedback_depth"],
         shared["seed"],
         shared["steps_override"],
-    ] + [lora_strength_spec(lid) for lid in loras]
+    ] + [lora_strength_spec(lid) for lid in loras] + list(extension_specs or ())
 
 
 class SA3Backend(DiffusionBackend):
@@ -238,8 +247,22 @@ class SA3Backend(DiffusionBackend):
         # knob-driven strength changes route through the pending stash
         # (D6b.5) so the refit stall is always announced.
         refit_mirror=None,
+        # Startup-selected model extension (a SelectedExtension) and its
+        # installed runtime. Both None on stock sessions, which must
+        # behave exactly as if the plugin system did not exist.
+        model_extension=None,
+        extension_runtime=None,
     ):
         super().__init__(adapter=adapter, codec=codec)
+        self._extension = model_extension
+        self._extension_runtime = extension_runtime
+        self._extension_knob_names = tuple(
+            spec.name for spec in (
+                model_extension.knob_specs if model_extension is not None else ()
+            )
+        )
+        cond = self._decorate(cond, source_latent_bct)
+        cond_b = self._decorate(cond_b, source_latent_bct)
         self._cond = cond
         self._cond_b = cond_b if cond_b is not None else cond
         # Live A↔B crossfade value and the bundle the next submit
@@ -290,6 +313,7 @@ class SA3Backend(DiffusionBackend):
         # request's ``aux_cond`` can be mapped back to the prompt it
         # carried even after a handle_set_prompt swap.
         self._cond_epoch = 0
+        self._prompt_tags = prompt_tags
         self._cond_history: list = [(cond.cond_bundle, 0, prompt_tags)]
         self._emerged_request = None
         self._emerged_marker = None  # (denoise, epoch) of the last log
@@ -365,6 +389,7 @@ class SA3Backend(DiffusionBackend):
         source_latent_bct=None,
         dit_backend: str = "eager",
         codec_backend: str = "eager",
+        model_extension=None,
         **kwargs,
     ) -> "SA3Backend":
         """Production assembly over a loaded
@@ -478,6 +503,19 @@ class SA3Backend(DiffusionBackend):
                 (int(sample_rate), waveform), int(sample_size),
             )
 
+        # Sampler follows the loaded checkpoint's training objective.
+        # Post-trained SA3 releases ("rf_denoiser") were trained and
+        # evaluated with deterministic ping-pong; a plain rectified-flow
+        # base wants Euler ODE. Assuming the post-trained objective for
+        # every SA3 checkpoint silently mis-samples the other family.
+        # An explicit caller-supplied ``sampler`` still wins.
+        kwargs.setdefault(
+            "sampler",
+            "ode"
+            if getattr(context, "diffusion_objective", None) == "rectified_flow"
+            else "pingpong",
+        )
+
         return cls(
             adapter=adapter,
             codec=context.make_codec(backend=codec_backend),
@@ -498,8 +536,60 @@ class SA3Backend(DiffusionBackend):
             eager_dit=context.dit,
             model_id=str(context.model_id),
             refit_mirror=refit_mirror,
+            model_extension=model_extension,
+            extension_runtime=getattr(context, "extension_runtime", None),
             **kwargs,
         )
+
+    def _source_latent_bct(self):
+        """The source anchor in SA3-native ``[1, 256, T]`` layout, or None.
+
+        Stored internally as engine-layout ``[1, T, 256]``; extensions are
+        handed the native layout their model actually consumes.
+        """
+        if self._source_latent_btc is None:
+            return None
+        return self._source_latent_btc.movedim(1, 2)
+
+    def _decorate(self, cond, source_latent_bct):
+        """Apply the extension's conditioning contribution to a capture.
+
+        Always builds a FRESH bundle: an in-flight SlotRequest holds a
+        reference to the bundle it was submitted with, and must keep
+        seeing that one across a prompt or source swap. The extension is
+        handed a copy, so even one that mutates its argument in place
+        cannot reach a bundle anyone else is holding.
+        """
+        if cond is None or self._extension_runtime is None:
+            return cond
+        from acestep.plugins.model_extensions import decorate_conditioning
+
+        decorated = decorate_conditioning(
+            self._extension_runtime, dict(cond.cond_bundle), source_latent_bct,
+        )
+        return replace(cond, cond_bundle=dict(decorated))
+
+    def _apply_extension_controls(self, knobs: dict) -> None:
+        """Hand the extension its own namespaced knob values.
+
+        Runs unlocked, on the streaming runner — the same thread the
+        extension's model code runs on. ``_control_lock`` exists to order
+        the COMMAND thread's prompt/source swaps against the tick loop,
+        and holding it here would only put arbitrary plugin code, every
+        tick, in the path of a swap. An extension that keeps state its
+        ``decorate_conditioning`` also touches (which the command thread
+        does call) owns that synchronization itself; the contract is
+        documented on ``ModelExtensionRuntime.apply_controls``.
+        """
+        if self._extension_runtime is None or not self._extension_knob_names:
+            return
+        values = {
+            name: knobs[name]
+            for name in self._extension_knob_names
+            if name in knobs
+        }
+        if values:
+            self._extension_runtime.apply_controls(values)
 
     def _build_pipeline(self, steps: int):
         from acestep.engine.diffusion import DiffusionConfig
@@ -549,7 +639,12 @@ class SA3Backend(DiffusionBackend):
         )
 
     def knob_specs(self, lora_ids=()) -> list:
-        return sa3_knob_specs(loras=list(lora_ids or []))
+        return sa3_knob_specs(
+            loras=list(lora_ids or []),
+            extension_specs=(
+                self._extension.knob_specs if self._extension is not None else ()
+            ),
+        )
 
     def lora_compatible(self, metadata: dict) -> bool:
         return sa3_lora_compatible(metadata, self._model_id)
@@ -793,9 +888,11 @@ class SA3Backend(DiffusionBackend):
         t0 = time.perf_counter()
         # Conditioner EXECUTION under the D5 lock: a concurrent LoRA
         # mutation of the conditioner's parametrizations (runner
-        # rendezvous) must not interleave with this capture.
+        # rendezvous) must not interleave with this capture. Extension
+        # decoration is NOT conditioner execution and stays outside it.
         with self._conditioner_lock:
             cond, sched_factory = self._prompt_rebuilder(tags, self._steps)
+        cond = self._decorate(cond, self._source_latent_bct())
         rebuild_ms = (time.perf_counter() - t0) * 1000
         if int(cond.latent_frames) != int(self._cond.latent_frames):
             # Duration is fixed for the session lifetime, so the latent
@@ -809,6 +906,7 @@ class SA3Backend(DiffusionBackend):
         if tags_b and tags_b != tags:
             with self._conditioner_lock:
                 cond_b, _ = self._prompt_rebuilder(tags_b, self._steps)
+            cond_b = self._decorate(cond_b, self._source_latent_bct())
             if int(cond_b.latent_frames) != int(cond.latent_frames):
                 raise ValueError(
                     f"sa3 prompt-B swap changed latent_frames "
@@ -838,6 +936,7 @@ class SA3Backend(DiffusionBackend):
             # the next cond epoch; keep a short identity history so latents
             # still in flight on the OLD bundle stay attributable.
             self._cond_epoch += 1
+            self._prompt_tags = tags
             self._cond_history.append((cond.cond_bundle, self._cond_epoch, tags))
             del self._cond_history[:-4]
         logger.info(
@@ -881,6 +980,23 @@ class SA3Backend(DiffusionBackend):
         with self._control_lock:
             self._source_latent_btc = latent_btc
             self._latent_history.clear()
+            if self._extension_runtime is not None:
+                # An extension may condition on the source, so re-decorate
+                # against the new anchor. Rebuilding both captures (rather
+                # than editing their bundles) is what keeps in-flight slots
+                # finishing on the conditioning they were submitted with.
+                old_a, old_b = self._cond, self._cond_b
+                self._cond = self._decorate(old_a, latent_bct)
+                self._cond_b = (
+                    self._cond if old_b is old_a
+                    else self._decorate(old_b, latent_bct)
+                )
+                self._active_bundle = self._blend_bundles(self._blend)
+                self._cond_epoch += 1
+                self._cond_history.append(
+                    (self._cond.cond_bundle, self._cond_epoch, self._prompt_tags),
+                )
+                del self._cond_history[:-4]
         logger.info(
             "sa3_source_swapped samples={} sample_rate={} encode_ms={:.1f}",
             int(waveform.shape[-1]), int(sample_rate), encode_ms,
@@ -977,6 +1093,8 @@ class SA3Backend(DiffusionBackend):
                         continue
                     if abs(lora_str - desc.strength) > 0.02:
                         self.set_lora_strength(desc.id, lora_str)
+
+        self._apply_extension_controls(knobs)
 
         # Source-lock strength rides the shared override so a strength
         # bump engages the blend on in-flight slots submitted while it

--- a/acestep/streaming/sa3_session.py
+++ b/acestep/streaming/sa3_session.py
@@ -422,6 +422,12 @@ def create_sa3_session(
                 "cond": cond,
                 "cond_b": cond_b,
                 "source_latent_bct": source_latent,
+                # The same pair the encode above consumed. The backend
+                # keeps it only for an extension's conditioning hook; it
+                # is the truncated, stereo-normalized waveform, i.e. the
+                # audio the anchor actually represents rather than the
+                # raw upload.
+                "source_audio": (SAMPLE_RATE, waveform),
                 "duration_s": duration_s,
                 "dit_backend": dit_backend,
                 "codec_backend": codec_backend,

--- a/acestep/streaming/sa3_session.py
+++ b/acestep/streaming/sa3_session.py
@@ -74,16 +74,59 @@ _CONTEXTS: dict = {}
 _CONTEXTS_LOCK = threading.Lock()
 
 
-def get_sa3_context(model_id: str):
-    """Load-or-reuse the process-cached SA3Context for ``model_id``."""
+def sa3_context_key(model_id: str, *, checkpoint_dir=None, extension=None) -> tuple:
+    """Cache key identifying one exact loaded SA3 model.
+
+    Includes the checkpoint's CONTENT identity, not just its path: an
+    operator-supplied directory can be rewritten in place between runs
+    (a training loop that keeps overwriting the same weights), and two
+    different models sharing a path must not share a cached context.
+
+    Also includes the installed extension's identity, version, and
+    configuration fingerprint, so two differently-configured model graphs
+    can never collide on one cached entry.
+    """
+    from acestep.engine.sa3_helpers import sa3_checkpoint_identity
+
+    checkpoint = (
+        None if checkpoint_dir is None
+        else sa3_checkpoint_identity(checkpoint_dir)
+    )
+    ext_key = None if extension is None else extension.cache_key()
+    return (model_id, checkpoint, ext_key)
+
+
+def get_sa3_context(model_id: str, *, checkpoint_dir=None, extension=None):
+    """Load-or-reuse the process-cached SA3Context for one exact model."""
     from acestep.engine.sa3_context import SA3Context
 
+    key = sa3_context_key(
+        model_id, checkpoint_dir=checkpoint_dir, extension=extension,
+    )
     with _CONTEXTS_LOCK:
-        context = _CONTEXTS.get(model_id)
+        context = _CONTEXTS.get(key)
         if context is None:
-            context = SA3Context(model_id)
-            _CONTEXTS[model_id] = context
+            context = SA3Context(
+                model_id, checkpoint_dir=checkpoint_dir, extension=extension,
+            )
+            _CONTEXTS[key] = context
         return context
+
+
+def evict_sa3_contexts() -> int:
+    """Drop and close every cached SA3 context. Returns how many.
+
+    Server shutdown path: an installed extension may have attached itself
+    to the shared model, and ``close()`` is what detaches it.
+    """
+    with _CONTEXTS_LOCK:
+        contexts = list(_CONTEXTS.values())
+        _CONTEXTS.clear()
+    for context in contexts:
+        close = getattr(context, "close", None)
+        if close is not None:
+            close()
+    return len(contexts)
 
 
 def _delivered_samples(n_44k: int) -> int:
@@ -109,6 +152,8 @@ def _resolve_accel(value: str, component: str) -> str:
 def create_sa3_session(
     cls, *, audio, config, checkpoint, session_id,
     decoder_backend: str = "tensorrt", vae_backend: str = "tensorrt",
+    sa3_base_checkpoint_dir=None,
+    model_extension=None,
     **_unused,
 ):
     """Build a ready-to-run sa3 :class:`StreamingSession` (``cls``). See
@@ -130,7 +175,27 @@ def create_sa3_session(
     dit_backend = _resolve_accel(decoder_backend, "dit")
     codec_backend = _resolve_accel(vae_backend, "codec")
     model_id = checkpoint
-    context = get_sa3_context(model_id)
+    context = get_sa3_context(
+        model_id,
+        checkpoint_dir=sa3_base_checkpoint_dir,
+        extension=model_extension,
+    )
+
+    # An installed extension may not be runnable under a prebuilt
+    # acceleration plan. Resolve that BEFORE component construction so the
+    # duration clamp below sees the backend that will actually run: a
+    # TensorRT duration cap must not be imposed on an eager graph.
+    dit_backend, dit_downgrade = context.effective_dit_backend(dit_backend)
+    codec_backend, codec_downgrade = context.effective_codec_backend(codec_backend)
+    for component, reason in (("dit", dit_downgrade), ("codec", codec_downgrade)):
+        if reason:
+            # WARNING, not INFO: the operator asked for acceleration and is
+            # not getting it. This is the only point it can be reported —
+            # the verdict needs the installed runtime, which needs weights.
+            logger.warning(
+                "sa3_backend_downgraded component={} using=eager reason={}",
+                component, reason,
+            )
 
     waveform = audio.waveform[:2].float()
     # SA3 decodes stereo and geometry() declares 2 channels, so the
@@ -264,6 +329,12 @@ def create_sa3_session(
         src_np = src_np[:n_48k]
     n_channels = src_np.shape[1] if src_np.ndim > 1 else 1
 
+    # Stock family manifest plus this session's LoRA controls. Extension
+    # controls are deliberately NOT named here: they are composed in ONE
+    # place — SA3Backend.knob_specs() — and StreamingSession seeds this
+    # KnobState from that manifest during construction, so naming them
+    # here too would be a second composition point that could silently
+    # drift from the one the ready frame and coerce_knob_values use.
     virtual_knobs = KnobState(sa3_knob_specs(
         loras=initial_enable_ids if use_lora else [],
     ))
@@ -355,6 +426,7 @@ def create_sa3_session(
                 "dit_backend": dit_backend,
                 "codec_backend": codec_backend,
                 "lora_manager": lora_mgr,
+                "model_extension": model_extension,
             },
         )
         cleanup.pop_all()

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -2570,6 +2570,8 @@ class StreamingSession:
         decoder_backend: str = "tensorrt",
         vae_backend: str = "tensorrt",
         offload_text_encoder: bool = False,
+        sa3_base_checkpoint_dir: str | None = None,
+        model_extension=None,
         session_id: str,
     ) -> "StreamingSession":
         """Build a ready-to-run session for one connection.
@@ -2601,6 +2603,8 @@ class StreamingSession:
                 decoder_backend=decoder_backend,
                 vae_backend=vae_backend,
                 offload_text_encoder=offload_text_encoder,
+                sa3_base_checkpoint_dir=sa3_base_checkpoint_dir,
+                model_extension=model_extension,
             )
 
         waveform = audio.waveform

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -159,6 +159,16 @@ def _collect_repeated_arg(args: list[str], flag: str) -> list[str]:
     return values
 
 
+def _single_arg(args: list[str], flag: str) -> str | None:
+    """The last ``--flag value`` / ``--flag=value`` occurrence, or None.
+
+    Bounds-checked: a trailing flag with no value exits with the remedy
+    instead of raising IndexError out of argument parsing.
+    """
+    values = _collect_repeated_arg(args, flag)
+    return values[-1] if values else None
+
+
 def _resolve_video(name: str) -> Path | None:
     """Map a ``/videos/<name>`` request to a file inside ``VIDEOS_DIR``.
 
@@ -678,7 +688,9 @@ def _run_preflight(decoder_accel: str, vae_accel: str, checkpoint: str) -> None:
     )
 
 
-def _run_sa3_preflight(model_id: str) -> None:
+def _run_sa3_preflight(
+    model_id: str, *, base_checkpoint_dir: str | None = None,
+) -> None:
     """Boot fail-fast for the SA3 family.
 
     The ACE ``_run_preflight`` checks the wrong tree — SA3 weights and
@@ -687,10 +699,19 @@ def _run_sa3_preflight(model_id: str) -> None:
     vendored ``stable_audio_3`` source). A missing TRT engine is NOT
     fatal: SA3 degrades to the eager DiT at session create, so unlike
     the ACE path this preflight never gates on engines.
-    """
-    from acestep.engine.sa3_helpers import sa3_checkpoint_status
 
-    ok, msg = sa3_checkpoint_status(model_id)
+    ``base_checkpoint_dir`` validates an operator-supplied checkpoint
+    directory instead of the catalog location for ``model_id``.
+    """
+    from acestep.engine.sa3_helpers import (
+        sa3_checkpoint_status,
+        sa3_custom_checkpoint_status,
+    )
+
+    if base_checkpoint_dir:
+        ok, msg = sa3_custom_checkpoint_status(base_checkpoint_dir)
+    else:
+        ok, msg = sa3_checkpoint_status(model_id)
     if not ok:
         # ``msg`` carries the failure-specific remedy: a manual HF download
         # for missing weights (demon-setup does NOT fetch them), or
@@ -702,7 +723,10 @@ def _run_sa3_preflight(model_id: str) -> None:
         print(f"  {msg}")
         print("=" * 64)
         raise SystemExit(1)
-    logger.info("preflight_sa3_ok model_id={}", model_id)
+    logger.info(
+        "preflight_sa3_ok model_id={} base_dir={}",
+        model_id, base_checkpoint_dir,
+    )
 
 
 def main():
@@ -780,6 +804,23 @@ def main():
         from acestep.streaming.families import resolve_checkpoint
 
         backend_family, checkpoint = resolve_checkpoint(checkpoint)
+    # Operator-supplied SA3 base checkpoint directory: evaluates a
+    # non-catalog checkpoint without installing it into the managed
+    # models tree. Startup-only and never accepted from a client.
+    sa3_base_checkpoint_dir = _single_arg(args, "--sa3-base-checkpoint")
+    if sa3_base_checkpoint_dir and backend_family != "sa3":
+        raise SystemExit(
+            "[Server] --sa3-base-checkpoint requires an SA3 --checkpoint "
+            "alias (e.g. --checkpoint sa3-medium)"
+        )
+    # Model extension selection is startup-only and operator-controlled:
+    # a client can never name a plugin, a module, or a config path.
+    model_extension_id = _single_arg(args, "--model-extension")
+    model_extension_config = _single_arg(args, "--model-extension-config")
+    if model_extension_config and not model_extension_id:
+        raise SystemExit(
+            "[Server] --model-extension-config requires --model-extension"
+        )
     if "--control-host" in args:
         idx = args.index("--control-host")
         control_host = args[idx + 1]
@@ -817,6 +858,10 @@ def main():
             route, mount.root, mount.entry,
         )
 
+    # Bound in both branches: the shutdown path reads it, and --no-backend
+    # never reaches the selection code below.
+    model_extension = None
+
     if no_backend:
         ws_handler = _stub_handle_client
         logger.info(
@@ -837,7 +882,37 @@ def main():
                 _run_preflight(decoder_accel, vae_accel, checkpoint)
             elif backend_family == "sa3":
                 # `checkpoint` is the resolved SA3 model id here.
-                _run_sa3_preflight(checkpoint)
+                _run_sa3_preflight(
+                    checkpoint,
+                    base_checkpoint_dir=sa3_base_checkpoint_dir,
+                )
+
+        # Resolve the selected model extension at boot, before any
+        # session exists. Startup-only is a safety property AND a
+        # mechanical necessity: the knob manifest is published once on the
+        # ready frame, so an extension's controls must exist before the
+        # first client connects for them to ever be visible.
+        if model_extension_id:
+            from acestep.plugins.errors import PluginError
+            from acestep.plugins.selection import select_model_extension
+
+            try:
+                model_extension = select_model_extension(
+                    model_extension_id,
+                    family=backend_family,
+                    config_path=model_extension_config,
+                )
+            except PluginError as exc:
+                # Fail closed. Running stock after the operator explicitly
+                # asked for an extension would generate with a different
+                # model than the one requested, and sound entirely fine.
+                print()
+                print("=" * 64)
+                print("  Model extension unavailable")
+                print("=" * 64)
+                print(f"  {exc}")
+                print("=" * 64)
+                raise SystemExit(1) from exc
 
         # Defer the heavy import until we know we need it. Pulling this in
         # loads torch + acestep + TRT machinery; in --no-backend we never
@@ -858,6 +933,8 @@ def main():
                 checkpoint=checkpoint,
                 backend_family=backend_family,
                 offload_text_encoder=offload_text_encoder,
+                sa3_base_checkpoint_dir=sa3_base_checkpoint_dir,
+                model_extension=model_extension,
             )
 
         # Pay the one-time cold-start cost (TRT decoder-engine load,
@@ -1032,6 +1109,19 @@ def main():
             time.sleep(0.5)
     except KeyboardInterrupt:
         logger.info("server_shutdown reason=keyboard_interrupt")
+        if model_extension is not None:
+            # An installed extension may have attached itself to the
+            # process-cached model; close() is what detaches it. Best
+            # effort — shutdown must not hang on a misbehaving plugin.
+            try:
+                from acestep.streaming.sa3_session import evict_sa3_contexts
+
+                logger.info(
+                    "server_shutdown_evicted_contexts count={}",
+                    evict_sa3_contexts(),
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("server_shutdown_evict_failed error={}", exc)
         os._exit(0)
 
 

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -1007,6 +1007,8 @@ def handle_client(
     checkpoint: str = "acestep-v15-turbo",
     backend_family: str = "acestep",
     offload_text_encoder: bool = False,
+    sa3_base_checkpoint_dir: str | None = None,
+    model_extension=None,
 ):
     """Connection entrypoint. The body lives in ``_handle_client_body``;
     this wrapper exists only to own a single ``ExitStack`` so the
@@ -1021,6 +1023,8 @@ def handle_client(
                 checkpoint=checkpoint,
                 backend_family=backend_family,
                 offload_text_encoder=offload_text_encoder,
+                sa3_base_checkpoint_dir=sa3_base_checkpoint_dir,
+                model_extension=model_extension,
             )
     finally:
         # Final allocator trim, AFTER the body frame (the last holder of
@@ -1051,6 +1055,8 @@ def _handle_client_body(
     checkpoint: str,
     backend_family: str,
     offload_text_encoder: bool,
+    sa3_base_checkpoint_dir: str | None,
+    model_extension,
 ):
     logger.info(
         "client_connected decoder={} vae={} checkpoint={} family={} text_encoder={}",
@@ -1219,6 +1225,8 @@ def _handle_client_body(
                 decoder_backend=decoder_backend,
                 vae_backend=vae_backend,
                 offload_text_encoder=offload_text_encoder,
+                sa3_base_checkpoint_dir=sa3_base_checkpoint_dir,
+                model_extension=model_extension,
                 session_id=session_id,
             )
             with _ACTIVE_SLOT_LOCK:

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -61,7 +61,7 @@ lifetime of the process.
 from acestep.plugins import ConfigField, ModelExtensionSpec
 from acestep.streaming.knobs import KnobSpec
 
-PLUGIN_API = 1
+PLUGIN_API = 2
 
 def register(registry):
     registry.add_model_extension(
@@ -173,6 +173,55 @@ tick with no synchronization needed. Do not block.
 source swap). If it and `apply_controls` touch the same state, that is the
 one race DEMON does not serialize for you, and you own it. Keeping controls
 to plain scalar rebinds avoids the question entirely.
+
+### Conditioning on the session source
+
+`decorate_conditioning(bundle, source)` receives a `SourceView`, or `None`
+when the session has no source at all:
+
+```python
+from acestep.plugins import ModelExtensionRuntime
+
+class MyRuntime(ModelExtensionRuntime):
+    def decorate_conditioning(self, bundle, source=None):
+        if source is None or source.waveform is None:
+            return bundle
+        cond = my_analysis(source.waveform, source.sample_rate)
+        return {**bundle, "my_cond": cond}
+```
+
+| Field | What it is |
+|---|---|
+| `latent` | The encoded source anchor in the model's own native layout (`[1, C, T]` for `sa3`). |
+| `waveform` | The audio that latent was encoded from, or `None`. |
+| `sample_rate` | Sample rate of `waveform`, or `None`. |
+
+**Every field is optional.** A session created without a source has no
+latent; a source re-anchored from a latent DEMON did not encode itself has
+no waveform. Check before you use, and do not assume the shape of a session
+you did not create.
+
+The waveform is carried because DEMON already holds it. An extension whose
+condition derives from the audio rather than from its latent would otherwise
+have to decode the latent back to audio — real time spent per swap, to
+recover something the encoder had already discarded.
+
+**Treat both tensors as read-only.** They are the live session anchor
+itself, not copies, and the streaming runner reads them concurrently.
+
+**Size your condition from the conditioning bundle, never from a constant.**
+The latent window's length is a property of the session (its duration, the
+model's downsampling ratio, and the upstream alignment rules), and it is not
+a round number. Read it off the tensors you are handed — `source.latent`'s
+last axis, or the bundle's own geometry — and build to that. A hardcoded
+length is correct for exactly one session configuration and silently
+misaligned for every other.
+
+Note also that the generated window is slightly longer than the requested
+duration: upstream Stable Audio 3 adds a fixed span of duration **headroom**
+(`duration_padding_sec`), which the padding mask marks as valid space rather
+than masking off. It is a small fraction of a full-length window and a
+larger one of a short session.
 
 DEMON deliberately does not hold its control lock across your code: that
 lock exists to order the command thread against the tick loop, and putting

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,232 @@
+# Writing a DEMON plugin
+
+DEMON can be extended out-of-tree by an installed Python package. This
+document is the contract for plugin authors and the operator guide for
+running one.
+
+Plugins are **trusted, in-process Python**. This is an extensibility
+boundary, not a security sandbox. Plugins load only from operator-
+controlled startup configuration — a browser client can never name a
+plugin, a module path, a checkpoint, or a config file.
+
+## Import tiers
+
+| Tier | Where | Stability |
+|---|---|---|
+| **1** | `acestep.plugins` | Versioned by `PLUGIN_API_VERSION`. Changes only with a version bump. |
+| **2** | `acestep.engine.sa3_internals` | The documented, tested subset of vendored SA3 model internals an extension may traverse when it must build modules against the trunk architecture. Versioned by its own `API_VERSION`. |
+| **0** | everything else under `acestep.*` | Internal. Importing it is a bug in your plugin. |
+
+Tier 2 exists because some extensions genuinely cannot be written against
+an abstract API: if you are adding modules that participate in the
+transformer's computation, you need the real architecture. Tier 2 does not
+remove that coupling, it gives it one address — so a vendored model bump
+breaks one public, tested file with a clear message instead of failing
+silently inside your package. Assert `sa3_internals.API_VERSION` at install
+and fail closed on mismatch.
+
+## Anatomy of a plugin
+
+A plugin is an installed distribution advertising a `demon.plugins` entry
+point:
+
+```toml
+[project.entry-points."demon.plugins"]
+my_extension = "my_extension.plugin:register"
+```
+
+The referenced module must define, at module scope:
+
+- `PLUGIN_API` — the integer plugin API version you built against
+  (required). DEMON reads this **before** running your `register()`, so an
+  incompatible plugin never executes registration code against an API it
+  does not understand.
+- `register(registry)` — called with a `PluginRegistry` scoped to your
+  plugin (required).
+- `REQUIRES_DEMON`, `DESCRIPTION` — optional metadata.
+
+`REQUIRES_DEMON` is currently **advisory** and recorded in logs only.
+DEMON's distribution version tracks the ACE-Step model generation rather
+than an API contract, so enforcing a specifier against it would look like a
+guarantee while promising nothing. The real compatibility gates are
+`PLUGIN_API` and, for Tier-2 consumers, `sa3_internals.API_VERSION`.
+
+## Model extensions
+
+A *model extension* is a persistent, startup-selected participant in a
+loaded model. It is not a job or a recipe: it is part of the model for the
+lifetime of the process.
+
+```python
+from acestep.plugins import ConfigField, ModelExtensionSpec
+from acestep.streaming.knobs import KnobSpec
+
+PLUGIN_API = 1
+
+def register(registry):
+    registry.add_model_extension(
+        ModelExtensionSpec(
+            name="my_capability",
+            family="sa3",
+            create=MyExtension,
+            config_schema={
+                "weights": ConfigField(type="path", required=True),
+            },
+            knob_specs=(
+                KnobSpec(
+                    "plugin_my_extension_amount",
+                    default=1.0, min_val=0.0, max_val=2.0,
+                ),
+            ),
+        )
+    )
+```
+
+### Lifecycle
+
+1. `create(ExtensionContext)` → your extension object. Configuration is
+   already coerced against `config_schema`. This is the **earliest** hook
+   and the right place for validation only you can do — see
+   [Validating your own configuration](#validating-your-own-configuration).
+2. `validate_base_model(descriptor)` → `None` to accept, or `Rejection` to
+   abort boot. Runs **before** the weights load, so refuse cheaply. For
+   facts about the base model only. You may veto one; you may never
+   substitute one. Which weights load is the operator's decision.
+3. `config_fingerprint()` → a stable, non-secret string folded into the
+   model cache key.
+4. `install(model, model_config)` → your runtime object. It **must**
+   subclass `ModelExtensionRuntime`; DEMON checks at boot, because the
+   alternative is a missing hook surfacing as an `AttributeError` inside
+   the streaming runner. The base class defines a neutral default for
+   every hook, so subclassing costs you nothing.
+5. Per-session: `supports_dit_backend` / `supports_codec_backend`,
+   `decorate_conditioning`, `apply_controls`, `status` / `metrics`.
+6. `close()` at teardown.
+
+### Validating your own configuration
+
+`ConfigField(type="path")` is a **coercion, not a filesystem assertion**.
+It validates that the operator supplied a string; nothing is stat'd. DEMON
+cannot do better: it has no way to know whether your path is one you read
+(must already exist) or one you create (must not have to). The same goes
+for numeric ranges — `ConfigField` has no bounds, because a valid range is
+a fact about your architecture, not about JSON.
+
+So do it in your constructor, and raise `ExtensionConfigError`:
+
+```python
+class MyExtension(ModelExtension):
+    def __init__(self, context):
+        path = Path(str(context.config["weights"])).expanduser().resolve()
+        if not path.is_file():
+            raise ExtensionConfigError(f"weights not found: {path}")
+        self.weights = path
+```
+
+The constructor runs before the model cache key is computed and long
+before any weights load. Deferring the check costs the operator a
+multi-second load before they learn they made a typo — and note that
+`config_fingerprint()` is called *before* `validate_base_model`, so it must
+tolerate a missing file rather than being the thing that catches one.
+
+### Rules that are enforced, not merely documented
+
+**Knobs must be namespaced** as `plugin_<plugin_id>_<control>`. Registration
+fails otherwise. The namespace is also the whole anti-shadowing defense —
+no core or family knob is named `plugin_*`, so a name matching the pattern
+cannot collide with one, and DEMON keeps no separate blocklist of core names
+to go stale. Knobs must additionally be `float` or `int`, and must declare a
+default inside their own bounds (coercion clamps, so an out-of-range default
+would silently become a different value than the one you declared).
+
+`float`/`int` only is a real restriction: the browser control panel renders
+numeric knobs generically from manifest bounds, but binds enum/bool knobs by
+name and renders unknown ones disabled. An extension enum knob would appear
+in the manifest and be unusable.
+
+**Conditioning must not be mutated in place.** `decorate_conditioning` must
+return a fresh mapping. The bundle you are handed may already be referenced
+by requests in flight, and those requests must keep seeing the conditioning
+they were submitted with. DEMON hands you a copy, so a mistake here cannot
+reach anyone else's bundle — but returning a mutated input is still wrong.
+
+**`close()` must fully detach.** The loaded model is process-cached and
+shared across every session in the process. If you attached hooks or
+replaced modules, remove and restore them here. `close()` must be
+idempotent and must tolerate being called after a failed install.
+
+**Install failures are fatal.** If your `install()` raises after it has
+already mutated the model, DEMON calls `close()` on whatever was produced
+and then aborts boot. It does **not** fall back to the stock model: the
+operator explicitly asked for your extension, so running without it would
+generate with a different model than the one requested, and the output would
+sound entirely plausible.
+
+### Controls, and which thread calls you
+
+`apply_controls(values)` is called once per tick on the **streaming
+runner**, unlocked, with **only your own** knobs. That is the same thread
+that then runs your model code, so a value written here is read by that
+tick with no synchronization needed. Do not block.
+
+`decorate_conditioning` is called on the **command thread** (a prompt or
+source swap). If it and `apply_controls` touch the same state, that is the
+one race DEMON does not serialize for you, and you own it. Keeping controls
+to plain scalar rebinds avoids the question entirely.
+
+DEMON deliberately does not hold its control lock across your code: that
+lock exists to order the command thread against the tick loop, and putting
+arbitrary plugin code inside it, every tick, would put you in the path of
+every swap.
+
+Keep per-tick control state on the object you own (your model wrapper, for
+example). Do not expect DEMON to carry your values through its hot path.
+
+### Telemetry
+
+`status()` is operator-visible and must contain no filesystem paths,
+checkpoint metadata, training metrics, or proprietary architecture facts.
+`metrics()` is operator-only and is polled on demand rather than per
+generation, so it may be more expensive — but keep anything you expose on a
+per-generation path cheap.
+
+## Running one
+
+```powershell
+uv run python -u -m demos.realtime_motion_graph_web.run -- `
+  --checkpoint sa3-medium `
+  --model-extension my_extension.my_capability `
+  --model-extension-config <path-to>\my_extension.json
+```
+
+The config file is local, outside any repository, and keyed by qualified
+extension id so one file can configure several extensions and none can be
+applied to the wrong one by accident:
+
+```json
+{
+  "my_extension.my_capability": {
+    "weights": "/path/to/my_weights.pt"
+  }
+}
+```
+
+A selected extension that is missing, incompatible, misconfigured, or whose
+install fails **stops the server at boot**.
+
+Discovery runs only when an extension is selected, so a stock server never
+imports any plugin. Once one *is* selected, discovery imports **every**
+installed `demon.plugins` module, not just the selected one — a plugin's
+module-scope code runs whether or not you asked for it. Failures in an
+unselected plugin are isolated and logged rather than fatal; failures in
+the selected one are fatal.
+
+### Acceleration
+
+An extension that augments the transformer generally cannot run under a
+prebuilt TensorRT plan, because the plan contains only the stock graph.
+Return `BackendVerdict(False, reason)` from `supports_dit_backend` and DEMON
+falls back to eager, **reporting the downgrade at boot** rather than leaving
+the operator to discover it in a log line at session create. Duration
+normalization then uses the effective backend, so a TensorRT duration cap is
+not imposed on an eager graph.

--- a/tests/unit/test_plugin_discovery.py
+++ b/tests/unit/test_plugin_discovery.py
@@ -1,0 +1,256 @@
+"""Entry-point plugin discovery (Tier 1, no GPU).
+
+The asymmetry under test: a plugin the operator EXPLICITLY selected fails
+the process on any error, while an unselected broken plugin is isolated.
+Silently dropping a selected model extension would leave the server
+generating with a different model than the one that was asked for, and
+the output would look entirely plausible.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from acestep.plugins import (
+    PLUGIN_API_VERSION,
+    ConfigField,
+    ModelExtension,
+    ModelExtensionSpec,
+    PluginIncompatibleError,
+    PluginLoadError,
+    PluginNotFoundError,
+)
+from acestep.plugins import discovery
+from acestep.streaming.knobs import KnobSpec
+
+
+class _FakeDist:
+    def __init__(self, version):
+        self.version = version
+
+
+class _FakeEntryPoint:
+    """Mirrors importlib.metadata.EntryPoint semantics.
+
+    Notably ``load()`` resolves to the target ATTRIBUTE, not the module,
+    and discovery imports ``module`` by name — so the fake registers a
+    real module in ``sys.modules`` and exercises the real import path. An
+    earlier version of this fake returned the module from ``load()``,
+    which hid a genuine discovery bug.
+    """
+
+    def __init__(self, name, module, *, version="1.0.0", attr="register",
+                 import_error=None):
+        self.name = name
+        self.module = f"{name}._fake_plugin_module"
+        self.attr = attr
+        self.value = f"{self.module}:{attr}"
+        self.dist = _FakeDist(version)
+        if import_error is None:
+            sys.modules[self.module] = module
+        else:
+            sys.modules.pop(self.module, None)
+        self._import_error = import_error
+
+    def load(self):
+        return getattr(sys.modules[self.module], self.attr)
+
+
+def _plugin_module(
+    plugin_id, *, api=PLUGIN_API_VERSION, register=None, requires=None,
+):
+    module = types.ModuleType(f"{plugin_id}.plugin")
+    module.PLUGIN_API = api
+    if requires is not None:
+        module.REQUIRES_DEMON = requires
+    if register is not None:
+        module.register = register
+    else:
+        def _register(registry):
+            registry.add_model_extension(
+                ModelExtensionSpec(
+                    name="demo",
+                    family="sa3",
+                    create=lambda ctx: ModelExtension(),
+                    config_schema={"scale": ConfigField(type="float", required=False)},
+                    knob_specs=(
+                        KnobSpec(
+                            f"plugin_{plugin_id}_strength",
+                            default=1.0, min_val=0.0, max_val=3.0,
+                        ),
+                    ),
+                )
+            )
+        module.register = _register
+    return module
+
+
+def _patch_entry_points(monkeypatch, entry_points):
+    monkeypatch.setattr(
+        discovery, "_iter_entry_points",
+        lambda group: sorted(entry_points, key=lambda ep: ep.name),
+    )
+
+
+def test_discovers_and_registers_a_valid_plugin(monkeypatch):
+    _patch_entry_points(
+        monkeypatch, [_FakeEntryPoint("good_ext", _plugin_module("good_ext"))],
+    )
+
+    plugins = discovery.discover_plugins()
+
+    assert set(plugins) == {"good_ext"}
+    plugin = plugins["good_ext"]
+    assert plugin.manifest.version == "1.0.0"
+    assert plugin.capability_ids == ["demo"]
+
+
+def test_discovery_is_deterministic_by_entry_point_name(monkeypatch):
+    _patch_entry_points(monkeypatch, [
+        _FakeEntryPoint("zeta_ext", _plugin_module("zeta_ext")),
+        _FakeEntryPoint("alpha_ext", _plugin_module("alpha_ext")),
+    ])
+
+    assert list(discovery.discover_plugins()) == ["alpha_ext", "zeta_ext"]
+
+
+def test_wrong_plugin_api_is_rejected(monkeypatch):
+    _patch_entry_points(monkeypatch, [
+        _FakeEntryPoint(
+            "old_ext", _plugin_module("old_ext", api=PLUGIN_API_VERSION + 1),
+        ),
+    ])
+
+    with pytest.raises(PluginIncompatibleError, match="plugin API"):
+        discovery.discover_plugins(required=["old_ext"])
+
+
+def test_missing_plugin_api_declaration_is_rejected(monkeypatch):
+    module = _plugin_module("bare_ext")
+    del module.PLUGIN_API
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("bare_ext", module)])
+
+    with pytest.raises(PluginLoadError, match="PLUGIN_API"):
+        discovery.discover_plugins(required=["bare_ext"])
+
+
+def test_missing_register_callable_is_rejected(monkeypatch):
+    module = _plugin_module("noreg_ext")
+    del module.register
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("noreg_ext", module)])
+
+    with pytest.raises(PluginLoadError, match="register"):
+        discovery.discover_plugins(required=["noreg_ext"])
+
+
+def test_import_failure_is_reported_as_a_load_error(monkeypatch):
+    _patch_entry_points(monkeypatch, [
+        _FakeEntryPoint("broken_ext", None, import_error=True),
+    ])
+
+    with pytest.raises(PluginLoadError, match="failed to import"):
+        discovery.discover_plugins(required=["broken_ext"])
+
+
+def test_register_failure_is_reported(monkeypatch):
+    def _bad_register(registry):
+        raise RuntimeError("registration exploded")
+
+    _patch_entry_points(monkeypatch, [
+        _FakeEntryPoint(
+            "bad_ext", _plugin_module("bad_ext", register=_bad_register),
+        ),
+    ])
+
+    with pytest.raises(PluginLoadError, match="register\\(\\) failed"):
+        discovery.discover_plugins(required=["bad_ext"])
+
+
+def test_registration_error_surfaces_unchanged(monkeypatch):
+    from acestep.plugins import PluginRegistrationError
+
+    def _register(registry):
+        registry.add_model_extension(
+            ModelExtensionSpec(
+                name="demo", family="sa3", create=lambda ctx: ModelExtension(),
+                # Unnamespaced: must fail registration, not become a
+                # generic load error that hides the real cause.
+                knob_specs=(KnobSpec("strength", default=1.0, max_val=1.0),),
+            )
+        )
+
+    _patch_entry_points(monkeypatch, [
+        _FakeEntryPoint("ns_ext", _plugin_module("ns_ext", register=_register)),
+    ])
+
+    with pytest.raises(PluginRegistrationError, match="namespaced"):
+        discovery.discover_plugins(required=["ns_ext"])
+
+
+def test_unselected_broken_plugin_is_isolated(monkeypatch):
+    _patch_entry_points(monkeypatch, [
+        _FakeEntryPoint("broken_ext", None, import_error=True),
+        _FakeEntryPoint("good_ext", _plugin_module("good_ext")),
+    ])
+
+    # Nobody selected the broken one, so one bad optional plugin must not
+    # take the server down.
+    plugins = discovery.discover_plugins()
+
+    assert set(plugins) == {"good_ext"}
+
+
+def test_selected_broken_plugin_is_fatal(monkeypatch):
+    _patch_entry_points(monkeypatch, [
+        _FakeEntryPoint("broken_ext", None, import_error=True),
+        _FakeEntryPoint("good_ext", _plugin_module("good_ext")),
+    ])
+
+    with pytest.raises(PluginLoadError):
+        discovery.discover_plugins(required=["broken_ext"])
+
+
+def test_selected_but_uninstalled_plugin_is_fatal(monkeypatch):
+    _patch_entry_points(monkeypatch, [
+        _FakeEntryPoint("good_ext", _plugin_module("good_ext")),
+    ])
+
+    with pytest.raises(PluginNotFoundError, match="not installed"):
+        discovery.discover_plugins(required=["absent_ext"])
+
+
+def test_capability_ids_are_unique_across_plugins(monkeypatch):
+    # Two plugins each registering "demo" is fine: the qualified ids
+    # differ, so neither is silently dropped.
+    _patch_entry_points(monkeypatch, [
+        _FakeEntryPoint("one_ext", _plugin_module("one_ext")),
+        _FakeEntryPoint("two_ext", _plugin_module("two_ext")),
+    ])
+
+    plugins = discovery.discover_plugins()
+
+    assert plugins["one_ext"].capability_ids == ["demo"]
+    assert plugins["two_ext"].capability_ids == ["demo"]
+
+
+def test_requires_demon_is_recorded_but_not_enforced(monkeypatch):
+    # Deliberately advisory: DEMON's distribution version tracks the model
+    # generation, not an API contract. A plugin demanding an impossible
+    # version must still load rather than fail on a meaningless comparison.
+    _patch_entry_points(monkeypatch, [
+        _FakeEntryPoint(
+            "req_ext", _plugin_module("req_ext", requires=">=99.0"),
+        ),
+    ])
+
+    plugins = discovery.discover_plugins(required=["req_ext"])
+
+    assert plugins["req_ext"].manifest.requires_demon == ">=99.0"
+
+
+def test_no_plugins_installed_is_the_stock_path(monkeypatch):
+    _patch_entry_points(monkeypatch, [])
+    assert discovery.discover_plugins() == {}

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -1,0 +1,588 @@
+"""Plugin foundation + model-extension contract (Tier 1, no GPU).
+
+The highest-risk property here is not "does a plugin load" but "does a
+plugin's control actually reach the validation machinery". Knob coercion
+passes UNKNOWN names through verbatim and unclamped by design (curve
+specs, telemetry and lora_blend rely on it), so an extension knob that
+fails to reach the session's spec map does not fail loudly — it silently
+accepts anything a client sends. Several tests below exist specifically
+to pin that down.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from acestep.plugins import (
+    PLUGIN_API_VERSION,
+    BackendVerdict,
+    ConfigField,
+    ExtensionConfigError,
+    ModelExtension,
+    ModelExtensionRuntime,
+    ModelExtensionSpec,
+    PluginManifest,
+    PluginRegistry,
+    PluginRegistrationError,
+    Rejection,
+    validate_extension_config,
+)
+from acestep.plugins.model_extensions import ModelDescriptor
+from acestep.plugins.selection import (
+    SelectedExtension,
+    load_extension_config,
+    select_model_extension,
+    split_qualified_id,
+)
+from acestep.streaming.knobs import KnobSpec, coerce_knob_values
+
+PLUGIN_ID = "demo_ext"
+
+
+def _manifest(plugin_id=PLUGIN_ID, version="1.2.3"):
+    return PluginManifest(
+        id=plugin_id, version=version, plugin_api=PLUGIN_API_VERSION,
+    )
+
+
+def _registry(plugin_id=PLUGIN_ID, seen=None):
+    return PluginRegistry(_manifest(plugin_id), seen=seen)
+
+
+def _knob(name, **kw):
+    kw.setdefault("default", 1.0)
+    kw.setdefault("min_val", 0.0)
+    kw.setdefault("max_val", 3.0)
+    return KnobSpec(name, **kw)
+
+
+class _NoopExtension(ModelExtension):
+    """Neutral extension used to prove the contract without private code."""
+
+    def __init__(self, context):
+        self.context = context
+        self.installed_with = None
+        self.runtime = None
+
+    def validate_base_model(self, descriptor):
+        if descriptor.model_id == "unsupported":
+            return Rejection("test extension does not support this model")
+        return None
+
+    def config_fingerprint(self):
+        return f"scale={self.context.config.get('scale')}"
+
+    def install(self, model, model_config):
+        self.installed_with = (model, model_config)
+        self.runtime = _NoopRuntime()
+        return self.runtime
+
+
+class _NoopRuntime(ModelExtensionRuntime):
+    def __init__(self):
+        self.controls = None
+        self.closes = 0
+        self.decorated = 0
+
+    def supports_dit_backend(self, backend):
+        if backend == "tensorrt":
+            return BackendVerdict(False, "no accelerated plan for this graph")
+        return BackendVerdict(True)
+
+    def decorate_conditioning(self, bundle, source_latent_bct=None):
+        self.decorated += 1
+        return {**bundle, "extension_cond": source_latent_bct}
+
+    def apply_controls(self, values):
+        self.controls = dict(values)
+
+    def status(self):
+        return {"ready": True}
+
+    def close(self):
+        self.closes += 1
+
+
+def _spec(**kw):
+    kw.setdefault("name", "demo")
+    kw.setdefault("family", "sa3")
+    kw.setdefault("create", _NoopExtension)
+    kw.setdefault("knob_specs", (_knob(f"plugin_{PLUGIN_ID}_strength"),))
+    return ModelExtensionSpec(**kw)
+
+
+# ---- registration validation ------------------------------------------------
+
+
+def test_valid_extension_registers_with_a_qualified_id():
+    registry = _registry()
+    qualified = registry.add_model_extension(_spec())
+
+    assert qualified == f"{PLUGIN_ID}.demo"
+    assert "demo" in registry.model_extensions
+
+
+def test_registering_one_capability_name_twice_is_rejected():
+    # The reachable duplicate: one plugin registering the same name twice.
+    # Without this check the second silently overwrites the first in
+    # _model_extensions, and the operator gets whichever won.
+    registry = _registry()
+    registry.add_model_extension(_spec())
+
+    with pytest.raises(PluginRegistrationError, match="duplicate capability"):
+        registry.add_model_extension(_spec())
+
+
+def test_duplicate_capability_id_is_rejected_across_registries():
+    seen: set = set()
+    _registry(seen=seen).add_model_extension(_spec())
+
+    with pytest.raises(PluginRegistrationError, match="duplicate capability"):
+        _registry(seen=seen).add_model_extension(_spec())
+
+
+def test_unknown_family_is_rejected():
+    with pytest.raises(PluginRegistrationError, match="unknown backend family"):
+        _registry().add_model_extension(_spec(family="not_a_family"))
+
+
+def test_non_callable_create_is_rejected():
+    with pytest.raises(PluginRegistrationError, match="create must be callable"):
+        _registry().add_model_extension(_spec(create="nope"))
+
+
+def test_unnamespaced_knob_is_rejected():
+    with pytest.raises(PluginRegistrationError, match="must be namespaced"):
+        _registry().add_model_extension(
+            _spec(knob_specs=(_knob("strength"),)),
+        )
+
+
+def test_knob_namespaced_to_another_plugin_is_rejected():
+    with pytest.raises(PluginRegistrationError, match="must be namespaced"):
+        _registry().add_model_extension(
+            _spec(knob_specs=(_knob("plugin_other_plugin_strength"),)),
+        )
+
+
+def test_no_core_knob_can_reach_the_plugin_namespace():
+    # The namespace regex IS the shadowing defense, so the property it
+    # depends on is worth pinning: nothing in the core registry or any
+    # family universe is named plugin_*. If a core knob ever were, it
+    # could be shadowed by a plugin control that still passes validation.
+    from acestep.streaming.families import FAMILY_KNOB_UNIVERSES
+    from acestep.streaming.knobs import knob_specs
+
+    names = {spec.name for spec in knob_specs(True, loras=["<lora_id>"])}
+    for universe in FAMILY_KNOB_UNIVERSES.values():
+        names.update(spec.name for spec in universe())
+
+    assert "seed" in names          # the set is non-empty and real
+    assert "sa3_denoise" in names
+    assert not [n for n in names if n.startswith("plugin_")]
+
+
+def test_non_numeric_knob_type_is_rejected():
+    spec = KnobSpec(
+        f"plugin_{PLUGIN_ID}_mode", default="a", type="enum", options=("a", "b"),
+    )
+    with pytest.raises(PluginRegistrationError, match="must be one of"):
+        _registry().add_model_extension(_spec(knob_specs=(spec,)))
+
+
+def test_default_outside_its_own_bounds_is_rejected():
+    # Coercion clamps, so this default would silently become a different
+    # number than the one the plugin declared.
+    bad = _knob(f"plugin_{PLUGIN_ID}_strength", default=9.0, max_val=3.0)
+    with pytest.raises(PluginRegistrationError, match="outside"):
+        _registry().add_model_extension(_spec(knob_specs=(bad,)))
+
+
+def test_inverted_bounds_are_rejected():
+    bad = _knob(f"plugin_{PLUGIN_ID}_strength", min_val=2.0, max_val=1.0)
+    with pytest.raises(PluginRegistrationError, match="below"):
+        _registry().add_model_extension(_spec(knob_specs=(bad,)))
+
+
+def test_duplicate_knob_names_within_one_spec_are_rejected():
+    name = f"plugin_{PLUGIN_ID}_strength"
+    with pytest.raises(PluginRegistrationError, match="duplicate knob"):
+        _registry().add_model_extension(
+            _spec(knob_specs=(_knob(name), _knob(name))),
+        )
+
+
+def test_invalid_capability_name_is_rejected():
+    with pytest.raises(PluginRegistrationError, match="invalid capability name"):
+        _registry().add_model_extension(_spec(name="Bad Name"))
+
+
+# ---- the silent-passthrough hole -------------------------------------------
+
+
+def test_extension_knob_in_the_spec_map_is_clamped():
+    # The load-bearing property: once an extension knob reaches a session's
+    # spec map, an out-of-range client value is CLAMPED like any core knob.
+    name = f"plugin_{PLUGIN_ID}_strength"
+    specs = {name: _knob(name, min_val=0.0, max_val=3.0)}
+
+    clean, errors = coerce_knob_values({name: 99.0}, specs)
+
+    assert clean[name] == 3.0
+    assert errors
+
+
+def test_extension_knob_missing_from_the_spec_map_is_not_validated():
+    # The failure mode this whole namespacing/composition design exists to
+    # prevent: an unwired knob is passed through verbatim and unclamped,
+    # with no error. If composition regresses, values stop being coerced
+    # and nothing complains.
+    name = f"plugin_{PLUGIN_ID}_strength"
+
+    clean, errors = coerce_knob_values({name: 99.0}, {})
+
+    assert clean[name] == 99.0
+    assert not errors
+
+
+# ---- configuration ----------------------------------------------------------
+
+
+def _schema():
+    return {
+        "scale": ConfigField(type="float", required=True),
+        "label": ConfigField(type="str", required=False, default="x"),
+    }
+
+
+def test_config_validation_applies_defaults_and_coerces():
+    out = validate_extension_config("p.e", _schema(), {"scale": 2})
+    assert out == {"scale": 2.0, "label": "x"}
+
+
+def test_config_rejects_unknown_keys():
+    with pytest.raises(ExtensionConfigError, match="unknown configuration key"):
+        validate_extension_config("p.e", _schema(), {"scale": 1.0, "typo": 1})
+
+
+def test_config_rejects_missing_required_key():
+    with pytest.raises(ExtensionConfigError, match="missing required"):
+        validate_extension_config("p.e", _schema(), {})
+
+
+def test_config_rejects_wrong_type():
+    with pytest.raises(ExtensionConfigError, match="wrong type"):
+        validate_extension_config("p.e", _schema(), {"scale": "loud"})
+
+
+def test_config_rejects_bool_for_number():
+    # bool is an int subclass in Python; accepting True as 1.0 would be a
+    # silent misreading of an operator's config file.
+    with pytest.raises(ExtensionConfigError, match="wrong type"):
+        validate_extension_config("p.e", _schema(), {"scale": True})
+
+
+def test_config_rejects_non_integer_float_for_int():
+    schema = {"steps": ConfigField(type="int")}
+    with pytest.raises(ExtensionConfigError, match="wrong type"):
+        validate_extension_config("p.e", schema, {"steps": 1.5})
+
+
+def test_config_file_is_keyed_by_qualified_id(tmp_path):
+    path = tmp_path / "ext.json"
+    path.write_text(json.dumps({"demo_ext.demo": {"scale": 2.0}}), encoding="utf-8")
+
+    assert load_extension_config(path, "demo_ext.demo") == {"scale": 2.0}
+
+
+def test_config_file_without_the_selected_entry_fails(tmp_path):
+    path = tmp_path / "ext.json"
+    path.write_text(json.dumps({"other.thing": {}}), encoding="utf-8")
+
+    with pytest.raises(ExtensionConfigError, match="no entry for"):
+        load_extension_config(path, "demo_ext.demo")
+
+
+def test_missing_config_file_fails_with_the_path(tmp_path):
+    with pytest.raises(ExtensionConfigError, match="not found"):
+        load_extension_config(tmp_path / "absent.json", "demo_ext.demo")
+
+
+def test_malformed_config_file_fails(tmp_path):
+    path = tmp_path / "ext.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ExtensionConfigError, match="not valid JSON"):
+        load_extension_config(path, "demo_ext.demo")
+
+
+def test_no_config_path_means_empty_config():
+    assert load_extension_config(None, "demo_ext.demo") == {}
+
+
+# ---- selection --------------------------------------------------------------
+
+
+def _loaded_plugins(spec=None):
+    from acestep.plugins.api import LoadedPlugin
+
+    spec = spec or _spec()
+    return {
+        PLUGIN_ID: LoadedPlugin(
+            manifest=_manifest(), model_extensions={spec.name: spec},
+        )
+    }
+
+
+def test_no_selection_returns_none():
+    assert select_model_extension(None, family="sa3") is None
+    assert select_model_extension("", family="sa3") is None
+
+
+def test_selection_builds_a_configured_extension(tmp_path):
+    path = tmp_path / "ext.json"
+    path.write_text(
+        json.dumps({f"{PLUGIN_ID}.demo": {"scale": 2.0}}), encoding="utf-8",
+    )
+    spec = _spec(config_schema={"scale": ConfigField(type="float")})
+
+    selected = select_model_extension(
+        f"{PLUGIN_ID}.demo",
+        family="sa3",
+        config_path=path,
+        plugins=_loaded_plugins(spec),
+    )
+
+    assert isinstance(selected, SelectedExtension)
+    assert selected.config == {"scale": 2.0}
+    assert selected.knob_specs[0].name == f"plugin_{PLUGIN_ID}_strength"
+
+
+def test_selection_of_a_missing_plugin_fails():
+    from acestep.plugins.errors import PluginNotFoundError
+
+    with pytest.raises(PluginNotFoundError, match="not installed"):
+        select_model_extension("absent.demo", family="sa3", plugins={})
+
+
+def test_selection_of_a_missing_capability_fails():
+    from acestep.plugins.errors import PluginNotFoundError
+
+    with pytest.raises(PluginNotFoundError, match="no model extension"):
+        select_model_extension(
+            f"{PLUGIN_ID}.absent", family="sa3", plugins=_loaded_plugins(),
+        )
+
+
+def test_selection_across_families_fails():
+    with pytest.raises(ExtensionConfigError, match="backend family"):
+        select_model_extension(
+            f"{PLUGIN_ID}.demo", family="acestep", plugins=_loaded_plugins(),
+        )
+
+
+def test_malformed_qualified_id_fails():
+    from acestep.plugins.errors import PluginNotFoundError
+
+    for bad in ("noplugin", ".demo", "plugin."):
+        with pytest.raises(PluginNotFoundError, match="invalid model extension"):
+            split_qualified_id(bad)
+
+
+def test_public_status_omits_configuration(tmp_path):
+    path = tmp_path / "ext.json"
+    path.write_text(
+        json.dumps({f"{PLUGIN_ID}.demo": {"scale": 7.5}}), encoding="utf-8",
+    )
+    selected = select_model_extension(
+        f"{PLUGIN_ID}.demo",
+        family="sa3",
+        config_path=path,
+        plugins=_loaded_plugins(_spec(config_schema={"scale": ConfigField("float")})),
+    )
+
+    status = selected.public_status()
+
+    assert status["id"] == f"{PLUGIN_ID}.demo"
+    assert "7.5" not in json.dumps(status)
+    assert "scale" not in json.dumps(status)
+
+
+# ---- lifecycle --------------------------------------------------------------
+
+
+def _selected():
+    return select_model_extension(
+        f"{PLUGIN_ID}.demo", family="sa3", plugins=_loaded_plugins(),
+    )
+
+
+def test_full_lifecycle_install_decorate_apply_status_close():
+    selected = _selected()
+    descriptor = ModelDescriptor(
+        family="sa3", model_id="medium", checkpoint_dir="/models/x",
+    )
+    selected.validate_base_model(descriptor)
+
+    runtime = selected.install(model="MODEL", model_config={"k": 1})
+    assert selected.extension.installed_with == ("MODEL", {"k": 1})
+
+    bundle = {"cross_attn_cond": 1}
+    decorated = runtime.decorate_conditioning(bundle, "LATENT")
+    assert decorated["extension_cond"] == "LATENT"
+    # Fresh mapping: the input may already be referenced by in-flight work.
+    assert decorated is not bundle
+    assert "extension_cond" not in bundle
+
+    runtime.apply_controls({f"plugin_{PLUGIN_ID}_strength": 2.0})
+    assert runtime.controls == {f"plugin_{PLUGIN_ID}_strength": 2.0}
+
+    assert runtime.status() == {"ready": True}
+
+    runtime.close()
+    runtime.close()
+    assert runtime.closes == 2  # idempotent from the core's perspective
+
+
+def test_base_model_veto_aborts():
+    selected = _selected()
+    descriptor = ModelDescriptor(
+        family="sa3", model_id="unsupported", checkpoint_dir="/models/x",
+    )
+    with pytest.raises(ExtensionConfigError, match="refused the selected base"):
+        selected.validate_base_model(descriptor)
+
+
+def test_cache_key_tracks_configuration():
+    spec = _spec(config_schema={"scale": ConfigField(type="float")})
+
+    def _select(scale, tmp):
+        path = tmp / "c.json"
+        path.write_text(
+            json.dumps({f"{PLUGIN_ID}.demo": {"scale": scale}}), encoding="utf-8",
+        )
+        return select_model_extension(
+            f"{PLUGIN_ID}.demo",
+            family="sa3",
+            config_path=path,
+            plugins=_loaded_plugins(spec),
+        )
+
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        assert _select(1.0, tmp).cache_key() != _select(2.0, tmp).cache_key()
+        assert _select(1.0, tmp).cache_key() == _select(1.0, tmp).cache_key()
+
+
+def test_partial_install_failure_unwinds():
+    """An install that mutates the model then raises must still unwind."""
+    closed = []
+
+    class _Exploding(ModelExtension):
+        def __init__(self, context):
+            self.context = context
+
+        def close(self):
+            closed.append("extension")
+
+        def install(self, model, model_config):
+            raise RuntimeError("boom after attaching")
+
+    selected = select_model_extension(
+        f"{PLUGIN_ID}.demo",
+        family="sa3",
+        plugins=_loaded_plugins(_spec(create=_Exploding)),
+    )
+
+    with pytest.raises(RuntimeError, match="boom after attaching"):
+        selected.install(model="MODEL", model_config={})
+
+    assert closed == ["extension"]
+
+
+def test_install_returning_a_non_runtime_is_rejected():
+    # Caught at boot rather than as an AttributeError at a tick boundary:
+    # the base class gives every hook a neutral default, so a runtime that
+    # skips it is missing hooks the streaming runner will call.
+    class _Structural:
+        def apply_controls(self, values):
+            pass
+
+    class _Ext(ModelExtension):
+        def __init__(self, context):
+            pass
+
+        def install(self, model, model_config):
+            return _Structural()
+
+    selected = select_model_extension(
+        f"{PLUGIN_ID}.demo",
+        family="sa3",
+        plugins=_loaded_plugins(_spec(create=_Ext)),
+    )
+    with pytest.raises(ExtensionConfigError, match="does not subclass"):
+        selected.install(model="MODEL", model_config={})
+
+
+def test_partial_install_unwinds_without_a_close_override():
+    # ModelExtension.close() defaults to a no-op, so an extension whose
+    # install cannot fail dirty does not have to define one — the core's
+    # unwind path must not blow up on its absence.
+    class _Exploding(ModelExtension):
+        def __init__(self, context):
+            pass
+
+        def install(self, model, model_config):
+            raise RuntimeError("boom")
+
+    selected = select_model_extension(
+        f"{PLUGIN_ID}.demo",
+        family="sa3",
+        plugins=_loaded_plugins(_spec(create=_Exploding)),
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        selected.install(model="MODEL", model_config={})
+
+
+def test_install_returning_none_is_rejected():
+    class _Bad(ModelExtension):
+        def __init__(self, context):
+            pass
+
+        def install(self, model, model_config):
+            return None
+
+    selected = select_model_extension(
+        f"{PLUGIN_ID}.demo",
+        family="sa3",
+        plugins=_loaded_plugins(_spec(create=_Bad)),
+    )
+    with pytest.raises(ExtensionConfigError, match="must return a runtime"):
+        selected.install(model="MODEL", model_config={})
+
+
+def test_backend_verdicts_are_reported():
+    runtime = _selected().install(model="M", model_config={})
+    assert runtime.supports_dit_backend("eager").ok
+    verdict = runtime.supports_dit_backend("tensorrt")
+    assert not verdict.ok
+    assert verdict.reason
+
+
+def test_default_runtime_hooks_are_neutral():
+    # A minimal extension implementing nothing must behave exactly like no
+    # extension at all.
+    runtime = ModelExtensionRuntime()
+    bundle = {"a": 1}
+
+    assert runtime.supports_dit_backend("tensorrt").ok
+    assert runtime.supports_codec_backend("tensorrt").ok
+    assert runtime.decorate_conditioning(bundle) is bundle
+    assert runtime.status() == {}
+    assert runtime.metrics() == {}
+    runtime.apply_controls({})
+    runtime.close()

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -27,9 +27,13 @@ from acestep.plugins import (
     PluginRegistry,
     PluginRegistrationError,
     Rejection,
+    SourceView,
     validate_extension_config,
 )
-from acestep.plugins.model_extensions import ModelDescriptor
+from acestep.plugins.model_extensions import (
+    ModelDescriptor,
+    decorate_conditioning,
+)
 from acestep.plugins.selection import (
     SelectedExtension,
     load_extension_config,
@@ -91,9 +95,9 @@ class _NoopRuntime(ModelExtensionRuntime):
             return BackendVerdict(False, "no accelerated plan for this graph")
         return BackendVerdict(True)
 
-    def decorate_conditioning(self, bundle, source_latent_bct=None):
+    def decorate_conditioning(self, bundle, source=None):
         self.decorated += 1
-        return {**bundle, "extension_cond": source_latent_bct}
+        return {**bundle, "extension_cond": None if source is None else source.latent}
 
     def apply_controls(self, values):
         self.controls = dict(values)
@@ -429,7 +433,7 @@ def test_full_lifecycle_install_decorate_apply_status_close():
     assert selected.extension.installed_with == ("MODEL", {"k": 1})
 
     bundle = {"cross_attn_cond": 1}
-    decorated = runtime.decorate_conditioning(bundle, "LATENT")
+    decorated = runtime.decorate_conditioning(bundle, SourceView(latent="LATENT"))
     assert decorated["extension_cond"] == "LATENT"
     # Fresh mapping: the input may already be referenced by in-flight work.
     assert decorated is not bundle
@@ -586,3 +590,45 @@ def test_default_runtime_hooks_are_neutral():
     assert runtime.metrics() == {}
     runtime.apply_controls({})
     runtime.close()
+
+
+def test_source_view_fields_are_all_optional():
+    # A session may have no source at all, or a source whose waveform
+    # DEMON never held. Neither is an error, and an extension that reads
+    # a field it did not get must see None rather than an AttributeError.
+    empty = SourceView()
+    assert empty.latent is None
+    assert empty.waveform is None
+    assert empty.sample_rate is None
+
+    latent_only = SourceView(latent="L")
+    assert latent_only.latent == "L"
+    assert latent_only.waveform is None
+
+
+def test_source_view_carries_pre_encode_audio_alongside_the_latent():
+    view = SourceView(latent="L", waveform="W", sample_rate=44100)
+    assert (view.latent, view.waveform, view.sample_rate) == ("L", "W", 44100)
+
+
+def test_decorate_conditioning_helper_forwards_the_source_view():
+    seen = []
+
+    class _Runtime(ModelExtensionRuntime):
+        def decorate_conditioning(self, bundle, source=None):
+            seen.append(source)
+            return {**bundle, "x": 1}
+
+    view = SourceView(latent="L", waveform="W", sample_rate=48000)
+    out = decorate_conditioning(_Runtime(), {"a": 1}, view)
+    assert seen == [view]
+    assert out == {"a": 1, "x": 1}
+
+
+def test_decorate_conditioning_helper_treats_none_as_no_change():
+    class _Silent(ModelExtensionRuntime):
+        def decorate_conditioning(self, bundle, source=None):
+            return None
+
+    bundle = {"a": 1}
+    assert decorate_conditioning(_Silent(), bundle, SourceView()) is bundle

--- a/tests/unit/test_sa3_backend.py
+++ b/tests/unit/test_sa3_backend.py
@@ -150,6 +150,70 @@ def test_knob_defaults_flow_through_read_knobs():
     assert raw["feedback_depth"] == 1.0
 
 
+class _SamplerProbeContext:
+    """Minimal SA3Context stand-in for from_context sampler selection."""
+
+    device = torch.device("cpu")
+    dtype = torch.float32
+    # from_context reads both for the LoRA surface: the resident eager
+    # DiT (None => the TRT->eager swap is a no-op) and the lineage id.
+    dit = None
+    model_id = ""
+
+    def __init__(self, objective):
+        self.diffusion_objective = objective
+
+    def make_dit(self, **_kwargs):
+        return _ZeroDit()
+
+    def make_schedule_builder(self, _cond, steps):
+        return _schedule_builder_factory(steps)
+
+    def make_codec(self, **_kwargs):
+        return _FakeCodec()
+
+
+def _sampler_for(objective):
+    backend = SA3Backend.from_context(
+        _SamplerProbeContext(objective),
+        prompt="test",
+        duration_s=1.0,
+        knob_state=KnobState(sa3_knob_specs()),
+        cond=_FakeCond(),
+        source_latent_bct=torch.zeros(1, C, T),
+        steps=2,
+        depth=1,
+    )
+    return backend._sampler
+
+
+def test_from_context_selects_sampler_from_diffusion_objective():
+    # A plain rectified-flow base wants Euler ODE; the post-trained
+    # releases were trained and evaluated with deterministic ping-pong.
+    assert _sampler_for("rectified_flow") == "ode"
+    assert _sampler_for("rf_denoiser") == "pingpong"
+
+
+def test_from_context_sampler_defaults_to_pingpong_without_objective():
+    # A context predating the objective attribute must keep the historical
+    # behavior rather than silently switching samplers.
+    class _Legacy(_SamplerProbeContext):
+        def __init__(self):
+            pass
+
+    backend = SA3Backend.from_context(
+        _Legacy(),
+        prompt="test",
+        duration_s=1.0,
+        knob_state=KnobState(sa3_knob_specs()),
+        cond=_FakeCond(),
+        source_latent_bct=torch.zeros(1, C, T),
+        steps=2,
+        depth=1,
+    )
+    assert backend._sampler == "pingpong"
+
+
 def test_produce_emits_and_renders_windows():
     b = _backend()
     knobs = {"sa3_denoise": 0.7, "seed": 42, "steps_override": 3}

--- a/tests/unit/test_sa3_checkpoint_identity.py
+++ b/tests/unit/test_sa3_checkpoint_identity.py
@@ -1,0 +1,83 @@
+"""SA3 checkpoint identity + context cache keying (Tier 1, no GPU).
+
+The process context cache must key on WHAT was loaded, not merely where
+it came from. An operator-supplied checkpoint directory can be rewritten
+in place between runs (a training loop that keeps overwriting the same
+weights at the same path), so a path-only key would silently hand back
+the previously loaded model.
+"""
+
+from __future__ import annotations
+
+import json
+
+from acestep.engine.sa3_helpers import (
+    sa3_checkpoint_identity,
+    sa3_custom_checkpoint_status,
+)
+from acestep.streaming.sa3_session import sa3_context_key
+
+
+def _write_checkpoint(base, *, weights: bytes = b"w" * 64):
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "model_config.json").write_text(
+        json.dumps({"model": {"diffusion": {}}}), encoding="utf-8",
+    )
+    (base / "model.safetensors").write_bytes(weights)
+    return base
+
+
+def test_identity_changes_when_checkpoint_is_rewritten_in_place(tmp_path):
+    base = _write_checkpoint(tmp_path / "ckpt")
+    before = sa3_checkpoint_identity(base)
+
+    # Same path, different content — the exact shape a training run
+    # produces when it overwrites its "best" checkpoint.
+    _write_checkpoint(base, weights=b"w" * 128)
+    after = sa3_checkpoint_identity(base)
+
+    assert before != after
+
+
+def test_identity_is_stable_for_an_untouched_checkpoint(tmp_path):
+    base = _write_checkpoint(tmp_path / "ckpt")
+    assert sa3_checkpoint_identity(base) == sa3_checkpoint_identity(base)
+
+
+def test_identity_survives_a_missing_file(tmp_path):
+    # Used for cache keys, so it must not raise; the preflight is what
+    # reports a missing checkpoint with an actionable message.
+    identity = sa3_checkpoint_identity(tmp_path / "absent")
+    assert isinstance(identity, tuple)
+
+
+def test_context_key_distinguishes_rewritten_checkpoints(tmp_path):
+    base = _write_checkpoint(tmp_path / "ckpt")
+    before = sa3_context_key("medium", checkpoint_dir=base)
+
+    _write_checkpoint(base, weights=b"w" * 128)
+    after = sa3_context_key("medium", checkpoint_dir=base)
+
+    assert before != after
+
+
+def test_context_key_is_unchanged_for_the_catalog_path():
+    # No custom directory and no extension means the catalog location for
+    # the model id, whose identity is the model id itself — stock
+    # behavior must not start stat-ing the managed models tree on every
+    # session create.
+    assert sa3_context_key("small-music") == ("small-music", None, None)
+    assert sa3_context_key("small-music") != sa3_context_key("medium")
+
+
+def test_custom_checkpoint_status_reports_missing_layout(tmp_path):
+    ok, msg = sa3_custom_checkpoint_status(tmp_path / "nope")
+    assert not ok
+    assert "not found" in msg
+
+    partial = tmp_path / "partial"
+    partial.mkdir()
+    (partial / "model_config.json").write_text("{}", encoding="utf-8")
+    ok, msg = sa3_custom_checkpoint_status(partial)
+    assert not ok
+    assert "model.safetensors" in msg

--- a/tests/unit/test_sa3_extension_integration.py
+++ b/tests/unit/test_sa3_extension_integration.py
@@ -66,9 +66,9 @@ class _ProbeRuntime(ModelExtensionRuntime):
             return BackendVerdict(False, "no accelerated plan for this graph")
         return BackendVerdict(True)
 
-    def decorate_conditioning(self, bundle, source_latent_bct=None):
-        self.decorations.append(source_latent_bct)
-        return {**bundle, "probe_cond": source_latent_bct}
+    def decorate_conditioning(self, bundle, source=None):
+        self.decorations.append(source)
+        return {**bundle, "probe_cond": None if source is None else source.latent}
 
     def apply_controls(self, values):
         self.controls.append(dict(values))
@@ -377,3 +377,54 @@ def test_context_key_includes_extension_identity_and_config():
     assert stock != with_ext
     assert with_ext != other
     assert with_ext == sa3_context_key("medium", extension=_selected(scale=1.0))
+
+
+# ---- the source view --------------------------------------------------------
+
+
+def test_extension_receives_the_pre_encode_audio_with_the_latent():
+    # An extension whose condition derives from the audio rather than
+    # from its latent must not have to decode the latent to get it back.
+    runtime = _ProbeRuntime()
+    source = torch.randn(1, C, T)
+    waveform = torch.randn(2, N44)
+    _backend(
+        extension=_selected(), runtime=runtime, source=source,
+        source_audio=(44100, waveform),
+    )
+    view = runtime.decorations[0]
+    assert torch.equal(view.latent, source)
+    assert view.waveform is waveform
+    assert view.sample_rate == 44100
+
+
+def test_source_view_omits_audio_the_backend_was_never_given():
+    runtime = _ProbeRuntime()
+    _backend(extension=_selected(), runtime=runtime, source=torch.randn(1, C, T))
+    view = runtime.decorations[0]
+    assert view.latent is not None
+    assert view.waveform is None
+    assert view.sample_rate is None
+
+
+def test_source_swap_replaces_the_waveform_along_with_the_latent():
+    # The two halves of the view must always describe the SAME audio;
+    # keeping the old waveform beside a new anchor is silent wrongness.
+    runtime = _ProbeRuntime()
+    replacement_latent = torch.randn(1, C, T)
+    replacement_audio = torch.randn(2, N44)
+    backend = _backend(
+        extension=_selected(), runtime=runtime,
+        source=torch.randn(1, C, T),
+        source_audio=(44100, torch.randn(2, N44)),
+        source_encoder=lambda *_a: replacement_latent,
+    )
+
+    backend.handle_swap_source(replacement_audio, 48000)
+
+    view = runtime.decorations[-1]
+    assert torch.equal(view.latent, replacement_latent)
+    assert view.waveform is replacement_audio
+    assert view.sample_rate == 48000
+    # And the stored anchor agrees, so the NEXT prompt swap sees it too.
+    assert backend._source_view().waveform is replacement_audio

--- a/tests/unit/test_sa3_extension_integration.py
+++ b/tests/unit/test_sa3_extension_integration.py
@@ -1,0 +1,379 @@
+"""Model-extension lifecycle wired into the SA3 backend (Tier 1, no GPU).
+
+Two properties dominate:
+
+* **Stock is untouched.** With no extension selected, every path must
+  behave exactly as if the plugin system did not exist.
+* **In-flight conditioning is never mutated.** A prompt or source swap
+  rebuilds conditioning; requests already in the pipeline must keep
+  seeing the bundle they were submitted with, or they finish against
+  conditioning nobody asked for.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from acestep.engine.sa3_adapter import SA3Adapter
+from acestep.engine.sa3_stream_helpers import SA3Conditioning
+from acestep.plugins import (
+    BackendVerdict,
+    ConfigField,
+    ModelExtension,
+    ModelExtensionRuntime,
+    ModelExtensionSpec,
+)
+from acestep.plugins.api import LoadedPlugin, PluginManifest
+from acestep.plugins.selection import select_model_extension
+from acestep.streaming.knobs import KnobSpec, KnobState, coerce_knob_values
+from acestep.streaming.sa3_backend import SA3Backend, sa3_knob_specs
+from acestep.streaming.sa3_session import sa3_context_key
+
+from tests.unit.test_sa3_backend import (  # reuse the established fakes
+    C,
+    CTX,
+    N44,
+    T,
+    _FakeCodec,
+    _FakeCond,
+    _ZeroDit,
+    _schedule_builder_factory,
+)
+
+
+def _cond():
+    """A real SA3Conditioning: decoration rebuilds it with dataclass replace."""
+    fake = _FakeCond()
+    return SA3Conditioning(
+        cond_bundle=fake.cond_bundle,
+        sched_args={},
+        latent_frames=T,
+        audio_sample_size=N44,
+    )
+
+PLUGIN_ID = "probe_ext"
+KNOB = f"plugin_{PLUGIN_ID}_strength"
+
+
+class _ProbeRuntime(ModelExtensionRuntime):
+    def __init__(self):
+        self.controls = []
+        self.decorations = []
+        self.closed = 0
+
+    def supports_dit_backend(self, backend):
+        if backend == "tensorrt":
+            return BackendVerdict(False, "no accelerated plan for this graph")
+        return BackendVerdict(True)
+
+    def decorate_conditioning(self, bundle, source_latent_bct=None):
+        self.decorations.append(source_latent_bct)
+        return {**bundle, "probe_cond": source_latent_bct}
+
+    def apply_controls(self, values):
+        self.controls.append(dict(values))
+
+    def status(self):
+        return {"installed": True}
+
+    def close(self):
+        self.closed += 1
+
+
+class _ProbeExtension(ModelExtension):
+    def __init__(self, context):
+        self.context = context
+
+    def config_fingerprint(self):
+        return f"scale={self.context.config.get('scale')}"
+
+    def install(self, model, model_config):
+        return _ProbeRuntime()
+
+
+def _selected(scale=1.0):
+    spec = ModelExtensionSpec(
+        name="probe",
+        family="sa3",
+        create=_ProbeExtension,
+        config_schema={"scale": ConfigField(type="float", required=False, default=scale)},
+        knob_specs=(KnobSpec(KNOB, default=1.0, min_val=0.0, max_val=3.0),),
+    )
+    plugins = {
+        PLUGIN_ID: LoadedPlugin(
+            manifest=PluginManifest(
+                id=PLUGIN_ID, version="0.1.0", plugin_api=1,
+            ),
+            model_extensions={"probe": spec},
+        )
+    }
+    return select_model_extension(
+        f"{PLUGIN_ID}.probe", family="sa3", plugins=plugins,
+    )
+
+
+class _Context:
+    """SA3Context stand-in carrying an installed extension runtime."""
+
+    device = torch.device("cpu")
+    dtype = torch.float32
+    diffusion_objective = "rf_denoiser"
+    # See _SamplerProbeContext: from_context reads both for the LoRA surface.
+    dit = None
+    model_id = ""
+
+    def __init__(self, runtime=None):
+        self.extension_runtime = runtime
+
+    def make_dit(self, **_kw):
+        return _ZeroDit()
+
+    def make_schedule_builder(self, _cond, steps):
+        return _schedule_builder_factory(steps)
+
+    def make_codec(self, **_kw):
+        return _FakeCodec()
+
+
+def _backend(extension=None, runtime=None, source=None, cond=None, **kw):
+    """Direct construction, mirroring test_sa3_backend's harness.
+
+    Built directly rather than through ``from_context`` so individual
+    tests can supply their own prompt_rebuilder / source_encoder without
+    colliding with the closures from_context installs.
+    """
+    source = torch.randn(1, C, T) if source is None else source
+    steps = kw.pop("steps", 2)
+    adapter = SA3Adapter(
+        _ZeroDit(),
+        schedule_builder=_schedule_builder_factory(steps),
+        device="cpu",
+        dtype=torch.float32,
+    )
+    return SA3Backend(
+        adapter=adapter,
+        codec=_FakeCodec(),
+        cond=_cond() if cond is None else cond,
+        schedule_builder_factory=_schedule_builder_factory,
+        knob_state=KnobState(
+            sa3_knob_specs(
+                extension_specs=extension.knob_specs if extension else (),
+            ),
+        ),
+        source_latent_bct=source,
+        steps=steps,
+        depth=1,
+        vae_window_s=0.1,
+        model_extension=extension,
+        extension_runtime=runtime,
+        **kw,
+    )
+
+
+# ---- stock parity -----------------------------------------------------------
+
+
+def test_stock_knob_manifest_has_no_extension_knobs():
+    names = [s.name for s in sa3_knob_specs()]
+    assert not [n for n in names if n.startswith("plugin_")]
+
+
+def test_stock_backend_knob_specs_are_unchanged():
+    backend = _backend()
+    assert [s.name for s in backend.knob_specs()] == [
+        s.name for s in sa3_knob_specs()
+    ]
+
+
+def test_stock_conditioning_bundle_is_passed_through_untouched():
+    cond = _cond()
+    original = cond.cond_bundle
+    backend = _backend(cond=cond)
+    # No extension means no copy, no new keys, same object identity.
+    assert backend._cond.cond_bundle is original
+
+
+def test_stock_context_key_does_not_change_shape():
+    assert sa3_context_key("medium") == ("medium", None, None)
+
+
+# ---- knob composition -------------------------------------------------------
+
+
+def test_extension_knob_joins_the_family_manifest():
+    extension = _selected()
+    names = [s.name for s in sa3_knob_specs(extension_specs=extension.knob_specs)]
+    assert KNOB in names
+
+
+def test_backend_publishes_the_extension_knob():
+    extension = _selected()
+    backend = _backend(extension=extension, runtime=_ProbeRuntime())
+    assert KNOB in [s.name for s in backend.knob_specs()]
+
+
+def test_extension_knob_is_coerced_like_a_core_knob():
+    # The property that matters: the composed spec map is what validation
+    # runs against, so an out-of-range client value is clamped rather than
+    # passed through raw.
+    extension = _selected()
+    backend = _backend(extension=extension, runtime=_ProbeRuntime())
+    specs = {s.name: s for s in backend.knob_specs()}
+
+    clean, errors = coerce_knob_values({KNOB: 99.0}, specs)
+
+    assert clean[KNOB] == 3.0
+    assert errors
+
+
+# ---- conditioning decoration ------------------------------------------------
+
+
+def test_conditioning_is_decorated_at_construction():
+    runtime = _ProbeRuntime()
+    source = torch.randn(1, C, T)
+    backend = _backend(
+        extension=_selected(), runtime=runtime, source=source,
+    )
+
+    assert "probe_cond" in backend._cond.cond_bundle
+    assert torch.equal(backend._cond.cond_bundle["probe_cond"], source)
+
+
+def test_decoration_does_not_mutate_the_supplied_bundle():
+    cond = _cond()
+    original_bundle = cond.cond_bundle
+
+    backend = _backend(
+        extension=_selected(), runtime=_ProbeRuntime(), cond=cond,
+    )
+
+    assert "probe_cond" not in original_bundle
+    assert backend._cond.cond_bundle is not original_bundle
+
+
+def test_from_context_installs_the_runtime_from_the_context():
+    # Production assembly: the backend picks the installed runtime off the
+    # context rather than being handed one separately.
+    runtime = _ProbeRuntime()
+    backend = SA3Backend.from_context(
+        _Context(runtime),
+        prompt="a",
+        duration_s=1.0,
+        knob_state=KnobState(sa3_knob_specs()),
+        cond=_cond(),
+        source_latent_bct=torch.randn(1, C, T),
+        steps=2,
+        depth=1,
+        model_extension=_selected(),
+    )
+    assert backend._extension_runtime is runtime
+    assert "probe_cond" in backend._cond.cond_bundle
+
+
+def test_source_swap_rebuilds_conditioning_without_touching_the_old_bundle():
+    runtime = _ProbeRuntime()
+    initial = torch.randn(1, C, T)
+    replacement = torch.randn(1, C, T)
+    backend = _backend(
+        extension=_selected(), runtime=runtime, source=initial,
+        source_encoder=lambda *_a: replacement,
+    )
+    old_bundle = backend._active_bundle
+    assert torch.equal(old_bundle["probe_cond"], initial)
+
+    backend.handle_swap_source(torch.zeros(2, 48000), 48000)
+
+    new_bundle = backend._active_bundle
+    assert new_bundle is not old_bundle
+    # An in-flight request holding the old bundle must still see the old
+    # condition; nothing was edited underneath it.
+    assert torch.equal(old_bundle["probe_cond"], initial)
+    assert torch.equal(new_bundle["probe_cond"], replacement)
+
+
+def test_source_swap_advances_the_cond_epoch():
+    backend = _backend(
+        extension=_selected(), runtime=_ProbeRuntime(),
+        source_encoder=lambda *_a: torch.randn(1, C, T),
+    )
+    before = backend._cond_epoch
+    backend.handle_swap_source(torch.zeros(2, 48000), 48000)
+    assert backend._cond_epoch == before + 1
+
+
+def test_stock_source_swap_leaves_conditioning_alone():
+    backend = _backend(source_encoder=lambda *_a: torch.randn(1, C, T))
+    before_bundle = backend._active_bundle
+    before_epoch = backend._cond_epoch
+
+    backend.handle_swap_source(torch.zeros(2, 48000), 48000)
+
+    # No extension: the swap re-anchors the source only, exactly as before.
+    assert backend._active_bundle is before_bundle
+    assert backend._cond_epoch == before_epoch
+
+
+def test_prompt_swap_decorates_the_new_conditioning():
+    runtime = _ProbeRuntime()
+    source = torch.randn(1, C, T)
+    backend = _backend(
+        extension=_selected(), runtime=runtime, source=source,
+        prompt_rebuilder=lambda tags, steps: (
+            _cond(), _schedule_builder_factory,
+        ),
+    )
+    old_bundle = backend._active_bundle
+
+    backend.handle_set_prompt("new tags")
+
+    assert backend._active_bundle is not old_bundle
+    assert torch.equal(backend._cond.cond_bundle["probe_cond"], source)
+    assert "probe_cond" in old_bundle  # untouched, still attributable
+
+
+# ---- controls ---------------------------------------------------------------
+
+
+def test_extension_controls_are_applied_on_tick():
+    runtime = _ProbeRuntime()
+    extension = _selected()
+    backend = _backend(extension=extension, runtime=runtime)
+
+    knobs = {**backend.read_knobs(), "steps_override": 2, KNOB: 2.5}
+    backend.produce(knobs, CTX, "generate")
+
+    assert runtime.controls
+    assert runtime.controls[-1] == {KNOB: 2.5}
+
+
+def test_extension_receives_only_its_own_knobs():
+    runtime = _ProbeRuntime()
+    backend = _backend(extension=_selected(), runtime=runtime)
+
+    knobs = {**backend.read_knobs(), "steps_override": 2, KNOB: 1.0}
+    backend.produce(knobs, CTX, "generate")
+
+    assert set(runtime.controls[-1]) == {KNOB}
+
+
+def test_stock_backend_never_calls_control_hooks():
+    runtime = _ProbeRuntime()
+    backend = _backend()  # no extension
+    backend.produce(
+        {**backend.read_knobs(), "steps_override": 2}, CTX, "generate",
+    )
+    assert runtime.controls == []
+
+
+# ---- cache keys -------------------------------------------------------------
+
+
+def test_context_key_includes_extension_identity_and_config():
+    stock = sa3_context_key("medium")
+    with_ext = sa3_context_key("medium", extension=_selected(scale=1.0))
+    other = sa3_context_key("medium", extension=_selected(scale=2.0))
+
+    assert stock != with_ext
+    assert with_ext != other
+    assert with_ext == sa3_context_key("medium", extension=_selected(scale=1.0))

--- a/tests/unit/test_sa3_internals.py
+++ b/tests/unit/test_sa3_internals.py
@@ -1,0 +1,160 @@
+"""Structural canary for the Tier-2 SA3 internals contract (no GPU).
+
+:mod:`acestep.engine.sa3_internals` encapsulates the vendored
+``stable_audio_3`` object-graph shapes that a model extension has to
+traverse. Those shapes belong to a third-party package, so they can drift
+under us on a vendor bump — and the failure mode for an out-of-tree
+extension is not an ImportError, it is a model that runs and produces
+subtly wrong output.
+
+This test is the tripwire. It fails HERE, in public CI, the moment the
+accessors stop matching reality. Most of it runs against a synthetic
+stand-in so it needs neither checkpoints nor a GPU; the parts that need
+the vendored source skip cleanly when it is absent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from acestep.engine import sa3_internals as internals
+from acestep.engine.sa3_helpers import sa3_vendor_present
+
+
+class _Blocks(list):
+    pass
+
+
+class _Transformer:
+    def __init__(self, depth):
+        self.layers = _Blocks(object() for _ in range(depth))
+
+
+class _Dit:
+    def __init__(self, depth):
+        self.transformer = _Transformer(depth)
+
+
+class _Wrapper:
+    def __init__(self, depth):
+        self.model = _Dit(depth)
+        self.diffusion_objective = "rectified_flow"
+
+
+class _Model:
+    def __init__(self, depth):
+        self.model = _Wrapper(depth)
+
+
+class _Sam:
+    """Mirrors the attribute chain the accessors document."""
+
+    def __init__(self, depth=4):
+        self.model = _Model(depth)
+
+
+def test_accessors_traverse_the_documented_paths():
+    sam = _Sam(depth=4)
+
+    assert internals.trunk_wrapper(sam) is sam.model.model
+    assert internals.trunk_module(sam) is sam.model.model.model
+    assert internals.trunk_blocks(sam) is sam.model.model.model.transformer.layers
+    assert len(internals.trunk_blocks(sam)) == 4
+
+
+def test_check_layout_accepts_the_expected_shape():
+    internals.check_layout(_Sam(depth=2))
+
+
+def test_check_layout_rejects_a_trunk_with_no_blocks():
+    with pytest.raises(internals.LayoutError, match="no transformer blocks"):
+        internals.check_layout(_Sam(depth=0))
+
+
+def test_missing_attribute_names_the_failing_hop_and_the_vendor_pin():
+    sam = _Sam()
+    del sam.model.model.model.transformer.layers
+
+    with pytest.raises(internals.LayoutError) as excinfo:
+        internals.trunk_blocks(sam)
+
+    message = str(excinfo.value)
+    # The whole point is an actionable message rather than a bare
+    # AttributeError from four levels down someone else's package.
+    assert "trunk_blocks" in message
+    assert "layers" in message
+    assert internals.VENDOR_SHA in message
+    assert "sa3_internals" in message
+
+
+def test_replace_trunk_returns_the_previous_wrapper():
+    sam = _Sam()
+    original = internals.trunk_wrapper(sam)
+    sentinel = object()
+
+    previous = internals.replace_trunk(sam, sentinel)
+
+    assert previous is original
+    assert internals.trunk_wrapper(sam) is sentinel
+    # Restoration is the caller's job and must round-trip exactly.
+    internals.replace_trunk(sam, previous)
+    assert internals.trunk_wrapper(sam) is original
+
+
+def test_dit_architecture_config_extracts_objective_and_kwargs():
+    config = {
+        "model": {
+            "diffusion": {
+                "diffusion_objective": "rectified_flow",
+                "config": {"depth": 24, "embed_dim": 1536},
+            }
+        }
+    }
+
+    objective, kwargs = internals.dit_architecture_config(config)
+
+    assert objective == "rectified_flow"
+    assert kwargs == {"depth": 24, "embed_dim": 1536}
+    # Must be a copy: extensions mutate it to build a shallower branch.
+    kwargs["depth"] = 12
+    assert config["model"]["diffusion"]["config"]["depth"] == 24
+
+
+def test_dit_architecture_config_defaults_the_objective():
+    objective, _ = internals.dit_architecture_config(
+        {"model": {"diffusion": {"config": {}}}},
+    )
+    assert objective == "v"
+
+
+def test_dit_architecture_config_rejects_a_foreign_config():
+    with pytest.raises(internals.LayoutError, match="model.diffusion.config"):
+        internals.dit_architecture_config({"model": {}})
+
+
+def test_api_version_and_vendor_pin_are_declared():
+    # Extensions assert these at install; they must exist and be usable
+    # as equality/identity checks.
+    assert isinstance(internals.API_VERSION, int)
+    assert internals.API_VERSION >= 1
+    assert isinstance(internals.VENDOR_SHA, str) and len(internals.VENDOR_SHA) == 40
+
+
+@pytest.mark.skipif(
+    not sa3_vendor_present(), reason="vendored stable_audio_3 not on disk",
+)
+def test_vendored_dit_class_matches_the_documented_construction_surface():
+    # The real canary: the vendored transformer must still be importable
+    # where we look for it, and still accept the constructor arguments an
+    # extension builds a derived branch from.
+    import inspect
+
+    cls = internals.dit_class()
+    params = inspect.signature(cls.__init__).parameters
+
+    for expected in ("depth", "diffusion_objective"):
+        assert expected in params, (
+            f"vendored DiffusionTransformer no longer accepts {expected!r}; "
+            f"extensions building a derived branch will break "
+            f"(pin {internals.VENDOR_SHA})"
+        )


### PR DESCRIPTION
Lets an installed Python package extend a loaded model, out of tree, without
DEMON knowing anything about what the package does.

The core never branches on an extension's concrete type. It sees a spec, a
config schema, namespaced knobs and a lifecycle object. Selection is
startup-only and operator-controlled: a browser client can never name a
plugin, a module path, a checkpoint or a config file.

## Import tiers

| Tier | Where | Stability |
|---|---|---|
| 1 | `acestep.plugins` | Versioned by `PLUGIN_API_VERSION`. |
| 2 | `acestep.engine.sa3_internals` | Documented, tested subset of vendored SA3 internals, with its own `API_VERSION` and a structural canary test. |
| 0 | everything else under `acestep.*` | Internal. Importing it is a bug in the plugin. |

Tier 2 exists because an extension that adds modules participating in the
transformer's computation cannot be written against an abstract API. That
coupling is real, so it gets one public, tested address rather than being
spread across a package. A vendored model bump then breaks one file with a
clear message instead of failing silently somewhere else.

## Plugin API 2

`decorate_conditioning` receives a `SourceView` (latent, waveform, sample
rate) rather than a bare latent. This is a deliberately breaking change: an
API-1 runtime would bind the view where it expected a latent, so the version
gate has to reject it rather than let it run.

The waveform rides along because DEMON already holds it. An extension whose
condition derives from audio rather than from a latent would otherwise have
to decode the latent back to audio, spending real time per swap to recover
something that was in memory a moment earlier.

## Notes for review

- An installed extension forces the DiT to run **eager**. Prebuilt TensorRT
  plans contain only the stock graph, so running them would silently ignore
  the extension. The windowed VAE decoder keeps TensorRT.
- Conditioning is never mutated in place; `decorate_conditioning` returns a
  new bundle.
- With no plugin installed, every path is unchanged.

## Tests

`tests/unit`: 655 passed, 4 skipped.

`tests/unit/test_lora_facade_session.py` has 4 failures that are
**pre-existing on main** and untouched by this branch (the test file's blob
is byte-identical to main's). They are fixture rot: `session.py` reads
`pending_register` and the test never sets it.
