### PR TITLE
fix(enhance): force the variations sampler off the greedy line

### DIFF
--- a/demos/realtime_motion_graph_web/prompt_variations.py
+++ b/demos/realtime_motion_graph_web/prompt_variations.py
@@ -32,6 +32,13 @@ WHY A FORCED PREFIX RATHER THAN A SEED. Seeds have no notion of "nearby": two
 seeds are unrelated draws, so a seed cannot express distance. Prefix length
 can. Holding the head fixed and resampling the tail is the smallest meaningful
 change the model can make, and it grows monotonically as the prefix shortens.
+
+AND A FORCED FORK AT THE FIRST FREE TOKEN. Holding the head and sampling the
+tail is only a variation if the sampler actually leaves the greedy line, and
+on the model's own output it did not (see `_fork_tokens`). So the first free
+token is chosen for each lane -- distinct across lanes, never the greedy one --
+and only then does sampling take over. Every coordinate away from home is a
+different string from the anchor, by construction rather than by luck.
 """
 
 from __future__ import annotations
@@ -181,16 +188,32 @@ def _load():
             return None
 
 
-def _prefix_for(anchor_ids: list[int], amount: float) -> list[int]:
+def _prefix_for(anchor_ids: list[int], amount: float,
+                word_start: list[bool] | None = None) -> list[int]:
     """How much of the anchor survives at `amount`.
 
     The rewrite eats forward from the TAIL. The opening phrases dominate how a
     prompt is interpreted, so holding them and resampling the end is what makes
     a small move read as a small move rather than a different brief.
+
+    `word_start[i]` says whether anchor token i begins a word. When given, the
+    cut is moved back so the first FREED token is a word start: the fork below
+    replaces whole words. Cut mid-word, it was forced to pick a different
+    sub-word piece and wrote "phrasal", "phrassing", "close-molky".
     """
     n = len(anchor_ids)
     free = round(amount * MAX_FREE * n)
-    return anchor_ids[: n - min(free, n)]
+    # ANY move frees at least one token. On a short line the rounding gave
+    # the first few stops a free count of 0 -- the whole anchor forced, the
+    # sampler never consulted -- so the pad had a dead ring around home that
+    # widened as prompts got shorter. Away from home is away from home.
+    if amount > 0 and n > 0:
+        free = max(1, free)
+    keep = n - min(free, n)
+    if word_start is not None and 0 < keep < n:
+        while keep > 0 and not word_start[keep]:
+            keep -= 1
+    return anchor_ids[:keep]
 
 
 def _task(deck: str) -> str:
@@ -269,7 +292,8 @@ def point(text: str, deck: str = "sa3", lane: int = 0, stop: int = 0,
     string, so travelling out and back is lossless. That is the whole contract
     a client needs to treat this as navigation rather than a dice roll.
 
-    Stop 0 is the anchor itself.
+    Stop 0 is the anchor itself. Every other stop differs from it, and no two
+    lanes at a stop start their rewrite the same way (`_fork_tokens`).
     """
     loaded = _load()
     if loaded is None or not text.strip():
@@ -297,7 +321,9 @@ def point(text: str, deck: str = "sa3", lane: int = 0, stop: int = 0,
         # for that stop, so the two cannot diverge.
         enc_b = {k: v.repeat(lanes, 1) for k, v in enc.items()}
         out = _sample(torch, model, enc_b, anchor_ids, stop, stops,
-                      _seed_for(text), device, lanes)
+                      _seed_for(text), device, lanes,
+                      word_start=_word_starts(tok, anchor_ids),
+                      allowed=_word_start_mask(torch, tok))
         txt = tok.decode(out[lane], skip_special_tokens=True).strip()
     return txt or anchor_text
 
@@ -354,7 +380,8 @@ def clamp_coord(stop: int, lane: int, stops: int = STOPS,
     return (max(0, min(stops - 1, stop)), max(0, min(lanes - 1, lane)))
 
 
-def _sample(torch, model, enc_b, anchor_ids, stop, stops, seed, device, rows):
+def _sample(torch, model, enc_b, anchor_ids, stop, stops, seed, device, rows,
+            word_start=None, allowed=None):
     """One batched sampling pass at distance `stop`. Shared by both entry
     points so a coordinate cannot mean two different things.
 
@@ -371,9 +398,9 @@ def _sample(torch, model, enc_b, anchor_ids, stop, stops, seed, device, rows):
     harm, and the 503 gate above makes it rare.
     """
     amount = stop / (stops - 1)
-    prefix = _prefix_for(anchor_ids, amount)
-    dec = torch.tensor([[model.config.decoder_start_token_id] + prefix],
-                       device=device).repeat(rows, 1)
+    prefix = _prefix_for(anchor_ids, amount, word_start)
+    start = model.config.decoder_start_token_id
+    head = torch.tensor([[start] + prefix], device=device)
     # devices=[] restores the CPU generator ONLY, and torch.manual_seed is not
     # CPU-only -- _manual_seed_impl calls torch.cuda.manual_seed_all first. So
     # the empty list left the CUDA generator seeded from a prompt hash, which
@@ -383,7 +410,113 @@ def _sample(torch, model, enc_b, anchor_ids, stop, stops, seed, device, rows):
                 if torch.cuda.is_available() else [])
     with torch.random.fork_rng(devices=_devices):
         torch.manual_seed(seed)
+        # THE FORK. One decoder step on the held prefix gives the model's
+        # next-token distribution; each lane is handed a DIFFERENT first free
+        # token from it, and never the greedy one. See _fork_tokens for why
+        # sampling alone could not do this.
+        enc_1 = {k: v[:1] for k, v in enc_b.items()}
+        logits = model(**enc_1, decoder_input_ids=head).logits[0, -1]
+        forks = _fork_tokens(
+            torch, logits, rows, amount,
+            banned=(model.config.eos_token_id, model.config.pad_token_id, start),
+            allowed=allowed,
+        )
+        dec = torch.tensor([[start] + prefix + [t] for t in forks], device=device)
         return _generate(torch, model, enc_b, dec, amount)
+
+
+def _fork_tokens(torch, logits, rows: int, amount: float, banned=(),
+                 allowed=None) -> list[int]:
+    """A distinct first free token for each of `rows` lanes, never the greedy
+    one.
+
+    WHY SAMPLING ALONE WAS NOT ENOUGH. The checkpoint is a distillation of a
+    greedy enhancer, and the anchor the pad walks around is usually that
+    model's OWN output (the composer refines through the same endpoint). On
+    its own output the model is near-certain at every position, so "hold the
+    head, sample the tail" at top_k 4 / temperature 0.35 reproduced the
+    greedy line for lane after lane: measured on the fleet, 12/12 lanes at
+    stops 1-2, 11/12 at stops 5 and 8, returned the anchor text verbatim, and
+    the pad was dead over its inner two thirds. A client that (correctly)
+    writes nothing when the text is unchanged then showed a dot that moved
+    and a prompt that did not.
+
+    So the divergence is FORCED rather than hoped for. The greedy token is
+    banned at the first free position -- every coordinate away from home
+    therefore differs from the anchor -- and the lanes draw their first token
+    WITHOUT replacement from the top of what remains, so no two lanes at a
+    distance begin the same way. After that one token the ordinary sampler
+    continues, at the same top_k/temperature ramp as before, so a small move
+    still reads as a small move: one word forks and the line re-converges.
+
+    Deterministic under the caller's seeding (a CPU multinomial on a CPU
+    copy of the logits, so the result does not depend on the device the model
+    happens to run on).
+    """
+    scores = logits.detach().float().cpu().clone()
+    scores[int(torch.argmax(scores))] = float("-inf")
+    for b in banned:
+        if b is not None and 0 <= int(b) < scores.numel():
+            scores[int(b)] = float("-inf")
+    # WHOLE WORDS ONLY, when the caller can say which tokens start one. The
+    # fork sits on a word boundary (see _prefix_for), and a sub-word piece
+    # there glues onto the previous word: "tone" + "ness", "close-" + "molky".
+    if allowed is not None:
+        # The embedding table can be padded past the tokenizer's vocabulary
+        # (32128 vs 32100 on this checkpoint); the pad rows are never words.
+        ok = torch.zeros(scores.numel(), dtype=torch.bool)
+        n = min(scores.numel(), int(allowed.numel()))
+        ok[:n] = allowed[:n].cpu()
+        masked = scores.clone()
+        masked[~ok] = float("-inf")
+        if int(torch.isfinite(masked).sum()) >= 1:
+            scores = masked
+    live = int(torch.isfinite(scores).sum())
+    if live <= 0:
+        return [int(torch.argmax(logits))] * rows   # degenerate vocab; keep shape
+    # The pool is at least one candidate per lane, and as wide as the sampler's
+    # own top_k at this distance, so a far position may fork onto a rarer word
+    # than a near one.
+    k = min(live, max(rows, TOPK_MIN + round(amount * (TOPK_MAX - TOPK_MIN))))
+    temp = TEMP_MIN + amount * (TEMP_MAX - TEMP_MIN)
+    top = torch.topk(scores, k)
+    probs = torch.softmax(top.values / temp, dim=0)
+    n = min(rows, k)
+    pick = torch.multinomial(probs, n, replacement=False)
+    toks = [int(t) for t in top.indices[pick]]
+    # Fewer live candidates than lanes (a tiny vocabulary): repeat rather than
+    # fail -- the distinctness contract is best-effort past the vocab's size.
+    while len(toks) < rows:
+        toks.append(toks[len(toks) % n])
+    return toks
+
+
+_WORD_START_PIECE = "\u2581"   # sentencepiece's word-initial marker, "▁"
+_word_start_cache: dict = {}
+
+
+def _word_starts(tok, ids: list[int]) -> list[bool]:
+    """Per token: does it begin a word (sentencepiece "▁" piece)?"""
+    return [str(p).startswith(_WORD_START_PIECE)
+            for p in tok.convert_ids_to_tokens(list(ids))]
+
+
+def _word_start_mask(torch, tok):
+    """Vocabulary-wide word-start mask, built once per tokenizer.
+
+    Sized to the tokenizer's vocab; the caller slices it to the logits width
+    (a model's embedding table can be padded past the tokenizer's size, and
+    those rows are never word starts).
+    """
+    key = id(tok)
+    m = _word_start_cache.get(key)
+    if m is None:
+        n = len(tok)
+        pieces = tok.convert_ids_to_tokens(list(range(n)))
+        m = torch.tensor([str(p).startswith(_WORD_START_PIECE) for p in pieces],
+                         dtype=torch.bool)
+        _word_start_cache[key] = m
+    return m
 
 
 def _generate(torch, model, enc_b, dec, amount):

--- a/tests/unit/test_prompt_variations.py
+++ b/tests/unit/test_prompt_variations.py
@@ -219,3 +219,90 @@ class TestDownloadResidue:
         ok, msg = md.download_prompt_enhancer_model(target)
         assert ok is False and "no network" in msg
         assert not target.exists(), "an empty dir reads as a staged checkpoint"
+
+
+class TestPrefixAlwaysFreesSomething:
+    """Away from home is away from home."""
+
+    def test_any_positive_distance_frees_at_least_one_token(self):
+        # On a short line round(amount * MAX_FREE * n) was 0 for the first few
+        # stops: the whole anchor forced, the sampler never consulted, a dead
+        # ring around home that widened as prompts got shorter.
+        ids = list(range(6))
+        assert pv._prefix_for(ids, 1 / (pv.STOPS - 1)) == ids[:-1]
+        assert pv._prefix_for(ids, 0.0) == ids
+
+    def test_cut_snaps_back_to_a_word_start(self):
+        # Tokens 3 and 4 are pieces of one word (only 3 starts it). A cut that
+        # would free from token 4 must free from token 3 instead, so the fork
+        # replaces the whole word rather than gluing a new piece onto half of
+        # it -- "phras" + "al".
+        ids = list(range(6))
+        starts = [True, True, True, True, False, True]
+        # amount chosen so free == 2 -> keep == 4 -> not a word start -> 3
+        got = pv._prefix_for(ids, 0.6, starts)
+        assert got == ids[:3]
+        # A cut already on a word start is untouched.
+        assert pv._prefix_for(ids, 0.6, [True] * 6) == ids[:4]
+
+    def test_snap_never_runs_past_the_head(self):
+        ids = list(range(4))
+        assert pv._prefix_for(ids, 0.6, [False] * 4) == []
+
+
+class TestFork:
+    """The first free token: never the greedy one, distinct per lane."""
+
+    torch = pytest.importorskip("torch")
+
+    def test_allowed_mask_shorter_than_the_logits_is_padded(self):
+        # The checkpoint's embedding table is 32128 wide, its tokenizer 32100:
+        # the first run indexed a 32100 mask into 32128 logits and raised.
+        t = self.torch
+        allowed = t.ones(40, dtype=t.bool)
+        toks = pv._fork_tokens(t, self._logits(n=50), rows=4, amount=0.5, allowed=allowed)
+        assert len(set(toks)) == 4 and max(toks) < 40
+
+    def _logits(self, n=50, peak=7):
+        t = self.torch
+        x = t.linspace(-3.0, 3.0, n)
+        x[peak] = 20.0            # an overwhelmingly confident greedy token
+        return x
+
+    def test_greedy_is_never_chosen_and_lanes_are_distinct(self):
+        toks = pv._fork_tokens(self.torch, self._logits(), rows=12, amount=0.1)
+        assert 7 not in toks
+        assert len(set(toks)) == 12
+
+    def test_banned_ids_are_never_chosen(self):
+        toks = pv._fork_tokens(self.torch, self._logits(), rows=12, amount=0.5,
+                               banned=(0, 1, 49, None))
+        assert not {0, 1, 49} & set(toks)
+
+    def test_allowed_mask_restricts_to_word_starts(self):
+        t = self.torch
+        allowed = t.zeros(50, dtype=t.bool)
+        allowed[[10, 11, 12, 13]] = True
+        toks = pv._fork_tokens(t, self._logits(), rows=3, amount=0.5, allowed=allowed)
+        assert set(toks) <= {10, 11, 12, 13}
+        assert len(set(toks)) == 3
+
+    def test_deterministic_under_the_same_seed(self):
+        t = self.torch
+        t.manual_seed(123)
+        a = pv._fork_tokens(t, self._logits(), rows=12, amount=0.9)
+        t.manual_seed(123)
+        b = pv._fork_tokens(t, self._logits(), rows=12, amount=0.9)
+        assert a == b
+
+    def test_more_lanes_than_candidates_keeps_the_shape(self):
+        t = self.torch
+        toks = pv._fork_tokens(t, self._logits(n=5, peak=2), rows=12, amount=0.5)
+        assert len(toks) == 12
+        assert 2 not in toks
+
+    def test_all_banned_falls_back_rather_than_raising(self):
+        t = self.torch
+        toks = pv._fork_tokens(t, self._logits(n=3, peak=1), rows=2, amount=0.5,
+                               banned=(0, 1, 2))
+        assert len(toks) == 2


### PR DESCRIPTION
## Problem

Discord (hunter, Chris, 2026-09-01): "variations aren't really responding", "almost stuck, then got unstuck", "not hearing much of a difference".

The pad walks around an anchor that is usually the enhancer's **own output** (the composer refines through the same endpoint first). On its own output the distilled t5 is near-certain at every position, so "hold the head, sample the tail" reproduced the greedy decode. Measured on a fleet SA3 pod, refined anchor, 12 lanes per stop:

| stop | lanes returning the anchor text verbatim |
|---|---|
| 2 | 12 / 12 |
| 5 | 11 / 12 |
| 8 | 11 / 12 |
| 11 | 6 / 12 |
| 15 | 5 / 12 |

Across three anchors, 102 of 216 coordinates returned the anchor. DreamSampler correctly writes nothing when the text is unchanged, so the dot moved and the prompt did not. Hand-typed anchors mostly worked, which is why it seemed intermittent.

## Fix

`_fork_tokens`: one decoder step on the held prefix, ban the greedy token, hand each lane a distinct word-initial token drawn without replacement, then let the existing sampler continue. Also: the cut snaps to a word boundary (mid-word forks wrote "phrasal", "close-molky"), and any positive distance frees at least one token.

Same three anchors after: **0 of 216** coordinates return the anchor, 12/12 distinct lanes at every stop, real words. One extra forward pass per call (~+100 ms CPU, negligible on CUDA). Deterministic under the existing seeding.

## Tests

`tests/unit/test_prompt_variations.py`: +10 (prefix always frees, word-boundary snap, fork bans greedy/banned ids, distinct lanes, allowed mask incl. tokenizer-vs-embedding width, determinism, degenerate vocab). 57 passed together with `test_prompt_enhancer.py`.

Needs a pod re-bake to reach the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
