### PR TITLE
fix(sa3): stop serving the padded outro tail as playable audio

### DIFF
--- a/acestep/streaming/sa3_backend.py
+++ b/acestep/streaming/sa3_backend.py
@@ -203,6 +203,15 @@ class SA3Backend(DiffusionBackend):
         # stream (SlotRequest.sde_noise_seeded), the spike pipeline's
         # per-slot generator semantics.
         sampler: str = "pingpong",
+        # The conditioned song length in seconds — what seconds_total told
+        # the model to fill with music. The render window
+        # (cond.audio_sample_size) is LONGER: prepare_sa3_conditioning pads
+        # it by duration_padding_sec (6 s) of outro headroom, which the
+        # model deliberately fades to silence past seconds_total (upstream
+        # generate() trims it back off via truncate_output_to_duration).
+        # None (directly-constructed test backends) falls back to the full
+        # window, the pre-fix behavior.
+        playable_duration_s: Optional[float] = None,
         prompt_rebuilder: Optional[Callable] = None,
         prompt_tags: Optional[str] = None,
         # Prompt-B conditioning capture for the A/B crossfade. None
@@ -266,6 +275,14 @@ class SA3Backend(DiffusionBackend):
         self._depth = int(depth)
         self._default_seed = int(default_seed)
         self.vae_window = float(vae_window_s)
+        # Playable region: the conditioned song, never the padded outro
+        # headroom (see the ctor arg comment). Clamped into the window so
+        # a caller mistake can't declare more audio than the render holds.
+        window_s = cond.audio_sample_size / SA3_SAMPLE_RATE
+        self._playable_s = (
+            min(float(playable_duration_s), window_s)
+            if playable_duration_s else window_s
+        )
         # "pingpong"/"sde" (rf_denoiser-native, deterministic via seeded
         # renoise) | "ode" (euler; off-objective for SA3, debug only)
         self._sampler = sampler
@@ -483,6 +500,7 @@ class SA3Backend(DiffusionBackend):
             codec=context.make_codec(backend=codec_backend),
             cond=cond,
             cond_b=cond_b,
+            playable_duration_s=duration_s,
             schedule_builder_factory=(
                 lambda s: context.make_schedule_builder(cond, s)
             ),
@@ -735,7 +753,13 @@ class SA3Backend(DiffusionBackend):
         )
 
     def playable_duration_s(self):
-        return self._cond.audio_sample_size / SA3_SAMPLE_RATE
+        # The conditioned song length, NOT cond.audio_sample_size /
+        # SA3_SAMPLE_RATE: the render window carries duration_padding_sec
+        # of outro headroom past seconds_total, where the model fades to
+        # silence by design. Serving that padding as playable audio put a
+        # fade-out + silent tail at the end of every SA3 loop (the
+        # "silence from 9:30 to midnight" bug).
+        return self._playable_s
 
     def read_knobs(self) -> dict:
         return self.knob_state.get_all_values()

--- a/acestep/streaming/sa3_session.py
+++ b/acestep/streaming/sa3_session.py
@@ -246,10 +246,21 @@ def create_sa3_session(
         if not initial_enable_ids:
             logger.info("lora_startup_empty reason=catalog_only")
 
-    # Playable geometry comes from the conditioning capture (duration +
-    # SA3's padding, what the DiT actually generates), not the request.
-    playable_s = cond.audio_sample_size / context.sample_rate
-    n_48k = _delivered_samples(int(cond.audio_sample_size))
+    # Playable geometry is the CONDITIONED duration, not the render
+    # window. prepare_cond pads ``audio_sample_size`` out to duration +
+    # duration_padding_sec (6 s) of outro headroom, and the model fills
+    # that headroom with the fade-out/silence it generates past
+    # seconds_total — upstream ``generate()`` trims it back off
+    # (truncate_output_to_duration). Exposing the padded window as the
+    # playable buffer put ~6 s of fade + silence at the end of every SA3
+    # loop; the DiT still generates the full padded latent, we just never
+    # play or ship the padding.
+    playable_44k = min(
+        int(round(duration_s * context.sample_rate)),
+        int(cond.audio_sample_size),
+    )
+    playable_s = playable_44k / context.sample_rate
+    n_48k = _delivered_samples(playable_44k)
 
     # Initial client buffer: the (truncated) source at the delivery
     # rate, zero-padded out to the rendered length so the buffer the

--- a/tests/unit/test_sa3_backend.py
+++ b/tests/unit/test_sa3_backend.py
@@ -178,6 +178,30 @@ def test_produce_emits_and_renders_windows():
     assert full.start_sample == 0
 
 
+def test_playable_duration_excludes_duration_padding():
+    # prepare_sa3_conditioning pads the render window
+    # (cond.audio_sample_size) past seconds_total by duration_padding_sec
+    # of outro headroom, which the model fades to silence — upstream
+    # generate() trims it off (truncate_output_to_duration). The playable
+    # surface must stop at the conditioned duration, or every loop ends
+    # in the padded fade/silence (the "silence from 9:30 to midnight"
+    # DreamSampler report).
+    window_s = N44 / SA3_SAMPLE_RATE
+    song_s = window_s / 2
+    b = _backend(playable_duration_s=song_s)
+    assert abs(b.playable_duration_s() - song_s) < 1e-9
+    assert abs(b.geometry().duration_s - song_s) < 1e-9
+
+    # A caller value past the window clamps back inside it.
+    b2 = _backend(playable_duration_s=window_s + 10.0)
+    assert abs(b2.playable_duration_s() - window_s) < 1e-9
+
+    # Direct construction without the arg keeps the full window
+    # (pre-existing test-backend behavior).
+    b3 = _backend()
+    assert abs(b3.playable_duration_s() - window_s) < 1e-9
+
+
 def test_render_window_clamps_to_song_end():
     b = _backend()
     knobs = b.read_knobs()


### PR DESCRIPTION
## The bug

DreamSampler users report that "when the loop cycles back around, from 9:30 to about 12 o'clock the generative processes slow down & almost consistently there will be a section of silence" — with a source that has full audio for the whole duration (Discord report, 29 Aug).

## Root cause

`prepare_sa3_conditioning` mirrors upstream `StableAudioModel.generate()` up to the sampler call: it pads the render window by `duration_padding_sec` (6 s) of outro headroom, so `cond.audio_sample_size` covers **duration + 6 s** while `seconds_total` conditioning stays at **duration**. The model deliberately fades to silence past `seconds_total` — that padding is outro space by design, and upstream `generate()` trims it back off (`truncate_output_to_duration`).

The streaming port never trimmed it. `SA3Backend.playable_duration_s()`, `geometry().duration_s`, the wire-declared `duration`, and the client buffer were all sized from `cond.audio_sample_size` — so every SA3 loop plays ~6 s of generated fade + silence before wrapping.

It bites harder than 6 s in practice: `clamp_duration_for_trt` clamps a 60 s request down to ~54 s so the **padded** window fits the 646-latent TRT engine, which means a 60 s upload becomes a 54 s song inside a 60.0004 s buffer — the last 6 s of the user's own audio silently truncated *and* replaced by generated silence. On the plugin's ring UI, 54/60 of the circle is ~10:48, with the model's fade starting a couple of seconds earlier — the reported "9:30 to midnight".

## Evidence (live pods, headless probe)

Uploaded a synthetic 60.0 s source with constant energy (−25 dBFS to the very last sample) via `demos/realtime_motion_graph_web/headless_client.py`:

- **sa3 pod** (`backend=sa3`, `sa3_duration_s=60`): ready declares 60.000375 s; the initial buffer echo shows the source truncated at 54 s + zero pad; after a full lap the generated mirror holds ~−29 dBFS through ~52 s, fades at 52–54 s, then sits at **~−99 dBFS from 54 s to the end of the loop**.
- **ACE pod, same probe, same source**: generated audio holds −16…−18 dBFS across the entire 60 s ring including the final second — the tail silence is SA3-geometry-specific, not a runner/client issue.

## The fix

The DiT still generates the full padded latent — conditioning capture, source-anchor encode (`prepare_audio` at `cond.audio_sample_size`), and the TRT engine window are all untouched. Only the *playable surface* now stops at the conditioned duration:

- `SA3Backend` takes `playable_duration_s` (wired from `duration_s` in `from_context`); `playable_duration_s()` / `geometry().duration_s` return it. Directly-constructed test backends keep the full-window fallback.
- `create_sa3_session` sizes the initial client buffer / `state.duration` / `playback_samples` from the conditioned duration instead of the padded window — which also drives the runner's loop wrap (`eff_dur`), the wire `ready.duration`, and the backend-owned swap's rebuilt buffer (`state.playback_samples`).

The medium/windowed-codec render clamp already reads `playable_duration_s()`, so it follows automatically; window renders whose crossfade tail reaches past the playable end are clamped to the buffer by the runner, exactly as before.

Not addressed here (follow-up worthy): `clamp_duration_for_trt` still costs a 60 s request its last 6 s of source on engines whose window is 60 s + pad — after this fix that shows up honestly as a shorter loop instead of a silent tail. Building the engine window at duration + padding (or shrinking the pad for streaming) would recover it.

## Tests

- New `test_playable_duration_excludes_duration_padding` (playable < window, clamp into window, test-backend fallback).
- `tests/unit`: 580 passed; the 4 `test_lora_facade_session` failures pre-exist on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
