### PR TITLE
feat(enhance): tell a sound apart from a piece of music

### DIFF
--- a/demos/realtime_motion_graph_web/prompt_enhancer.py
+++ b/demos/realtime_motion_graph_web/prompt_enhancer.py
@@ -93,6 +93,30 @@ cinematic orchestral build, low strings, taiko hits, rising tension, percussion 
 bossa nova, nylon guitar, soft brushes, upright bass, intimate jazz club, warm
 melodic techno, hypnotic arpeggio, deep kick, analog bass, wide stereo
 
+FIRST, DECIDE WHAT THEY ASKED FOR.
+
+Some ideas name a SOUND or a SCENE rather than music: "thunderstorm", "chirping
+birds", "rain on a tin roof", "a door slamming in a warehouse", "traffic at night".
+Scoring those as an arrangement answers a question nobody asked — someone who types
+"thunderstorm" and receives dramatic orchestral strings did not get a thunderstorm.
+
+So judge the idea, then write accordingly:
+
+SOUND / SCENE — the idea names a real-world source, place or event, and no genre,
+instrument, artist or musical style. Describe THE SOUND ITSELF as a recording:
+lead with the source, then its acoustic character, the space it is in, and its
+motion over time. Instruments are allowed only as texture underneath, sparse or
+absent. Never assign it a genre.
+  thunderstorm -> distant thunder rolling closer, heavy rain on pavement, wind
+    gusting through trees, wide open air, low rumble building and receding
+  chirping birds -> dawn birdsong, layered calls near and far, still morning air,
+    faint rustling leaves, open outdoor space, gentle and unhurried
+
+MUSIC — anything naming a genre, instrument, artist, era, musical mood, or a scene
+that is asking to be SCORED ("epic battle", "sad film ending"). Use the pattern and
+examples above. When in doubt, choose MUSIC: an unwanted arrangement is a smaller
+failure than a flat field recording where someone wanted a track.
+
 RULES:
 - Stay faithful to the user's idea — honor any named artist, genre, era, or instrument
   they mention (e.g. "boards of canada style" -> that hazy, nostalgic analog sound).


### PR DESCRIPTION
Ask `/api/enhance` for **"thunderstorm"** today and you get dramatic orchestral strings with a thunder sample buried in them. The policy only knows how to write a track, so every idea becomes an arrangement — and someone who typed "thunderstorm" did not ask for one.

## What changes

The model judges first. An idea naming a **real-world source, place or event** with no genre, instrument, artist or style is described **as a recording**: the source, its acoustic character, the space it sits in, and how it moves over time — instruments allowed only as texture underneath. Everything else keeps the existing arrangement policy unchanged.

Ties go to MUSIC, deliberately: an unwanted arrangement is a smaller failure than a flat field recording when someone wanted a track.

The judgement is the **model's**, not a keyword list. World knowledge is the reason this runs on a hosted LLM at all, and the alternative is maintaining a vocabulary of every sound anyone might type — the thing that cannot be finished.

## Verified against the live endpoint, 7/7

| input | result |
|---|---|
| `Thunderstorm` | distant thunder rolling closer, heavy rain on pavement, wind gusting through trees |
| `chirping birds` | dawn birdsong, layered calls near and far, still morning air |
| `rain on a tin roof` | rain on metal roof, heavy drops striking and rolling, close intimate… |
| `epic battle` | cinematic orchestral, swelling brass and strings, taiko percussion |
| `80s techno` | 80s techno, analog synthesizer arpeggios, driving four-on-the-floor |
| `sad film ending` | cinematic orchestral arrangement, melancholic strings and piano |
| **`a storm, but as techno`** | **driving techno, deep industrial kick, rolling thunder texture underneath** |

That last row is the one worth watching: naming a genre pulls it back to MUSIC and the storm survives as texture, which is the right answer and the case a keyword matcher would get wrong.

## Scope

**Prompt text only** — 24 lines inside `_SYSTEM_SA3`. No new code paths, no config, no dependencies, nothing else in the file. `26/26` existing enhancer tests pass (`tests/unit/test_prompt_enhancer.py`).

Deliberately split out of a larger in-flight branch so it can land on its own — it needs none of that work, and that work has been holding it up.