### PR TITLE
feat(enhance): optional local prompt-enhancer backend, and a variations grid

### DIFF
--- a/acestep/model_downloader.py
+++ b/acestep/model_downloader.py
@@ -202,6 +202,14 @@ PROMPT_ENHANCER_MODEL_NAME = "prompt-enhancer"
 PROMPT_ENHANCER_DEFAULT_REPO = "daydreamlive/t5-small-enhancer"
 #: The files transformers needs to load it; anything else in the repo is
 #: ignored so a card or extra format does not bloat every pod.
+#: What must be present for the checkpoint to load at all. A t5 fine-tune may
+#: legitimately ship either a fast tokenizer (tokenizer.json) or a slow one
+#: (spiece.model), so neither is required on its own -- see the check below.
+PROMPT_ENHANCER_REQUIRED = [
+    "config.json",
+    "model.safetensors",
+    "tokenizer_config.json",
+]
 PROMPT_ENHANCER_ALLOW = [
     "config.json",
     "generation_config.json",
@@ -232,12 +240,13 @@ def check_prompt_enhancer_model_exists(model_dir: Optional[Path] = None) -> bool
     if model_dir is None:
         model_dir = get_prompt_enhancer_dir()
     model_dir = Path(model_dir)
-    # EVERY file, not just the weights. Checking two of seven meant a
-    # half-finished transfer -- rsync walks alphabetically, so an interrupt
-    # after spiece.model leaves both sentinels present and the tokenizer
-    # missing -- reported as complete, was never re-downloaded, and failed to
-    # load forever.
-    return all((model_dir / f).exists() for f in PROMPT_ENHANCER_ALLOW)
+    # The files transformers genuinely cannot start without. Checking only the
+    # weights let a half-finished transfer report complete (rsync walks
+    # alphabetically, so an interrupt after spiece.model left both sentinels
+    # present and the tokenizer missing). Requiring ALL SEVEN was the other
+    # error: a mirror that ships a slow tokenizer has no tokenizer.json, so the
+    # check could never pass and every boot re-downloaded 250 MB forever.
+    return all((model_dir / f).exists() for f in PROMPT_ENHANCER_REQUIRED)
 
 
 def download_prompt_enhancer_model(
@@ -735,6 +744,9 @@ def print_model_list():
     print("\n[Stem Separation Models]")
     print(f"  {MELBAND_ROFORMER_MODEL_NAME} -> {MELBAND_ROFORMER_REPO}")
 
+    print("\n[Prompt Enhancer] (optional)")
+    print(f"  {PROMPT_ENHANCER_MODEL_NAME} -> {get_prompt_enhancer_repo()}")
+
     print("\n" + "=" * 60)
 
 
@@ -829,6 +841,14 @@ Alternative using huggingface-cli (substitute your checkpoints dir):
         elif args.model == MELBAND_ROFORMER_MODEL_NAME:
             model_dir = get_melband_roformer_dir(args.dir) if args.dir else get_melband_roformer_dir()
             success, msg = download_melband_roformer_model(
+                model_dir,
+                args.force,
+                args.token,
+            )
+        elif args.model == PROMPT_ENHANCER_MODEL_NAME:
+            model_dir = (get_prompt_enhancer_dir(args.dir) if args.dir
+                         else get_prompt_enhancer_dir())
+            success, msg = download_prompt_enhancer_model(
                 model_dir,
                 args.force,
                 args.token,

--- a/acestep/model_downloader.py
+++ b/acestep/model_downloader.py
@@ -232,8 +232,12 @@ def check_prompt_enhancer_model_exists(model_dir: Optional[Path] = None) -> bool
     if model_dir is None:
         model_dir = get_prompt_enhancer_dir()
     model_dir = Path(model_dir)
-    return ((model_dir / "model.safetensors").exists()
-            and (model_dir / "spiece.model").exists())
+    # EVERY file, not just the weights. Checking two of seven meant a
+    # half-finished transfer -- rsync walks alphabetically, so an interrupt
+    # after spiece.model leaves both sentinels present and the tokenizer
+    # missing -- reported as complete, was never re-downloaded, and failed to
+    # load forever.
+    return all((model_dir / f).exists() for f in PROMPT_ENHANCER_ALLOW)
 
 
 def download_prompt_enhancer_model(
@@ -250,8 +254,6 @@ def download_prompt_enhancer_model(
     if model_dir is None:
         model_dir = get_prompt_enhancer_dir()
     model_dir = Path(model_dir)
-    model_dir.mkdir(parents=True, exist_ok=True)
-
     if not force and check_prompt_enhancer_model_exists(model_dir):
         return True, f"Prompt enhancer already exists at {model_dir}"
 
@@ -264,6 +266,10 @@ def download_prompt_enhancer_model(
     try:
         from huggingface_hub import snapshot_download
 
+        # Created only once the download is actually about to run, so a
+        # failure does not leave an empty directory that later reads as a
+        # staged checkpoint.
+        model_dir.mkdir(parents=True, exist_ok=True)
         snapshot_download(
             repo_id=repo,
             local_dir=str(model_dir),

--- a/acestep/model_downloader.py
+++ b/acestep/model_downloader.py
@@ -7,6 +7,7 @@ with intelligent fallback between download sources.
 """
 
 import os
+import shutil
 import sys
 import argparse
 from typing import Optional, List, Dict, Tuple
@@ -246,7 +247,14 @@ def check_prompt_enhancer_model_exists(model_dir: Optional[Path] = None) -> bool
     # present and the tokenizer missing). Requiring ALL SEVEN was the other
     # error: a mirror that ships a slow tokenizer has no tokenizer.json, so the
     # check could never pass and every boot re-downloaded 250 MB forever.
-    return all((model_dir / f).exists() for f in PROMPT_ENHANCER_REQUIRED)
+    if not all((model_dir / f).exists() for f in PROMPT_ENHANCER_REQUIRED):
+        return False
+    # ...and a tokenizer of SOME kind. A t5 fine-tune ships a fast one
+    # (tokenizer.json) or a slow one (spiece.model); requiring both meant a
+    # legitimate mirror could never pass, and requiring neither -- which is
+    # what this did -- let a directory report complete and then fail to load.
+    return any((model_dir / f).exists()
+               for f in ("tokenizer.json", "spiece.model"))
 
 
 def download_prompt_enhancer_model(
@@ -278,6 +286,7 @@ def download_prompt_enhancer_model(
         # Created only once the download is actually about to run, so a
         # failure does not leave an empty directory that later reads as a
         # staged checkpoint.
+        created = not model_dir.exists()
         model_dir.mkdir(parents=True, exist_ok=True)
         snapshot_download(
             repo_id=repo,
@@ -287,6 +296,11 @@ def download_prompt_enhancer_model(
             force_download=force,
         )
     except Exception as exc:
+        # Remove a directory we created and did not fill. Left behind, it makes
+        # os.path.isdir true, so the loader tries it, fails, and (before this
+        # commit) latched local enhancement off for the process lifetime.
+        if created:
+            shutil.rmtree(model_dir, ignore_errors=True)
         error_msg = f"Prompt enhancer download failed: {exc}"
         logger.error(error_msg)
         return False, error_msg

--- a/acestep/model_downloader.py
+++ b/acestep/model_downloader.py
@@ -193,6 +193,104 @@ MAIN_MODEL_COMPONENTS = [
 DEFAULT_LM_MODEL = "acestep-5Hz-lm-1.7B"
 
 # Auxiliary models stored directly under ACESTEP_MODELS_DIR.
+#: Local prompt enhancer. The source repo is CONFIGURABLE rather than a
+#: constant: deployments that build their own images point this at their own
+#: mirror, and a private repo needs a token the public path never wants.
+#:   DEMON_ENHANCER_REPO   HuggingFace repo id (default below)
+#:   HF_TOKEN              read token, when that repo is private
+PROMPT_ENHANCER_MODEL_NAME = "prompt-enhancer"
+PROMPT_ENHANCER_DEFAULT_REPO = "daydreamlive/t5-small-enhancer"
+#: The files transformers needs to load it; anything else in the repo is
+#: ignored so a card or extra format does not bloat every pod.
+PROMPT_ENHANCER_ALLOW = [
+    "config.json",
+    "generation_config.json",
+    "model.safetensors",
+    "special_tokens_map.json",
+    "spiece.model",
+    "tokenizer.json",
+    "tokenizer_config.json",
+]
+
+
+def get_prompt_enhancer_repo() -> str:
+    """The repo to pull the prompt enhancer from."""
+    return (os.environ.get("DEMON_ENHANCER_REPO", "").strip()
+            or PROMPT_ENHANCER_DEFAULT_REPO)
+
+
+def get_prompt_enhancer_dir(custom_dir: Optional[str] = None) -> Path:
+    """Where the prompt-enhancer checkpoint lives."""
+    if custom_dir:
+        return Path(custom_dir)
+    from acestep.paths import prompt_enhancer_dir
+    return prompt_enhancer_dir()
+
+
+def check_prompt_enhancer_model_exists(model_dir: Optional[Path] = None) -> bool:
+    """True when the weights and tokenizer are both present."""
+    if model_dir is None:
+        model_dir = get_prompt_enhancer_dir()
+    model_dir = Path(model_dir)
+    return ((model_dir / "model.safetensors").exists()
+            and (model_dir / "spiece.model").exists())
+
+
+def download_prompt_enhancer_model(
+    model_dir: Optional[Path] = None,
+    force: bool = False,
+    token: Optional[str] = None,
+) -> Tuple[bool, str]:
+    """Download the prompt-enhancer checkpoint from HuggingFace.
+
+    OPTIONAL, and its absence is not an error: the enhancer falls back to the
+    hosted backend when this checkpoint is missing, so a failed or skipped
+    download degrades a feature rather than breaking a pod.
+    """
+    if model_dir is None:
+        model_dir = get_prompt_enhancer_dir()
+    model_dir = Path(model_dir)
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    if not force and check_prompt_enhancer_model_exists(model_dir):
+        return True, f"Prompt enhancer already exists at {model_dir}"
+
+    repo = get_prompt_enhancer_repo()
+    if token is None:
+        token = os.environ.get("HF_TOKEN", "").strip() or None
+    print(f"Downloading prompt enhancer from {repo}...")
+    print(f"Destination: {model_dir}")
+
+    try:
+        from huggingface_hub import snapshot_download
+
+        snapshot_download(
+            repo_id=repo,
+            local_dir=str(model_dir),
+            allow_patterns=PROMPT_ENHANCER_ALLOW,
+            token=token,
+            force_download=force,
+        )
+    except Exception as exc:
+        error_msg = f"Prompt enhancer download failed: {exc}"
+        logger.error(error_msg)
+        return False, error_msg
+
+    return True, f"Prompt enhancer downloaded to {model_dir}"
+
+
+def ensure_prompt_enhancer_model(
+    model_dir: Optional[Path] = None,
+    token: Optional[str] = None,
+) -> Tuple[bool, str]:
+    """Ensure the prompt-enhancer checkpoint is available, downloading if needed."""
+    if model_dir is None:
+        model_dir = get_prompt_enhancer_dir()
+    if check_prompt_enhancer_model_exists(model_dir):
+        return True, "Prompt enhancer is available"
+    return download_prompt_enhancer_model(model_dir, token=token)
+
+
 MELBAND_ROFORMER_MODEL_NAME = "melband-roformer"
 MELBAND_ROFORMER_REPO = "daydreamlive/MelBandRoFormer"
 MELBAND_ROFORMER_MODEL_FILE = "MelBandRoformer_fp16.safetensors"

--- a/acestep/model_downloader.py
+++ b/acestep/model_downloader.py
@@ -201,8 +201,6 @@ DEFAULT_LM_MODEL = "acestep-5Hz-lm-1.7B"
 #:   HF_TOKEN              read token, when that repo is private
 PROMPT_ENHANCER_MODEL_NAME = "prompt-enhancer"
 PROMPT_ENHANCER_DEFAULT_REPO = "daydreamlive/t5-small-enhancer"
-#: The files transformers needs to load it; anything else in the repo is
-#: ignored so a card or extra format does not bloat every pod.
 #: What must be present for the checkpoint to load at all. A t5 fine-tune may
 #: legitimately ship either a fast tokenizer (tokenizer.json) or a slow one
 #: (spiece.model), so neither is required on its own -- see the check below.
@@ -211,6 +209,8 @@ PROMPT_ENHANCER_REQUIRED = [
     "model.safetensors",
     "tokenizer_config.json",
 ]
+#: The files transformers needs to load it; anything else in the repo is
+#: ignored so a card or extra format does not bloat every pod.
 PROMPT_ENHANCER_ALLOW = [
     "config.json",
     "generation_config.json",
@@ -280,13 +280,13 @@ def download_prompt_enhancer_model(
     print(f"Downloading prompt enhancer from {repo}...")
     print(f"Destination: {model_dir}")
 
+    # Read before the try: the except below consults it, and it must be bound
+    # even when the very first statement inside (the lazy huggingface_hub
+    # import) is what raised.
+    created = not model_dir.exists()
     try:
         from huggingface_hub import snapshot_download
 
-        # Created only once the download is actually about to run, so a
-        # failure does not leave an empty directory that later reads as a
-        # staged checkpoint.
-        created = not model_dir.exists()
         model_dir.mkdir(parents=True, exist_ok=True)
         snapshot_download(
             repo_id=repo,
@@ -863,8 +863,7 @@ Alternative using huggingface-cli (substitute your checkpoints dir):
                 args.token,
             )
         elif args.model == PROMPT_ENHANCER_MODEL_NAME:
-            model_dir = (get_prompt_enhancer_dir(args.dir) if args.dir
-                         else get_prompt_enhancer_dir())
+            model_dir = get_prompt_enhancer_dir(args.dir)
             success, msg = download_prompt_enhancer_model(
                 model_dir,
                 args.force,

--- a/acestep/model_downloader.py
+++ b/acestep/model_downloader.py
@@ -299,7 +299,10 @@ def download_prompt_enhancer_model(
         # Remove a directory we created and did not fill. Left behind, it makes
         # os.path.isdir true, so the loader tries it, fails, and (before this
         # commit) latched local enhancement off for the process lifetime.
-        if created:
+        # Only if we made it AND nothing arrived in it. Removing it
+        # unconditionally would delete a checkpoint another worker finished
+        # while ours was failing -- a 250 MB loss to spare an empty directory.
+        if created and model_dir.is_dir() and not any(model_dir.iterdir()):
             shutil.rmtree(model_dir, ignore_errors=True)
         error_msg = f"Prompt enhancer download failed: {exc}"
         logger.error(error_msg)

--- a/acestep/paths.py
+++ b/acestep/paths.py
@@ -170,6 +170,16 @@ def melband_roformer_model_path(
     return melband_roformer_dir() / filename
 
 
+def prompt_enhancer_dir() -> Path:
+    """Directory containing the local prompt-enhancer checkpoint.
+
+    Override with ``DEMON_ENHANCER_DIR`` when pointing at a checkpoint outside
+    the models tree (bring-up, or an image that stages it elsewhere).
+    """
+    override = os.environ.get("DEMON_ENHANCER_DIR", "").strip()
+    return Path(override) if override else models_dir() / "PromptEnhancer"
+
+
 def fixtures_dir() -> Path:
     """Directory containing test fixture audio and precomputed sidecars."""
     return models_dir() / "fixtures"

--- a/demos/realtime_motion_graph_web/prompt_enhancer.py
+++ b/demos/realtime_motion_graph_web/prompt_enhancer.py
@@ -252,7 +252,11 @@ def _ask_haiku(system: str, user: str) -> str | None:
 #:             deployment behaves exactly as it did before this existed.
 #:   "local"   the fine-tuned local checkpoint, falling back to hosted when it
 #:             is absent or declines.
-#:   "auto"    local when a checkpoint is installed, hosted otherwise.
+#:   "auto"    accepted as a synonym for "local". The fallback design makes the
+#:             documented distinction ("local when a checkpoint is installed")
+#:             unobservable: local ALWAYS degrades to hosted when the
+#:             checkpoint is missing, so there is nothing extra for "auto" to
+#:             decide. Kept so a deployment stating intent does not error.
 #:
 #: Set with DEMON_ENHANCER_PROVIDER. An unknown value is treated as "hosted"
 #: rather than erroring: a typo in a deployment env should cost the faster
@@ -260,7 +264,7 @@ def _ask_haiku(system: str, user: str) -> str | None:
 _PROVIDERS = ("hosted", "local", "auto")
 
 
-def _resolve_provider(override: str = "") -> str:
+def resolve_provider(override: str = "") -> str:
     o = (override or "").strip().lower()
     if o in _PROVIDERS:
         return o
@@ -302,7 +306,7 @@ def enhance_prompt(idea: str, backend: str = "acestep",
     # prompt text and returns "" on anything it cannot handle, so an empty
     # answer is a routing signal rather than a failure -- fall through to the
     # hosted policy below exactly as if it had not been configured.
-    if _resolve_provider(provider) in ("local", "auto"):
+    if resolve_provider(provider) in ("local", "auto"):
         local = _sanitize(_local_enhance(idea, backend))
         if local:
             return local, True

--- a/demos/realtime_motion_graph_web/prompt_enhancer.py
+++ b/demos/realtime_motion_graph_web/prompt_enhancer.py
@@ -251,17 +251,14 @@ def _ask_haiku(system: str, user: str) -> str | None:
 #:   "hosted"  the hosted LLM, as always. THE DEFAULT -- an existing
 #:             deployment behaves exactly as it did before this existed.
 #:   "local"   the fine-tuned local checkpoint, falling back to hosted when it
-#:             is absent or declines.
-#:   "auto"    accepted as a synonym for "local". The fallback design makes the
-#:             documented distinction ("local when a checkpoint is installed")
-#:             unobservable: local ALWAYS degrades to hosted when the
-#:             checkpoint is missing, so there is nothing extra for "auto" to
-#:             decide. Kept so a deployment stating intent does not error.
+#:             is absent or declines. There is deliberately no "auto": local
+#:             ALWAYS degrades to hosted when the checkpoint is missing, so an
+#:             auto mode would have nothing extra to decide.
 #:
 #: Set with DEMON_ENHANCER_PROVIDER. An unknown value is treated as "hosted"
 #: rather than erroring: a typo in a deployment env should cost the faster
 #: path, not the endpoint.
-_PROVIDERS = ("hosted", "local", "auto")
+_PROVIDERS = ("hosted", "local")
 
 
 def resolve_provider(override: str = "") -> str:
@@ -306,7 +303,7 @@ def enhance_prompt(idea: str, backend: str = "acestep",
     # prompt text and returns "" on anything it cannot handle, so an empty
     # answer is a routing signal rather than a failure -- fall through to the
     # hosted policy below exactly as if it had not been configured.
-    if resolve_provider(provider) in ("local", "auto"):
+    if resolve_provider(provider) == "local":
         local = _sanitize(_local_enhance(idea, backend))
         if local:
             return local, True

--- a/demos/realtime_motion_graph_web/prompt_enhancer.py
+++ b/demos/realtime_motion_graph_web/prompt_enhancer.py
@@ -246,7 +246,40 @@ def _ask_haiku(system: str, user: str) -> str | None:
     return None
 
 
-def enhance_prompt(idea: str, backend: str = "acestep") -> tuple[str, bool]:
+#: Which provider answers /api/enhance.
+#:
+#:   "hosted"  the hosted LLM, as always. THE DEFAULT -- an existing
+#:             deployment behaves exactly as it did before this existed.
+#:   "local"   the fine-tuned local checkpoint, falling back to hosted when it
+#:             is absent or declines.
+#:   "auto"    local when a checkpoint is installed, hosted otherwise.
+#:
+#: Set with DEMON_ENHANCER_PROVIDER. An unknown value is treated as "hosted"
+#: rather than erroring: a typo in a deployment env should cost the faster
+#: path, not the endpoint.
+_PROVIDERS = ("hosted", "local", "auto")
+
+
+def _resolve_provider(override: str = "") -> str:
+    o = (override or "").strip().lower()
+    if o in _PROVIDERS:
+        return o
+    env = os.environ.get("DEMON_ENHANCER_PROVIDER", "").strip().lower()
+    return env if env in _PROVIDERS else "hosted"
+
+
+def _local_enhance(idea: str, backend: str) -> str:
+    """The local checkpoint's answer, or "" if it has none."""
+    try:
+        from .prompt_variations import enhance as _enhance
+
+        return _enhance(idea, backend)
+    except Exception:
+        return ""
+
+
+def enhance_prompt(idea: str, backend: str = "acestep",
+                   provider: str = "") -> tuple[str, bool]:
     """Expand a rough idea into a rich prompt for the active backend.
 
     ``backend`` selects the model family policy. ``"sa3"`` uses a full-track
@@ -264,6 +297,16 @@ def enhance_prompt(idea: str, backend: str = "acestep") -> tuple[str, bool]:
     idea = (idea or "").strip()
     if not idea:
         return idea, False
+
+    # The local checkpoint first when asked for. It is trained on structured
+    # prompt text and returns "" on anything it cannot handle, so an empty
+    # answer is a routing signal rather than a failure -- fall through to the
+    # hosted policy below exactly as if it had not been configured.
+    if _resolve_provider(provider) in ("local", "auto"):
+        local = _sanitize(_local_enhance(idea, backend))
+        if local:
+            return local, True
+
     if backend == "sa3":
         if _sa3_wants_solo(idea):
             system = _SYSTEM_SA3_SOLO

--- a/demos/realtime_motion_graph_web/prompt_variations.py
+++ b/demos/realtime_motion_graph_web/prompt_variations.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import contextlib
 import os
 import threading
+import time
 
 #: Sampler freedom at the two ends of the travel. Both ramp with distance: near
 #: the anchor the sampler is nearly greedy, far from it it is free to leave.
@@ -109,6 +110,15 @@ def _resolve_device(torch) -> str:
 
 _loaded = None
 _load_failed = False
+#: When a failed load may be retried. A failure that can resolve on its own -- a
+#: half-staged checkpoint, a volume not mounted yet -- must not latch, or "auto"
+#: becomes a one-shot decision taken by whoever sent the first request. But
+#: retrying freely is worse: _load holds a BLOCKING lock across from_pretrained,
+#: so N requests against a corrupt checkpoint serialise into N x load-time, in
+#: front of the audio thread. Measured: 20 requests, 30s wall, 26s worst case,
+#: repeating on every later burst. So it backs off instead of choosing.
+_retry_after = 0.0
+_RETRY_COOLDOWN_S = 60.0
 
 
 def _load():
@@ -121,9 +131,11 @@ def _load():
     concurrent misses, so the first N simultaneous requests to a cold process
     each load the checkpoint. It also would not let a failure be retried.
     """
-    global _loaded, _load_failed
+    global _loaded, _load_failed, _retry_after
     if _loaded is not None or _load_failed:
         return _loaded
+    if time.monotonic() < _retry_after:
+        return None
     # CHEAP AND LOCK-FREE when there is no checkpoint. Otherwise every request
     # on a pod configured local-with-no-model queued on a blocking mutex around
     # a stat() -- the unbounded queue in front of the audio thread that the
@@ -133,6 +145,8 @@ def _load():
     with _load_lock:
         if _loaded is not None or _load_failed:
             return _loaded
+        if time.monotonic() < _retry_after:
+            return None   # another thread just failed; do not pile on
         try:
             # INSIDE the try. These used to sit above it, so a deployment
             # without torch/transformers raised ImportError out of the endpoint
@@ -156,14 +170,16 @@ def _load():
             _loaded = (tok, model, device)
             return _loaded
         except ImportError:
-            # The only permanent failure: torch/transformers are not installed
-            # and will not appear. Everything else -- a half-staged checkpoint,
-            # a volume not mounted yet, a corrupt file being re-downloaded --
-            # can resolve on its own, and latching made "auto" a one-shot
-            # decision taken by whoever happened to send the first request.
+            # Permanent: the packages are absent and will not appear.
             _load_failed = True
             return None
         except Exception:
+            # Recoverable in principle, so no latch -- but backed off, because
+            # every retry costs a full load attempt under the lock. Note this
+            # catches ValueError/OSError/JSONDecodeError, which is what a
+            # corrupt or half-written checkpoint actually raises; ImportError
+            # above is the only failure that is genuinely permanent.
+            _retry_after = time.monotonic() + _RETRY_COOLDOWN_S
             return None
 
 
@@ -301,6 +317,38 @@ def _anchor(tok, model, enc):
     ids = [int(i) for i in out[0]
            if int(i) not in (tok.pad_token_id, tok.eos_token_id)]
     return ids, tok.decode(out[0], skip_special_tokens=True).strip()
+
+
+def route_query(params: dict) -> tuple[str, int, int]:
+    """Turn a parsed query string into ("grid"|"point"|"reject", stop, lane).
+
+    A pure function so it can be tested: this lived inside the request handler,
+    where it was wrong in both directions at once. `?lane=5` with no stop ran
+    the full grid -- roughly ten times the work, for a request that plainly
+    names one coordinate -- and `?lane=abc` refused a grid, which never reads
+    lane at all.
+
+    Blank and absent mean the same thing (no coordinate asked for). Garbage
+    does not: it is a client bug, and answering it with the most expensive
+    thing on the endpoint is how a typo becomes a denial of service.
+    """
+    def read(name):
+        raw = (params.get(name, [""])[0] or "").strip()
+        if not raw:
+            return None, False
+        try:
+            return int(raw), True
+        except ValueError:
+            return None, True
+
+    stop, stop_given = read("stop")
+    lane, lane_given = read("lane")
+    if (stop_given and stop is None) or (lane_given and lane is None):
+        return ("reject", 0, 0)
+    if not stop_given and not lane_given:
+        return ("grid", 0, 0)
+    stop, lane = clamp_coord(stop or 0, lane or 0)
+    return ("point", stop, lane)
 
 
 def clamp_coord(stop: int, lane: int, stops: int = STOPS,

--- a/demos/realtime_motion_graph_web/prompt_variations.py
+++ b/demos/realtime_motion_graph_web/prompt_variations.py
@@ -109,7 +109,7 @@ def _resolve_device(torch) -> str:
 _loaded = None
 _load_failed = False
 #: When a failed load may be retried. A failure that can resolve on its own -- a
-#: half-staged checkpoint, a volume not mounted yet -- must not latch, or "auto"
+#: half-staged checkpoint, a volume not mounted yet -- must not latch, or "local"
 #: becomes a one-shot decision taken by whoever sent the first request. But
 #: retrying freely is worse: _load holds a BLOCKING lock across from_pretrained,
 #: so N requests against a corrupt checkpoint serialise into N x load-time, in

--- a/demos/realtime_motion_graph_web/prompt_variations.py
+++ b/demos/realtime_motion_graph_web/prompt_variations.py
@@ -38,7 +38,7 @@ change the model can make, and it grows monotonically as the prefix shortens.
 
 from __future__ import annotations
 
-import functools
+import contextlib
 import os
 import threading
 
@@ -137,7 +137,11 @@ def _load():
 
             path = _model_dir()
             if not os.path.isdir(path):
-                _load_failed = True
+                # NOT latched. A checkpoint staged after the first request --
+                # a slow download, a volume mounted late -- must be picked up,
+                # and "auto" is documented as "local when a checkpoint is
+                # installed". Latching made that a one-shot decision taken by
+                # whoever happened to send the first request.
                 return None
             tok = AutoTokenizer.from_pretrained(path, legacy=False)
             model = T5ForConditionalGeneration.from_pretrained(path)
@@ -189,6 +193,7 @@ class Busy(Exception):
     """Raised instead of queueing. See `_generating`."""
 
 
+@contextlib.contextmanager
 def _generating():
     """Admit one generation, or refuse.
 
@@ -197,10 +202,20 @@ def _generating():
     session -- the server already documents that starving that thread closes
     sessions with a keepalive timeout. Refusing immediately bounds the damage
     an unauthenticated caller can do to one in-flight generation.
+
+    A CONTEXT MANAGER, not the Lock. This returned `_lock` itself, so
+    `with _generating():` called Lock.__enter__ -- which IS acquire() -- on a
+    non-reentrant lock the same thread had just taken. It deadlocked on the
+    FIRST call, wedging that connection thread forever while holding the lock,
+    so every later request got Busy for the life of the process. A gate meant
+    to bound the damage instead guaranteed it.
     """
     if not _lock.acquire(blocking=False):
         raise Busy()
-    return _lock
+    try:
+        yield
+    finally:
+        _lock.release()
 
 
 def enhance(text: str, deck: str = "sa3") -> str:
@@ -308,7 +323,14 @@ def _sample(torch, model, enc_b, anchor_ids, stop, stops, seed, device, rows):
     prefix = _prefix_for(anchor_ids, amount)
     dec = torch.tensor([[model.config.decoder_start_token_id] + prefix],
                        device=device).repeat(rows, 1)
-    with torch.random.fork_rng(devices=[]):
+    # devices=[] restores the CPU generator ONLY, and torch.manual_seed is not
+    # CPU-only -- _manual_seed_impl calls torch.cuda.manual_seed_all first. So
+    # the empty list left the CUDA generator seeded from a prompt hash, which
+    # is exactly the audio-seed corruption this was written to prevent, and
+    # the fleet now defaults this model onto CUDA. Fork whatever devices exist.
+    _devices = (list(range(torch.cuda.device_count()))
+                if torch.cuda.is_available() else [])
+    with torch.random.fork_rng(devices=_devices):
         torch.manual_seed(seed)
         return _generate(torch, model, enc_b, dec, amount)
 

--- a/demos/realtime_motion_graph_web/prompt_variations.py
+++ b/demos/realtime_motion_graph_web/prompt_variations.py
@@ -1,0 +1,231 @@
+"""A local prompt enhancer, and a neighbourhood of variations around a prompt.
+
+`/api/enhance` has always expanded a rough idea into a rich prompt by asking a
+hosted LLM. That costs an API key, a network round trip, and a per-call fee for
+an answer that is highly repetitive across a session.
+
+This module offers a second backend for the same job: a small seq2seq model
+(t5-small class) fine-tuned on that LLM's own output, running in-process on the
+pod. It answers in roughly a tenth of the time, needs no key, and is
+deterministic. It is NOT a general instruction model -- it was trained on
+structured, composed prompt text and degrades on free-form input, so it is
+opt-in per deployment and the hosted backend remains the default.
+
+TWO ENTRY POINTS.
+
+``enhance`` is the one-shot: a prompt in, a richer one out, greedy so the same
+input always yields the same output.
+
+``neighbourhood`` answers a different question -- "what else is near this
+prompt?" -- and answers it for the WHOLE neighbourhood at once rather than one
+point at a time. A client exploring nearby prompts interactively would
+otherwise issue a request per interaction, which is a round trip per gesture.
+
+It can answer wholesale because the reachable set is small and finite:
+
+  * distance from the anchor collapses to an integer -- how many of the
+    anchor's leading tokens are held fixed, bounded to MAX_FREE of the line;
+  * variety at a given distance is LANES discrete sampling streams.
+
+So one anchor has a few hundred reachable strings, all deterministic. Generate
+them in one batched pass and the client can index the result locally.
+
+WHY A FORCED PREFIX RATHER THAN A SEED. Seeds have no notion of "nearby": two
+seeds are unrelated draws, so a seed cannot express distance. Prefix length
+can. Holding the head fixed and resampling the tail is the smallest meaningful
+change the model can make, and it grows monotonically as the prefix shortens.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import threading
+
+#: Sampler freedom at the two ends of the travel. Both ramp with distance: near
+#: the anchor the sampler is nearly greedy, far from it it is free to leave.
+TOPK_MIN, TOPK_MAX = 4, 40
+TEMP_MIN, TEMP_MAX = 0.35, 1.35
+#: Most of the line always survives. Beyond roughly this fraction freed, the
+#: model stops varying the brief and starts answering it again, so distance
+#: past that point means nothing.
+MAX_FREE = 0.55
+#: Distinct sampling streams at a given distance. Enough that a deliberate move
+#: lands somewhere else, few enough that each stays reachable and repeatable.
+LANES = 12
+#: Distance steps returned. More than this is wasted: the prefix length is an
+#: integer token count, so adjacent steps start colliding on a short line.
+STOPS = 16
+
+_MODEL_ENV = "DEMON_ENHANCER_DIR"
+_lock = threading.Lock()
+
+
+def _model_dir() -> str:
+    """Where the fine-tuned checkpoint lives.
+
+    Under the models directory like every other checkpoint, never in the
+    repository. ``DEMON_ENHANCER_DIR`` overrides for local experiments.
+    """
+    if os.environ.get(_MODEL_ENV):
+        return os.environ[_MODEL_ENV]
+    try:
+        from acestep.paths import prompt_enhancer_dir
+
+        return str(prompt_enhancer_dir())
+    except Exception:
+        base = os.environ.get(
+            "ACESTEP_MODELS_DIR",
+            os.path.expanduser("~/.daydream-scope/models/demon"),
+        )
+        return os.path.join(base, "PromptEnhancer")
+
+
+@functools.lru_cache(maxsize=1)
+def _load():
+    """Tokenizer + model, once.
+
+    Returns None when the checkpoint is absent or unloadable, so every caller
+    degrades to the hosted backend instead of failing the request.
+    """
+    import torch
+    from transformers import AutoTokenizer, T5ForConditionalGeneration
+
+    path = _model_dir()
+    if not os.path.isdir(path):
+        return None
+    try:
+        tok = AutoTokenizer.from_pretrained(path, legacy=False)
+        model = T5ForConditionalGeneration.from_pretrained(path)
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        model.to(device).eval()
+        return tok, model, device
+    except Exception:
+        return None
+
+
+def available() -> bool:
+    """True when the local checkpoint is present and loadable."""
+    return _load() is not None
+
+
+def _prefix_for(anchor_ids: list[int], amount: float) -> list[int]:
+    """How much of the anchor survives at `amount`.
+
+    The rewrite eats forward from the TAIL. The opening phrases dominate how a
+    prompt is interpreted, so holding them and resampling the end is what makes
+    a small move read as a small move rather than a different brief.
+    """
+    n = len(anchor_ids)
+    free = round(amount * MAX_FREE * n)
+    return anchor_ids[: n - min(free, n)]
+
+
+def _task(deck: str) -> str:
+    """Task prefix the model was trained with, per prompt family."""
+    return "enhance studio: " if deck == "sa3" else "enhance arranger: "
+
+
+def _seed_for(text: str) -> int:
+    """A seed that is stable across processes.
+
+    Python's ``hash()`` is salted per interpreter (PYTHONHASHSEED), so using it
+    would give a different neighbourhood after every restart -- and the whole
+    contract here is that a variation you liked is still there when you come
+    back to it.
+    """
+    import zlib
+
+    return zlib.crc32(text.encode("utf-8")) & 0x7FFFFFFF
+
+
+def enhance(text: str, deck: str = "sa3") -> str:
+    """Expand `text` into a richer prompt. Greedy, so it is reproducible.
+
+    Returns "" when the local checkpoint is unavailable or produced nothing,
+    which the caller should treat as "fall back to the hosted backend".
+    """
+    loaded = _load()
+    if loaded is None or not text.strip():
+        return ""
+    tok, model, device = loaded
+    import torch
+
+    with _lock, torch.inference_mode():
+        enc = tok(_task(deck) + text, return_tensors="pt", max_length=160,
+                  truncation=True).to(device)
+        out = model.generate(**enc, max_new_tokens=128, num_beams=1,
+                             do_sample=False, no_repeat_ngram_size=3)
+    return tok.decode(out[0], skip_special_tokens=True).strip()
+
+
+def neighbourhood(text: str, deck: str = "sa3", lanes: int = LANES,
+                  stops: int = STOPS) -> dict:
+    """Every prompt reachable near `text`, in one batched pass.
+
+    Returns ``{"anchor": str, "lanes": int, "stops": int, "grid": [[str]]}``
+    where ``grid[lane][stop]`` is the prompt at that coordinate, stop 0 being
+    the anchor itself and higher stops progressively further from it. Empty
+    dict when the local checkpoint is unavailable.
+
+    STOP 0 IS THE ANCHOR, EXACTLY, in every lane. Travelling away and back has
+    to return precisely where you were, or the control is lossy and no client
+    can offer it as navigation.
+
+    BATCHED ALONG THE LANE AXIS. Every lane shares one distance, so the forced
+    prefix is identical across the batch and needs no ragged decoder padding --
+    and one sampling call over `lanes` identical rows draws `lanes` independent
+    variants, which is what a lane is. Batching the other way (one lane, every
+    distance) would need variable-length decoder inputs for no gain.
+
+    ONE SEED FOR THE WHOLE TRAVEL, reset before each stop. Every distance then
+    starts from an identical RNG state and differs only in how much of the line
+    was freed, so moving outward DIVERGES from where you were instead of
+    teleporting. Seeding per stop instead is still reproducible, but makes
+    every distance an independent draw: measured, that roughly doubled the edit
+    distance between adjacent steps, turning travel into a shuffle.
+    """
+    loaded = _load()
+    if loaded is None or not text.strip():
+        return {}
+    tok, model, device = loaded
+    import torch
+
+    with _lock, torch.inference_mode():
+        enc = tok(_task(deck) + text, return_tensors="pt", max_length=160,
+                  truncation=True).to(device)
+        anchor_out = model.generate(**enc, max_new_tokens=128, num_beams=1,
+                                    do_sample=False, no_repeat_ngram_size=3)
+        anchor_ids = [int(i) for i in anchor_out[0]
+                      if int(i) not in (tok.pad_token_id, tok.eos_token_id)]
+        anchor_text = tok.decode(anchor_out[0], skip_special_tokens=True).strip()
+        if not anchor_ids:
+            return {}
+
+        anchor_seed = _seed_for(text)
+        grid = [[anchor_text] for _ in range(lanes)]
+        enc_b = {k: v.repeat(lanes, 1) for k, v in enc.items()}
+
+        for s in range(1, stops):
+            amount = s / (stops - 1)
+            prefix = _prefix_for(anchor_ids, amount)
+            dec = torch.tensor([[model.config.decoder_start_token_id] + prefix],
+                               device=device).repeat(lanes, 1)
+            topk = TOPK_MIN + round(amount * (TOPK_MAX - TOPK_MIN))
+            temp = TEMP_MIN + amount * (TEMP_MAX - TEMP_MIN)
+            torch.manual_seed(anchor_seed)
+            out = model.generate(
+                **enc_b,
+                decoder_input_ids=dec,
+                max_new_tokens=128,
+                num_beams=1,
+                do_sample=True,
+                top_k=topk,
+                temperature=temp,
+                no_repeat_ngram_size=3,
+            )
+            for lane in range(lanes):
+                txt = tok.decode(out[lane], skip_special_tokens=True).strip()
+                grid[lane].append(txt or anchor_text)
+
+    return {"anchor": anchor_text, "lanes": lanes, "stops": stops, "grid": grid}

--- a/demos/realtime_motion_graph_web/prompt_variations.py
+++ b/demos/realtime_motion_graph_web/prompt_variations.py
@@ -124,6 +124,12 @@ def _load():
     global _loaded, _load_failed
     if _loaded is not None or _load_failed:
         return _loaded
+    # CHEAP AND LOCK-FREE when there is no checkpoint. Otherwise every request
+    # on a pod configured local-with-no-model queued on a blocking mutex around
+    # a stat() -- the unbounded queue in front of the audio thread that the
+    # non-blocking gate below exists to prevent, one function earlier.
+    if not os.path.isdir(_model_dir()):
+        return None
     with _load_lock:
         if _loaded is not None or _load_failed:
             return _loaded
@@ -149,8 +155,15 @@ def _load():
             model.to(device).eval()
             _loaded = (tok, model, device)
             return _loaded
-        except Exception:
+        except ImportError:
+            # The only permanent failure: torch/transformers are not installed
+            # and will not appear. Everything else -- a half-staged checkpoint,
+            # a volume not mounted yet, a corrupt file being re-downloaded --
+            # can resolve on its own, and latching made "auto" a one-shot
+            # decision taken by whoever happened to send the first request.
             _load_failed = True
+            return None
+        except Exception:
             return None
 
 

--- a/demos/realtime_motion_graph_web/prompt_variations.py
+++ b/demos/realtime_motion_graph_web/prompt_variations.py
@@ -1,4 +1,4 @@
-"""A local prompt enhancer, and a neighbourhood of variations around a prompt.
+"""A local prompt enhancer, and prompts near a given one.
 
 `/api/enhance` has always expanded a rough idea into a rich prompt by asking a
 hosted LLM. That costs an API key, a network round trip, and a per-call fee for
@@ -16,19 +16,17 @@ TWO ENTRY POINTS.
 ``enhance`` is the one-shot: a prompt in, a richer one out, greedy so the same
 input always yields the same output.
 
-``neighbourhood`` answers a different question -- "what else is near this
-prompt?" -- and answers it for the WHOLE neighbourhood at once rather than one
-point at a time. A client exploring nearby prompts interactively would
-otherwise issue a request per interaction, which is a round trip per gesture.
+``point`` answers a different question -- "what else is near this prompt?" --
+one coordinate at a time. Distance from the anchor collapses to an integer
+(how many of the anchor's leading tokens are held fixed, bounded to MAX_FREE
+of the line) and variety at a given distance is LANES discrete sampling
+streams, so a client can walk the space by asking for coordinates.
 
-It can answer wholesale because the reachable set is small and finite:
-
-  * distance from the anchor collapses to an integer -- how many of the
-    anchor's leading tokens are held fixed, bounded to MAX_FREE of the line;
-  * variety at a given distance is LANES discrete sampling streams.
-
-So one anchor has a few hundred reachable strings, all deterministic. Generate
-them in one batched pass and the client can index the result locally.
+Answering the WHOLE neighbourhood in one call was tried and withdrawn. The
+reachable set is small enough to precompute, which sounds like the better
+shape -- but a generation holds the lock below for its whole duration, and a
+grid is fifteen of them. One coordinate is ~0.14s on a 5090; a grid was
+seconds, during which nothing else here could answer at all.
 
 WHY A FORCED PREFIX RATHER THAN A SEED. Seeds have no notion of "nearby": two
 seeds are unrelated draws, so a seed cannot express distance. Prefix length
@@ -269,15 +267,14 @@ def enhance(text: str, deck: str = "sa3") -> str:
 
 def point(text: str, deck: str = "sa3", lane: int = 0, stop: int = 0,
           stops: int = STOPS, lanes: int = LANES) -> str:
-    """ONE coordinate of the neighbourhood, for callers that cannot wait.
+    """ONE coordinate near `text`: `stop` is distance, `lane` picks which
+    neighbour at that distance.
 
-    ``neighbourhood`` is the efficient shape, but it answers in seconds. A
-    client that starts exploring before its grid has arrived would otherwise
-    have nothing to show, so this answers a single coordinate in roughly the
-    time of one decode and the grid takes over silently once it lands.
+    Deterministic in both: the same anchor and coordinate always give the same
+    string, so travelling out and back is lossless. That is the whole contract
+    a client needs to treat this as navigation rather than a dice roll.
 
-    Consistent with ``neighbourhood``: same anchor, same lane, same stop gives
-    the same string from either call, so the handover is invisible.
+    Stop 0 is the anchor itself.
     """
     loaded = _load()
     if loaded is None or not text.strip():
@@ -320,7 +317,7 @@ def _anchor(tok, model, enc):
 
 
 def route_query(params: dict) -> tuple[str, int, int]:
-    """Turn a parsed query string into ("grid"|"point"|"reject", stop, lane).
+    """Turn a parsed query string into ("point"|"reject", stop, lane).
 
     A pure function so it can be tested: this lived inside the request handler,
     where it was wrong in both directions at once. `?lane=5` with no stop ran
@@ -328,9 +325,9 @@ def route_query(params: dict) -> tuple[str, int, int]:
     names one coordinate -- and `?lane=abc` refused a grid, which never reads
     lane at all.
 
-    Blank and absent mean the same thing (no coordinate asked for). Garbage
-    does not: it is a client bug, and answering it with the most expensive
-    thing on the endpoint is how a typo becomes a denial of service.
+    Blank and absent mean the same thing: the origin, which is the anchor.
+    Garbage does not -- it is a client bug, and answering it at all is how a
+    typo becomes work the pod did not need to do.
     """
     def read(name):
         raw = (params.get(name, [""])[0] or "").strip()
@@ -345,8 +342,6 @@ def route_query(params: dict) -> tuple[str, int, int]:
     lane, lane_given = read("lane")
     if (stop_given and stop is None) or (lane_given and lane is None):
         return ("reject", 0, 0)
-    if not stop_given and not lane_given:
-        return ("grid", 0, 0)
     stop, lane = clamp_coord(stop or 0, lane or 0)
     return ("point", stop, lane)
 
@@ -404,56 +399,3 @@ def _generate(torch, model, enc_b, dec, amount):
         temperature=TEMP_MIN + amount * (TEMP_MAX - TEMP_MIN),
         no_repeat_ngram_size=3,
     )
-
-
-def neighbourhood(text: str, deck: str = "sa3", lanes: int = LANES,
-                  stops: int = STOPS) -> dict:
-    """Every prompt reachable near `text`, in one batched pass.
-
-    Returns ``{"anchor": str, "lanes": int, "stops": int, "grid": [[str]]}``
-    where ``grid[lane][stop]`` is the prompt at that coordinate, stop 0 being
-    the anchor itself and higher stops progressively further from it. Empty
-    dict when the local checkpoint is unavailable.
-
-    STOP 0 IS THE ANCHOR, EXACTLY, in every lane. Travelling away and back has
-    to return precisely where you were, or the control is lossy and no client
-    can offer it as navigation.
-
-    BATCHED ALONG THE LANE AXIS. Every lane shares one distance, so the forced
-    prefix is identical across the batch and needs no ragged decoder padding --
-    and one sampling call over `lanes` identical rows draws `lanes` independent
-    variants, which is what a lane is. Batching the other way (one lane, every
-    distance) would need variable-length decoder inputs for no gain.
-
-    ONE SEED FOR THE WHOLE TRAVEL, reset before each stop. Every distance then
-    starts from an identical RNG state and differs only in how much of the line
-    was freed, so moving outward DIVERGES from where you were instead of
-    teleporting. Seeding per stop instead is still reproducible, but makes
-    every distance an independent draw: measured, that roughly doubled the edit
-    distance between adjacent steps, turning travel into a shuffle.
-    """
-    loaded = _load()
-    if loaded is None or not text.strip():
-        return {}
-    tok, model, device = loaded
-    import torch
-
-    with _generating(), torch.inference_mode():
-        enc = tok(_task(deck) + text, return_tensors="pt", max_length=160,
-                  truncation=True).to(device)
-        anchor_ids, anchor_text = _anchor(tok, model, enc)
-        if not anchor_ids:
-            return {}
-
-        seed = _seed_for(text)
-        grid = [[anchor_text] for _ in range(lanes)]
-        enc_b = {k: v.repeat(lanes, 1) for k, v in enc.items()}
-
-        for s in range(1, stops):
-            out = _sample(torch, model, enc_b, anchor_ids, s, stops, seed,
-                          device, lanes)
-            for lane in range(lanes):
-                txt = tok.decode(out[lane], skip_special_tokens=True).strip()
-                grid[lane].append(txt or anchor_text)
-
-    return {"anchor": anchor_text, "lanes": lanes, "stops": stops, "grid": grid}

--- a/demos/realtime_motion_graph_web/prompt_variations.py
+++ b/demos/realtime_motion_graph_web/prompt_variations.py
@@ -58,7 +58,12 @@ LANES = 12
 STOPS = 16
 
 _MODEL_ENV = "DEMON_ENHANCER_DIR"
+#: Serialises generation. Held only while a model is actually decoding.
 _lock = threading.Lock()
+#: Serialises LOADING, which _lock cannot: every caller does _load() before
+#: taking _lock, and functools.lru_cache does NOT hold a lock across the wrapped
+#: call -- N concurrent first requests run N full checkpoint loads.
+_load_lock = threading.Lock()
 
 
 def _model_dir() -> str:
@@ -102,27 +107,47 @@ def _resolve_device(torch) -> str:
     return "cpu"
 
 
-@functools.lru_cache(maxsize=1)
+_loaded = None
+_load_failed = False
+
+
 def _load():
     """Tokenizer + model, once.
 
     Returns None when the checkpoint is absent or unloadable, so every caller
     degrades to the hosted backend instead of failing the request.
-    """
-    import torch
-    from transformers import AutoTokenizer, T5ForConditionalGeneration
 
-    path = _model_dir()
-    if not os.path.isdir(path):
-        return None
-    try:
-        tok = AutoTokenizer.from_pretrained(path, legacy=False)
-        model = T5ForConditionalGeneration.from_pretrained(path)
-        device = _resolve_device(torch)
-        model.to(device).eval()
-        return tok, model, device
-    except Exception:
-        return None
+    NOT lru_cache: that memoises the return value but does not serialise
+    concurrent misses, so the first N simultaneous requests to a cold process
+    each load the checkpoint. It also would not let a failure be retried.
+    """
+    global _loaded, _load_failed
+    if _loaded is not None or _load_failed:
+        return _loaded
+    with _load_lock:
+        if _loaded is not None or _load_failed:
+            return _loaded
+        try:
+            # INSIDE the try. These used to sit above it, so a deployment
+            # without torch/transformers raised ImportError out of the endpoint
+            # as a 500 rather than degrading to the hosted backend, which is
+            # the opposite of what every docstring here promises.
+            import torch
+            from transformers import AutoTokenizer, T5ForConditionalGeneration
+
+            path = _model_dir()
+            if not os.path.isdir(path):
+                _load_failed = True
+                return None
+            tok = AutoTokenizer.from_pretrained(path, legacy=False)
+            model = T5ForConditionalGeneration.from_pretrained(path)
+            device = _resolve_device(torch)
+            model.to(device).eval()
+            _loaded = (tok, model, device)
+            return _loaded
+        except Exception:
+            _load_failed = True
+            return None
 
 
 def available() -> bool:
@@ -160,6 +185,24 @@ def _seed_for(text: str) -> int:
     return zlib.crc32(text.encode("utf-8")) & 0x7FFFFFFF
 
 
+class Busy(Exception):
+    """Raised instead of queueing. See `_generating`."""
+
+
+def _generating():
+    """Admit one generation, or refuse.
+
+    A blocking lock turns concurrent callers into an unbounded queue in front
+    of multi-second work, in the same process (and GIL) as a live audio
+    session -- the server already documents that starving that thread closes
+    sessions with a keepalive timeout. Refusing immediately bounds the damage
+    an unauthenticated caller can do to one in-flight generation.
+    """
+    if not _lock.acquire(blocking=False):
+        raise Busy()
+    return _lock
+
+
 def enhance(text: str, deck: str = "sa3") -> str:
     """Expand `text` into a richer prompt. Greedy, so it is reproducible.
 
@@ -172,7 +215,7 @@ def enhance(text: str, deck: str = "sa3") -> str:
     tok, model, device = loaded
     import torch
 
-    with _lock, torch.inference_mode():
+    with _generating(), torch.inference_mode():
         enc = tok(_task(deck) + text, return_tensors="pt", max_length=160,
                   truncation=True).to(device)
         out = model.generate(**enc, max_new_tokens=128, num_beams=1,
@@ -195,12 +238,13 @@ def point(text: str, deck: str = "sa3", lane: int = 0, stop: int = 0,
     loaded = _load()
     if loaded is None or not text.strip():
         return ""
+    stop, lane = clamp_coord(stop, lane, stops, lanes)
     if stop <= 0:
         return enhance(text, deck)
     tok, model, device = loaded
     import torch
 
-    with _lock, torch.inference_mode():
+    with _generating(), torch.inference_mode():
         enc = tok(_task(deck) + text, return_tensors="pt", max_length=160,
                   truncation=True).to(device)
         anchor_ids, anchor_text = _anchor(tok, model, enc)
@@ -231,14 +275,45 @@ def _anchor(tok, model, enc):
     return ids, tok.decode(out[0], skip_special_tokens=True).strip()
 
 
+def clamp_coord(stop: int, lane: int, stops: int = STOPS,
+                lanes: int = LANES) -> tuple[int, int]:
+    """Force a caller-supplied coordinate into the grid.
+
+    Both arrive from a query string. Unclamped, `lane` indexes a tensor row
+    (IndexError -> 500, raised AFTER the whole batch has been generated) and
+    `stop` scales top_k/temperature without bound, so a large value asks for
+    near-uniform sampling that never draws EOS -- a knob for making every
+    request maximally expensive.
+    """
+    return (max(0, min(stops - 1, stop)), max(0, min(lanes - 1, lane)))
+
+
 def _sample(torch, model, enc_b, anchor_ids, stop, stops, seed, device, rows):
     """One batched sampling pass at distance `stop`. Shared by both entry
-    points so a coordinate cannot mean two different things."""
+    points so a coordinate cannot mean two different things.
+
+    FORKS THE GLOBAL RNG. torch.manual_seed is process-wide and the audio
+    engine draws from the same generator -- acestep/engine/stream.py seeds it
+    and then immediately calls torch.randn for its noise. Seeding here without
+    restoring would hand that slot noise derived from a prompt hash instead of
+    the user's seed, silently breaking audio reproducibility. fork_rng puts the
+    state back, so nothing outside this function can observe our seeding.
+
+    The converse -- a stream reseeding mid-grid and perturbing OUR sampling --
+    is not fixable from this side without a process-wide RNG lock. It costs
+    determinism of the grid under concurrent load, which is the far smaller
+    harm, and the 503 gate above makes it rare.
+    """
     amount = stop / (stops - 1)
     prefix = _prefix_for(anchor_ids, amount)
     dec = torch.tensor([[model.config.decoder_start_token_id] + prefix],
                        device=device).repeat(rows, 1)
-    torch.manual_seed(seed)
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(seed)
+        return _generate(torch, model, enc_b, dec, amount)
+
+
+def _generate(torch, model, enc_b, dec, amount):
     return model.generate(
         **enc_b, decoder_input_ids=dec, max_new_tokens=128, num_beams=1,
         do_sample=True,
@@ -280,7 +355,7 @@ def neighbourhood(text: str, deck: str = "sa3", lanes: int = LANES,
     tok, model, device = loaded
     import torch
 
-    with _lock, torch.inference_mode():
+    with _generating(), torch.inference_mode():
         enc = tok(_task(deck) + text, return_tensors="pt", max_length=160,
                   truncation=True).to(device)
         anchor_ids, anchor_text = _anchor(tok, model, enc)

--- a/demos/realtime_motion_graph_web/prompt_variations.py
+++ b/demos/realtime_motion_graph_web/prompt_variations.py
@@ -81,6 +81,27 @@ def _model_dir() -> str:
         return os.path.join(base, "PromptEnhancer")
 
 
+def _resolve_device(torch) -> str:
+    """CPU BY DEFAULT, even when a GPU is present.
+
+    This model is small, but a pod's GPU is running a realtime audio pipeline
+    and a few hundred milliseconds of contention there is audible. The work
+    here is never on a latency path a listener can hear -- it happens while
+    generated audio is already playing -- so it belongs on the idle CPU rather
+    than in front of the thing that must not stutter.
+
+    ``DEMON_ENHANCER_DEVICE=cuda`` opts in where that trade is worth making
+    (a dedicated pod, or once contention has actually been measured);
+    ``auto`` restores the usual take-the-GPU-if-present behaviour.
+    """
+    want = os.environ.get("DEMON_ENHANCER_DEVICE", "cpu").strip().lower()
+    if want == "cpu":
+        return "cpu"
+    if want in ("cuda", "auto"):
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    return "cpu"
+
+
 @functools.lru_cache(maxsize=1)
 def _load():
     """Tokenizer + model, once.
@@ -97,7 +118,7 @@ def _load():
     try:
         tok = AutoTokenizer.from_pretrained(path, legacy=False)
         model = T5ForConditionalGeneration.from_pretrained(path)
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+        device = _resolve_device(torch)
         model.to(device).eval()
         return tok, model, device
     except Exception:
@@ -159,6 +180,74 @@ def enhance(text: str, deck: str = "sa3") -> str:
     return tok.decode(out[0], skip_special_tokens=True).strip()
 
 
+def point(text: str, deck: str = "sa3", lane: int = 0, stop: int = 0,
+          stops: int = STOPS, lanes: int = LANES) -> str:
+    """ONE coordinate of the neighbourhood, for callers that cannot wait.
+
+    ``neighbourhood`` is the efficient shape, but it answers in seconds. A
+    client that starts exploring before its grid has arrived would otherwise
+    have nothing to show, so this answers a single coordinate in roughly the
+    time of one decode and the grid takes over silently once it lands.
+
+    Consistent with ``neighbourhood``: same anchor, same lane, same stop gives
+    the same string from either call, so the handover is invisible.
+    """
+    loaded = _load()
+    if loaded is None or not text.strip():
+        return ""
+    if stop <= 0:
+        return enhance(text, deck)
+    tok, model, device = loaded
+    import torch
+
+    with _lock, torch.inference_mode():
+        enc = tok(_task(deck) + text, return_tensors="pt", max_length=160,
+                  truncation=True).to(device)
+        anchor_ids, anchor_text = _anchor(tok, model, enc)
+        if not anchor_ids:
+            return ""
+        # THE FULL LANE BATCH, then index it -- not `lane + 1` rows.
+        #
+        # Sampling consumes the random stream per batch, so a narrower batch
+        # gives a row a different draw than the same row inside the grid: two
+        # of five test coordinates disagreed that way, which would make the pad
+        # jump under the pointer the instant the grid replaced this answer.
+        # Computing the whole stop costs one batch instead of a fraction of one
+        # (~700 ms against ~300 ms here) and is exactly the work the grid does
+        # for that stop, so the two cannot diverge.
+        enc_b = {k: v.repeat(lanes, 1) for k, v in enc.items()}
+        out = _sample(torch, model, enc_b, anchor_ids, stop, stops,
+                      _seed_for(text), device, lanes)
+        txt = tok.decode(out[lane], skip_special_tokens=True).strip()
+    return txt or anchor_text
+
+
+def _anchor(tok, model, enc):
+    """The greedy decode: ids without specials, and the readable string."""
+    out = model.generate(**enc, max_new_tokens=128, num_beams=1,
+                         do_sample=False, no_repeat_ngram_size=3)
+    ids = [int(i) for i in out[0]
+           if int(i) not in (tok.pad_token_id, tok.eos_token_id)]
+    return ids, tok.decode(out[0], skip_special_tokens=True).strip()
+
+
+def _sample(torch, model, enc_b, anchor_ids, stop, stops, seed, device, rows):
+    """One batched sampling pass at distance `stop`. Shared by both entry
+    points so a coordinate cannot mean two different things."""
+    amount = stop / (stops - 1)
+    prefix = _prefix_for(anchor_ids, amount)
+    dec = torch.tensor([[model.config.decoder_start_token_id] + prefix],
+                       device=device).repeat(rows, 1)
+    torch.manual_seed(seed)
+    return model.generate(
+        **enc_b, decoder_input_ids=dec, max_new_tokens=128, num_beams=1,
+        do_sample=True,
+        top_k=TOPK_MIN + round(amount * (TOPK_MAX - TOPK_MIN)),
+        temperature=TEMP_MIN + amount * (TEMP_MAX - TEMP_MIN),
+        no_repeat_ngram_size=3,
+    )
+
+
 def neighbourhood(text: str, deck: str = "sa3", lanes: int = LANES,
                   stops: int = STOPS) -> dict:
     """Every prompt reachable near `text`, in one batched pass.
@@ -194,36 +283,17 @@ def neighbourhood(text: str, deck: str = "sa3", lanes: int = LANES,
     with _lock, torch.inference_mode():
         enc = tok(_task(deck) + text, return_tensors="pt", max_length=160,
                   truncation=True).to(device)
-        anchor_out = model.generate(**enc, max_new_tokens=128, num_beams=1,
-                                    do_sample=False, no_repeat_ngram_size=3)
-        anchor_ids = [int(i) for i in anchor_out[0]
-                      if int(i) not in (tok.pad_token_id, tok.eos_token_id)]
-        anchor_text = tok.decode(anchor_out[0], skip_special_tokens=True).strip()
+        anchor_ids, anchor_text = _anchor(tok, model, enc)
         if not anchor_ids:
             return {}
 
-        anchor_seed = _seed_for(text)
+        seed = _seed_for(text)
         grid = [[anchor_text] for _ in range(lanes)]
         enc_b = {k: v.repeat(lanes, 1) for k, v in enc.items()}
 
         for s in range(1, stops):
-            amount = s / (stops - 1)
-            prefix = _prefix_for(anchor_ids, amount)
-            dec = torch.tensor([[model.config.decoder_start_token_id] + prefix],
-                               device=device).repeat(lanes, 1)
-            topk = TOPK_MIN + round(amount * (TOPK_MAX - TOPK_MIN))
-            temp = TEMP_MIN + amount * (TEMP_MAX - TEMP_MIN)
-            torch.manual_seed(anchor_seed)
-            out = model.generate(
-                **enc_b,
-                decoder_input_ids=dec,
-                max_new_tokens=128,
-                num_beams=1,
-                do_sample=True,
-                top_k=topk,
-                temperature=temp,
-                no_repeat_ngram_size=3,
-            )
+            out = _sample(torch, model, enc_b, anchor_ids, s, stops, seed,
+                          device, lanes)
             for lane in range(lanes):
                 txt = tok.decode(out[lane], skip_special_tokens=True).strip()
                 grid[lane].append(txt or anchor_text)

--- a/demos/realtime_motion_graph_web/prompt_variations.py
+++ b/demos/realtime_motion_graph_web/prompt_variations.py
@@ -181,11 +181,6 @@ def _load():
             return None
 
 
-def available() -> bool:
-    """True when the local checkpoint is present and loadable."""
-    return _load() is not None
-
-
 def _prefix_for(anchor_ids: list[int], amount: float) -> list[int]:
     """How much of the anchor survives at `amount`.
 

--- a/demos/realtime_motion_graph_web/prompt_variations.py
+++ b/demos/realtime_motion_graph_web/prompt_variations.py
@@ -156,10 +156,10 @@ def _load():
             path = _model_dir()
             if not os.path.isdir(path):
                 # NOT latched. A checkpoint staged after the first request --
-                # a slow download, a volume mounted late -- must be picked up,
-                # and "auto" is documented as "local when a checkpoint is
-                # installed". Latching made that a one-shot decision taken by
-                # whoever happened to send the first request.
+                # a slow download, a volume mounted late -- must be picked up:
+                # the provider contract is that local starts answering
+                # whenever the checkpoint appears. Latching made that a
+                # one-shot decision taken by whoever sent the first request.
                 return None
             tok = AutoTokenizer.from_pretrained(path, legacy=False)
             model = T5ForConditionalGeneration.from_pretrained(path)

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -326,7 +326,14 @@ def _process_request(connection, request):
         # Unparseable is a client bug, not a coordinate. `?stop=abc` used to
         # clamp to 0 and run a full greedy enhance under the busy lock -- the
         # escalation the parse guard was added to stop, one branch over.
-        if (has_stop and not _parsed("stop")) or (has_lane and not _parsed("lane")):
+        # `lane` is only meaningful with a `stop`. Refusing a grid because an
+        # unused parameter was garbage, and -- worse -- serving a full grid for
+        # `?lane=5` with no stop, were the same mistake from both directions:
+        # the cheap point request must not escalate, and the grid must not be
+        # refused for a field it never reads.
+        if has_stop and not _parsed("stop"):
+            return _json_response(remote, "/api/variations", {"ok": False})
+        if has_stop and has_lane and not _parsed("lane"):
             return _json_response(remote, "/api/variations", {"ok": False})
         try:
             if has_stop:
@@ -346,6 +353,9 @@ def _process_request(connection, request):
             # as a 500, while every docstring in prompt_variations promises the
             # caller falls back to the hosted backend instead.
             if not isinstance(exc, Busy):
+                # Degrading silently makes "no checkpoint", "client sent
+                # nonsense" and "the model crashed" the same 200 on the wire.
+                logger.warning("variations_failed error={}", repr(exc))
                 return _json_response(remote, "/api/variations", {"ok": False})
             body = json.dumps({"ok": False, "busy": True}).encode()
             _log_http(remote, 503, "GET", "/api/variations")

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -284,7 +284,7 @@ def _process_request(connection, request):
         from urllib.parse import parse_qs
 
         from .prompt_enhancer import _resolve_provider
-        from .prompt_variations import Busy, clamp_coord, neighbourhood, point
+        from .prompt_variations import Busy, neighbourhood, point, route_query
 
         query = url.split("?", 1)[1] if "?" in url else ""
         params = parse_qs(query)
@@ -298,46 +298,12 @@ def _process_request(connection, request):
         if _resolve_provider() == "hosted":
             return _json_response(remote, "/api/variations", {"ok": False})
 
-        def _parsed(name: str) -> bool:
-            raw = (params.get(name, [""])[0] or "").strip()
-            if not raw:
-                return True
-            try:
-                int(raw)
-                return True
-            except ValueError:
-                return False
-
-        def _int(name: str):
-            """(value, was_present). A blank/absent param and an unparseable
-            one must NOT be the same answer: `?stop=abc` used to fall through
-            to the sentinel and silently escalate a cheap point request into a
-            full grid."""
-            raw = (params.get(name, [""])[0] or "").strip()
-            if not raw:
-                return 0, False
-            try:
-                return int(raw), True
-            except ValueError:
-                return 0, True
-
-        stop, has_stop = _int("stop")
-        lane, has_lane = _int("lane")
-        # Unparseable is a client bug, not a coordinate. `?stop=abc` used to
-        # clamp to 0 and run a full greedy enhance under the busy lock -- the
-        # escalation the parse guard was added to stop, one branch over.
-        # `lane` is only meaningful with a `stop`. Refusing a grid because an
-        # unused parameter was garbage, and -- worse -- serving a full grid for
-        # `?lane=5` with no stop, were the same mistake from both directions:
-        # the cheap point request must not escalate, and the grid must not be
-        # refused for a field it never reads.
-        if has_stop and not _parsed("stop"):
+        route, stop, lane = route_query(params)
+        if route == "reject":
             return _json_response(remote, "/api/variations", {"ok": False})
-        if has_stop and has_lane and not _parsed("lane"):
-            return _json_response(remote, "/api/variations", {"ok": False})
+
         try:
-            if has_stop:
-                stop, lane = clamp_coord(stop, lane)
+            if route == "point":
                 txt = point(anchor, deck, lane=lane, stop=stop)
                 # `anchor` is NOT the variation. It named the greedy anchor on
                 # the grid path and the variation here, so a client showing

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -284,7 +284,7 @@ def _process_request(connection, request):
         from urllib.parse import parse_qs
 
         from .prompt_enhancer import _resolve_provider
-        from .prompt_variations import Busy, neighbourhood, point, route_query
+        from .prompt_variations import Busy, point, route_query
 
         query = url.split("?", 1)[1] if "?" in url else ""
         params = parse_qs(query)
@@ -303,16 +303,8 @@ def _process_request(connection, request):
             return _json_response(remote, "/api/variations", {"ok": False})
 
         try:
-            if route == "point":
-                txt = point(anchor, deck, lane=lane, stop=stop)
-                # `anchor` is NOT the variation. It named the greedy anchor on
-                # the grid path and the variation here, so a client showing
-                # "your base prompt" showed the wrong string on this branch.
-                payload = {"text": txt, "lane": lane, "stop": stop,
-                           "ok": bool(txt)}
-            else:
-                grid = neighbourhood(anchor, deck)
-                payload = {**grid, "ok": bool(grid)}
+            txt = point(anchor, deck, lane=lane, stop=stop)
+            payload = {"text": txt, "lane": lane, "stop": stop, "ok": bool(txt)}
         except Exception as exc:   # noqa: BLE001 -- see below
             # EVERY failure degrades, not just Busy. A CUDA OOM, a tokenizer
             # error or an IndexError used to propagate out of _process_request

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -298,6 +298,16 @@ def _process_request(connection, request):
         if _resolve_provider() == "hosted":
             return _json_response(remote, "/api/variations", {"ok": False})
 
+        def _parsed(name: str) -> bool:
+            raw = (params.get(name, [""])[0] or "").strip()
+            if not raw:
+                return True
+            try:
+                int(raw)
+                return True
+            except ValueError:
+                return False
+
         def _int(name: str):
             """(value, was_present). A blank/absent param and an unparseable
             one must NOT be the same answer: `?stop=abc` used to fall through
@@ -312,7 +322,12 @@ def _process_request(connection, request):
                 return 0, True
 
         stop, has_stop = _int("stop")
-        lane, _ = _int("lane")
+        lane, has_lane = _int("lane")
+        # Unparseable is a client bug, not a coordinate. `?stop=abc` used to
+        # clamp to 0 and run a full greedy enhance under the busy lock -- the
+        # escalation the parse guard was added to stop, one branch over.
+        if (has_stop and not _parsed("stop")) or (has_lane and not _parsed("lane")):
+            return _json_response(remote, "/api/variations", {"ok": False})
         try:
             if has_stop:
                 stop, lane = clamp_coord(stop, lane)
@@ -325,7 +340,13 @@ def _process_request(connection, request):
             else:
                 grid = neighbourhood(anchor, deck)
                 payload = {**grid, "ok": bool(grid)}
-        except Busy:
+        except Exception as exc:   # noqa: BLE001 -- see below
+            # EVERY failure degrades, not just Busy. A CUDA OOM, a tokenizer
+            # error or an IndexError used to propagate out of _process_request
+            # as a 500, while every docstring in prompt_variations promises the
+            # caller falls back to the hosted backend instead.
+            if not isinstance(exc, Busy):
+                return _json_response(remote, "/api/variations", {"ok": False})
             body = json.dumps({"ok": False, "busy": True}).encode()
             _log_http(remote, 503, "GET", "/api/variations")
             return Response(
@@ -343,7 +364,7 @@ def _process_request(connection, request):
     if path_only == "/api/enhance":
         from urllib.parse import parse_qs
 
-        from .prompt_enhancer import enhance_prompt
+        from .prompt_enhancer import _resolve_provider, enhance_prompt
 
         query = url.split("?", 1)[1] if "?" in url else ""
         params = parse_qs(query)
@@ -354,7 +375,14 @@ def _process_request(connection, request):
         # `provider` picks WHO answers (hosted LLM vs the local checkpoint);
         # `backend` picks WHICH prompt policy. Orthogonal, hence two params.
         # Blank means "whatever this pod is configured for".
+        # The client may ask for a provider, but it may not ARM one the
+        # deployment opted out of: _resolve_provider lets a valid override beat
+        # the env, so ?provider=local forced local inference on a pod
+        # configured hosted -- the exact thing /api/variations' gate exists to
+        # prevent, reachable one endpoint over. An override may only narrow.
         provider = params.get("provider", [""])[0]
+        if _resolve_provider() == "hosted":
+            provider = "hosted"
         enhanced, ok = enhance_prompt(idea, backend, provider)
         body = json.dumps({"enhanced": enhanced, "ok": ok}).encode()
         _log_http(remote, 200, "GET", "/api/enhance")  # redact prompt

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -254,6 +254,36 @@ def _process_request(connection, request):
     # unchanged with ok=false, so every frontend treats enhance as best-effort
     # and never blocks. The prompt rides the query string to stay on this
     # all-GET probe surface; it's redacted from the access log.
+    # The VARIATIONS pad, answered WHOLE rather than per position. The pad is a
+    # gesture -- the plugin re-fires the moment a reply lands and the pointer
+    # has moved -- so a request per position would be a round trip per pixel of
+    # drag. The reachable set is small and deterministic (an integer prefix
+    # length x LANES sampling streams), so one call returns the entire grid and
+    # dragging becomes a local array lookup. Same all-GET probe surface as
+    # /api/enhance; prompt redacted from the access log. Absent checkpoint ->
+    # ok=false and the client simply does not offer the pad.
+    if path_only == "/api/variations":
+        from urllib.parse import parse_qs
+
+        from .prompt_variations import neighbourhood
+
+        query = url.split("?", 1)[1] if "?" in url else ""
+        params = parse_qs(query)
+        anchor = (params.get("prompt", [""])[0] or "").strip()
+        deck = _resolve_enhance_backend(params.get("backend", [""])[0])
+        grid = neighbourhood(anchor, deck)
+        body = json.dumps({**grid, "ok": bool(grid)}).encode()
+        _log_http(remote, 200, "GET", "/api/variations")  # redact prompt
+        return Response(
+            200, "OK",
+            Headers([
+                ("Content-Type", "application/json; charset=utf-8"),
+                ("Content-Length", str(len(body))),
+                *_PUBLIC_HTTP_HEADERS,
+            ]),
+            body,
+        )
+
     if path_only == "/api/enhance":
         from urllib.parse import parse_qs
 
@@ -265,7 +295,11 @@ def _process_request(connection, request):
         # Pod infers the backend from its own checkpoint family; the client's
         # optional backend= hint only overrides when it names a known policy.
         backend = _resolve_enhance_backend(params.get("backend", [""])[0])
-        enhanced, ok = enhance_prompt(idea, backend)
+        # `provider` picks WHO answers (hosted LLM vs the local checkpoint);
+        # `backend` picks WHICH prompt policy. Orthogonal, hence two params.
+        # Blank means "whatever this pod is configured for".
+        provider = params.get("provider", [""])[0]
+        enhanced, ok = enhance_prompt(idea, backend, provider)
         body = json.dumps({"enhanced": enhanced, "ok": ok}).encode()
         _log_http(remote, 200, "GET", "/api/enhance")  # redact prompt
         return Response(

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -265,14 +265,34 @@ def _process_request(connection, request):
     if path_only == "/api/variations":
         from urllib.parse import parse_qs
 
-        from .prompt_variations import neighbourhood
+        from .prompt_variations import neighbourhood, point
 
         query = url.split("?", 1)[1] if "?" in url else ""
         params = parse_qs(query)
         anchor = (params.get("prompt", [""])[0] or "").strip()
         deck = _resolve_enhance_backend(params.get("backend", [""])[0])
-        grid = neighbourhood(anchor, deck)
-        body = json.dumps({**grid, "ok": bool(grid)}).encode()
+
+        # ?stop= asks for ONE coordinate instead of the grid, for a client that
+        # has started exploring before its grid arrived: ~0.4s against several
+        # seconds. Identical strings either way, so the grid can replace these
+        # answers silently as soon as it lands.
+        def _int(name: str) -> int | None:
+            raw = (params.get(name, [""])[0] or "").strip()
+            try:
+                return int(raw)
+            except ValueError:
+                return None
+
+        stop = _int("stop")
+        if stop is not None:
+            lane = _int("lane") or 0
+            txt = point(anchor, deck, lane=lane, stop=stop)
+            payload = {"anchor": txt, "lane": lane, "stop": stop,
+                       "text": txt, "ok": bool(txt)}
+        else:
+            grid = neighbourhood(anchor, deck)
+            payload = {**grid, "ok": bool(grid)}
+        body = json.dumps(payload).encode()
         _log_http(remote, 200, "GET", "/api/variations")  # redact prompt
         return Response(
             200, "OK",

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -187,7 +187,10 @@ def _json_response(remote, path: str, payload: dict) -> "Response":
     """A JSON reply for the variations endpoint. Deliberately NOT carrying
     _PUBLIC_HTTP_HEADERS: those include `Access-Control-Allow-Origin: *`,
     which is right for a cheap read-only probe and wrong for something that
-    costs seconds of model time per call."""
+    costs seconds of model time per call. This intentionally excludes
+    cross-origin BROWSER clients (the web demo frontend included) -- the
+    consumer is the plugin, which talks to this port directly and is not
+    CORS-bound. Add the header only if the web UI ever grows the pad."""
     body = json.dumps(payload).encode()
     _log_http(remote, 200, "GET", path)   # redact prompt
     return Response(
@@ -272,18 +275,18 @@ def _process_request(connection, request):
     # unchanged with ok=false, so every frontend treats enhance as best-effort
     # and never blocks. The prompt rides the query string to stay on this
     # all-GET probe surface; it's redacted from the access log.
-    # The VARIATIONS pad, answered WHOLE rather than per position. The pad is a
-    # gesture -- the plugin re-fires the moment a reply lands and the pointer
-    # has moved -- so a request per position would be a round trip per pixel of
-    # drag. The reachable set is small and deterministic (an integer prefix
-    # length x LANES sampling streams), so one call returns the entire grid and
-    # dragging becomes a local array lookup. Same all-GET probe surface as
-    # /api/enhance; prompt redacted from the access log. Absent checkpoint ->
-    # ok=false and the client simply does not offer the pad.
+    # The VARIATIONS pad, answered ONE COORDINATE per call: `stop` is distance
+    # from the anchor, `lane` picks which neighbour at that distance, and both
+    # are deterministic so the client can cache what it has seen. (Answering
+    # the whole grid in one call was tried and withdrawn -- a grid holds the
+    # generation lock for seconds, during which nothing else here can answer;
+    # see the prompt_variations module docstring.) Same all-GET probe surface
+    # as /api/enhance; prompt redacted from the access log. Absent checkpoint
+    # -> ok=false and the client simply does not offer the pad.
     if path_only == "/api/variations":
         from urllib.parse import parse_qs
 
-        from .prompt_enhancer import _resolve_provider
+        from .prompt_enhancer import resolve_provider
         from .prompt_variations import Busy, point, route_query
 
         query = url.split("?", 1)[1] if "?" in url else ""
@@ -295,7 +298,7 @@ def _process_request(connection, request):
         # is armed by the checkpoint merely being on disk, which a deployment
         # cannot control once an image has been baked from a pod that had one
         # -- so "opt in per deployment" would quietly become a fleet default.
-        if _resolve_provider() == "hosted":
+        if resolve_provider() == "hosted":
             return _json_response(remote, "/api/variations", {"ok": False})
 
         route, stop, lane = route_query(params)
@@ -332,7 +335,7 @@ def _process_request(connection, request):
     if path_only == "/api/enhance":
         from urllib.parse import parse_qs
 
-        from .prompt_enhancer import _resolve_provider, enhance_prompt
+        from .prompt_enhancer import resolve_provider, enhance_prompt
 
         query = url.split("?", 1)[1] if "?" in url else ""
         params = parse_qs(query)
@@ -344,12 +347,12 @@ def _process_request(connection, request):
         # `backend` picks WHICH prompt policy. Orthogonal, hence two params.
         # Blank means "whatever this pod is configured for".
         # The client may ask for a provider, but it may not ARM one the
-        # deployment opted out of: _resolve_provider lets a valid override beat
+        # deployment opted out of: resolve_provider lets a valid override beat
         # the env, so ?provider=local forced local inference on a pod
         # configured hosted -- the exact thing /api/variations' gate exists to
         # prevent, reachable one endpoint over. An override may only narrow.
         provider = params.get("provider", [""])[0]
-        if _resolve_provider() == "hosted":
+        if resolve_provider() == "hosted":
             provider = "hosted"
         enhanced, ok = enhance_prompt(idea, backend, provider)
         body = json.dumps({"enhanced": enhanced, "ok": ok}).encode()

--- a/demos/realtime_motion_graph_web/server.py
+++ b/demos/realtime_motion_graph_web/server.py
@@ -183,6 +183,24 @@ def _log_http(remote: str, status: int, method: str, url: str):
     )
 
 
+def _json_response(remote, path: str, payload: dict) -> "Response":
+    """A JSON reply for the variations endpoint. Deliberately NOT carrying
+    _PUBLIC_HTTP_HEADERS: those include `Access-Control-Allow-Origin: *`,
+    which is right for a cheap read-only probe and wrong for something that
+    costs seconds of model time per call."""
+    body = json.dumps(payload).encode()
+    _log_http(remote, 200, "GET", path)   # redact prompt
+    return Response(
+        200, "OK",
+        Headers([
+            ("Content-Type", "application/json; charset=utf-8"),
+            ("Content-Length", str(len(body))),
+            *_NO_CACHE_HEADERS,
+        ]),
+        body,
+    )
+
+
 def _process_request(connection, request):
     """Return a :class:`Response` for plain HTTP; return ``None`` to let
     the websockets library finish the WebSocket upgrade.
@@ -265,44 +283,62 @@ def _process_request(connection, request):
     if path_only == "/api/variations":
         from urllib.parse import parse_qs
 
-        from .prompt_variations import neighbourhood, point
+        from .prompt_enhancer import _resolve_provider
+        from .prompt_variations import Busy, clamp_coord, neighbourhood, point
 
         query = url.split("?", 1)[1] if "?" in url else ""
         params = parse_qs(query)
         anchor = (params.get("prompt", [""])[0] or "").strip()
         deck = _resolve_enhance_backend(params.get("backend", [""])[0])
 
-        # ?stop= asks for ONE coordinate instead of the grid, for a client that
-        # has started exploring before its grid arrived: ~0.4s against several
-        # seconds. Identical strings either way, so the grid can replace these
-        # answers silently as soon as it lands.
-        def _int(name: str) -> int | None:
-            raw = (params.get(name, [""])[0] or "").strip()
-            try:
-                return int(raw)
-            except ValueError:
-                return None
+        # GATED ON THE SAME SETTING AS /api/enhance. Without this the endpoint
+        # is armed by the checkpoint merely being on disk, which a deployment
+        # cannot control once an image has been baked from a pod that had one
+        # -- so "opt in per deployment" would quietly become a fleet default.
+        if _resolve_provider() == "hosted":
+            return _json_response(remote, "/api/variations", {"ok": False})
 
-        stop = _int("stop")
-        if stop is not None:
-            lane = _int("lane") or 0
-            txt = point(anchor, deck, lane=lane, stop=stop)
-            payload = {"anchor": txt, "lane": lane, "stop": stop,
-                       "text": txt, "ok": bool(txt)}
-        else:
-            grid = neighbourhood(anchor, deck)
-            payload = {**grid, "ok": bool(grid)}
-        body = json.dumps(payload).encode()
-        _log_http(remote, 200, "GET", "/api/variations")  # redact prompt
-        return Response(
-            200, "OK",
-            Headers([
-                ("Content-Type", "application/json; charset=utf-8"),
-                ("Content-Length", str(len(body))),
-                *_PUBLIC_HTTP_HEADERS,
-            ]),
-            body,
-        )
+        def _int(name: str):
+            """(value, was_present). A blank/absent param and an unparseable
+            one must NOT be the same answer: `?stop=abc` used to fall through
+            to the sentinel and silently escalate a cheap point request into a
+            full grid."""
+            raw = (params.get(name, [""])[0] or "").strip()
+            if not raw:
+                return 0, False
+            try:
+                return int(raw), True
+            except ValueError:
+                return 0, True
+
+        stop, has_stop = _int("stop")
+        lane, _ = _int("lane")
+        try:
+            if has_stop:
+                stop, lane = clamp_coord(stop, lane)
+                txt = point(anchor, deck, lane=lane, stop=stop)
+                # `anchor` is NOT the variation. It named the greedy anchor on
+                # the grid path and the variation here, so a client showing
+                # "your base prompt" showed the wrong string on this branch.
+                payload = {"text": txt, "lane": lane, "stop": stop,
+                           "ok": bool(txt)}
+            else:
+                grid = neighbourhood(anchor, deck)
+                payload = {**grid, "ok": bool(grid)}
+        except Busy:
+            body = json.dumps({"ok": False, "busy": True}).encode()
+            _log_http(remote, 503, "GET", "/api/variations")
+            return Response(
+                503, "Service Unavailable",
+                Headers([
+                    ("Content-Type", "application/json; charset=utf-8"),
+                    ("Content-Length", str(len(body))),
+                    ("Retry-After", "5"),
+                    *_NO_CACHE_HEADERS,
+                ]),
+                body,
+            )
+        return _json_response(remote, "/api/variations", payload)
 
     if path_only == "/api/enhance":
         from urllib.parse import parse_qs

--- a/tests/unit/test_prompt_variations.py
+++ b/tests/unit/test_prompt_variations.py
@@ -12,9 +12,16 @@ rather than something that only runs on a pod.
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from demos.realtime_motion_graph_web import prompt_variations as pv
+
+
+def _enter_ok() -> bool:
+    with pv._generating():
+        return True
 
 
 class TestClampCoord:
@@ -73,18 +80,45 @@ class TestSeed:
 
 
 class TestBusyGate:
-    """One generation at a time, and a refusal rather than a queue."""
+    """One generation at a time, and a refusal rather than a queue.
+
+    These must run under a TIMEOUT. The first version of `_generating`
+    returned the Lock itself, so `with _generating():` re-acquired a
+    non-reentrant lock on the same thread and deadlocked -- and a hanging test
+    is not a failing test, which is exactly why it shipped. Every case here
+    runs on a worker thread and asserts it finished.
+    """
+
+    @staticmethod
+    def _run(fn, seconds=5.0):
+        out = []
+        t = threading.Thread(target=lambda: out.append(fn()), daemon=True)
+        t.start()
+        t.join(timeout=seconds)
+        assert not t.is_alive(), "deadlocked -- _generating must not block"
+        return out[0]
+
+    def test_the_body_actually_runs(self):
+        assert self._run(lambda: [1 for _ in [0] if _enter_ok()][0]) == 1
 
     def test_second_caller_is_refused_not_queued(self):
-        with pv._generating():
-            with pytest.raises(pv.Busy):
-                pv._generating()
+        def go():
+            with pv._generating():
+                try:
+                    with pv._generating():
+                        return "admitted"
+                except pv.Busy:
+                    return "refused"
+        assert self._run(go) == "refused"
 
     def test_lock_is_released_for_the_next_caller(self):
-        with pv._generating():
-            pass
-        with pv._generating():
-            pass   # would raise Busy if the first had not released
+        def go():
+            with pv._generating():
+                pass
+            with pv._generating():
+                pass
+            return not pv._lock.locked()
+        assert self._run(go) is True
 
 
 class TestDegradation:

--- a/tests/unit/test_prompt_variations.py
+++ b/tests/unit/test_prompt_variations.py
@@ -126,13 +126,12 @@ class TestDegradation:
         # Every docstring promises callers fall back to the hosted backend
         # rather than seeing a 500.
         monkeypatch.setattr(pv, "_load", lambda: None)
-        assert pv.neighbourhood("techno", "sa3") == {}
         assert pv.point("techno", "sa3", lane=0, stop=3) == ""
         assert pv.enhance("techno", "sa3") == ""
 
     def test_empty_prompt_is_not_work(self, monkeypatch):
         monkeypatch.setattr(pv, "_load", lambda: ("tok", "model", "cpu"))
-        assert pv.neighbourhood("   ", "sa3") == {}
+        assert pv.point("   ", "sa3", lane=0, stop=3) == ""
         assert pv.enhance("", "sa3") == ""
 
 
@@ -141,19 +140,22 @@ class TestRouteQuery:
 
     This lived inline in `_process_request`, where it could not be tested, and
     it was wrong in both directions at once: `?lane=5` with no stop served a
-    full grid (the expensive path, for a request that named a coordinate), and
-    `?lane=abc` refused one (for a field the grid never reads).
+    full neighbourhood -- the expensive path, for a request that named a
+    coordinate -- while `?lane=abc` refused one, for a field that path never
+    read. Every shape now resolves to a coordinate or a refusal.
     """
 
-    def test_no_params_is_a_grid(self):
-        assert pv.route_query({}) == ("grid", 0, 0)
+    def test_no_params_is_the_origin(self):
+        # Which is the anchor -- the cheapest possible answer, and the right
+        # one. It used to be a full neighbourhood: the most expensive thing on
+        # the endpoint, for a request that asked for nothing in particular.
+        assert pv.route_query({}) == ("point", 0, 0)
 
     def test_stop_selects_a_point(self):
         assert pv.route_query({"stop": ["3"]}) == ("point", 3, 0)
         assert pv.route_query({"stop": ["3"], "lane": ["5"]}) == ("point", 3, 5)
 
-    def test_lane_alone_names_a_coordinate_not_a_grid(self):
-        # It was a grid: ~10x the work, for a request that clearly wants one.
+    def test_lane_alone_names_a_coordinate(self):
         assert pv.route_query({"lane": ["5"]}) == ("point", 0, 5)
 
     def test_garbage_is_refused_not_escalated(self):
@@ -167,7 +169,7 @@ class TestRouteQuery:
         assert pv.route_query({"stop": ["9" * 400]}) == ("point", pv.STOPS - 1, 0)
 
     def test_blank_is_absent_not_garbage(self):
-        assert pv.route_query({"stop": [""], "lane": [""]}) == ("grid", 0, 0)
+        assert pv.route_query({"stop": [""], "lane": [""]}) == ("point", 0, 0)
 
     def test_coordinates_are_clamped(self):
         assert pv.route_query({"stop": ["999"], "lane": ["999"]}) == (

--- a/tests/unit/test_prompt_variations.py
+++ b/tests/unit/test_prompt_variations.py
@@ -134,3 +134,58 @@ class TestDegradation:
         monkeypatch.setattr(pv, "_load", lambda: ("tok", "model", "cpu"))
         assert pv.neighbourhood("   ", "sa3") == {}
         assert pv.enhance("", "sa3") == ""
+
+
+class TestRouteQuery:
+    """How a query string becomes a decision.
+
+    This lived inline in `_process_request`, where it could not be tested, and
+    it was wrong in both directions at once: `?lane=5` with no stop served a
+    full grid (the expensive path, for a request that named a coordinate), and
+    `?lane=abc` refused one (for a field the grid never reads).
+    """
+
+    def test_no_params_is_a_grid(self):
+        assert pv.route_query({}) == ("grid", 0, 0)
+
+    def test_stop_selects_a_point(self):
+        assert pv.route_query({"stop": ["3"]}) == ("point", 3, 0)
+        assert pv.route_query({"stop": ["3"], "lane": ["5"]}) == ("point", 3, 5)
+
+    def test_lane_alone_names_a_coordinate_not_a_grid(self):
+        # It was a grid: ~10x the work, for a request that clearly wants one.
+        assert pv.route_query({"lane": ["5"]}) == ("point", 0, 5)
+
+    def test_garbage_is_refused_not_escalated(self):
+        assert pv.route_query({"stop": ["abc"]})[0] == "reject"
+        assert pv.route_query({"lane": ["abc"]})[0] == "reject"
+        assert pv.route_query({"stop": ["3"], "lane": ["abc"]})[0] == "reject"
+    def test_absurd_numbers_clamp_rather_than_overflow(self):
+        # A 400-digit stop is a valid integer. It used to reach
+        # `amount = stop / (stops - 1)` and raise OverflowError -- an
+        # unauthenticated 500. Clamping first makes it merely pointless.
+        assert pv.route_query({"stop": ["9" * 400]}) == ("point", pv.STOPS - 1, 0)
+
+    def test_blank_is_absent_not_garbage(self):
+        assert pv.route_query({"stop": [""], "lane": [""]}) == ("grid", 0, 0)
+
+    def test_coordinates_are_clamped(self):
+        assert pv.route_query({"stop": ["999"], "lane": ["999"]}) == (
+            "point", pv.STOPS - 1, pv.LANES - 1)
+        assert pv.route_query({"stop": ["-5"], "lane": ["-5"]}) == ("point", 0, 0)
+
+
+class TestDownloadResidue:
+    """A failed download must not leave something that reads as a checkpoint."""
+
+    def test_import_failure_does_not_crash(self, monkeypatch, tmp_path):
+        # `created` was assigned AFTER the lazy huggingface_hub import that the
+        # same `except` catches, so a lean image got UnboundLocalError from the
+        # function whose whole contract is to degrade.
+        import acestep.model_downloader as md
+
+        monkeypatch.setattr(md, "get_prompt_enhancer_repo", lambda: "x/y")
+        target = tmp_path / "PromptEnhancer"
+        ok, msg = md.download_prompt_enhancer_model(target)
+        assert ok is False and isinstance(msg, str)
+        assert not target.exists(), "an empty dir reads as a staged checkpoint"

--- a/tests/unit/test_prompt_variations.py
+++ b/tests/unit/test_prompt_variations.py
@@ -1,0 +1,102 @@
+"""Checks for the variations grid that do not need the checkpoint.
+
+The module is index arithmetic, RNG seeding and a batch/point equivalence, and
+the equivalence has already been broken once: `point` built a narrower batch to
+save work, sampling consumes the random stream per batch, and two of five
+coordinates came back different from the grid's. A client indexing a cached
+grid would have seen the answer change under it the moment the grid landed.
+
+Everything here runs without torch or the weights, so it is a real gate in CI
+rather than something that only runs on a pod.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from demos.realtime_motion_graph_web import prompt_variations as pv
+
+
+class TestClampCoord:
+    """`stop` and `lane` arrive from a query string."""
+
+    def test_lane_cannot_index_off_the_batch(self):
+        # Unclamped this reached `out[lane]` on a 12-row tensor: IndexError,
+        # 500, and raised only AFTER the whole batch had been generated.
+        assert pv.clamp_coord(0, 999)[1] == pv.LANES - 1
+        assert pv.clamp_coord(0, -5)[1] == 0
+
+    def test_stop_cannot_run_the_sampler_off_its_range(self):
+        # amount = stop/(stops-1) feeds top_k and temperature unbounded, so a
+        # large stop asks for near-uniform sampling that rarely draws EOS --
+        # every row then runs the full token budget.
+        assert pv.clamp_coord(10**6, 0)[0] == pv.STOPS - 1
+        assert pv.clamp_coord(-5, 0)[0] == 0
+
+    def test_in_range_is_untouched(self):
+        assert pv.clamp_coord(7, 3) == (7, 3)
+
+
+class TestPrefix:
+    """Distance is a count of anchor tokens held fixed."""
+
+    def test_zero_distance_keeps_the_whole_anchor(self):
+        ids = list(range(31))
+        assert pv._prefix_for(ids, 0.0) == ids
+
+    def test_travel_is_monotonic_and_bounded(self):
+        ids = list(range(31))
+        lengths = [len(pv._prefix_for(ids, s / (pv.STOPS - 1)))
+                   for s in range(pv.STOPS)]
+        assert lengths == sorted(lengths, reverse=True)
+        # MAX_FREE is the point past which the model answers the brief again
+        # instead of varying it, so the head must always survive.
+        assert lengths[-1] >= len(ids) * (1 - pv.MAX_FREE) - 1
+
+    def test_anchor_shorter_than_the_stop_count(self):
+        for n in (1, 2, 3):
+            ids = list(range(n))
+            for s in range(pv.STOPS):
+                got = pv._prefix_for(ids, s / (pv.STOPS - 1))
+                assert 0 <= len(got) <= n
+                assert got == ids[: len(got)]
+
+
+class TestSeed:
+    def test_stable_across_processes(self):
+        # Python's hash() is salted per interpreter, so using it would give a
+        # different neighbourhood after every pod restart -- and the pad's
+        # whole contract is that a variation you liked is still there.
+        assert pv._seed_for("techno") == pv._seed_for("techno")
+        assert pv._seed_for("techno") != pv._seed_for("house")
+        assert 0 <= pv._seed_for("x" * 500) <= 0x7FFFFFFF
+
+
+class TestBusyGate:
+    """One generation at a time, and a refusal rather than a queue."""
+
+    def test_second_caller_is_refused_not_queued(self):
+        with pv._generating():
+            with pytest.raises(pv.Busy):
+                pv._generating()
+
+    def test_lock_is_released_for_the_next_caller(self):
+        with pv._generating():
+            pass
+        with pv._generating():
+            pass   # would raise Busy if the first had not released
+
+
+class TestDegradation:
+    def test_absent_checkpoint_returns_empty_not_an_exception(self, monkeypatch):
+        # Every docstring promises callers fall back to the hosted backend
+        # rather than seeing a 500.
+        monkeypatch.setattr(pv, "_load", lambda: None)
+        assert pv.neighbourhood("techno", "sa3") == {}
+        assert pv.point("techno", "sa3", lane=0, stop=3) == ""
+        assert pv.enhance("techno", "sa3") == ""
+
+    def test_empty_prompt_is_not_work(self, monkeypatch):
+        monkeypatch.setattr(pv, "_load", lambda: ("tok", "model", "cpu"))
+        assert pv.neighbourhood("   ", "sa3") == {}
+        assert pv.enhance("", "sa3") == ""

--- a/tests/unit/test_prompt_variations.py
+++ b/tests/unit/test_prompt_variations.py
@@ -162,6 +162,7 @@ class TestRouteQuery:
         assert pv.route_query({"stop": ["abc"]})[0] == "reject"
         assert pv.route_query({"lane": ["abc"]})[0] == "reject"
         assert pv.route_query({"stop": ["3"], "lane": ["abc"]})[0] == "reject"
+
     def test_absurd_numbers_clamp_rather_than_overflow(self):
         # A 400-digit stop is a valid integer. It used to reach
         # `amount = stop / (stops - 1)` and raise OverflowError -- an
@@ -183,11 +184,38 @@ class TestDownloadResidue:
     def test_import_failure_does_not_crash(self, monkeypatch, tmp_path):
         # `created` was assigned AFTER the lazy huggingface_hub import that the
         # same `except` catches, so a lean image got UnboundLocalError from the
-        # function whose whole contract is to degrade.
+        # function whose whole contract is to degrade. Forcing the ImportError
+        # (a None entry in sys.modules makes the in-function import raise) is
+        # what actually exercises that path -- letting snapshot_download fail
+        # against a bogus repo only covered the download-error branch, and did
+        # it with real network I/O from a unit test.
+        import sys
+
         import acestep.model_downloader as md
 
         monkeypatch.setattr(md, "get_prompt_enhancer_repo", lambda: "x/y")
+        monkeypatch.setitem(sys.modules, "huggingface_hub", None)
         target = tmp_path / "PromptEnhancer"
         ok, msg = md.download_prompt_enhancer_model(target)
         assert ok is False and isinstance(msg, str)
+        assert not target.exists(), "an empty dir reads as a staged checkpoint"
+
+    def test_download_failure_removes_only_a_dir_we_created(self, monkeypatch, tmp_path):
+        # The download-error branch, without network: snapshot_download raises,
+        # and the empty directory the function just made must not survive to
+        # read as a staged checkpoint.
+        import sys
+        import types
+
+        import acestep.model_downloader as md
+
+        def boom(**kwargs):
+            raise RuntimeError("no network in unit tests")
+
+        fake = types.SimpleNamespace(snapshot_download=boom)
+        monkeypatch.setattr(md, "get_prompt_enhancer_repo", lambda: "x/y")
+        monkeypatch.setitem(sys.modules, "huggingface_hub", fake)
+        target = tmp_path / "PromptEnhancer"
+        ok, msg = md.download_prompt_enhancer_model(target)
+        assert ok is False and "no network" in msg
         assert not target.exists(), "an empty dir reads as a staged checkpoint"


### PR DESCRIPTION
## What

Two additions to the prompt-enhancement surface, both optional and both off by default.

**A second provider for `/api/enhance`.** Today it can only ask a hosted LLM: that needs an API key, a network round trip, and a per-call fee for answers that repeat constantly within a session. This adds a small seq2seq model (t5-small class), fine-tuned on that LLM's own output, running in-process — roughly a tenth of the latency, no key, deterministic.

**`/api/variations`**, which answers *"what else is near this prompt?"* — one coordinate per call.

## Configuration

| variable | meaning |
|---|---|
| `DEMON_ENHANCER_PROVIDER` | `hosted` (**default**, identical to today) / `local` |
| `DEMON_ENHANCER_REPO` | HuggingFace repo to fetch the checkpoint from |
| `DEMON_ENHANCER_DIR` | local checkpoint path, for images that stage it themselves |
| `DEMON_ENHANCER_DEVICE` | `cpu` (**default** — the GPU is running a realtime audio pipeline) / `cuda` / `auto` |
| `HF_TOKEN` | read token, when the repo is private |

`/api/enhance?provider=` overrides per request, but may only narrow: a client cannot arm `local` on a pod configured `hosted`. `provider` picks *who answers*; the existing `backend` picks *which prompt policy* — orthogonal, hence two parameters.

## Why it is safe to merge before anyone uses it

- The default is `hosted`. An existing deployment sets nothing and behaves exactly as before — verified: with no API key the default still declines and echoes the caller's text unchanged with `ok=false`.
- The model is narrow. It was trained on structured prompt text and degrades on free-form input, so it returns `""` for anything it cannot handle and the hosted policy answers instead. A missing checkpoint takes the same path.
- The checkpoint is **not in the repository** and the download is optional. A failed or skipped fetch costs the feature, never the pod.

## `/api/variations`

Distance from the anchor collapses to an integer (`stop`: how many leading tokens stay fixed, bounded to `MAX_FREE` of the line), and variety at a given distance is `LANES` discrete sampling streams (`lane`). Both are deterministic, so a client can cache every coordinate it has seen and travelling out and back is lossless.

```
GET /api/variations?prompt=<anchor>&stop=<0..15>&lane=<0..11>
-> {"text": str, "stop": int, "lane": int, "ok": true}
```

Answering the whole neighbourhood in one call was tried and **withdrawn**: a grid holds the generation lock for its entire duration (seconds), during which nothing else on the endpoint can answer — one coordinate is ~0.14 s on a 5090. Concurrent callers get an immediate `503 {"busy": true}` with `Retry-After` rather than queueing in front of the live audio thread.

Two implementation choices that are load-bearing rather than incidental:

- **Batched along the lane axis, even for a single coordinate.** Sampling consumes the random stream per batch, so a narrower batch would give a lane a different draw than the same lane computed alongside its siblings — the answer would change depending on how it was asked for. Every request computes the full lane batch for its stop and indexes it.
- **One seed for the whole travel** (`crc32` of the anchor — not `hash()`, which is salted per interpreter), reset per stop, so each distance starts from an identical RNG state and differs only in how much of the line was freed. Seeding per stop is equally reproducible, but makes every distance an independent draw — measured, that roughly doubled the edit distance between adjacent steps, turning travel into a shuffle you can slide back to.

## Verified

Against the real checkpoint:

- stop 0 returns the anchor **exactly**, in every lane — travelling away and back is lossless
- all 12 lanes distinct at maximum distance
- byte-identical output across repeated calls and process restarts
- default provider unchanged with no API key; an unknown provider value falls back to `hosted`

Plus a checkpoint-free unit suite (`tests/unit/test_prompt_variations.py`) covering coordinate clamping, prefix monotonicity, seed stability, the non-blocking busy gate (under a deadlock watchdog), query routing, and download-failure residue — no torch, no network, so it gates in CI.

## Post-review updates (2026-08-31)

- Rebased onto `main` (the SOUND/SCENE prompt-policy section landed separately as #334 and deduplicated cleanly).
- Fixed an `UnboundLocalError` in `download_prompt_enhancer_model`: `created` was assigned after the lazy `huggingface_hub` import inside the same `try`, so on an image without that package the `except` crashed instead of degrading. The covering test now forces the `ImportError` and a second test stubs `snapshot_download` — neither touches the network.
- `resolve_provider` is public now that `server.py` imports it; the `auto` provider value was dropped entirely (the fallback design made it an unobservable synonym for `local` — an unknown value still falls back safely to `hosted`); dead `available()` helper removed; stale whole-grid comments brought in line with the one-coordinate contract.
