### PR TITLE
fix(sa3): drop old-anchor latents on source swap

### DIFF
--- a/acestep/streaming/sa3_backend.py
+++ b/acestep/streaming/sa3_backend.py
@@ -857,11 +857,17 @@ class SA3Backend(DiffusionBackend):
         taps are covers of the OLD source; blending them into the new
         anchor would smear the previous song across the swap).
 
-        In-flight pipeline slots finish on the old anchor — the swap
-        emerges within pipeline depth, exactly the handle_set_prompt
-        convention. At ``sa3_denoise`` = 1.0 slot init is pure noise and
-        the anchor only re-enters when denoise drops below 1 (or via
-        x0_target), matching create-time semantics.
+        In-flight pipeline slots were initialised from the old anchor
+        and finish on it; what emerges from them is a cover of the
+        PREVIOUS source. Unlike a prompt swap (where the old bundle
+        emerging for a few ticks is a soft transition) that audio does
+        not belong in the new buffer at all, so ``_generate`` discards
+        those latents as they emerge and the cached latent is dropped
+        here: the runner then has nothing to render until the first
+        new-anchor slot completes, and the client keeps playing the
+        source it was just handed. At ``sa3_denoise`` = 1.0 slot init is
+        pure noise and the anchor only re-enters when denoise drops
+        below 1 (or via x0_target), matching create-time semantics.
         """
         if self._source_encoder is None:
             raise RuntimeError(
@@ -881,6 +887,13 @@ class SA3Backend(DiffusionBackend):
         with self._control_lock:
             self._source_latent_btc = latent_btc
             self._latent_history.clear()
+            # The cached latent is a cover of the old source. Rendering it
+            # at the new source's playhead (gap-fill, DiT-pause reuse)
+            # would play the previous song over the new one until the
+            # first new-anchor slot emerges; without it the runner writes
+            # nothing and the client plays the swapped-in source instead.
+            self._last_result_latent = None
+            self._current_result = None
         logger.info(
             "sa3_source_swapped samples={} sample_rate={} encode_ms={:.1f}",
             int(waveform.shape[-1]), int(sample_rate), encode_ms,
@@ -1082,9 +1095,17 @@ class SA3Backend(DiffusionBackend):
         if latent is not None:
             # The request this latent was generated from (valid only
             # right after a finishing tick — see StreamPipeline).
-            self._emerged_request = getattr(
-                self.pipeline, "last_finished_request", None,
-            )
+            req = getattr(self.pipeline, "last_finished_request", None)
+            # A slot submitted before a source swap was initialised from
+            # the old anchor and its latent is a cover of the previous
+            # source; it must not be rendered into the new one. Every
+            # request carries the anchor object it was built against as
+            # x0_target, so identity against the live anchor is the test
+            # (handle_swap_source replaces the object).
+            if req is not None and req.x0_target is not self._source_latent_btc:
+                logger.info("sa3_gen_discarded reason=source_swapped")
+                return None
+            self._emerged_request = req
         return latent
 
     def _cond_meta_for(self, bundle) -> tuple:

--- a/tests/unit/test_sa3_backend.py
+++ b/tests/unit/test_sa3_backend.py
@@ -414,6 +414,40 @@ def test_handle_swap_source_reanchors_and_clears_history():
     )
 
 
+def test_handle_swap_source_discards_covers_of_the_old_source():
+    """Slots submitted before the swap were initialised from the old
+    anchor, so what emerges from them is the previous source. Neither
+    those latents nor the cached one may be rendered into the new
+    buffer; the first adopted latent after a swap is a new-anchor one."""
+    old_src = torch.randn(1, C, T)
+    new_latent_bct = torch.randn(1, C, T)
+    b = _backend(
+        source_latent_bct=old_src,
+        source_encoder=lambda waveform, sample_rate, sample_size: new_latent_bct,
+    )
+    knobs = _knobs(b)
+    for _ in range(10):
+        b.produce(knobs, CTX, "generate")
+    assert b.has_renderable_state()
+
+    b.handle_swap_source(torch.zeros(2, 48000), 48000)
+    # Nothing to render until a new-anchor slot completes.
+    assert not b.has_renderable_state()
+    assert b.render_window(0.0) is None
+
+    fresh = []
+    for _ in range(10):
+        fresh.append(b.produce(knobs, CTX, "generate"))
+        if fresh[-1]:
+            break
+    # The in-flight old-anchor slots emerged first and were discarded...
+    assert fresh[:-1] and not any(fresh[:-1])
+    assert fresh[-1] is True
+    # ...and the adopted latent came from a request built on the new anchor.
+    assert b._emerged_request.x0_target is b._source_latent_btc
+    assert b.has_renderable_state()
+
+
 def test_handle_swap_source_without_encoder_fails_loudly():
     b = _backend()  # direct construction: no source_encoder
     try:


### PR DESCRIPTION
After a source swap the SA3 backend kept rendering covers of the previous source: the cached latent (gap-fill, DiT-pause reuse) and the slots still in flight, which emerge over the next pipeline depth. The old song played over the new one for a second or more after every swap.

- `handle_swap_source` drops `_last_result_latent` / `_current_result` (ACE already does this in `sync_source`).
- `_generate` discards a finished latent whose request was built on a previous anchor (`x0_target` identity), logged as `sa3_gen_discarded reason=source_swapped`.

Until the first new-anchor slot completes the runner writes nothing and the client plays the swapped-in source, same as session create. Observed live: 5 discards per swap at the default depth, then clean output.

Tests: new `test_handle_swap_source_discards_covers_of_the_old_source`; `tests/unit` 553 passed, the 4 `test_lora_facade_session` failures are pre-existing on main.
