### PR TITLE
feat(sa3): server-side render resize on source swap

### DIFF
--- a/acestep/streaming/families.py
+++ b/acestep/streaming/families.py
@@ -70,6 +70,10 @@ def _make_sa3(ss):
     return SA3Backend.from_context(
         init["context"],
         prompt=ss.state.prompt_text,
+        # The live B prompt seeds the backend's tag pair: a swap-resize
+        # re-captures conditioning for BOTH prompts, and without this a
+        # resize before any set_prompt would collapse the A/B blend to A.
+        prompt_b=ss.state.prompt_text_b,
         duration_s=float(init["duration_s"]),
         knob_state=ss.virtual_knobs,
         state=ss.state,

--- a/acestep/streaming/generator_backend.py
+++ b/acestep/streaming/generator_backend.py
@@ -144,6 +144,15 @@ class Capabilities:
 
     refines_audio: bool = False
     swap: bool = False
+    # ``swap_source`` accepts an optional ``duration_s``: the backend
+    # re-derives its render geometry for the new source instead of
+    # padding/truncating it into the window frozen at session create.
+    # Meaningful only alongside ``swap``; backends whose swap already
+    # follows the source length (ACE) leave it False — there the resize
+    # is implicit and the field would promise nothing new. Clients use
+    # this bit to skip the disconnect→reconnect they otherwise need for
+    # a different-length source (the DreamSampler resize-reconnect).
+    swap_resize: bool = False
     timbre: bool = False
     structure: bool = False
     write_audio: bool = False

--- a/acestep/streaming/generator_backend.py
+++ b/acestep/streaming/generator_backend.py
@@ -365,6 +365,14 @@ class GeneratorBackend(Protocol):
         mode does this). Tracks crop and source swaps."""
         ...
 
+    def max_duration_s(self) -> Optional[float]:
+        """Longest render window this backend can ever hold, or None
+        when it has no fixed ceiling. Read by the session's swap path to
+        cap a ``swap_resize`` request before the source is truncated for
+        the backend, so the ceiling stays backend-owned rather than
+        hardcoded family-by-family in the session layer."""
+        ...
+
     # ---- stall signaling --------------------------------------------------
 
     def has_pending_refit(self) -> bool:

--- a/acestep/streaming/sa3_backend.py
+++ b/acestep/streaming/sa3_backend.py
@@ -53,6 +53,7 @@ plan Phase 5).
 
 from __future__ import annotations
 
+import math
 import threading
 import time
 from collections import deque
@@ -81,6 +82,22 @@ from acestep.streaming.knobs import (
 DELIVERY_SAMPLE_RATE = 48000
 SA3_SAMPLE_RATE = 44100
 SA3_LATENT_RATE_HZ = 44100.0 / 4096.0
+
+# small-music generates at most a 120 s window (sample_size 5292032 at
+# 44.1 kHz); longer sources are anchored by their first 120 s. Defined
+# here (not sa3_session, which imports this module) so the swap-resize
+# path can clamp a requested window without an import cycle.
+SA3_MAX_DURATION_S = 120.0
+
+
+def delivered_samples(n_44k: int) -> int:
+    """48 kHz sample count of the backend's delivery resample for an
+    ``n_44k``-sample native decode — mirrors torchaudio's
+    ``ceil(new * n / orig)`` (gcd-reduced) so the audio engine buffer
+    and the rendered windows agree on geometry to the sample."""
+    g = math.gcd(DELIVERY_SAMPLE_RATE, SA3_SAMPLE_RATE)
+    new, orig = DELIVERY_SAMPLE_RATE // g, SA3_SAMPLE_RATE // g
+    return -(-new * n_44k // orig)
 
 # Largest tap index the feedback delay can address. Derived from the
 # shared registry spec (the same one the manifest serves) so the knob
@@ -214,6 +231,16 @@ class SA3Backend(DiffusionBackend):
         playable_duration_s: Optional[float] = None,
         prompt_rebuilder: Optional[Callable] = None,
         prompt_tags: Optional[str] = None,
+        prompt_tags_b: Optional[str] = None,
+        # ``(new_duration_s, tags_a, tags_b, steps) -> (duration_s, cond,
+        # cond_b | None, dit, schedule_builder_factory)`` — the render-
+        # geometry rebuild behind the swap-resize path
+        # (:meth:`handle_swap_source` with ``duration_s``). Supplied by
+        # :meth:`from_context` (a closure over the SA3Context + the
+        # session's accel/LoRA preferences); None on directly-constructed
+        # test backends, where a resize request fails loudly and the
+        # ``swap_resize`` capability bit stays off.
+        resizer: Optional[Callable] = None,
         # Prompt-B conditioning capture for the A/B crossfade. None
         # (or identical to ``cond``) means no B prompt: the blend is a
         # no-op and handle_set_prompt_blend keeps serving bundle A.
@@ -269,6 +296,18 @@ class SA3Backend(DiffusionBackend):
         self._prompt_rebuilder = prompt_rebuilder
         # Source re-encode hook for handle_swap_source (see ctor arg).
         self._source_encoder = source_encoder
+        # Render-geometry rebuild hook for the swap-resize path (see
+        # ctor arg); gates the swap_resize capability bit.
+        self._resizer = resizer
+        # The live prompt pair, tracked for geometry rebuilds: a resize
+        # must re-capture conditioning for what the user is CURRENTLY
+        # hearing, not the create-time prompts. handle_set_prompt keeps
+        # these current.
+        self._tags_a = prompt_tags
+        self._tags_b = (
+            prompt_tags_b if prompt_tags_b not in (None, "", prompt_tags)
+            else None
+        )
         self.knob_state = knob_state
         self.state = state
         self._steps = int(steps)
@@ -474,14 +513,48 @@ class SA3Backend(DiffusionBackend):
                         "use the eager-DiT swap", exc,
                     )
 
+        # The session's LIVE duration. A box (not the create-time float)
+        # so a swap-resize retargets every later prompt rebuild too —
+        # otherwise handle_set_prompt would re-capture at the create-time
+        # length and trip its own latent_frames guard.
+        duration_box = [float(duration_s)]
+
         def _prompt_rebuilder(tags: str, steps_now: int):
-            # Per-prompt re-conditioning (handle_set_prompt): same fixed
-            # duration, fresh T5Gemma capture + a schedule-builder
-            # factory closed over the NEW cond's sched_args.
+            # Per-prompt re-conditioning (handle_set_prompt): the
+            # session's current duration, fresh T5Gemma capture + a
+            # schedule-builder factory closed over the NEW cond's
+            # sched_args.
             new_cond = context.prepare_cond(
-                prompt=tags, duration=duration_s, steps=steps_now,
+                prompt=tags, duration=duration_box[0], steps=steps_now,
             )
             return new_cond, (
+                lambda s, _c=new_cond: context.make_schedule_builder(_c, s)
+            )
+
+        def _resizer(new_duration_s: float, tags_a: str,
+                     tags_b: Optional[str], steps_now: int):
+            # Render-geometry rebuild (handle_swap_source's resize path):
+            # the same clamp + capture + DiT-selection recipe the create
+            # path runs (sa3_session), against the live prompt pair. The
+            # box is updated only after every capture succeeded, so a
+            # failed resize leaves prompt rebuilds on the old geometry.
+            d = min(float(new_duration_s), SA3_MAX_DURATION_S)
+            d = context.clamp_duration_for_trt(d, backend=dit_backend)
+            new_cond = context.prepare_cond(
+                prompt=tags_a, duration=d, steps=steps_now,
+            )
+            new_cond_b = (
+                context.prepare_cond(prompt=tags_b, duration=d, steps=steps_now)
+                if tags_b and tags_b != tags_a else None
+            )
+            new_dit = context.make_dit(
+                latent_frames=new_cond.latent_frames,
+                seconds_total=d,
+                backend=dit_backend,
+                prefer_refittable=want_lora,
+            )
+            duration_box[0] = d
+            return d, new_cond, new_cond_b, new_dit, (
                 lambda s, _c=new_cond: context.make_schedule_builder(_c, s)
             )
 
@@ -509,7 +582,9 @@ class SA3Backend(DiffusionBackend):
             source_latent_bct=source_latent,
             prompt_rebuilder=_prompt_rebuilder,
             prompt_tags=prompt,
+            prompt_tags_b=prompt_b,
             source_encoder=_source_encoder,
+            resizer=_resizer,
             # D6a: the eager DiT module stays resident on the context
             # even when make_dit returned a TRT wrapper — the interim
             # LoRA fallback swaps to it.
@@ -552,8 +627,16 @@ class SA3Backend(DiffusionBackend):
         # lora: on when the session asked for it (config.lora) AND the
         # create path built the family manager — the same gate shape as
         # ACE's use_lora bit.
+        # swap_resize: the swap may carry duration_s and the backend
+        # re-derives its render geometry for it (handle_swap_source's
+        # resize path) — declared only when the from_context assembly
+        # supplied both the resizer and the source encoder, so a client
+        # can trust the bit instead of probing.
         return Capabilities(
             refines_audio=True, loop_band=True, swap=True,
+            swap_resize=bool(
+                self._resizer is not None and self._source_encoder is not None
+            ),
             render_anchor_queue=True,
             lora=bool(self._use_lora and self._lora_mgr is not None),
         )
@@ -864,22 +947,38 @@ class SA3Backend(DiffusionBackend):
             self._cond_epoch += 1
             self._cond_history.append((cond.cond_bundle, self._cond_epoch, tags))
             del self._cond_history[:-4]
+            # Keep the live pair current for geometry rebuilds (the
+            # swap-resize path re-captures conditioning at these tags).
+            self._tags_a = tags
+            self._tags_b = tags_b if (tags_b and tags_b != tags) else None
         logger.info(
             "sa3_prompt_applied tags={!r} tags_b={!r} cond_epoch={} "
             "rebuild_ms={:.1f}",
             tags, tags_b, self._cond_epoch, rebuild_ms,
         )
 
-    def handle_swap_source(self, waveform, sample_rate) -> None:
+    def handle_swap_source(self, waveform, sample_rate,
+                           duration_s: Optional[float] = None) -> Optional[int]:
         """Re-anchor the session on a new source (the session's
         backend-owned ``swap_source`` hook, dispatched from
         ``_apply_swap_if_pending`` on the runner thread). SAME-encodes
-        ``waveform`` at the session's FIXED latent geometry
+        ``waveform`` at the session's latent geometry
         (``cond.audio_sample_size`` — prepare_audio pads/truncates, so
         any upload length lands on the same [1, T, 256] anchor shape),
         then swaps the anchor and drops the feedback latent ring (its
         taps are covers of the OLD source; blending them into the new
         anchor would smear the previous song across the swap).
+
+        ``duration_s`` (the wire's opt-in swap-resize request) re-derives
+        the render geometry FIRST: fresh conditioning captures for the
+        live prompt pair at the new duration, a DiT re-selected for the
+        new latent window, a rebuilt pipeline (which structurally drops
+        every in-flight old-geometry slot), and the anchor encoded at the
+        NEW ``audio_sample_size``. Returns the new playback-buffer length
+        in delivery-rate samples when the geometry changed, else None —
+        the session resizes its buffer/state from that. Absent
+        ``duration_s`` (legacy clients) the geometry stays frozen at its
+        session-create value, byte-identical to the old behavior.
 
         In-flight pipeline slots were initialised from the old anchor
         and finish on it; what emerges from them is a cover of the
@@ -898,17 +997,101 @@ class SA3Backend(DiffusionBackend):
                 "SA3Backend was constructed without a source_encoder; "
                 "handle_swap_source requires the from_context assembly"
             )
-        with self._control_lock:
-            sample_size = int(self._cond.audio_sample_size)
+        new_geom = None
+        if duration_s is not None:
+            if self._resizer is None:
+                raise RuntimeError(
+                    "SA3Backend was constructed without a resizer; "
+                    "swap-resize requires the from_context assembly"
+                )
+            t0 = time.perf_counter()
+            # Conditioner EXECUTION under the D5 lock, exactly like
+            # handle_set_prompt: a concurrent LoRA mutation of the
+            # conditioner's parametrizations must not interleave with
+            # these captures.
+            with self._conditioner_lock:
+                d, cond, cond_b, dit, sched_factory = self._resizer(
+                    float(duration_s), self._tags_a or "",
+                    self._tags_b, self._steps,
+                )
+            resize_ms = (time.perf_counter() - t0) * 1000
+            if int(cond.latent_frames) == int(self._cond.latent_frames):
+                # The request lands on the geometry we already have
+                # (clamped to the same window, or within one latent
+                # frame): keep the session exactly as-is and take the
+                # cheap re-anchor path below. The fresh captures are
+                # dropped — publishing them would only churn the cond
+                # epoch for a no-op.
+                logger.info(
+                    "sa3_swap_resize_noop requested_s={:.1f} playable_s={:.1f}",
+                    float(duration_s), self._playable_s,
+                )
+            else:
+                new_geom = {
+                    "duration_s": d, "cond": cond, "cond_b": cond_b,
+                    "dit": dit, "sched_factory": sched_factory,
+                }
+                logger.info(
+                    "sa3_swap_resize requested_s={:.1f} duration_s={:.1f} "
+                    "latent_frames={}->{} rebuild_ms={:.1f}",
+                    float(duration_s), d, int(self._cond.latent_frames),
+                    int(cond.latent_frames), resize_ms,
+                )
+
+        sample_size = int(
+            (new_geom["cond"] if new_geom else self._cond).audio_sample_size
+        )
         t0 = time.perf_counter()
+        # Encode BEFORE publishing any geometry: if this raises, the
+        # session keeps its previous consistent state end to end (the
+        # session layer publishes SwapFailed and nothing moved).
         latent_bct = self._source_encoder(waveform, sample_rate, sample_size)
         encode_ms = (time.perf_counter() - t0) * 1000
         latent_btc = latent_bct.movedim(1, 2).contiguous()
+        dropped_mirror = False
         # Publish atomically w.r.t. the command thread's conditioning
         # swaps (same lock discipline as handle_set_prompt); the runner
         # reads the anchor on its own thread, which is also the thread
         # calling this hook.
         with self._control_lock:
+            if new_geom is not None:
+                self._cond = new_geom["cond"]
+                self._cond_b = (
+                    new_geom["cond_b"] if new_geom["cond_b"] is not None
+                    else new_geom["cond"]
+                )
+                self._active_bundle = self._blend_bundles(self._blend)
+                self._schedule_builder_factory = new_geom["sched_factory"]
+                # New window, new (possibly eager-fallback) DiT: publish
+                # both the accelerated reference and the live one, then
+                # let the D6a sync below re-assert the LoRA-active eager
+                # preference. The refit mirror wrapped the OLD engine —
+                # it cannot survive a geometry change; dropping it
+                # degrades LoRA to the eager-DiT swap (weights still
+                # live on the shared torch modules via the manager).
+                self._dit_accel = new_geom["dit"]
+                self.adapter.dit = new_geom["dit"]
+                if self._refit_mirror is not None:
+                    self._refit_mirror = None
+                    dropped_mirror = True
+                window_s = self._cond.audio_sample_size / SA3_SAMPLE_RATE
+                self._playable_s = min(new_geom["duration_s"], window_s)
+                # Emerged-generation labeling, as in handle_set_prompt:
+                # the resized bundle gets the next cond epoch.
+                self._cond_epoch += 1
+                self._cond_history.append(
+                    (self._cond.cond_bundle, self._cond_epoch, self._tags_a),
+                )
+                del self._cond_history[:-4]
+                # Old-geometry render cache cannot be sliced into the
+                # new window.
+                self._rendered_for = None
+                self._rendered_48k = None
+                # Rebuild the ring at the new schedule/geometry — this
+                # also structurally drops every in-flight old-geometry
+                # slot (their latents have the wrong shape for the new
+                # window and must never emerge).
+                self.pipeline = self._build_pipeline(self._steps)
             self._source_latent_btc = latent_btc
             self._latent_history.clear()
             # The cached latent is a cover of the old source. Rendering it
@@ -918,10 +1101,28 @@ class SA3Backend(DiffusionBackend):
             # nothing and the client plays the swapped-in source instead.
             self._last_result_latent = None
             self._current_result = None
+        if dropped_mirror:
+            logger.warning(
+                "sa3_refit_mirror_dropped reason=swap_resize (LoRA falls "
+                "back to the eager-DiT swap for the rest of the session)"
+            )
+        if new_geom is not None:
+            # Re-assert the D6a preference against the NEW accelerated
+            # DiT (LoRA active -> eager module, which is size-agnostic).
+            self._sync_dit_for_lora()
         logger.info(
-            "sa3_source_swapped samples={} sample_rate={} encode_ms={:.1f}",
+            "sa3_source_swapped samples={} sample_rate={} encode_ms={:.1f}"
+            " resized={}",
             int(waveform.shape[-1]), int(sample_rate), encode_ms,
+            new_geom is not None,
         )
+        if new_geom is None:
+            return None
+        playable_44k = min(
+            int(round(self._playable_s * SA3_SAMPLE_RATE)),
+            int(self._cond.audio_sample_size),
+        )
+        return delivered_samples(playable_44k)
 
     def handle_set_prompt_blend(self, value: float) -> None:
         """Crossfade the live conditioning between the A and B captures

--- a/acestep/streaming/sa3_backend.py
+++ b/acestep/streaming/sa3_backend.py
@@ -57,6 +57,7 @@ import math
 import threading
 import time
 from collections import deque
+from contextlib import ExitStack
 from typing import Callable, Optional
 
 import torch
@@ -229,17 +230,25 @@ class SA3Backend(DiffusionBackend):
         # None (directly-constructed test backends) falls back to the full
         # window, the pre-fix behavior.
         playable_duration_s: Optional[float] = None,
+        # ``(tags, steps, duration_s) -> (cond, schedule_builder_factory)``
+        # — the per-prompt re-conditioning hook behind
+        # :meth:`handle_set_prompt`. The backend passes its LIVE
+        # duration (``_duration_s``) so a post-resize prompt swap
+        # re-captures at the new geometry.
         prompt_rebuilder: Optional[Callable] = None,
         prompt_tags: Optional[str] = None,
         prompt_tags_b: Optional[str] = None,
         # ``(new_duration_s, tags_a, tags_b, steps) -> (duration_s, cond,
         # cond_b | None, dit, schedule_builder_factory)`` — the render-
         # geometry rebuild behind the swap-resize path
-        # (:meth:`handle_swap_source` with ``duration_s``). Supplied by
-        # :meth:`from_context` (a closure over the SA3Context + the
-        # session's accel/LoRA preferences); None on directly-constructed
-        # test backends, where a resize request fails loudly and the
-        # ``swap_resize`` capability bit stays off.
+        # (:meth:`handle_swap_source` with ``duration_s``). Must be PURE:
+        # it builds the new geometry and returns it, mutating nothing, so
+        # a resize that fails downstream (the anchor encode) leaves the
+        # session exactly as it was. Supplied by :meth:`from_context` (a
+        # closure over the SA3Context + the session's accel/LoRA
+        # preferences); None on directly-constructed test backends, where
+        # a resize request fails loudly and the ``swap_resize``
+        # capability bit stays off.
         resizer: Optional[Callable] = None,
         # Prompt-B conditioning capture for the A/B crossfade. None
         # (or identical to ``cond``) means no B prompt: the blend is a
@@ -318,10 +327,18 @@ class SA3Backend(DiffusionBackend):
         # headroom (see the ctor arg comment). Clamped into the window so
         # a caller mistake can't declare more audio than the render holds.
         window_s = cond.audio_sample_size / SA3_SAMPLE_RATE
-        self._playable_s = (
-            min(float(playable_duration_s), window_s)
-            if playable_duration_s else window_s
+        # The LIVE conditioning duration — what seconds_total was told,
+        # BEFORE the playable clamp. The single owner of the session's
+        # render geometry: prompt rebuilds capture at it, and the
+        # swap-resize path commits a new value here (under
+        # ``_control_lock``, atomically with the cond it belongs to)
+        # only once the whole resize has landed. Keeping it on the
+        # backend rather than in a from_context closure is what makes a
+        # resize that fails downstream of its captures a clean no-op.
+        self._duration_s = (
+            float(playable_duration_s) if playable_duration_s else window_s
         )
+        self._playable_s = min(self._duration_s, window_s)
         # "pingpong"/"sde" (rf_denoiser-native, deterministic via seeded
         # renoise) | "ode" (euler; off-objective for SA3, debug only)
         self._sampler = sampler
@@ -513,19 +530,17 @@ class SA3Backend(DiffusionBackend):
                         "use the eager-DiT swap", exc,
                     )
 
-        # The session's LIVE duration. A box (not the create-time float)
-        # so a swap-resize retargets every later prompt rebuild too —
-        # otherwise handle_set_prompt would re-capture at the create-time
-        # length and trip its own latent_frames guard.
-        duration_box = [float(duration_s)]
-
-        def _prompt_rebuilder(tags: str, steps_now: int):
-            # Per-prompt re-conditioning (handle_set_prompt): the
-            # session's current duration, fresh T5Gemma capture + a
+        def _prompt_rebuilder(tags: str, steps_now: int, duration_now: float):
+            # Per-prompt re-conditioning (handle_set_prompt): a fresh
+            # T5Gemma capture at the duration the BACKEND says is live
+            # (create-time, or whatever a swap-resize committed) + a
             # schedule-builder factory closed over the NEW cond's
-            # sched_args.
+            # sched_args. The duration is passed in rather than closed
+            # over so the backend stays the single owner of the live
+            # geometry — a resize that fails downstream of its captures
+            # can then leave nothing behind to retarget later rebuilds.
             new_cond = context.prepare_cond(
-                prompt=tags, duration=duration_box[0], steps=steps_now,
+                prompt=tags, duration=float(duration_now), steps=steps_now,
             )
             return new_cond, (
                 lambda s, _c=new_cond: context.make_schedule_builder(_c, s)
@@ -535,9 +550,11 @@ class SA3Backend(DiffusionBackend):
                      tags_b: Optional[str], steps_now: int):
             # Render-geometry rebuild (handle_swap_source's resize path):
             # the same clamp + capture + DiT-selection recipe the create
-            # path runs (sa3_session), against the live prompt pair. The
-            # box is updated only after every capture succeeded, so a
-            # failed resize leaves prompt rebuilds on the old geometry.
+            # path runs (sa3_session), against the live prompt pair.
+            # PURE: nothing here mutates session state, so a failure
+            # anywhere in (or after) it leaves the old geometry whole —
+            # the backend commits the new duration only once the resize
+            # has fully landed.
             d = min(float(new_duration_s), SA3_MAX_DURATION_S)
             d = context.clamp_duration_for_trt(d, backend=dit_backend)
             new_cond = context.prepare_cond(
@@ -553,7 +570,6 @@ class SA3Backend(DiffusionBackend):
                 backend=dit_backend,
                 prefer_refittable=want_lora,
             )
-            duration_box[0] = d
             return d, new_cond, new_cond_b, new_dit, (
                 lambda s, _c=new_cond: context.make_schedule_builder(_c, s)
             )
@@ -835,6 +851,13 @@ class SA3Backend(DiffusionBackend):
             op, lora_id, (time.perf_counter() - t0) * 1000,
         )
 
+    def max_duration_s(self):
+        """The family's render ceiling — small-music generates at most a
+        120 s window. Read by the session's swap-resize path so the
+        clamp stays backend-owned (the resizer applies the same bound
+        to the request it conditions at)."""
+        return SA3_MAX_DURATION_S
+
     def playable_duration_s(self):
         # The conditioned song length, NOT cond.audio_sample_size /
         # SA3_SAMPLE_RATE: the render window carries duration_padding_sec
@@ -902,25 +925,36 @@ class SA3Backend(DiffusionBackend):
         # mutation of the conditioner's parametrizations (runner
         # rendezvous) must not interleave with this capture.
         with self._conditioner_lock:
-            cond, sched_factory = self._prompt_rebuilder(tags, self._steps)
+            # ``_duration_s`` is read under the same lock the resize
+            # path holds across its whole publish, so this capture can
+            # never straddle a geometry change.
+            cond, sched_factory = self._prompt_rebuilder(
+                tags, self._steps, self._duration_s,
+            )
         rebuild_ms = (time.perf_counter() - t0) * 1000
         if int(cond.latent_frames) != int(self._cond.latent_frames):
-            # Duration is fixed for the session lifetime, so the latent
-            # geometry must hold: a mismatch would desync the ring
-            # buffer, the source anchor, and the cond bundle.
+            # A prompt swap never changes geometry — it captures at the
+            # live ``_duration_s``, which only ``handle_swap_source``'s
+            # resize path moves (and only atomically with ``_cond``). A
+            # mismatch here means those two drifted apart, which would
+            # desync the ring buffer, the source anchor, and the cond
+            # bundle.
             raise ValueError(
                 f"sa3 prompt swap changed latent_frames "
-                f"({self._cond.latent_frames} -> {cond.latent_frames}); "
-                f"duration is fixed per session"
+                f"({self._cond.latent_frames} -> {cond.latent_frames}) at "
+                f"duration_s={self._duration_s:.1f}; geometry only moves "
+                f"through a swap-resize"
             )
         if tags_b and tags_b != tags:
             with self._conditioner_lock:
-                cond_b, _ = self._prompt_rebuilder(tags_b, self._steps)
+                cond_b, _ = self._prompt_rebuilder(
+                    tags_b, self._steps, self._duration_s,
+                )
             if int(cond_b.latent_frames) != int(cond.latent_frames):
                 raise ValueError(
                     f"sa3 prompt-B swap changed latent_frames "
                     f"({cond.latent_frames} -> {cond_b.latent_frames}); "
-                    f"duration is fixed per session"
+                    f"the A/B pair must share one geometry"
                 )
         else:
             cond_b = cond
@@ -997,119 +1031,166 @@ class SA3Backend(DiffusionBackend):
                 "SA3Backend was constructed without a source_encoder; "
                 "handle_swap_source requires the from_context assembly"
             )
+        if duration_s is not None and self._resizer is None:
+            raise RuntimeError(
+                "SA3Backend was constructed without a resizer; "
+                "swap-resize requires the from_context assembly"
+            )
         new_geom = None
-        if duration_s is not None:
-            if self._resizer is None:
-                raise RuntimeError(
-                    "SA3Backend was constructed without a resizer; "
-                    "swap-resize requires the from_context assembly"
-                )
-            t0 = time.perf_counter()
-            # Conditioner EXECUTION under the D5 lock, exactly like
-            # handle_set_prompt: a concurrent LoRA mutation of the
-            # conditioner's parametrizations must not interleave with
-            # these captures.
-            with self._conditioner_lock:
+        dropped_mirror = False
+        degraded_to_eager = False
+        # A RESIZE holds the D5 conditioner lock across its whole span —
+        # captures, encode AND publish — where handle_set_prompt holds it
+        # for the captures alone. Both extra reasons are about a
+        # handle_set_prompt racing this on the command thread:
+        #   * its capture must not read _duration_s and _cond from
+        #     opposite sides of the change, which would trip its own
+        #     latent_frames guard on a perfectly ordinary prompt swap;
+        #   * a prompt swap that published INTO the gap would be silently
+        #     reverted by the captures this resize already took against
+        #     the pre-swap _tags_a.
+        # Lock order is conditioner -> control, the only nesting in this
+        # class (handle_set_prompt takes them strictly one after the
+        # other). A PLAIN swap enters neither and stays byte-identical to
+        # the pre-resize path.
+        with ExitStack() as resize_guard:
+            if duration_s is not None:
+                resize_guard.enter_context(self._conditioner_lock)
+                t0 = time.perf_counter()
                 d, cond, cond_b, dit, sched_factory = self._resizer(
                     float(duration_s), self._tags_a or "",
                     self._tags_b, self._steps,
                 )
-            resize_ms = (time.perf_counter() - t0) * 1000
-            if int(cond.latent_frames) == int(self._cond.latent_frames):
-                # The request lands on the geometry we already have
-                # (clamped to the same window, or within one latent
-                # frame): keep the session exactly as-is and take the
-                # cheap re-anchor path below. The fresh captures are
-                # dropped — publishing them would only churn the cond
-                # epoch for a no-op.
-                logger.info(
-                    "sa3_swap_resize_noop requested_s={:.1f} playable_s={:.1f}",
-                    float(duration_s), self._playable_s,
-                )
-            else:
-                new_geom = {
-                    "duration_s": d, "cond": cond, "cond_b": cond_b,
-                    "dit": dit, "sched_factory": sched_factory,
-                }
-                logger.info(
-                    "sa3_swap_resize requested_s={:.1f} duration_s={:.1f} "
-                    "latent_frames={}->{} rebuild_ms={:.1f}",
-                    float(duration_s), d, int(self._cond.latent_frames),
-                    int(cond.latent_frames), resize_ms,
-                )
+                resize_ms = (time.perf_counter() - t0) * 1000
+                if int(cond.latent_frames) == int(self._cond.latent_frames):
+                    # The request lands on the geometry we already have
+                    # (clamped to the same window, or within one latent
+                    # frame): keep the session exactly as-is — including
+                    # _duration_s — and take the cheap re-anchor path
+                    # below. The fresh captures are dropped; publishing
+                    # them would only churn the cond epoch for a no-op.
+                    logger.info(
+                        "sa3_swap_resize_noop requested_s={:.1f} "
+                        "playable_s={:.1f}",
+                        float(duration_s), self._playable_s,
+                    )
+                else:
+                    new_geom = {
+                        "duration_s": d, "cond": cond, "cond_b": cond_b,
+                        "dit": dit, "sched_factory": sched_factory,
+                    }
+                    logger.info(
+                        "sa3_swap_resize requested_s={:.1f} duration_s={:.1f} "
+                        "latent_frames={}->{} rebuild_ms={:.1f}",
+                        float(duration_s), d, int(self._cond.latent_frames),
+                        int(cond.latent_frames), resize_ms,
+                    )
 
-        sample_size = int(
-            (new_geom["cond"] if new_geom else self._cond).audio_sample_size
-        )
-        t0 = time.perf_counter()
-        # Encode BEFORE publishing any geometry: if this raises, the
-        # session keeps its previous consistent state end to end (the
-        # session layer publishes SwapFailed and nothing moved).
-        latent_bct = self._source_encoder(waveform, sample_rate, sample_size)
-        encode_ms = (time.perf_counter() - t0) * 1000
-        latent_btc = latent_bct.movedim(1, 2).contiguous()
-        dropped_mirror = False
-        # Publish atomically w.r.t. the command thread's conditioning
-        # swaps (same lock discipline as handle_set_prompt); the runner
-        # reads the anchor on its own thread, which is also the thread
-        # calling this hook.
-        with self._control_lock:
+            # Read unlocked: audio_sample_size is invariant for a given
+            # geometry (handle_set_prompt's guard enforces exactly that),
+            # and a resize can't be racing us — either we hold the
+            # conditioner lock above, or no geometry change is in play.
+            sample_size = int(
+                (new_geom["cond"] if new_geom else self._cond).audio_sample_size
+            )
+            t0 = time.perf_counter()
+            # Encode BEFORE publishing any geometry: if this raises, the
+            # session keeps its previous consistent state end to end (the
+            # session layer publishes SwapFailed and nothing moved). The
+            # resizer is pure, so there is nothing of the new geometry to
+            # roll back here.
+            latent_bct = self._source_encoder(waveform, sample_rate, sample_size)
+            encode_ms = (time.perf_counter() - t0) * 1000
+            latent_btc = latent_bct.movedim(1, 2).contiguous()
+            # Publish atomically w.r.t. the command thread's conditioning
+            # swaps (same lock discipline as handle_set_prompt); the runner
+            # reads the anchor on its own thread, which is also the thread
+            # calling this hook.
+            with self._control_lock:
+                if new_geom is not None:
+                    self._cond = new_geom["cond"]
+                    self._cond_b = (
+                        new_geom["cond_b"] if new_geom["cond_b"] is not None
+                        else new_geom["cond"]
+                    )
+                    self._active_bundle = self._blend_bundles(self._blend)
+                    self._schedule_builder_factory = new_geom["sched_factory"]
+                    # New window, new (possibly eager-fallback) DiT: publish
+                    # both the accelerated reference and the live one, then
+                    # let the D6a sync below re-assert the LoRA-active eager
+                    # preference. The refit mirror wrapped the OLD engine —
+                    # it cannot survive a geometry change; dropping it
+                    # degrades LoRA to the eager-DiT swap (weights still
+                    # live on the shared torch modules via the manager).
+                    # The outgoing wrapper is released by refcount: nothing
+                    # else holds it once the pipeline below is rebuilt, and
+                    # its TRT execution context + device buffers go with it.
+                    degraded_to_eager = (
+                        self._dit_eager is not None
+                        and new_geom["dit"] is self._dit_eager
+                        and self._dit_accel is not self._dit_eager
+                    )
+                    self._dit_accel = new_geom["dit"]
+                    self.adapter.dit = new_geom["dit"]
+                    if self._refit_mirror is not None:
+                        self._refit_mirror = None
+                        dropped_mirror = True
+                    window_s = self._cond.audio_sample_size / SA3_SAMPLE_RATE
+                    # Commit the new geometry LAST-ish, and only here:
+                    # _duration_s and _cond move together under one lock,
+                    # so a prompt rebuild can never capture at a duration
+                    # the live cond doesn't match.
+                    self._duration_s = new_geom["duration_s"]
+                    self._playable_s = min(self._duration_s, window_s)
+                    # Emerged-generation labeling, as in handle_set_prompt:
+                    # the resized bundle gets the next cond epoch.
+                    self._cond_epoch += 1
+                    self._cond_history.append(
+                        (self._cond.cond_bundle, self._cond_epoch, self._tags_a),
+                    )
+                    del self._cond_history[:-4]
+                    # Old-geometry render cache cannot be sliced into the
+                    # new window.
+                    self._rendered_for = None
+                    self._rendered_48k = None
+                    # Rebuild the ring at the new schedule/geometry — this
+                    # also structurally drops every in-flight old-geometry
+                    # slot (their latents have the wrong shape for the new
+                    # window and must never emerge).
+                    self.pipeline = self._build_pipeline(self._steps)
+                self._source_latent_btc = latent_btc
+                self._latent_history.clear()
+                # The cached latent is a cover of the old source. Rendering it
+                # at the new source's playhead (gap-fill, DiT-pause reuse)
+                # would play the previous song over the new one until the
+                # first new-anchor slot emerges; without it the runner writes
+                # nothing and the client plays the swapped-in source instead.
+                self._last_result_latent = None
+                self._current_result = None
             if new_geom is not None:
-                self._cond = new_geom["cond"]
-                self._cond_b = (
-                    new_geom["cond_b"] if new_geom["cond_b"] is not None
-                    else new_geom["cond"]
-                )
-                self._active_bundle = self._blend_bundles(self._blend)
-                self._schedule_builder_factory = new_geom["sched_factory"]
-                # New window, new (possibly eager-fallback) DiT: publish
-                # both the accelerated reference and the live one, then
-                # let the D6a sync below re-assert the LoRA-active eager
-                # preference. The refit mirror wrapped the OLD engine —
-                # it cannot survive a geometry change; dropping it
-                # degrades LoRA to the eager-DiT swap (weights still
-                # live on the shared torch modules via the manager).
-                self._dit_accel = new_geom["dit"]
-                self.adapter.dit = new_geom["dit"]
-                if self._refit_mirror is not None:
-                    self._refit_mirror = None
-                    dropped_mirror = True
-                window_s = self._cond.audio_sample_size / SA3_SAMPLE_RATE
-                self._playable_s = min(new_geom["duration_s"], window_s)
-                # Emerged-generation labeling, as in handle_set_prompt:
-                # the resized bundle gets the next cond epoch.
-                self._cond_epoch += 1
-                self._cond_history.append(
-                    (self._cond.cond_bundle, self._cond_epoch, self._tags_a),
-                )
-                del self._cond_history[:-4]
-                # Old-geometry render cache cannot be sliced into the
-                # new window.
-                self._rendered_for = None
-                self._rendered_48k = None
-                # Rebuild the ring at the new schedule/geometry — this
-                # also structurally drops every in-flight old-geometry
-                # slot (their latents have the wrong shape for the new
-                # window and must never emerge).
-                self.pipeline = self._build_pipeline(self._steps)
-            self._source_latent_btc = latent_btc
-            self._latent_history.clear()
-            # The cached latent is a cover of the old source. Rendering it
-            # at the new source's playhead (gap-fill, DiT-pause reuse)
-            # would play the previous song over the new one until the
-            # first new-anchor slot emerges; without it the runner writes
-            # nothing and the client plays the swapped-in source instead.
-            self._last_result_latent = None
-            self._current_result = None
+                # Re-assert the D6a preference against the NEW accelerated
+                # DiT (LoRA active -> eager module, which is size-agnostic).
+                # Still under the conditioner lock, so the adapter's DiT
+                # can't be read half-swapped by a LoRA rendezvous.
+                self._sync_dit_for_lora()
+
         if dropped_mirror:
             logger.warning(
                 "sa3_refit_mirror_dropped reason=swap_resize (LoRA falls "
                 "back to the eager-DiT swap for the rest of the session)"
             )
-        if new_geom is not None:
-            # Re-assert the D6a preference against the NEW accelerated
-            # DiT (LoRA active -> eager module, which is size-agnostic).
-            self._sync_dit_for_lora()
+        if degraded_to_eager:
+            # No built engine covers the new latent window, so make_dit
+            # handed back the eager module (~5x slower per step). The
+            # session runs degraded from here; without this line the only
+            # trace is an INFO deep inside make_dit, and "the pod got slow
+            # after a swap" is unanswerable from the logs.
+            logger.warning(
+                "sa3_dit_deaccelerated reason=swap_resize duration_s={:.1f} "
+                "latent_frames={} (no TRT engine covers the resized window; "
+                "the session falls back to the eager DiT)",
+                self._duration_s, int(self._cond.latent_frames),
+            )
         logger.info(
             "sa3_source_swapped samples={} sample_rate={} encode_ms={:.1f}"
             " resized={}",

--- a/acestep/streaming/sa3_session.py
+++ b/acestep/streaming/sa3_session.py
@@ -37,7 +37,6 @@ consumes the construction payload this module stashes via
 
 from __future__ import annotations
 
-import math
 import threading
 
 import numpy as np
@@ -46,15 +45,13 @@ from acestep.engine.obs import logger
 from acestep.streaming.knobs import KnobState
 from acestep.streaming.sa3_backend import (
     DELIVERY_SAMPLE_RATE,
+    SA3_MAX_DURATION_S,
     SA3_SAMPLE_RATE,
+    delivered_samples as _delivered_samples,
     sa3_knob_specs,
 )
 from acestep.streaming.source import SAMPLE_RATE
 from acestep.streaming.state import SessionState
-
-# small-music generates at most a 120 s window (sample_size 5292032 at
-# 44.1 kHz); longer sources are anchored by their first 120 s.
-SA3_MAX_DURATION_S = 120.0
 
 # Ring-buffer depth ceiling. The eager SA3 pipeline has no TRT batch
 # profile to read a cap from; depth 8 is what the spike stress demo
@@ -84,16 +81,6 @@ def get_sa3_context(model_id: str):
             context = SA3Context(model_id)
             _CONTEXTS[model_id] = context
         return context
-
-
-def _delivered_samples(n_44k: int) -> int:
-    """48 kHz sample count of the backend's delivery resample for an
-    ``n_44k``-sample native decode — mirrors torchaudio's
-    ``ceil(new * n / orig)`` (gcd-reduced) so the audio engine buffer
-    and the rendered windows agree on geometry to the sample."""
-    g = math.gcd(DELIVERY_SAMPLE_RATE, SA3_SAMPLE_RATE)
-    new, orig = DELIVERY_SAMPLE_RATE // g, SA3_SAMPLE_RATE // g
-    return -(-new * n_44k // orig)
 
 
 def _resolve_accel(value: str, component: str) -> str:

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -1163,6 +1163,7 @@ class StreamingSession:
                 state.swap_pending.get("stem_source_mode"),
                 known_fixtures=KNOWN_FIXTURES,
             )
+            new_duration_s = state.swap_pending.get("duration_s")
             if new_wf is None:
                 return
             state.swap_pending["waveform"] = None
@@ -1172,6 +1173,7 @@ class StreamingSession:
             state.swap_pending["time_signature"] = None
             state.swap_pending["fixture_name"] = None
             state.swap_pending["stem_source_mode"] = None
+            state.swap_pending["duration_s"] = None
 
         # Backend control hook (universal op, family-specific
         # implementation, the handle_set_prompt convention): a backend
@@ -1181,7 +1183,9 @@ class StreamingSession:
         # defines no hook — byte-identical path.
         handle = getattr(self.backend, "handle_swap_source", None)
         if handle is not None:
-            self._apply_swap_backend_owned(handle, new_wf, new_fixture_name)
+            self._apply_swap_backend_owned(
+                handle, new_wf, new_fixture_name, new_duration_s,
+            )
             return
 
         # Initialized to None so the finally below can None-guard
@@ -1405,21 +1409,48 @@ class StreamingSession:
                 except Exception:
                     pass
 
-    def _apply_swap_backend_owned(self, handle, new_wf, fixture_name) -> None:
-        """Fixed-geometry swap for backends that own their source anchor
-        (the ``handle_swap_source`` hook — SA3). None of the ACE body
-        applies: no TRT profile management (the render geometry is fixed
-        for the session), no BPM/key detection or conditioning re-encode
-        (the backend owns conditioning; nullable metadata per the
-        capability mask), no stem extraction or canvas (both
-        capability-gated off). The backend re-encodes its anchor at the
-        session's fixed duration; the client buffer becomes the new
-        source padded/truncated to the UNCHANGED playback geometry.
+    def _apply_swap_backend_owned(
+        self, handle, new_wf, fixture_name, duration_s=None,
+    ) -> None:
+        """Swap for backends that own their source anchor (the
+        ``handle_swap_source`` hook — SA3). None of the ACE body
+        applies: no TRT profile management, no BPM/key detection or
+        conditioning re-encode (the backend owns conditioning; nullable
+        metadata per the capability mask), no stem extraction or canvas
+        (both capability-gated off). The backend re-encodes its anchor;
+        by default at the session's fixed create-time geometry, with the
+        client buffer padded/truncated to the UNCHANGED playback length.
+
+        ``duration_s`` — honored only when the backend declares
+        ``swap_resize`` — asks the backend to re-derive its render
+        geometry for the new source instead (fresh conditioning + DiT +
+        pipeline at the new window); the hook then returns the new
+        playback length and the session's duration/buffer follow it, so
+        ``SwapReady`` carries the RESIZED geometry to the client.
         Publishes :class:`SwapReady` / :class:`SwapFailed` like the ACE
         body. Runner thread (before_tick), like everything above."""
         state = self.state
         try:
-            wf = new_wf[:, : int(self.max_seconds * SAMPLE_RATE)].float()
+            resize_s = None
+            if duration_s:
+                if getattr(self.backend.capabilities(), "swap_resize", False):
+                    resize_s = float(duration_s)
+                else:
+                    logger.info(
+                        "swap_duration_ignored backend={} reason=no_swap_resize",
+                        self.backend.name,
+                    )
+            # The truncation ceiling: the session's playable length —
+            # lifted to the requested window on a resize, so a LONGER
+            # new source isn't pre-cut back to the old geometry before
+            # the backend ever sees it (the backend clamps the request
+            # to its own caps; the buffer pad/truncate below re-aligns).
+            cap_s = self.max_seconds
+            if resize_s is not None:
+                from acestep.streaming.sa3_backend import SA3_MAX_DURATION_S
+
+                cap_s = max(cap_s, min(resize_s, SA3_MAX_DURATION_S))
+            wf = new_wf[:, : int(cap_s * SAMPLE_RATE)].float()
             if wf.shape[0] == 1:
                 # Stereo delivery geometry (sa3_session create parity):
                 # upmix a mono upload rather than hand the backend a
@@ -1427,19 +1458,31 @@ class StreamingSession:
                 wf = wf.repeat(2, 1)
             logger.info(
                 "source_swap_start backend_owned={} duration_s={:.1f} "
-                "channels={} fixture_name={}",
+                "channels={} fixture_name={} resize_s={}",
                 self.backend.name, wf.shape[-1] / SAMPLE_RATE,
-                wf.shape[0], fixture_name,
+                wf.shape[0], fixture_name, resize_s,
             )
-            handle(wf, SAMPLE_RATE)
+            new_playback = (
+                handle(wf, SAMPLE_RATE, duration_s=resize_s)
+                if resize_s is not None else handle(wf, SAMPLE_RATE)
+            )
 
             # Fresh client buffer: the (truncated) new source at the
-            # delivery rate, zero-padded out to the session's fixed
-            # render geometry — the same shape the create path shipped,
-            # so the runner keeps patching windows into a matching
-            # buffer and the wire duration doesn't move.
+            # delivery rate, zero-padded out to the session's render
+            # geometry — unchanged for a plain swap (the create-time
+            # shape, so the wire duration doesn't move), the backend's
+            # returned length after a resize.
             src_np = wf.cpu().numpy().T.copy()   # [N, C] float32
             with state._lock:
+                if new_playback:
+                    state.playback_samples = int(new_playback)
+                    state.duration = new_playback / SAMPLE_RATE
+                    # Later swap truncation follows the new window
+                    # (the same role max_seconds plays from create).
+                    self.max_seconds = float(
+                        self.backend.playable_duration_s()
+                        or state.duration,
+                    )
                 n_play = int(state.playback_samples)
                 if src_np.shape[0] < n_play:
                     src_np = np.concatenate([
@@ -2387,11 +2430,20 @@ class StreamingSession:
         time_signature: str | None = None,
         fixture_name: str | None = None,
         stem_source_mode: str | None = None,
+        duration_s: float | int | None = None,
         origin: CommandOrigin = CommandOrigin.PRIMARY,
     ) -> None:
         """Stage a source swap. The runner applies it inside
         ``before_tick``; publishes :class:`SwapReady` or
-        :class:`SwapFailed` when the swap completes."""
+        :class:`SwapFailed` when the swap completes.
+
+        ``duration_s`` is the opt-in swap-resize request (wire field of
+        the same name): a backend declaring ``swap_resize`` re-derives
+        its render geometry for the new source instead of
+        padding/truncating it into the session-create window. Ignored —
+        loudly — when the backend doesn't declare the capability, so a
+        legacy pod and a new client stay compatible in both directions.
+        """
         state = self.state
         state.last_activity_ts = time.monotonic()
         # Placement belongs to the old source's coordinate space. Clear as
@@ -2412,6 +2464,11 @@ class StreamingSession:
             state.swap_pending["stem_source_mode"] = normalize_stem_source_mode(
                 stem_source_mode,
             )
+            try:
+                dur = float(duration_s) if duration_s is not None else None
+            except (TypeError, ValueError):
+                dur = None
+            state.swap_pending["duration_s"] = dur if dur and dur > 0 else None
 
     @requires_capability("write_audio", "write_audio")
     def write_audio(

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -1187,6 +1187,16 @@ class StreamingSession:
                 handle, new_wf, new_fixture_name, new_duration_s,
             )
             return
+        if new_duration_s:
+            # The ACE body below re-derives its geometry from the new
+            # source unconditionally, so a resize request has nothing to
+            # ask for — but say so rather than dropping the field on the
+            # floor (the backend-owned path logs the same way when the
+            # capability is off).
+            logger.info(
+                "swap_duration_ignored backend={} reason=geometry_follows_source",
+                self.backend.name,
+            )
 
         # Initialized to None so the finally below can None-guard
         # cleanly in the (rare) case an exception fires between the
@@ -1445,11 +1455,16 @@ class StreamingSession:
             # new source isn't pre-cut back to the old geometry before
             # the backend ever sees it (the backend clamps the request
             # to its own caps; the buffer pad/truncate below re-aligns).
+            # The ceiling itself is backend-owned (``max_duration_s``,
+            # optional like every other family hook here) — this body
+            # stays free of family constants.
             cap_s = self.max_seconds
             if resize_s is not None:
-                from acestep.streaming.sa3_backend import SA3_MAX_DURATION_S
-
-                cap_s = max(cap_s, min(resize_s, SA3_MAX_DURATION_S))
+                read_cap = getattr(self.backend, "max_duration_s", None)
+                ceiling = read_cap() if read_cap is not None else None
+                cap_s = max(
+                    cap_s, min(resize_s, ceiling) if ceiling else resize_s,
+                )
             wf = new_wf[:, : int(cap_s * SAMPLE_RATE)].float()
             if wf.shape[0] == 1:
                 # Stereo delivery geometry (sa3_session create parity):

--- a/acestep/streaming/state.py
+++ b/acestep/streaming/state.py
@@ -39,6 +39,9 @@ def _default_swap_pending() -> dict:
         "time_signature": None,
         "fixture_name": None,
         "stem_source_mode": None,
+        # Opt-in swap-resize request (wire ``duration_s``): the render
+        # window to re-derive for the new source, None = keep geometry.
+        "duration_s": None,
     }
 
 

--- a/demos/realtime_motion_graph_web/protocol.py
+++ b/demos/realtime_motion_graph_web/protocol.py
@@ -469,6 +469,17 @@ COMMANDS: tuple = (
                       description="When true, the server loads the named source "
                                   "off its own disk and NO binary frame is "
                                   "sent."),
+            FieldSpec("duration_s", "float", nullable=True,
+                      description="Opt-in swap-resize: the render window (s) to "
+                                  "re-derive for the new source, on backends "
+                                  "whose geometry is otherwise frozen at session "
+                                  "create (SA3). Honored only when ready's "
+                                  "capabilities declare swap_resize — the "
+                                  "session then re-conditions at the new "
+                                  "duration and swap_ready carries the RESIZED "
+                                  "duration + buffer. Absent/ignored = the "
+                                  "legacy fixed-geometry swap (source padded/"
+                                  "truncated into the old window)."),
         ),
         binary=True,
         binary_optional=True,

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -1959,6 +1959,7 @@ def _handle_client_body(
                     time_signature=data.get("time_signature"),
                     fixture_name=data.get("fixture_name"),
                     stem_source_mode=data.get("stem_source_mode"),
+                    duration_s=data.get("duration_s"),
                     origin=origin,
                 )
             elif mtype == "write_audio":

--- a/packages/demon-client/types/wireContract.gen.hpp
+++ b/packages/demon-client/types/wireContract.gen.hpp
@@ -191,6 +191,8 @@ namespace command {
     inline constexpr const char* kStemSourceMode = "stem_source_mode";
     /** When true, the server loads the named source off its own disk and NO binary frame is sent. */
     inline constexpr const char* kUseServerSource = "use_server_source";
+    /** Opt-in swap-resize: the render window (s) to re-derive for the new source, on backends whose geometry is otherwise frozen at session create (SA3). Honored only when ready's capabilities declare swap_resize — the session then re-conditions at the new duration and swap_ready carries the RESIZED duration + buffer. Absent/ignored = the legacy fixed-geometry swap (source padded/truncated into the old window). */
+    inline constexpr const char* kDurationS = "duration_s";
 
     namespace stem_source_mode {
       inline constexpr const char* kFull = "full";

--- a/packages/demon-client/types/wireContract.gen.ts
+++ b/packages/demon-client/types/wireContract.gen.ts
@@ -267,6 +267,8 @@ export interface SwapSourceCommand {
   stem_source_mode?: "full" | "vocals" | "instruments";
   /** When true, the server loads the named source off its own disk and NO binary frame is sent. */
   use_server_source?: boolean;
+  /** Opt-in swap-resize: the render window (s) to re-derive for the new source, on backends whose geometry is otherwise frozen at session create (SA3). Honored only when ready's capabilities declare swap_resize — the session then re-conditions at the new duration and swap_ready carries the RESIZED duration + buffer. Absent/ignored = the legacy fixed-geometry swap (source padded/truncated into the old window). */
+  duration_s?: number | null;
 }
 
 export interface WriteAudioCommand {

--- a/tests/unit/test_sa3_backend.py
+++ b/tests/unit/test_sa3_backend.py
@@ -19,6 +19,7 @@ from acestep.streaming.generator_backend import TickContext
 from acestep.streaming.knobs import KnobState
 from acestep.streaming.sa3_backend import (
     DELIVERY_SAMPLE_RATE,
+    SA3_MAX_DURATION_S,
     SA3_SAMPLE_RATE,
     SA3Backend,
     delivered_samples,
@@ -380,8 +381,8 @@ def test_prompt_blend_without_b_is_a_noop():
 def test_set_prompt_recaptures_b_and_invalidates_schedules():
     captures = []
 
-    def rebuilder(tags, steps):
-        captures.append(tags)
+    def rebuilder(tags, steps, duration_s):
+        captures.append((tags, duration_s))
         cond = _FakeCond()
         return cond, lambda s: _schedule_builder_factory(s)
 
@@ -390,7 +391,9 @@ def test_set_prompt_recaptures_b_and_invalidates_schedules():
     assert b.pipeline._schedule_cache
 
     b.handle_set_prompt("tags a", tags_b="tags b")
-    assert captures == ["tags a", "tags b"]
+    # Both captures ran at the backend's LIVE duration, not a value
+    # closed over at assembly time.
+    assert captures == [("tags a", b._duration_s), ("tags b", b._duration_s)]
     # The builder swap changes what the same denoise key would build —
     # stale schedules must not survive the prompt change.
     assert not b.pipeline._schedule_cache
@@ -599,6 +602,106 @@ def test_handle_swap_source_resize_without_resizer_fails_loudly():
         assert "resizer" in str(exc)
     else:
         raise AssertionError("expected RuntimeError without a resizer")
+
+
+def test_resize_failure_after_captures_leaves_prompt_control_working():
+    """A resize that dies AFTER its captures — the encode OOMs on the
+    geometry that was just grown — must leave the session whole. The
+    part that is easy to get wrong is the LIVE duration: if the captures
+    had already retargeted it, every later prompt swap would re-capture
+    at a geometry the session never adopted and trip its own
+    latent_frames guard, permanently. The resizer is pure and the
+    duration is committed with the cond, so nothing is left behind."""
+    def encoder(waveform, sample_rate, sample_size):
+        raise RuntimeError("cuda oom on the resized window")
+
+    def resizer(new_duration_s, tags_a, tags_b, steps):
+        cond = _FakeCondSized(2 * T)
+        return (
+            cond.audio_sample_size / SA3_SAMPLE_RATE, cond, None,
+            _ZeroDit(), _schedule_builder_factory,
+        )
+
+    captures: list = []
+
+    def rebuilder(tags, steps, duration_s):
+        captures.append((tags, duration_s))
+        return _FakeCond(), _schedule_builder_factory
+
+    b = _backend(
+        source_latent_bct=torch.randn(1, C, T),
+        source_encoder=encoder,
+        resizer=resizer,
+        prompt_rebuilder=rebuilder,
+        prompt_tags="warm tags",
+    )
+    old_cond, old_pipeline = b._cond, b.pipeline
+    old_duration, old_playable = b._duration_s, b._playable_s
+
+    try:
+        b.handle_swap_source(torch.zeros(2, 96000), 48000, duration_s=60.0)
+    except RuntimeError as exc:
+        assert "cuda oom" in str(exc)
+    else:
+        raise AssertionError("expected the encode failure to propagate")
+
+    # Nothing of the new geometry landed.
+    assert b._cond is old_cond
+    assert b.pipeline is old_pipeline
+    assert b._duration_s == old_duration
+    assert b._playable_s == old_playable
+    assert b._source_latent_btc.shape == (1, T, C)
+
+    # The regression: the next prompt swap still captures at the OLD
+    # duration, so its latent_frames guard passes.
+    b.handle_set_prompt("cooler tags")
+    assert captures == [("cooler tags", old_duration)]
+    assert b._cond is not old_cond
+    assert b._tags_a == "cooler tags"
+
+
+def test_resize_noop_does_not_move_the_live_duration():
+    """A request that clamps back onto the current window leaves the
+    session untouched — including the duration later prompt rebuilds
+    capture at."""
+    b, _encodes, _resizes = _resize_backend(T)
+    old_duration = b._duration_s
+
+    b.handle_swap_source(
+        torch.zeros(2, 48000), 48000, duration_s=N44 / SA3_SAMPLE_RATE,
+    )
+
+    assert b._duration_s == old_duration
+
+
+def test_prompt_rebuilds_follow_a_committed_resize():
+    """After a resize lands, handle_set_prompt captures at the NEW
+    duration (otherwise it would re-capture at the create-time length
+    and trip its own geometry guard)."""
+    new_frames = 2 * T
+    captures: list = []
+
+    def rebuilder(tags, steps, duration_s):
+        captures.append((tags, duration_s))
+        return _FakeCondSized(new_frames), _schedule_builder_factory
+
+    b, _encodes, _resizes = _resize_backend(
+        new_frames, prompt_rebuilder=rebuilder,
+    )
+    requested_s = new_frames * 4096 / SA3_SAMPLE_RATE
+    b.handle_swap_source(torch.zeros(2, 96000), 48000, duration_s=requested_s)
+    assert abs(b._duration_s - requested_s) < 1e-6
+
+    b.handle_set_prompt("after the resize")
+
+    assert captures == [("after the resize", b._duration_s)]
+    assert int(b._cond.latent_frames) == new_frames
+
+
+def test_max_duration_s_is_backend_owned():
+    """The session's swap path reads the family ceiling off the backend
+    instead of importing an SA3 constant."""
+    assert _backend().max_duration_s() == SA3_MAX_DURATION_S
 
 
 def test_plain_swap_with_resizer_keeps_geometry():

--- a/tests/unit/test_sa3_backend.py
+++ b/tests/unit/test_sa3_backend.py
@@ -21,6 +21,7 @@ from acestep.streaming.sa3_backend import (
     DELIVERY_SAMPLE_RATE,
     SA3_SAMPLE_RATE,
     SA3Backend,
+    delivered_samples,
     sa3_knob_specs,
 )
 
@@ -480,6 +481,140 @@ def test_handle_swap_source_without_encoder_fails_loudly():
         assert "source_encoder" in str(exc)
     else:
         raise AssertionError("expected RuntimeError without source_encoder")
+
+
+class _FakeCondSized:
+    """A _FakeCond at an arbitrary latent-frame count, for resize tests."""
+
+    def __init__(self, frames: int):
+        self.cond_bundle = {
+            "cross_attn_cond": torch.ones(1, 3, 4),
+            "cross_attn_mask": torch.ones(1, 3),
+            "cfg_scale": 1.0,
+        }
+        self.latent_frames = frames
+        self.audio_sample_size = frames * 4096
+
+
+def _resize_backend(new_frames: int, **kw):
+    """Backend wired with a fake resizer that lands on ``new_frames``
+    (the create-time geometry is T frames / N44 samples) plus an
+    encoder that records the sample_size it was asked for."""
+    encodes: list = []
+    resizes: list = []
+
+    def encoder(waveform, sample_rate, sample_size):
+        encodes.append(int(sample_size))
+        frames = int(sample_size) // 4096
+        return torch.randn(1, C, frames)
+
+    def resizer(new_duration_s, tags_a, tags_b, steps):
+        resizes.append((float(new_duration_s), tags_a, tags_b, int(steps)))
+        cond = _FakeCondSized(new_frames)
+        return (
+            cond.audio_sample_size / SA3_SAMPLE_RATE, cond, None,
+            _ZeroDit(), _schedule_builder_factory,
+        )
+
+    b = _backend(
+        source_latent_bct=torch.randn(1, C, T),
+        source_encoder=encoder,
+        resizer=resizer,
+        prompt_tags="warm tags",
+        **kw,
+    )
+    return b, encodes, resizes
+
+
+def test_handle_swap_source_resize_rederives_geometry():
+    """duration_s re-derives the render geometry: new cond captures at
+    the live prompt, a rebuilt pipeline, the anchor encoded at the NEW
+    sample size, and the hook returns the new delivery-rate playback
+    length for the session to adopt."""
+    new_frames = 2 * T
+    b, encodes, resizes = _resize_backend(new_frames)
+    assert b.capabilities().swap_resize is True
+    old_cond = b._cond
+    old_pipeline = b.pipeline
+    old_playable = b.playable_duration_s()
+
+    requested_s = new_frames * 4096 / SA3_SAMPLE_RATE
+    got = b.handle_swap_source(
+        torch.zeros(2, 96000), 48000, duration_s=requested_s,
+    )
+
+    # The resizer saw the request against the live prompt pair.
+    assert resizes == [(requested_s, "warm tags", None, b._steps)]
+    # The anchor was encoded at the NEW window, not the old one.
+    assert encodes == [new_frames * 4096]
+    assert b._source_latent_btc.shape == (1, new_frames, C)
+    # Geometry followed: cond, playable duration, pipeline all new.
+    assert b._cond is not old_cond
+    assert int(b._cond.latent_frames) == new_frames
+    assert b.pipeline is not old_pipeline
+    assert b.playable_duration_s() > old_playable
+    assert abs(b.geometry().duration_s - requested_s) < 1e-6
+    # The session resizes its buffer from the returned length.
+    expected_44k = min(
+        int(round(b.playable_duration_s() * SA3_SAMPLE_RATE)),
+        new_frames * 4096,
+    )
+    assert got == delivered_samples(expected_44k)
+    # History/caches of the old geometry are gone.
+    assert len(b._latent_history) == 0
+    assert b._last_result_latent is None
+    assert not b.has_renderable_state()
+
+
+def test_handle_swap_source_resize_noop_on_same_geometry():
+    """A duration_s that clamps back onto the current window (same
+    latent_frames) must not churn the session: same cond, same
+    pipeline, plain re-anchor, None returned (buffer length holds)."""
+    b, encodes, resizes = _resize_backend(T)
+    old_cond = b._cond
+    old_pipeline = b.pipeline
+
+    got = b.handle_swap_source(
+        torch.zeros(2, 48000), 48000, duration_s=N44 / SA3_SAMPLE_RATE,
+    )
+
+    assert len(resizes) == 1          # the captures ran...
+    assert got is None                # ...but nothing was adopted
+    assert b._cond is old_cond
+    assert b.pipeline is old_pipeline
+    assert encodes == [N44]           # legacy re-anchor at the old window
+
+
+def test_handle_swap_source_resize_without_resizer_fails_loudly():
+    b = _backend(
+        source_latent_bct=torch.randn(1, C, T),
+        source_encoder=lambda waveform, sample_rate, sample_size: (
+            torch.randn(1, C, T)
+        ),
+    )  # direct construction: encoder but no resizer
+    assert b.capabilities().swap_resize is False
+    try:
+        b.handle_swap_source(torch.zeros(2, 48000), 48000, duration_s=30.0)
+    except RuntimeError as exc:
+        assert "resizer" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError without a resizer")
+
+
+def test_plain_swap_with_resizer_keeps_geometry():
+    """No duration_s = the legacy fixed-geometry swap, byte-identical:
+    old clients keep exactly the behavior they shipped against."""
+    b, encodes, resizes = _resize_backend(2 * T)
+    old_cond = b._cond
+    old_pipeline = b.pipeline
+
+    got = b.handle_swap_source(torch.zeros(2, 48000), 48000)
+
+    assert got is None
+    assert resizes == []
+    assert encodes == [N44]
+    assert b._cond is old_cond
+    assert b.pipeline is old_pipeline
 
 
 def test_decode_seed_follows_the_emerged_request_seed():

--- a/tests/unit/test_swap_resize_session.py
+++ b/tests/unit/test_swap_resize_session.py
@@ -1,0 +1,257 @@
+"""Session-side adoption of a backend-owned swap resize.
+
+``StreamingSession._apply_swap_backend_owned`` is the half of the
+swap-resize path that lives above the backend: it gates the request on
+the ``swap_resize`` capability, lifts the truncation ceiling so a longer
+source survives long enough for the backend to see it, and adopts the
+playback length the hook hands back (``duration`` / ``playback_samples``
+/ ``max_seconds`` / the client buffer). Driven here with a stub backend
+and unbound session methods — no GPU, no model load, same pattern as
+test_lora_facade_session.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from acestep.streaming.generator_backend import Capabilities
+from acestep.streaming.session import SAMPLE_RATE, StreamingSession
+
+# 48 kHz delivery: the create-time window and what a resize grows it to.
+OLD_PLAY = 12 * SAMPLE_RATE
+NEW_PLAY = 30 * SAMPLE_RATE
+
+
+class _StubBackend:
+    """Backend-owned-swap surface: records the hook call, returns a new
+    playback length when asked to resize."""
+
+    name = "sa3-stub"
+
+    def __init__(self, *, swap_resize=True, new_playback=None,
+                 max_duration_s=None, raises=None):
+        self._caps = Capabilities(swap=True, swap_resize=swap_resize)
+        self._new_playback = new_playback
+        self._max_duration_s = max_duration_s
+        self._raises = raises
+        self.calls: list = []
+        self.playable_s = OLD_PLAY / SAMPLE_RATE
+
+    def capabilities(self):
+        return self._caps
+
+    def playable_duration_s(self):
+        return self.playable_s
+
+    def handle_swap_source(self, waveform, sample_rate, duration_s=None):
+        self.calls.append({
+            "samples": int(waveform.shape[-1]),
+            "channels": int(waveform.shape[0]),
+            "sample_rate": int(sample_rate),
+            "duration_s": duration_s,
+        })
+        if self._raises is not None:
+            raise self._raises
+        if duration_s is None or self._new_playback is None:
+            return None
+        self.playable_s = self._new_playback / SAMPLE_RATE
+        return self._new_playback
+
+
+class _MaxDurationBackend(_StubBackend):
+    """Declares the optional family ceiling hook."""
+
+    def max_duration_s(self):
+        return self._max_duration_s
+
+
+class _Bus:
+    def __init__(self):
+        self.events: list = []
+
+    def publish(self, event):
+        self.events.append(event)
+
+
+class _AudioEng:
+    def __init__(self, n):
+        self.current = np.zeros((n, 2), dtype=np.float32)
+        self.position = 999
+        self.loop_band = (1.0, 2.0)
+
+    def swap(self, data):
+        self.current = data
+
+
+class _SwapSession:
+    """Just enough StreamingSession surface for the backend-owned swap."""
+
+    _apply_swap_backend_owned = StreamingSession._apply_swap_backend_owned
+
+    def __init__(self, backend, *, max_seconds=OLD_PLAY / SAMPLE_RATE):
+        self.backend = backend
+        self.max_seconds = max_seconds
+        self.audio_eng = _AudioEng(OLD_PLAY)
+        self.bus = _Bus()
+        self.state = types.SimpleNamespace(
+            _lock=threading.Lock(),
+            playback_samples=OLD_PLAY,
+            duration=OLD_PLAY / SAMPLE_RATE,
+            n_channels=2,
+            source_epoch=3,
+            bpm=None, key=None, time_signature=None,
+        )
+
+    def swap(self, seconds, *, duration_s=None, channels=2):
+        wf = torch.ones(channels, int(seconds * SAMPLE_RATE))
+        self._apply_swap_backend_owned(
+            self.backend.handle_swap_source, wf, None, duration_s,
+        )
+        return wf
+
+
+def _ready(ss):
+    assert len(ss.bus.events) == 1, ss.bus.events
+    return ss.bus.events[0]
+
+
+def test_resize_adopts_the_returned_playback_length():
+    """The hook's return value IS the new session geometry: duration,
+    playback_samples, the later-swap ceiling, and the client buffer all
+    follow it, and SwapReady carries the resized shape."""
+    be = _StubBackend(new_playback=NEW_PLAY)
+    ss = _SwapSession(be)
+
+    ss.swap(30.0, duration_s=30.0)
+
+    assert be.calls[0]["duration_s"] == 30.0
+    assert ss.state.playback_samples == NEW_PLAY
+    assert abs(ss.state.duration - 30.0) < 1e-6
+    # The ceiling for LATER swaps follows the new window, not the
+    # create-time one.
+    assert abs(ss.max_seconds - 30.0) < 1e-6
+    assert len(ss.audio_eng.current) == NEW_PLAY
+    # A band from the previous song is meaningless against the new
+    # buffer, and playback restarts at its head.
+    assert ss.audio_eng.loop_band is None
+    assert ss.audio_eng.position == 0
+    assert ss.state.source_epoch == 4
+
+    ready = _ready(ss)
+    assert abs(ready.duration - 30.0) < 1e-6
+    assert len(ready.initial_buffer) == NEW_PLAY
+    assert ready.channels == 2
+
+
+def test_resize_to_a_shorter_window_truncates_the_buffer():
+    be = _StubBackend(new_playback=6 * SAMPLE_RATE)
+    ss = _SwapSession(be)
+
+    ss.swap(6.0, duration_s=6.0)
+
+    assert ss.state.playback_samples == 6 * SAMPLE_RATE
+    assert len(ss.audio_eng.current) == 6 * SAMPLE_RATE
+    assert abs(ss.max_seconds - 6.0) < 1e-6
+
+
+def test_short_source_is_padded_out_to_the_resized_window():
+    """The client buffer always matches the render geometry: a source
+    shorter than the requested window is zero-padded, not left ragged."""
+    be = _StubBackend(new_playback=NEW_PLAY)
+    ss = _SwapSession(be)
+
+    ss.swap(10.0, duration_s=30.0)
+
+    buf = ss.audio_eng.current
+    assert len(buf) == NEW_PLAY
+    assert buf[: 10 * SAMPLE_RATE].any()
+    assert not buf[10 * SAMPLE_RATE:].any()   # the pad
+
+
+def test_plain_swap_keeps_the_session_geometry():
+    """No duration_s = the legacy fixed-geometry swap: the hook is called
+    without the kwarg and nothing about the session's shape moves."""
+    be = _StubBackend(new_playback=NEW_PLAY)
+    ss = _SwapSession(be)
+
+    ss.swap(30.0)
+
+    assert be.calls == [{
+        "samples": OLD_PLAY, "channels": 2,
+        "sample_rate": SAMPLE_RATE, "duration_s": None,
+    }]
+    assert ss.state.playback_samples == OLD_PLAY
+    assert abs(ss.max_seconds - OLD_PLAY / SAMPLE_RATE) < 1e-6
+    assert len(_ready(ss).initial_buffer) == OLD_PLAY
+
+
+def test_resize_is_ignored_without_the_capability():
+    """A new client against a backend that doesn't declare swap_resize:
+    the field is dropped (loudly) and the swap runs the legacy path —
+    the hook never sees a duration_s it might not accept."""
+    be = _StubBackend(swap_resize=False, new_playback=NEW_PLAY)
+    ss = _SwapSession(be)
+
+    ss.swap(30.0, duration_s=30.0)
+
+    assert be.calls[0]["duration_s"] is None
+    assert be.calls[0]["samples"] == OLD_PLAY   # cut at the old ceiling
+    assert ss.state.playback_samples == OLD_PLAY
+
+
+def test_resize_lifts_the_truncation_ceiling_for_a_longer_source():
+    """Without the lift, a 30 s upload would be cut to the 12 s session
+    window before the backend ever saw it and the resize would have
+    nothing to grow into."""
+    be = _StubBackend(new_playback=NEW_PLAY)
+    ss = _SwapSession(be)
+
+    ss.swap(30.0, duration_s=30.0)
+
+    assert be.calls[0]["samples"] == 30 * SAMPLE_RATE
+
+
+def test_backend_ceiling_bounds_the_lifted_truncation():
+    """The ceiling is backend-owned: a request past the family's cap is
+    bounded by max_duration_s, not by a constant in the session layer."""
+    be = _MaxDurationBackend(new_playback=NEW_PLAY, max_duration_s=20.0)
+    ss = _SwapSession(be)
+
+    ss.swap(60.0, duration_s=60.0)
+
+    assert be.calls[0]["samples"] == 20 * SAMPLE_RATE
+    # The request itself still reaches the backend unclamped — it owns
+    # the conditioning decision.
+    assert be.calls[0]["duration_s"] == 60.0
+
+
+def test_mono_upload_is_upmixed_before_the_backend_sees_it():
+    be = _StubBackend(new_playback=NEW_PLAY)
+    ss = _SwapSession(be)
+
+    ss.swap(30.0, duration_s=30.0, channels=1)
+
+    assert be.calls[0]["channels"] == 2
+
+
+def test_backend_failure_publishes_swap_failed_and_moves_nothing():
+    be = _StubBackend(new_playback=NEW_PLAY, raises=RuntimeError("cuda oom"))
+    ss = _SwapSession(be)
+
+    ss.swap(30.0, duration_s=30.0)
+
+    assert ss.state.playback_samples == OLD_PLAY
+    assert abs(ss.state.duration - OLD_PLAY / SAMPLE_RATE) < 1e-6
+    assert abs(ss.max_seconds - OLD_PLAY / SAMPLE_RATE) < 1e-6
+    assert ss.state.source_epoch == 3
+    assert len(ss.audio_eng.current) == OLD_PLAY
+    failed = _ready(ss)
+    assert "cuda oom" in failed.error


### PR DESCRIPTION
## What

An SA3 session's render geometry is frozen at create: `prepare_cond` pins
`audio_sample_size`, the DiT is selected for that latent window, and every later
`swap_source` is SAME-encoded *into* it — so a longer clip loses its end and a
shorter one plays a silent tail. The DreamSampler plugin works around this by
dropping the WebSocket and re-handshaking whenever a swapped clip's length
differs from the session window by more than a second, which costs the user
seconds of silence for what is underneath a ~13 ms conditioning rebuild.

This lets the swap carry the resize instead. `swap_source` gains an optional
`duration_s` field and the SA3 backend declares a new `swap_resize` capability.
When a swap carries `duration_s`, the backend re-captures conditioning for the
live prompt pair at the new duration, re-selects the DiT for the new latent
window, rebuilds the pipeline (structurally dropping every in-flight
old-geometry slot), re-encodes the anchor at the new sample size, and returns
the new delivery-rate playback length; the session adopts it (`duration`,
`playback_samples`, `max_seconds`, audio-engine buffer) and `swap_ready` carries
the resized duration + buffer — the wire shape clients already parse.

## Backward compatibility

Verified against a live pod on a 5090, both directions:

| combo | behavior |
| --- | --- |
| old client + new server | swap without `duration_s` is byte-identical (12 s window held through a 30 s upload) |
| new client + old server | unknown field ignored; `ready` lacks the `swap_resize` bit, so the client keeps its reconnect fallback |
| new client + new server | 12 s→30 s and 30 s→12 s swaps resize in-session; fresh slices cover the full new window (tail RMS matches head RMS) |

## Notes

- A resize request that clamps back onto the current window (same
  `latent_frames`) is a loud no-op re-anchor, so a client repeatedly committing
  a >120 s clip can't churn the session.
- The refit mirror wraps the old engine and can't survive a geometry change; a
  resize drops it and LoRA degrades to the eager-DiT swap, weights intact on the
  shared torch modules.
- `_prompt_rebuilder` now reads the session's live duration through a shared box,
  so a post-resize prompt swap re-captures at the new geometry instead of
  tripping its own `latent_frames` guard.
- `SA3_MAX_DURATION_S` and the delivery-resample helper move to `sa3_backend`
  (imported by `sa3_session`) to avoid an import cycle.
- Wire types regenerated (`kDurationS` on `swap_source`).

## Tests

- New unit tests in `tests/unit/test_sa3_backend.py`: resize re-derives geometry,
  same-geometry no-op, missing-resizer loud failure, plain-swap-with-resizer
  keeps geometry. `test_sa3_backend.py` + `test_wire_contract.py` green (53
  passed). Full unit suite: only the 4 pre-existing `test_lora_facade_session`
  failures (present on `main` without this change) remain.

Plugin side: daydreamlive/daydream-plugins#301

🤖 Generated with [Claude Code](https://claude.com/claude-code)