### PR TITLE
feat(sa3): sa3_sigmas — an explicit per-step noise schedule

### DIFF
--- a/acestep/engine/sa3_adapter.py
+++ b/acestep/engine/sa3_adapter.py
@@ -65,6 +65,15 @@ class SA3Adapter:
         # mutates this and must invalidate the pipeline's schedule
         # cache — the cache is keyed by denoise alone.
         self.shift_alpha: float = 1.0
+        # AN EXPLICIT SCHEDULE (the ``sa3_sigmas`` knob): per-step noise
+        # levels, normalized so 1.0 is "start from the strength knob" and
+        # the final 0 is implied. When set it REPLACES the builder's stock
+        # schedule outright — this is the streaming analogue of a
+        # StreamDiffusion ``t_index_list`` — and the step count is its
+        # length, which the backend enforces by rebuilding the pipeline.
+        # shift_alpha still composes on top (1.0 = untouched), so SHIFT
+        # becomes a macro over a hand-placed schedule rather than dead.
+        self.sigmas_override: Optional[List[float]] = None
         self._device = torch.device(device)
         self._dtype = dtype
         # The spike's cond stacker (pads cross-attn tensors to the
@@ -74,7 +83,12 @@ class SA3Adapter:
     # ---- ModelAdapter ------------------------------------------------------
 
     def build_schedule(self, config, denoise: float, device, dtype) -> torch.Tensor:
-        schedule = self.schedule_builder(float(denoise)).detach().float()
+        if self.sigmas_override:
+            schedule = torch.tensor(
+                list(self.sigmas_override) + [0.0], dtype=torch.float32,
+            ) * float(denoise)
+        else:
+            schedule = self.schedule_builder(float(denoise)).detach().float()
         if schedule.ndim != 1:
             raise ValueError(
                 f"SA3 schedule must be 1-D, got {tuple(schedule.shape)}"

--- a/acestep/engine/trt/sa3_build.py
+++ b/acestep/engine/trt/sa3_build.py
@@ -31,7 +31,8 @@ on first use.
   producer-built graph until it is.
   :func:`acestep.engine.sa3_trt.find_dit_engine` prefers an fp8 engine when one
   covers the window, else fp16mixed.
-* **SAME-L window decoder**: ``dec_dynamic_triton_swa.onnx``,
+* **SAME-L window decoder**: ``dec_fp16.onnx`` (upstream renamed it from
+  ``dec_dynamic_triton_swa.onnx`` on 2026-08-28, same bytes),
   STRONGLY_TYPED; needs the ``samel::diff_attn_swa`` plugin registered
   before the ONNX parse (vendored tree, via
   :func:`acestep.engine.sa3_trt._register_same_plugin`).
@@ -128,7 +129,11 @@ DIT_FP8_ONNX_FILES = (
     "onnx/sa3-m/dit_fp8.onnx",
     "onnx/sa3-m/dit_fp8.onnx.data",
 )
-SAME_L_ONNX_FILES = ("onnx/same-l/dec_dynamic_triton_swa.onnx",)
+# Upstream renamed this on 2026-08-28 ("Rename the autoencoder ONNX to match
+# the engine naming scheme"); the bytes are unchanged (same LFS object as
+# the old dec_dynamic_triton_swa.onnx), so engines keyed on the ONNX hash
+# still match.
+SAME_L_ONNX_FILES = ("onnx/same-l/dec_fp16.onnx",)
 
 # Canonical DiT latent profiles for --all. min=1 keeps short windows
 # on-engine; the names must keep the sa3_m_dit_l{min}_{opt}_{max} shape

--- a/acestep/streaming/sa3_backend.py
+++ b/acestep/streaming/sa3_backend.py
@@ -29,6 +29,14 @@ Control surface (everything else off, capability-gated):
 * ``sa3_shift`` — relative schedule warp on top of the checkpoint's
   dist_shift (``SA3Adapter.shift_alpha``); changes invalidate the
   pipeline's per-denoise schedule cache.
+* ``sa3_sigmas`` — an EXPLICIT per-step schedule, the streaming analogue
+  of StreamDiffusion's ``t_index_list``: a list of noise levels in
+  (0, 1], strictly decreasing, 1.0 meaning "start from ``sa3_denoise``"
+  and the final 0 implied. Its length IS the step count, so it overrides
+  ``steps_override`` while set. Not a :class:`KnobSpec` on purpose —
+  the registry only types scalars and would coerce a list to NaN — so
+  it rides the params channel as a pass-through key, validated here by
+  :func:`parse_sigmas`; anything invalid is ignored rather than applied.
 * ``x0_target`` / ``feedback`` / ``feedback_depth`` — taken FROM the
   shared registry (identical semantics to ACE, solver-level latent
   mechanics that are family-agnostic): the source-lock morph toward
@@ -184,6 +192,43 @@ def sa3_knob_specs(loras: tuple | list = ()) -> list:
         shared["seed"],
         shared["steps_override"],
     ] + [lora_strength_spec(lid) for lid in loras]
+
+
+#: Matches ``steps_override``'s registry ceiling.
+SIGMAS_MAX_STEPS = 16
+
+
+def parse_sigmas(value) -> Optional[list]:
+    """Validate a ``sa3_sigmas`` wire value into a schedule, or ``None``.
+
+    Accepts a list/tuple of numbers or a comma/space-separated string (what
+    a person types into the plugin). Valid means 1..16 entries, every one
+    finite and in (0, 1], strictly decreasing. ``None`` for anything else —
+    including empty — so a half-typed list never reaches the solver and the
+    stock schedule stays in force until the text makes sense.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        parts = [p for p in value.replace(",", " ").split() if p]
+    elif isinstance(value, (list, tuple)):
+        parts = list(value)
+    else:
+        return None
+    if not 1 <= len(parts) <= SIGMAS_MAX_STEPS:
+        return None
+    out: list = []
+    for p in parts:
+        try:
+            f = float(p)
+        except (TypeError, ValueError):
+            return None
+        if not (f == f) or f <= 0.0 or f > 1.0:   # NaN, non-positive, >1
+            return None
+        if out and f >= out[-1]:
+            return None
+        out.append(f)
+    return out
 
 
 class SA3Backend(DiffusionBackend):
@@ -1274,6 +1319,14 @@ class SA3Backend(DiffusionBackend):
                 self.adapter.shift_alpha = shift
                 self.pipeline.invalidate_schedule_cache()
 
+        # Explicit schedule: same hot-apply + cache-invalidate contract as
+        # the warp. Compared as lists so an unchanged list is a no-op tick.
+        sigmas = parse_sigmas(knobs.get("sa3_sigmas"))
+        if sigmas != self.adapter.sigmas_override:
+            with self._control_lock:
+                self.adapter.sigmas_override = sigmas
+                self.pipeline.invalidate_schedule_cache()
+
         # Per-LoRA live strength (the ACE per-tick convention): iterate
         # the catalog so the active set can change at runtime; strength
         # only flows for ENABLED entries, gated by the shared 0.02
@@ -1311,7 +1364,12 @@ class SA3Backend(DiffusionBackend):
         return {
             "denoise": float(knobs.get("sa3_denoise", 1.0)),
             "seed": int(knobs.get("seed", self._default_seed)),
-            "steps": int(knobs.get("steps_override", self._steps)),
+            # The list's length is the step count while it is set; the
+            # (steps+1,)-shaped schedule cache makes any other value wrong.
+            "steps": (
+                len(sigmas) if sigmas
+                else int(knobs.get("steps_override", self._steps))
+            ),
             "shift": shift,
             "x0_target": x0_str,
             "feedback": float(knobs.get("feedback", 0.0)),

--- a/tests/unit/test_sa3_adapter.py
+++ b/tests/unit/test_sa3_adapter.py
@@ -286,3 +286,43 @@ def test_shift_alpha_invalid_fails_loudly():
     adapter.shift_alpha = 0.0
     with pytest.raises(ValueError, match="shift_alpha"):
         adapter.build_schedule(config, 1.0, "cpu", torch.float32)
+
+
+def test_sigmas_override_replaces_the_stock_schedule():
+    # The streaming t_index_list: hand-placed levels, scaled by the strength
+    # knob, final 0 implied. The builder must not be consulted at all.
+    adapter = _adapter(steps=4)
+    config = DiffusionConfig(
+        infer_steps=4, infer_method="ode", noise_on_cpu=True, dcw_enabled=False,
+    )
+    adapter.sigmas_override = [1.0, 0.5, 0.25, 0.1]
+    got = adapter.build_schedule(config, 0.8, "cpu", torch.float32)
+    assert torch.allclose(got, torch.tensor([0.8, 0.4, 0.2, 0.08, 0.0]))
+
+    # SHIFT still composes as a macro over the explicit list: endpoints
+    # pinned, still strictly decreasing.
+    adapter.shift_alpha = 2.0
+    warped = adapter.build_schedule(config, 0.8, "cpu", torch.float32)
+    assert warped[0].item() == got[0].item() and warped[-1].item() == 0.0
+    assert torch.all(warped[:-1] > warped[1:])
+
+    # Clearing it returns the builder's schedule exactly.
+    adapter.shift_alpha = 1.0
+    adapter.sigmas_override = None
+    assert torch.equal(
+        adapter.build_schedule(config, 0.8, "cpu", torch.float32),
+        _schedule_builder(4)(0.8),
+    )
+
+
+def test_sigmas_override_length_must_match_steps():
+    # A 3-entry list on a 4-step pipeline is the backend's bug to prevent
+    # (it rebuilds on length change); the adapter refuses loudly rather
+    # than silently truncating a schedule someone placed by hand.
+    adapter = _adapter(steps=4)
+    config = DiffusionConfig(
+        infer_steps=4, infer_method="ode", noise_on_cpu=True, dcw_enabled=False,
+    )
+    adapter.sigmas_override = [1.0, 0.5, 0.1]
+    with pytest.raises(ValueError, match="length mismatch"):
+        adapter.build_schedule(config, 1.0, "cpu", torch.float32)

--- a/tests/unit/test_sa3_backend.py
+++ b/tests/unit/test_sa3_backend.py
@@ -1037,3 +1037,70 @@ def test_close_drops_mirror_and_pending():
     assert b._refit_mirror is None
     assert b._pending_lora_strengths == {}
     assert mgr.closed is True
+
+
+# ---- sa3_sigmas: an explicit schedule -------------------------------------
+
+
+def test_parse_sigmas_accepts_lists_and_typed_text_only_when_sane():
+    from acestep.streaming.sa3_backend import parse_sigmas
+    assert parse_sigmas([1.0, 0.85, 0.65, 0.3]) == [1.0, 0.85, 0.65, 0.3]
+    assert parse_sigmas("1.0, 0.85, 0.65, 0.3") == [1.0, 0.85, 0.65, 0.3]
+    assert parse_sigmas("1 .5 .1") == [1.0, 0.5, 0.1]
+    assert parse_sigmas([0.9]) == [0.9]                # first < 1 is allowed
+    # Everything below must be ignored, not applied.
+    assert parse_sigmas(None) is None
+    assert parse_sigmas("") is None
+    assert parse_sigmas([]) is None
+    assert parse_sigmas("1.0, 0.5, 0.5") is None       # not strictly decreasing
+    assert parse_sigmas("0.5, 1.0") is None            # increasing
+    assert parse_sigmas("1.0, 0.0") is None            # the final 0 is implied
+    assert parse_sigmas("1.2, 0.5") is None            # above 1
+    assert parse_sigmas("1.0, abc") is None
+    assert parse_sigmas("1.0, nan") is None
+    assert parse_sigmas([1.0] + [1.0 - i * 0.05 for i in range(1, 17)]) is None  # 17 entries
+    assert parse_sigmas(3.0) is None
+
+
+def test_sa3_sigmas_replaces_schedule_and_drives_step_count():
+    b = _backend()                                   # 3 steps
+    knobs = _knobs(b)
+    b.produce(knobs, CTX, "generate")
+    stock = b.pipeline._schedule_cache[1.0].clone()
+
+    # Same length as the pipeline: applied in place, cache invalidated.
+    b.produce({**knobs, "sa3_sigmas": "1.0, 0.6, 0.2"}, CTX, "generate")
+    assert b.adapter.sigmas_override == [1.0, 0.6, 0.2]
+    got = b.pipeline._schedule_cache[1.0]
+    assert torch.allclose(got, torch.tensor([1.0, 0.6, 0.2, 0.0]))
+    assert not torch.allclose(got, stock)
+
+    # A longer list IS a step-count change: the pipeline rebuilds, and the
+    # override survives the rebuild (it lives on the adapter).
+    before = b.pipeline
+    b.produce({**knobs, "sa3_sigmas": [1.0, 0.7, 0.4, 0.15]}, CTX, "generate")
+    assert b._steps == 4 and b.pipeline is not before
+    assert torch.allclose(
+        b.pipeline._schedule_cache[1.0],
+        torch.tensor([1.0, 0.7, 0.4, 0.15, 0.0]),
+    )
+
+    # Unchanged list: no cache churn.
+    cache_id = id(b.pipeline._schedule_cache)
+    b.produce({**knobs, "sa3_sigmas": [1.0, 0.7, 0.4, 0.15]}, CTX, "generate")
+    assert id(b.pipeline._schedule_cache) == cache_id and 1.0 in b.pipeline._schedule_cache
+
+
+def test_sa3_sigmas_invalid_or_cleared_falls_back_to_steps_override():
+    b = _backend()
+    knobs = _knobs(b)
+    b.produce({**knobs, "sa3_sigmas": [1.0, 0.6, 0.2]}, CTX, "generate")
+    assert b.adapter.sigmas_override == [1.0, 0.6, 0.2]
+
+    # Half-typed text: ignored, stock schedule back, steps from the knob.
+    b.produce({**knobs, "sa3_sigmas": "1.0, 0."}, CTX, "generate")
+    assert b.adapter.sigmas_override is None
+    assert b._steps == knobs["steps_override"]
+    assert torch.allclose(
+        b.pipeline._schedule_cache[1.0], _schedule_builder_factory(b._steps)(1.0),
+    )


### PR DESCRIPTION
The streaming analogue of StreamDiffusion's `t_index_list`, asked for from the plugin: *"can I directly have `sigmas = [1.0, 0.85, 0.65, 0.3, ...]` on the vst?"*

## What existed

SA3's schedule was a three-parameter family — step count, `sigma_max` (`sa3_denoise`) and the `sa3_shift` warp over the checkpoint's stock curve. You could cluster steps toward noise or toward clean; you could not *place* them. Two steps at two chosen levels had no expression.

## The knob

`sa3_sigmas`: a list of per-step levels in (0, 1], strictly decreasing, `1.0` meaning "start from `sa3_denoise`", the final 0 implied. `[1.0, 0.85, 0.65, 0.3]` is four steps at exactly those levels.

- **Its length is the step count** and overrides `steps_override` while set. A length change goes through the existing pipeline rebuild — schedules are `(steps+1,)`-shaped and the per-denoise cache would otherwise serve the wrong size.
- **SHIFT still composes on top**, so it becomes a macro over a hand-placed schedule rather than a dead knob.
- **Not a `KnobSpec`, deliberately.** The registry types scalars only and would coerce a list to NaN. It rides the params channel as a pass-through key (`coerce_knob_values` leaves unregistered keys verbatim; `KnobState` keeps them) and is validated in the backend by `parse_sigmas`, which accepts a list or the comma/space text a person types.
- **Anything invalid is ignored, not applied** — including a half-typed list — so the previous schedule keeps playing until the text makes sense. The plugin mirrors the same parser, so what its field accepts is what the pod applies.
- The adapter refuses a list whose length disagrees with `infer_steps` rather than truncating a schedule someone placed by hand.

TensorRT is unaffected: `t` is a runtime input, and step count is just how many times the DiT is called.

## Tests (52 pass, up from 44)

Override replaces the stock schedule and scales by strength · SHIFT composes with pinned endpoints · clearing restores the builder exactly · length mismatch fails loudly · `parse_sigmas` accepts only sane input (rejects `1.0, 0.5, 0.5`, `0.5, 1.0`, `1.0, 0.0`, `1.2`, NaN, 17 entries) · a list applies in place and invalidates the cache · a longer list rebuilds the pipeline and survives it · an unchanged list does not churn the cache · invalid text falls back to `steps_override`.

Run on CPU torch here (`tests/unit/test_sa3_adapter.py`, `test_sa3_backend.py`, `test_knob_homonyms.py`).

## Pairs with

The rtmg-vst side adds a SIGMAS field on the SA3 deck that sends this key (separate PR). **Needs a pod re-bake to reach the fleet.**

## Caveat worth saying out loud

The serving model is the ARC distillation, trained around its stock schedule. `sa3_shift` being bounded to 0.25–4 suggests there's a cliff somewhere; a hand-placed list can walk off it. This lands the lever; finding the usable range is the listening that comes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jmVRt5vLoU9b7WE5ZiqKp