### PR TITLE
fix(sa3): condition loops as a slice of a longer song, with a wrapped anchor

### DIFF
--- a/acestep/engine/sa3_context.py
+++ b/acestep/engine/sa3_context.py
@@ -24,8 +24,11 @@ when it is absent.
 
 from __future__ import annotations
 
-from typing import Callable
+import math
+import os
+from typing import Callable, Mapping
 
+import numpy as np
 import torch
 
 from acestep.engine.obs import logger
@@ -40,6 +43,108 @@ from acestep.engine.sa3_helpers import (
 # codec. SAME-S (small-music) full-decodes in ~11 ms flat — windowing
 # would only add seam surface there.
 WINDOWED_DECODE_MODELS = {"medium"}
+
+# ---- Song-length conditioning -------------------------------------------
+# What ``seconds_total`` tells the SA3 DiT (see
+# ``prepare_sa3_conditioning``): upstream training labels every example
+# with the FULL file length, so a label equal to the render window means
+# "the whole song, ending here" and the model composes an outro into the
+# last seconds of every loop (the DreamSampler "song ending" report).
+# A label longer than the window is the training regime for "a slice of
+# a longer track" — no ending at the loop boundary. Measured with
+# ``scripts/sa3/tail_probe.py`` on sa3-medium (5090): under the legacy
+# label every probed loop ended in a 17-24 dB fade over its last 2 s
+# (30 s cuts and the full 57.6 s default track alike, sa3_denoise 0.9
+# and 1.0); under a 180 s label the same loops stay flat. 120 s is NOT
+# enough — it equals the model's training window, so it still reads as
+# "the whole file", and the fade came back in every run.
+SONG_SECONDS_ENV = "DEMON_SA3_SONG_SECONDS"
+SONG_SCHEDULE_ENV = "DEMON_SA3_SONG_SCHEDULE"
+OUTRO_PAD_ENV = "DEMON_SA3_OUTRO_PAD_S"
+# Default song-length label, seconds. ``0`` in the env var disables the
+# label (legacy: label = render duration + 6 s outro pad).
+DEFAULT_SONG_SECONDS: float = 180.0
+# The conditioner's ``max_val`` (model_config ``seconds_total`` number
+# conditioner); labels above it saturate the Fourier features.
+SONG_SECONDS_MAX = 384.0
+# Upstream ``generate()`` pads the render window by 6 s of outro headroom
+# because the model fades past the label; the pad is silence. Under the
+# song-length label there is no outro to make room for, but the render
+# still gets a few seconds past the loop: the source anchor is TILED
+# (the loop wrapped around onto its own start) into that extra window
+# instead of zero-padded, so the anchor never hard-stops inside the
+# render. Measured (tail_probe, sa3_denoise 0.9): with the anchor ending
+# at the window's last frame the model still resolved some full-length
+# loops into a fade, label or not; wrapped, the tail stays flat. Only
+# the loop itself is playable (``playable_duration_s``). The wrap is
+# also what the TRT clamp now costs a 60 s loop on the 646-latent
+# engine (~57 s, was ~54 s under the 6 s pad); ``DEMON_SA3_OUTRO_PAD_S=0``
+# trades the wrap for the full 60 s.
+LEGACY_OUTRO_PAD_S = 6.0
+DEFAULT_LOOP_WRAP_S = 3.0
+
+
+def song_seconds_setting(env: Mapping[str, str] | None = None) -> float | None:
+    """The configured song-length label, or None when disabled."""
+    env = os.environ if env is None else env
+    raw = env.get(SONG_SECONDS_ENV)
+    if raw is None or raw.strip() == "":
+        value = DEFAULT_SONG_SECONDS
+    else:
+        try:
+            value = float(raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"{SONG_SECONDS_ENV} must be a number of seconds (0 disables), "
+                f"got {raw!r}"
+            ) from exc
+    if value <= 0:
+        return None
+    return min(value, SONG_SECONDS_MAX)
+
+
+def song_schedule_from_window(env: Mapping[str, str] | None = None) -> bool:
+    """``DEMON_SA3_SONG_SCHEDULE``: ``song`` (default, training-consistent:
+    the dist-shift schedule follows the label) or ``window`` (the
+    schedule follows the render length)."""
+    env = os.environ if env is None else env
+    mode = env.get(SONG_SCHEDULE_ENV, "song").strip().lower()
+    if mode not in ("song", "window"):
+        raise ValueError(
+            f"{SONG_SCHEDULE_ENV} must be song|window, got {mode!r}"
+        )
+    return mode == "window"
+
+
+def outro_pad_setting(
+    song_seconds: float | None, env: Mapping[str, str] | None = None,
+) -> float:
+    """Extra render window past the loop, seconds: the wrapped-loop
+    headroom (:data:`DEFAULT_LOOP_WRAP_S`) under a song-length label,
+    the upstream 6 s silent outro pad otherwise; ``DEMON_SA3_OUTRO_PAD_S``
+    overrides either (``0`` = window exactly the loop)."""
+    env = os.environ if env is None else env
+    raw = env.get(OUTRO_PAD_ENV)
+    if raw is not None and raw.strip() != "":
+        try:
+            pad = float(raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"{OUTRO_PAD_ENV} must be a number of seconds, got {raw!r}"
+            ) from exc
+        return max(0.0, pad)
+    return DEFAULT_LOOP_WRAP_S if song_seconds is not None else LEGACY_OUTRO_PAD_S
+
+
+def label_seconds_for(duration_s: float, song_seconds: float | None) -> float:
+    """The ``seconds_total`` label for a render of ``duration_s``: the song
+    length when it is longer than the render, else the render itself
+    (legacy semantics — a loop longer than the label is still "the whole
+    song")."""
+    duration_s = float(duration_s)
+    if song_seconds is None or float(song_seconds) <= duration_s:
+        return duration_s
+    return float(song_seconds)
 
 
 class SA3Context:
@@ -67,9 +172,17 @@ class SA3Context:
             self.sam.model.pretransform.downsampling_ratio          # 4096
         )
         self.latent_channels = int(self.sam.model.io_channels)      # 256
+        # Song-length conditioning, resolved once per process (env-driven
+        # so a pod can A/B it without a code change).
+        self.song_seconds = song_seconds_setting()
+        self.schedule_from_window = song_schedule_from_window()
+        self.outro_pad_s = outro_pad_setting(self.song_seconds)
         logger.info(
-            "sa3_model_loaded model_id={} latent_rate_hz={:.4f} dtype={}",
+            "sa3_model_loaded model_id={} latent_rate_hz={:.4f} dtype={} "
+            "song_seconds={} schedule={} outro_pad_s={:.1f}",
             model_id, self.sample_rate / self.downsampling_ratio, self.dtype,
+            self.song_seconds, "window" if self.schedule_from_window else "song",
+            self.outro_pad_s,
         )
 
     @property
@@ -140,23 +253,48 @@ class SA3Context:
             return SA3SAMEWindowCodec(self, use_trt=(backend == "tensorrt"))
         return SA3SAMECodec(self)
 
+    def cond_seconds_total(self, duration_s: float) -> float:
+        """The ``seconds_total`` label a render of ``duration_s`` is
+        conditioned with (see :func:`label_seconds_for`). Every consumer
+        of the label — the eager cond capture and the TRT DiT's seconds
+        scalar — must go through here so they can't disagree."""
+        return label_seconds_for(duration_s, self.song_seconds)
+
+    def window_latent_frames(self, duration_s: float) -> int:
+        """Latent frames of the render window for ``duration_s`` (the
+        requested length + :attr:`outro_pad_s`, aligned the way
+        ``prepare_sa3_conditioning`` sizes it). Pure arithmetic on the
+        model config — no model call."""
+        audio_samples = self.sam._adapt_sample_size(
+            [{"seconds_total": float(duration_s)}],
+            self._helpers.SA3_DEFAULT_SAMPLE_SIZE,
+            self.outro_pad_s,
+        )
+        return int(audio_samples) // self.downsampling_ratio
+
     def clamp_duration_for_trt(
-        self, duration_s: float, *, padding_s: float = 6.0, backend: str = "eager",
+        self, duration_s: float, *, backend: str = "eager",
     ) -> float:
-        """Clamp a requested duration so its padded latent window fits a
-        built TRT DiT engine — landing on the fast path instead of
-        silently falling back to the ~5x-slower eager DiT. No-op for
-        models without engines (small) or durations already inside.
-        No-op unless ``backend="tensorrt"`` (see :meth:`make_dit`) —
-        the eager DiT has no length cap worth truncating the source
-        for."""
-        from acestep.engine.sa3_trt import trt_duration_cap_s
+        """Clamp a requested duration so its (padded, aligned) latent
+        window fits a built TRT DiT engine — landing on the fast path
+        instead of silently falling back to the ~5x-slower eager DiT.
+        No-op for models without engines (small) or durations already
+        inside. No-op unless ``backend="tensorrt"`` (see
+        :meth:`make_dit`) — the eager DiT has no length cap worth
+        truncating the source for."""
+        from acestep.engine.sa3_trt import max_dit_engine_latents
 
         if backend != "tensorrt":
             return duration_s
-        cap = trt_duration_cap_s(self.model_id, padding_s=padding_s)
-        if cap is None or duration_s <= cap:
+        max_l = max_dit_engine_latents(self.model_id)
+        if max_l is None or self.window_latent_frames(duration_s) <= max_l:
             return duration_s
+        # Walk down in 0.1 s steps against the SAME window arithmetic the
+        # capture uses, so alignment rounding can't push the clamped
+        # window one frame past the engine.
+        cap = math.floor(duration_s * 10.0) / 10.0
+        while cap > 0 and self.window_latent_frames(cap) > max_l:
+            cap = round(cap - 0.1, 1)
         logger.warning(
             "sa3_duration_clamped_for_trt model_id={} requested_s={:.1f} cap_s={:.1f}",
             self.model_id, duration_s, cap,
@@ -167,9 +305,13 @@ class SA3Context:
 
     def prepare_cond(self, *, prompt: str, duration: float, steps: int):
         """Capture the DiT kwargs + schedule inputs for one prompt and
-        fixed duration (the spike's ``SA3Conditioning``)."""
+        fixed render duration (the spike's ``SA3Conditioning``), labelled
+        with :meth:`cond_seconds_total` and padded by :attr:`outro_pad_s`."""
         return self._helpers.prepare_sa3_conditioning(
             self.sam, prompt=prompt, duration=duration, steps=steps,
+            duration_padding_sec=self.outro_pad_s,
+            song_seconds_total=self.song_seconds,
+            schedule_from_window=self.schedule_from_window,
         )
 
     def make_schedule_builder(
@@ -206,10 +348,34 @@ class SA3Context:
 
     def encode_source(self, audio_input, audio_sample_size: int) -> torch.Tensor:
         """SAME-encode an audio source for audio-to-audio streaming.
-        Returns the native ``[1, 256, T]`` latent."""
+        Returns the native ``[1, 256, T]`` latent. Under the song-length
+        label the source is tiled to fill the render window (see
+        :meth:`tile_loop`); otherwise upstream's ``prepare_audio``
+        zero-pads it."""
+        if self.song_seconds is not None:
+            audio_input = self.tile_loop(audio_input, audio_sample_size)
         return self._helpers.encode_sa3_source(
             self.sam, audio_input, audio_sample_size,
         )
+
+    def tile_loop(self, audio_input, audio_sample_size: int):
+        """Wrap a ``(sample_rate, waveform[C, N])`` loop around onto its
+        own start until it covers ``audio_sample_size`` model-rate
+        samples (plus one, so the resample can't leave a zero frame).
+        The anchor then continues past the playable loop end the way
+        the loop itself does when it cycles — no hard stop for the
+        model to read as a song ending. A source already covering the
+        window is returned untouched (``prepare_audio`` crops it)."""
+        sr, wav = audio_input
+        if isinstance(wav, np.ndarray):
+            wav = torch.from_numpy(wav)
+        n = int(wav.shape[-1])
+        target = math.ceil(int(audio_sample_size) * float(sr) / self.sample_rate) + 1
+        if n <= 0 or n >= target:
+            return audio_input
+        reps = math.ceil(target / n)
+        tiled = wav.repeat(*([1] * (wav.dim() - 1)), reps)[..., :target]
+        return sr, tiled
 
 
 class SA3SAMECodec:

--- a/acestep/engine/sa3_stream_helpers.py
+++ b/acestep/engine/sa3_stream_helpers.py
@@ -73,6 +73,11 @@ def stack_sa3_cond_bundles(bundles: list[dict]) -> dict:
     return out
 
 
+# Upstream ``generate()``'s default render ceiling (120 s @ 44.1 kHz);
+# ``_adapt_sample_size`` shrinks the window to the requested duration.
+SA3_DEFAULT_SAMPLE_SIZE = 5292032
+
+
 @dataclass
 class SA3Conditioning:
     """Precomputed SA3 conditioning and schedule metadata for one prompt."""
@@ -81,6 +86,11 @@ class SA3Conditioning:
     sched_args: dict
     latent_frames: int
     audio_sample_size: int
+    # The ``seconds_total`` the conditioner was fed (the song-length
+    # LABEL, see prepare_sa3_conditioning). A TRT DiT rebuilds its
+    # seconds token from this scalar, so it must be handed the same
+    # value the eager cond bundle embeds. None on legacy constructions.
+    seconds_total: Optional[float] = None
 
 
 @dataclass(frozen=True)
@@ -113,17 +123,44 @@ def prepare_sa3_conditioning(
     prompt: str,
     duration: float,
     steps: int,
-    sample_size: int = 5292032,
+    sample_size: int = SA3_DEFAULT_SAMPLE_SIZE,
     duration_padding_sec: float = 6.0,
     cfg_scale: float = 1.0,
     apg_scale: float = 1.0,
     dist_shift=None,
+    song_seconds_total: Optional[float] = None,
+    schedule_from_window: bool = False,
 ) -> SA3Conditioning:
     """Build SA3 conditioning without running the sampler.
 
     This mirrors ``StableAudioModel.generate`` up to the call into
     ``sample_diffusion`` and returns the exact DiT kwargs plus the schedule
     inputs needed by the streaming pipeline.
+
+    ``duration`` is the RENDER length: it sizes the latent window
+    (``audio_sample_size`` = duration + ``duration_padding_sec``, aligned).
+
+    ``song_seconds_total`` is what the model is TOLD the song is. Upstream
+    training (``PadCrop`` in ``stable_audio_3/data/utils.py``) labels every
+    example with the FULL file length, whatever the crop: a window cut from
+    a 200 s track is conditioned with ``seconds_total=200``, while a file
+    shorter than the window is zero-padded and conditioned with its own
+    length — so ``seconds_total == duration`` means "this is the whole
+    song, it ends here", and the model writes an outro (then silence; the
+    training config even extends examples with silence past the end).
+    Passing a song length LONGER than the window puts the render in the
+    other training regime — "a slice from the middle of a longer track"
+    — so no ending (and no intro) is composed at the loop boundary; the
+    attention padding mask then covers the whole window (a long-file crop
+    is fully valid in training too). None / ``<= duration`` keeps the
+    upstream ``generate()`` semantics (the label is the render duration).
+
+    ``schedule_from_window`` keeps the dist-shift timestep schedule
+    derived from the render length even when the label is longer.
+    Training shifted by the label-derived length (``diffusion.py``,
+    ``use_effective_length_for_schedule``), so False is the
+    training-consistent default; True is the A/B fallback if the longer
+    label moves the denoise dial's feel.
     """
     from stable_audio_3.data.utils import (
         compute_effective_seq_len_from_conditioning,
@@ -131,11 +168,18 @@ def prepare_sa3_conditioning(
     )
 
     device = str(sam.device)
+    duration = float(duration)
+    label_seconds = duration
+    if song_seconds_total is not None and float(song_seconds_total) > duration:
+        label_seconds = float(song_seconds_total)
     conditioning, _negative = sam._build_conditioning_dicts(
-        prompt, None, duration, batch_size=1,
+        prompt, None, label_seconds, batch_size=1,
     )
+    # The render window follows the REQUESTED duration, never the label:
+    # a 180 s label on a 30 s loop must not grow the latent to 186 s.
+    window_conditioning = [{"seconds_total": duration}]
     audio_sample_size = sam._adapt_sample_size(
-        conditioning, sample_size, duration_padding_sec,
+        window_conditioning, sample_size, duration_padding_sec,
     )
     downsampling_ratio = sam.model.pretransform.downsampling_ratio
     latent_frames = audio_sample_size // downsampling_ratio
@@ -156,6 +200,10 @@ def prepare_sa3_conditioning(
         for k, v in conditioning_inputs.items()
     }
 
+    # Label-derived latent length: drives the attention padding mask and
+    # (by default) the dist-shift schedule, exactly as upstream sampling
+    # derives both from the conditioning's seconds_total. With a label
+    # longer than the window this clamps to the full window = all valid.
     effective_seq_len = compute_effective_seq_len_from_conditioning(
         conditioning, sam.model.sample_rate, downsampling_ratio, device,
     )
@@ -164,6 +212,11 @@ def prepare_sa3_conditioning(
         max=latent_frames,
     ).long()
     padding_mask = create_padding_mask_from_lengths(valid_lengths, latent_frames)
+    sched_seq_len = effective_seq_len
+    if schedule_from_window and label_seconds != duration:
+        sched_seq_len = compute_effective_seq_len_from_conditioning(
+            window_conditioning, sam.model.sample_rate, downsampling_ratio, device,
+        )
 
     cond_bundle = {
         **conditioning_inputs,
@@ -177,8 +230,8 @@ def prepare_sa3_conditioning(
     sched_args = {
         "steps": steps,
         "dist_shift": dist_shift if dist_shift is not None else sam.model.sampling_dist_shift,
-        "effective_seq_len": effective_seq_len.detach().cpu()
-        if torch.is_tensor(effective_seq_len) else effective_seq_len,
+        "effective_seq_len": sched_seq_len.detach().cpu()
+        if torch.is_tensor(sched_seq_len) else sched_seq_len,
         "fallback_seq_len": latent_frames,
     }
     return SA3Conditioning(
@@ -186,6 +239,7 @@ def prepare_sa3_conditioning(
         sched_args=sched_args,
         latent_frames=latent_frames,
         audio_sample_size=audio_sample_size,
+        seconds_total=label_seconds,
     )
 
 

--- a/acestep/engine/sa3_trt.py
+++ b/acestep/engine/sa3_trt.py
@@ -528,13 +528,3 @@ class SameLWindowTRTDecoder:
             # PCM-baked engine flavor: (1, N, 2) int scaled to int16 range.
             return (out[0].to(torch.float32).T / 32767.0).clamp(-1, 1)
         return out[0].float().clamp(-1, 1)
-
-
-def trt_duration_cap_s(model_id: str, *, padding_s: float) -> Optional[float]:
-    """Largest requested duration whose padded latent window still fits
-    a built DiT engine for ``model_id`` (None = no engine)."""
-    max_l = max_dit_engine_latents(model_id)
-    if max_l is None:
-        return None
-    total_s = max_l * SAMPLES_PER_LATENT / SA3_SAMPLE_RATE
-    return math.floor((total_s - padding_s) * 10.0) / 10.0

--- a/acestep/streaming/sa3_backend.py
+++ b/acestep/streaming/sa3_backend.py
@@ -221,14 +221,14 @@ class SA3Backend(DiffusionBackend):
         # stream (SlotRequest.sde_noise_seeded), the spike pipeline's
         # per-slot generator semantics.
         sampler: str = "pingpong",
-        # The conditioned song length in seconds — what seconds_total told
-        # the model to fill with music. The render window
-        # (cond.audio_sample_size) is LONGER: prepare_sa3_conditioning pads
-        # it by duration_padding_sec (6 s) of outro headroom, which the
-        # model deliberately fades to silence past seconds_total (upstream
-        # generate() trims it back off via truncate_output_to_duration).
-        # None (directly-constructed test backends) falls back to the full
-        # window, the pre-fix behavior.
+        # The requested loop length in seconds — the audio we play. The
+        # render window (cond.audio_sample_size) can be LONGER:
+        # prepare_sa3_conditioning pads it by the context's outro_pad_s
+        # (6 s under the legacy whole-song label, where the model fades
+        # to silence past seconds_total and upstream generate() trims it
+        # via truncate_output_to_duration; 0 under the song-length label)
+        # plus alignment rounding. None (directly-constructed test
+        # backends) falls back to the full window, the pre-fix behavior.
         playable_duration_s: Optional[float] = None,
         # ``(tags, steps, duration_s) -> (cond, schedule_builder_factory)``
         # — the per-prompt re-conditioning hook behind
@@ -492,7 +492,10 @@ class SA3Backend(DiffusionBackend):
         adapter = SA3Adapter(
             context.make_dit(
                 latent_frames=cond.latent_frames,
-                seconds_total=duration_s,
+                # The song-length LABEL (not the render length): the
+                # TRT DiT rebuilds its seconds token from this scalar
+                # and must embed what the eager cond bundle embeds.
+                seconds_total=context.cond_seconds_total(duration_s),
                 backend=dit_backend,
                 prefer_refittable=want_lora,
             ),
@@ -566,7 +569,7 @@ class SA3Backend(DiffusionBackend):
             )
             new_dit = context.make_dit(
                 latent_frames=new_cond.latent_frames,
-                seconds_total=d,
+                seconds_total=context.cond_seconds_total(d),
                 backend=dit_backend,
                 prefer_refittable=want_lora,
             )
@@ -859,12 +862,13 @@ class SA3Backend(DiffusionBackend):
         return SA3_MAX_DURATION_S
 
     def playable_duration_s(self):
-        # The conditioned song length, NOT cond.audio_sample_size /
-        # SA3_SAMPLE_RATE: the render window carries duration_padding_sec
-        # of outro headroom past seconds_total, where the model fades to
-        # silence by design. Serving that padding as playable audio put a
-        # fade-out + silent tail at the end of every SA3 loop (the
-        # "silence from 9:30 to midnight" bug).
+        # The requested loop length, NOT cond.audio_sample_size /
+        # SA3_SAMPLE_RATE: the render window can carry outro headroom
+        # (and alignment rounding) past the loop. Under the legacy
+        # whole-song label the model fades that headroom to silence by
+        # design, and serving it as playable audio put a fade-out +
+        # silent tail at the end of every SA3 loop (the "silence from
+        # 9:30 to midnight" bug, #336).
         return self._playable_s
 
     def read_knobs(self) -> dict:

--- a/acestep/streaming/sa3_session.py
+++ b/acestep/streaming/sa3_session.py
@@ -233,15 +233,15 @@ def create_sa3_session(
         if not initial_enable_ids:
             logger.info("lora_startup_empty reason=catalog_only")
 
-    # Playable geometry is the CONDITIONED duration, not the render
+    # Playable geometry is the REQUESTED duration, not the render
     # window. prepare_cond pads ``audio_sample_size`` out to duration +
-    # duration_padding_sec (6 s) of outro headroom, and the model fills
-    # that headroom with the fade-out/silence it generates past
-    # seconds_total — upstream ``generate()`` trims it back off
-    # (truncate_output_to_duration). Exposing the padded window as the
-    # playable buffer put ~6 s of fade + silence at the end of every SA3
-    # loop; the DiT still generates the full padded latent, we just never
-    # play or ship the padding.
+    # context.outro_pad_s (upstream's 6 s of outro headroom under the
+    # legacy whole-song label, where the model fills it with the
+    # fade-out/silence it generates past seconds_total; 0 under the
+    # song-length label, see SA3Context) plus alignment rounding.
+    # Exposing the padded window as the playable buffer put ~6 s of
+    # fade + silence at the end of every SA3 loop (#336); the DiT still
+    # generates the full window, we just never play or ship the padding.
     playable_44k = min(
         int(round(duration_s * context.sample_rate)),
         int(cond.audio_sample_size),

--- a/scripts/sa3/tail_probe.py
+++ b/scripts/sa3/tail_probe.py
@@ -1,0 +1,141 @@
+"""Tail probe: does an SA3 loop end in a fade/silence?
+
+Runs headless PRIMARY sessions against a local DEMON pod, one per
+(sa3_denoise, seed), using a server fixture (default: DreamSampler's
+default track) as the source, waits for a full lap of fresh audio, then
+reports the per-second RMS of the loop's last seconds against its body.
+A run is flagged ENDING when the last 3 s sit more than 8 dB under the
+body median. Every lap is also written to ``~/tail_probe_out/`` as a
+wav for listening, plus a JSON summary per label.
+
+  # 30 s cut of the fixture, both product denoise regimes, 3 seeds
+  python scripts/sa3/tail_probe.py --label legacy --duration 30 \
+      --denoise 1.0 0.9 --seeds 1 2 3
+  # the fixture at its own length (what the plugin does): --duration 0
+  python scripts/sa3/tail_probe.py --label full --duration 0 --denoise 0.9
+
+This is the measurement behind the song-length label
+(``DEMON_SA3_SONG_SECONDS``, see ``acestep/engine/sa3_context.py``):
+restart the pod with the env var to A/B, then run the probe under a
+new ``--label``.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import wave
+
+import numpy as np
+
+# Repo root FIRST on sys.path (AGENTS.md: a sibling ACE-Step checkout can
+# shadow ``acestep`` / ``demos`` otherwise).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from demos.realtime_motion_graph_web.headless_client import HeadlessClient  # noqa: E402
+
+SR = 48000
+PROMPT = ("upbeat electronic dance track, driving four-on-the-floor drums, "
+          "punchy synth bass, bright arpeggios, 124 bpm")
+
+
+def tone(seconds: float) -> np.ndarray:
+    t = np.arange(int(seconds * SR)) / SR
+    x = (0.25 * np.sin(2 * np.pi * 220.0 * t)).astype(np.float32)
+    return np.stack([x, x])
+
+
+def db(x: float) -> float:
+    return 20.0 * np.log10(max(x, 1e-6))
+
+
+def run_one(args, denoise: float, seed: int) -> dict:
+    cfg = {
+        "prompt": PROMPT, "sde": False, "lora": False,
+        "depth": 4, "steps": 8,
+        "client_id": f"tail-probe-{args.label}",
+    }
+    if args.duration > 0:
+        cfg["sa3_duration_s"] = float(args.duration)
+    wav = None
+    if args.synthetic:
+        wav = tone(args.duration)
+    else:
+        cfg["use_server_fixture"] = True
+        cfg["fixture_name"] = args.fixture
+    client = HeadlessClient(args.url, cfg, wav)
+    client._raw = {"sa3_denoise": float(denoise), "seed": int(seed)}
+    t0 = time.time()
+    ready = client.start(timeout_s=900)
+    dur = float(ready["duration"])
+    settle = args.settle if args.settle > 0 else dur + 20.0
+    while time.time() - t0 < settle and client.running:
+        time.sleep(0.5)
+    if not client.running:
+        print(f"FAIL client died: {client.closed_reason}", flush=True)
+        client.stop()
+        return {"denoise": denoise, "seed": seed, "error": client.closed_reason}
+    m = client.mirror.copy()
+    slices = client.slice_count
+    client.stop()
+
+    mono = m.mean(axis=1)
+    n_bins = int(len(mono) // SR)
+    bins = [db(float(np.sqrt((mono[i * SR:(i + 1) * SR] ** 2).mean())))
+            for i in range(n_bins)]
+    body = bins[2:max(3, n_bins - 10)]
+    body_med = float(np.median(body))
+    tail8 = bins[-8:]
+    last3 = float(np.mean(bins[-3:]))
+    drop = body_med - last3
+    ending = drop > 8.0
+    out_dir = os.path.expanduser("~/tail_probe_out")
+    os.makedirs(out_dir, exist_ok=True)
+    path = os.path.join(out_dir, f"{args.label}_d{denoise:.2f}_s{seed}_{int(dur)}s.wav")
+    with wave.open(path, "wb") as w:
+        w.setnchannels(m.shape[1]); w.setsampwidth(2); w.setframerate(SR)
+        w.writeframes((np.clip(m, -1, 1) * 32767).astype("<i2").tobytes())
+    rec = {
+        "label": args.label, "denoise": denoise, "seed": seed, "duration": dur,
+        "slices": slices, "body_median_db": round(body_med, 1),
+        "last3_mean_db": round(last3, 1), "drop_db": round(drop, 1),
+        "ending": ending,
+        "tail8_db": [round(b, 1) for b in tail8], "wav": path,
+    }
+    print(
+        f"[{args.label}] denoise={denoise:.2f} seed={seed} dur={dur:.1f}s "
+        f"slices={slices} body={body_med:.1f}dB last3={last3:.1f}dB "
+        f"drop={drop:+.1f}dB {'ENDING' if ending else 'ok'} "
+        f"tail8={[round(b) for b in tail8]}", flush=True,
+    )
+    return rec
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", required=True)
+    ap.add_argument("--url", default="ws://127.0.0.1:1318/")
+    ap.add_argument("--duration", type=float, default=30.0,
+                    help="sa3_duration_s (a cut of the fixture); 0 = the fixture's own length")
+    ap.add_argument("--denoise", type=float, nargs="+", default=[1.0, 0.9])
+    ap.add_argument("--seeds", type=int, nargs="+", default=[1, 2, 3])
+    ap.add_argument("--settle", type=float, default=0.0,
+                    help="seconds to wait per session (default: duration + 20)")
+    ap.add_argument("--fixture", default="low_fi_Gm_loop_60s_gnm.wav")
+    ap.add_argument("--synthetic", action="store_true")
+    args = ap.parse_args()
+    recs = []
+    for d in args.denoise:
+        for s in args.seeds:
+            recs.append(run_one(args, d, s))
+            time.sleep(1.0)
+    good = [r for r in recs if "error" not in r]
+    n_end = sum(1 for r in good if r["ending"])
+    mean_drop = float(np.mean([r["drop_db"] for r in good])) if good else float("nan")
+    print(f"SUMMARY label={args.label} runs={len(good)} endings={n_end} "
+          f"mean_drop={mean_drop:+.1f}dB", flush=True)
+    with open(os.path.expanduser(f"~/tail_probe_out/{args.label}.json"), "w") as f:
+        json.dump(recs, f, indent=1)
+
+
+main()

--- a/tests/unit/test_sa3_song_length.py
+++ b/tests/unit/test_sa3_song_length.py
@@ -1,0 +1,291 @@
+"""Song-length conditioning for SA3 (the "every loop ends in an outro"
+fix). CPU-only: the conditioning helper runs against a stub model and a
+stub of the two ``stable_audio_3.data.utils`` functions it imports."""
+
+from __future__ import annotations
+
+import math
+import sys
+import types
+
+import pytest
+import torch
+
+from acestep.engine import sa3_context as ctx_mod
+from acestep.engine import sa3_stream_helpers as helpers
+
+SR = 44100
+DS = 4096
+ALIGN = DS * 2  # chunk_size 32 // stride 16 -> 2 latents
+
+
+# ---- env resolution -------------------------------------------------------
+
+
+def test_song_seconds_setting_defaults_and_overrides():
+    assert ctx_mod.song_seconds_setting({}) == ctx_mod.DEFAULT_SONG_SECONDS
+    assert ctx_mod.song_seconds_setting({ctx_mod.SONG_SECONDS_ENV: ""}) == (
+        ctx_mod.DEFAULT_SONG_SECONDS
+    )
+    # 0 (or negative) disables the label -> legacy semantics.
+    assert ctx_mod.song_seconds_setting({ctx_mod.SONG_SECONDS_ENV: "0"}) is None
+    assert ctx_mod.song_seconds_setting({ctx_mod.SONG_SECONDS_ENV: "-3"}) is None
+    assert ctx_mod.song_seconds_setting({ctx_mod.SONG_SECONDS_ENV: "240"}) == 240.0
+    # Clamped to the conditioner's max_val.
+    assert ctx_mod.song_seconds_setting({ctx_mod.SONG_SECONDS_ENV: "9000"}) == (
+        ctx_mod.SONG_SECONDS_MAX
+    )
+    with pytest.raises(ValueError):
+        ctx_mod.song_seconds_setting({ctx_mod.SONG_SECONDS_ENV: "long"})
+
+
+def test_song_schedule_setting():
+    assert ctx_mod.song_schedule_from_window({}) is False
+    assert ctx_mod.song_schedule_from_window(
+        {ctx_mod.SONG_SCHEDULE_ENV: "window"}) is True
+    assert ctx_mod.song_schedule_from_window(
+        {ctx_mod.SONG_SCHEDULE_ENV: "Song"}) is False
+    with pytest.raises(ValueError):
+        ctx_mod.song_schedule_from_window({ctx_mod.SONG_SCHEDULE_ENV: "x"})
+
+
+def test_outro_pad_setting():
+    # Wrapped-loop headroom under a song label; upstream's 6 s silent
+    # outro pad otherwise.
+    assert ctx_mod.outro_pad_setting(180.0, {}) == ctx_mod.DEFAULT_LOOP_WRAP_S
+    assert ctx_mod.outro_pad_setting(180.0, {ctx_mod.OUTRO_PAD_ENV: "0"}) == 0.0
+    assert ctx_mod.outro_pad_setting(None, {}) == ctx_mod.LEGACY_OUTRO_PAD_S
+    assert ctx_mod.outro_pad_setting(180.0, {ctx_mod.OUTRO_PAD_ENV: "2.5"}) == 2.5
+    assert ctx_mod.outro_pad_setting(None, {ctx_mod.OUTRO_PAD_ENV: "-1"}) == 0.0
+    with pytest.raises(ValueError):
+        ctx_mod.outro_pad_setting(None, {ctx_mod.OUTRO_PAD_ENV: "six"})
+
+
+def test_label_seconds_for():
+    assert ctx_mod.label_seconds_for(30.0, 180.0) == 180.0
+    assert ctx_mod.label_seconds_for(30.0, None) == 30.0
+    # A loop longer than the label is still "the whole song".
+    assert ctx_mod.label_seconds_for(200.0, 180.0) == 200.0
+    assert ctx_mod.label_seconds_for(30, 30.0) == 30.0
+
+
+# ---- prepare_sa3_conditioning against a stub model --------------------------
+
+
+class _Param:
+    dtype = torch.float32
+
+
+class _Pretransform:
+    downsampling_ratio = DS
+
+
+class _Inner:
+    def parameters(self):
+        yield _Param()
+
+
+class _Model:
+    sample_rate = SR
+    io_channels = 256
+    sampling_dist_shift = None
+    pretransform = _Pretransform()
+    model = _Inner()
+
+    def conditioner(self, conditioning, device):
+        # Record what the conditioner was fed; return a token per entry.
+        self.fed = conditioning
+        return {"prompt": torch.zeros(1, 4, 8)}
+
+    def get_conditioning_inputs(self, tensors):
+        return {"cross_attn_cond": tensors["prompt"]}
+
+
+class _Sam:
+    """The slice of ``StableAudioModel`` the helper touches."""
+
+    device = "cpu"
+    model_config = {"model": {"pretransform": {"config": {"encoder": {
+        "config": {"chunk_size": 32, "strides": [16]}}}}}}
+
+    def __init__(self):
+        self.model = _Model()
+
+    @staticmethod
+    def _build_conditioning_dicts(prompt, negative_prompt, duration, batch_size):
+        return [{"prompt": prompt, "seconds_total": duration}] * batch_size, None
+
+    def _adapt_sample_size(self, conditioning, sample_size, duration_padding_sec):
+        # Upstream's arithmetic: (seconds + pad) * sr, rounded up to the
+        # chunk alignment, capped at sample_size.
+        max_seconds = max(c["seconds_total"] for c in conditioning)
+        target = int((max_seconds + duration_padding_sec) * SR)
+        target = ((target + ALIGN - 1) // ALIGN) * ALIGN
+        return min(target, sample_size)
+
+
+@pytest.fixture
+def stub_vendor(monkeypatch):
+    """``stable_audio_3.data.utils`` with the two pure functions the
+    helper imports (mirrors of the vendored implementations)."""
+    def compute_effective_seq_len_from_conditioning(
+        conditioning, sample_rate, downsampling_ratio=1, device="cpu",
+    ):
+        lens = [
+            math.ceil(int(c["seconds_total"] * sample_rate) / downsampling_ratio)
+            for c in conditioning
+        ]
+        return torch.tensor(lens, dtype=torch.float32)
+
+    def create_padding_mask_from_lengths(valid_lengths, total_seq_len):
+        positions = torch.arange(total_seq_len).unsqueeze(0)
+        return positions < valid_lengths.unsqueeze(1)
+
+    utils = types.ModuleType("stable_audio_3.data.utils")
+    utils.compute_effective_seq_len_from_conditioning = (
+        compute_effective_seq_len_from_conditioning
+    )
+    utils.create_padding_mask_from_lengths = create_padding_mask_from_lengths
+    pkg = types.ModuleType("stable_audio_3")
+    data = types.ModuleType("stable_audio_3.data")
+    pkg.data = data
+    data.utils = utils
+    for name, mod in (("stable_audio_3", pkg), ("stable_audio_3.data", data),
+                      ("stable_audio_3.data.utils", utils)):
+        monkeypatch.setitem(sys.modules, name, mod)
+
+
+def _frames(seconds):
+    return math.ceil(int(seconds * SR) / DS)
+
+
+def test_legacy_label_equals_render_duration(stub_vendor):
+    sam = _Sam()
+    cond = helpers.prepare_sa3_conditioning(
+        sam, prompt="p", duration=30.0, steps=8, duration_padding_sec=6.0,
+    )
+    assert sam.model.fed[0]["seconds_total"] == 30.0
+    assert cond.seconds_total == 30.0
+    # Window = 30 + 6 s pad; the mask marks the padded tail invalid only
+    # past the 6 s headroom (here: nothing past it, so all valid).
+    assert cond.audio_sample_size == sam._adapt_sample_size(
+        [{"seconds_total": 30.0}], helpers.SA3_DEFAULT_SAMPLE_SIZE, 6.0,
+    )
+    assert cond.latent_frames == cond.audio_sample_size // DS
+    assert cond.sched_args["effective_seq_len"].item() == _frames(30.0)
+
+
+def test_song_label_keeps_the_window_and_relabels(stub_vendor):
+    sam = _Sam()
+    legacy = helpers.prepare_sa3_conditioning(
+        sam, prompt="p", duration=30.0, steps=8, duration_padding_sec=0.0,
+    )
+    song = helpers.prepare_sa3_conditioning(
+        sam, prompt="p", duration=30.0, steps=8, duration_padding_sec=0.0,
+        song_seconds_total=180.0,
+    )
+    # The model is told 180 s ...
+    assert sam.model.fed[0]["seconds_total"] == 180.0
+    assert song.seconds_total == 180.0
+    # ... but the render window is still the 30 s loop.
+    assert song.audio_sample_size == legacy.audio_sample_size
+    assert song.latent_frames == legacy.latent_frames
+    # A slice of a longer song is fully valid to attention.
+    assert bool(song.cond_bundle["padding_mask"].all())
+    # Training-consistent default: the dist-shift schedule follows the label.
+    assert song.sched_args["effective_seq_len"].item() == _frames(180.0)
+    assert song.sched_args["fallback_seq_len"] == song.latent_frames
+
+
+def test_song_label_not_longer_than_render_is_legacy(stub_vendor):
+    sam = _Sam()
+    cond = helpers.prepare_sa3_conditioning(
+        sam, prompt="p", duration=60.0, steps=8, song_seconds_total=45.0,
+    )
+    assert sam.model.fed[0]["seconds_total"] == 60.0
+    assert cond.seconds_total == 60.0
+
+
+def test_schedule_from_window_decouples_the_shift(stub_vendor):
+    sam = _Sam()
+    cond = helpers.prepare_sa3_conditioning(
+        sam, prompt="p", duration=30.0, steps=8, duration_padding_sec=0.0,
+        song_seconds_total=180.0, schedule_from_window=True,
+    )
+    assert sam.model.fed[0]["seconds_total"] == 180.0
+    assert cond.sched_args["effective_seq_len"].item() == _frames(30.0)
+    assert bool(cond.cond_bundle["padding_mask"].all())
+
+
+# ---- SA3Context seam (no model load) --------------------------------------
+
+
+def _bare_context(song_seconds, outro_pad_s):
+    c = ctx_mod.SA3Context.__new__(ctx_mod.SA3Context)
+    c.model_id = "medium"
+    c.sam = _Sam()
+    c.downsampling_ratio = DS
+    c.sample_rate = SR
+    c.song_seconds = song_seconds
+    c.schedule_from_window = False
+    c.outro_pad_s = outro_pad_s
+    c._helpers = helpers
+    return c
+
+
+def test_context_label_and_window_frames():
+    c = _bare_context(180.0, 0.0)
+    assert c.cond_seconds_total(30.0) == 180.0
+    assert c.cond_seconds_total(300.0) == 300.0
+    # 60 s, no pad: 2646000 samples -> aligned to 8192 -> 646 latents.
+    assert c.window_latent_frames(60.0) == 646
+    legacy = _bare_context(None, 6.0)
+    assert legacy.cond_seconds_total(30.0) == 30.0
+    assert legacy.window_latent_frames(60.0) == 712  # 66 s padded window
+
+
+def test_clamp_duration_for_trt_uses_the_window_arithmetic(monkeypatch):
+    from acestep.engine import sa3_trt
+
+    monkeypatch.setattr(sa3_trt, "max_dit_engine_latents", lambda mid: 646)
+    # Eager never clamps.
+    assert _bare_context(180.0, 0.0).clamp_duration_for_trt(
+        90.0, backend="eager") == 90.0
+    # Under the song label a 60 s loop fits the 646-latent engine exactly
+    # (the #336 follow-up: no more 54 s clamp).
+    assert _bare_context(180.0, 0.0).clamp_duration_for_trt(
+        60.0, backend="tensorrt") == 60.0
+    # Legacy pad still costs the tail: 60 + 6 s doesn't fit, cap lands on
+    # the largest 0.1 s step whose padded window does.
+    cap = _bare_context(None, 6.0).clamp_duration_for_trt(
+        60.0, backend="tensorrt")
+    assert cap < 60.0
+    legacy = _bare_context(None, 6.0)
+    assert legacy.window_latent_frames(cap) <= 646
+    assert legacy.window_latent_frames(round(cap + 0.1, 1)) > 646
+
+
+def test_tile_loop_wraps_the_source_to_the_window():
+    c = _bare_context(180.0, 3.0)
+    sr = 48000
+    loop = torch.arange(2 * sr, dtype=torch.float32).reshape(2, sr)  # 1 s, 2 ch
+    window = 3 * SR  # 3 s of model-rate samples
+    out_sr, tiled = c.tile_loop((sr, loop), window)
+    assert out_sr == sr
+    target = math.ceil(window * sr / SR) + 1
+    assert tiled.shape == (2, target)
+    # The second lap starts where the first ended: sample N == sample 0.
+    assert torch.equal(tiled[:, sr], loop[:, 0])
+    assert torch.equal(tiled[:, :sr], loop)
+    # numpy in, tensor out; already-covering sources are untouched.
+    _, tiled_np = c.tile_loop((sr, loop.numpy()), window)
+    assert tiled_np.shape == (2, target)
+    long = torch.zeros(2, 10 * sr)
+    assert c.tile_loop((sr, long), window)[1] is long
+    # Legacy (no label) never tiles: encode_source passes the input through.
+    seen = {}
+    legacy = _bare_context(None, 6.0)
+    legacy._helpers = types.SimpleNamespace(
+        encode_sa3_source=lambda sam, ai, n: seen.setdefault("ai", ai))
+    legacy.encode_source((sr, loop), window)
+    assert seen["ai"][1] is loop


### PR DESCRIPTION
## The bug

DreamSampler loops keep ending in a fade-out to silence over the last ~2 s of the ring — most visibly in Studio / "no input guidance" use (`sa3_denoise` 1.0), but also at the 0.9 default (Discord, 2 Sep: "the song ending phenomenon ... may be an unavoidable side effect of using no input audio for guidance"). This is after #336, which only removed the *padded* tail we were serving as playable audio; the fade *inside* the loop is the model composing an outro.

## Root cause: we tell the model the loop is a whole song

SA3's only structured conditioning besides the prompt is `seconds_total`. In upstream training (`stable_audio_3/data/utils.py::PadCrop`) that label is always the **full file length**, whatever the crop: a 120 s window cut from a 200 s track is labelled 200; a 30 s file is zero-padded to the window and labelled 30. The training config additionally extends examples with silence past the end (`silence_extension_scale_seconds`) and weights the padded region in the loss. So the model has learned two regimes:

* `seconds_total` ≤ the window → "this is the whole song, it ends at `seconds_total`": intro, outro, then silence.
* `seconds_total` > the window → "an unknown slice from the middle of a longer track": no forced beginning or ending.

`prepare_sa3_conditioning` passed `duration` straight through as `seconds_total`, so every DreamSampler loop was conditioned as a complete 30 s (or 57 s, or 12 s) song. The outro in the last seconds is the model being faithful. With a source anchor at low denoise the source pulls the tail back up; at 0.9–1.0 the prior wins — exactly the reported pattern.

## The fix

Label the render as a slice of a longer song. `prepare_sa3_conditioning` now separates the **render window** (still the requested `duration`, aligned) from the **label** fed to the conditioner (`song_seconds_total`, default 180 s via `SA3Context`). The attention padding mask follows the label as upstream does (a long-file crop is fully valid), and so does the dist-shift schedule (training shifted by the label-derived length; `DEMON_SA3_SONG_SCHEDULE=window` keeps the schedule on the render length as an A/B fallback).

**Second half, for the audio-to-audio regime.** The label alone fixed denoise 1.0 everywhere but was source-dependent at 0.8–0.9: some loops (the `inside_confusion` fixture, and any 30 s hard cut of a longer file) still faded. The anchor there ends at the window's very last frame — a hard stop the model reads as "the music ends here", label or not. So under the label the render window gets 3 s of headroom past the loop (`DEFAULT_LOOP_WRAP_S`) and the anchor is **tiled** into it — the loop wrapped onto its own start, the way it will actually play — instead of upstream's zero pad (`SA3Context.tile_loop`, applied in `encode_source`, so the create path, swap re-anchor and swap-resize all get it). Only the loop itself is playable, as before (#336). With that, every previously failing case measured flat.

`clamp_duration_for_trt` now walks the real window arithmetic (`_adapt_sample_size` + alignment) instead of a padding subtraction, so alignment rounding can't push a clamped window one frame past the engine. The 3 s wrap means a 60 s loop on the 646-latent medium engine clamps to ~57 s (was ~54 s under the 6 s pad); `DEMON_SA3_OUTRO_PAD_S=0` trades the wrap for the full 60 s.

The TRT DiT rebuilds its seconds token from a runtime scalar, so both DiT call sites (create and swap-resize) now take the label through `context.cond_seconds_total()`; no engine rebuild.

Env knobs, all read once at model load and logged on the `sa3_model_loaded` line:

* `DEMON_SA3_SONG_SECONDS` — the label, seconds (default 180; `0` = legacy whole-song label + 6 s pad; clamped to the conditioner's 384 s max).
* `DEMON_SA3_SONG_SCHEDULE` — `song` (default) | `window`.
* `DEMON_SA3_OUTRO_PAD_S` — override the render headroom past the loop (default 3 s wrapped loop under the label, 6 s silence in legacy).

## Measurements (`scripts/sa3/tail_probe.py`, sa3-medium eager, 5090 dev box)

Headless PRIMARY sessions against the pod, one per (denoise, seed), server fixture as the source, full lap of fresh audio, then per-second RMS of the last seconds vs. the body median. "ENDING" = last 3 s more than 8 dB under the body. Tail columns are the last 8 s in dB.

**30 s cut of the default track (`low_fi_Gm_loop_60s_gnm`)**

| label | denoise | seeds | endings | typical tail (last 8 s, dB) |
|---|---|---|---|---|
| legacy (30 s) | 1.0 | 1 2 3 | **3/3** | -14 -15 -14 -14 -14 -16 **-34 -56** |
| legacy (30 s) | 0.9 | 1 2 3 | **3/3** | -14 -15 -14 -15 -14 -16 **-34 -56** |
| 180 s | 1.0 | 1 2 3 | 0/3 | -17 -14 -14 -15 -14 -14 -14 -14 |
| 120 s | 1.0 | 1 2 | **2/2** | -14 -15 -14 -14 -13 -17 **-39 -58** |
| 180 s | 0.9 | 1 2 3 | 3/3 (see below) | -15 -15 -15 -15 -14 -18 -33 -49 |
| 180 s | 0.95 | 1 | 0/1 | flat |
| 180 s | 0.8 | 1 | 1/1 | fade |
| 180 s | 0.5 / 0.0 | 1 | 0/2 | flat (0.0 = source passthrough) |
| 180 s, synthetic tone source | 0.9 / 0.0 | 1 | 0/2 | flat |

120 s is not enough: it equals the model's 120 s training window, so it still reads as "the whole file".

The 30 s-cut rows at 0.8–0.9 are a probe artefact worth knowing about: the source there is a hard mid-phrase cut out of a 57.6 s file, and at mid-high denoise the model resolves that cut as an ending. A synthetic constant tone cut the same way doesn't trigger it, and neither does the same fixture at its own length (below). DreamSampler never sends a cut source — the loop length *is* the source length — so the realistic rows are these:

**Full-length fixtures (`--duration 0`, the plugin's geometry)**

| label | fixture | denoise | seeds | endings | tail (last 8 s, dB) |
|---|---|---|---|---|---|
| legacy | low_fi 57.6 s | 0.9 | 1 2 | **2/2** | -16 -16 -15 -16 -15 -17 **-30 -52** |
| legacy | low_fi 57.6 s | 1.0 | 1 2 | **2/2** | -14 -14 -14 -14 -13 -16 **-36 -58** |
| 180 s | low_fi 57.6 s | 0.9 | 2 3 | 0/2 | -22 -21 -21 -20 -19 -20 -22 -21 |
| 180 s | low_fi 57.6 s | 0.8 | 1 | 0/1 | -17 -16 -17 -17 -17 -17 -17 -17 |
| 180 s | inside_confusion 56.6 s | 0.9 | 1 2 | see note | -17 -17 -17 -17 -17 -16 -19 **-46** |

The `inside_confusion` fixture is flat to its last sample in passthrough (denoise 0.0), so that fade is the model's, not the source's: the label alone is not enough when the anchor hard-stops at the window end. Hence the wrapped anchor:

**Label + wrapped anchor (the PR as shipped), the previously failing cases**

| fixture / geometry | denoise | seeds | endings | tail (last 8 s, dB) |
|---|---|---|---|---|
| inside_confusion 56.6 s | 0.9 | 1 2 | 0/2 | -19 -19 -19 -19 -19 -18 -18 -19 |
| low_fi, 30 s hard cut | 0.9 | 1 2 | 0/2 | -14 -15 -15 -15 -15 -15 -14 -14 |
| low_fi 57.6 s | 1.0 | 1 | 0/1 | -14 -14 -14 -14 -13 -14 -14 -14 |
| low_fi 57.6 s | 0.9 | 1 | 0/1 | -23 -15 -15 -16 -16 -16 -16 -16 |

Legacy on the same full-length track: 4/4 endings (0.9 and 1.0, two seeds each, 16–23 dB drops). Every lap is saved as a wav on the dev box under `~/tail_probe_out/` for listening.

## Tests

* New `tests/unit/test_sa3_song_length.py`: env resolution (defaults, `0` disables, clamp to 384, `song|window`, pad override), `prepare_sa3_conditioning` against a stub model + stubbed `stable_audio_3.data.utils` (label vs. window separation, all-valid mask, schedule source, legacy when label ≤ duration), the `SA3Context` seam (`cond_seconds_total`, `window_latent_frames`, the new TRT clamp against the window arithmetic), and `tile_loop` (wraps onto its own start, numpy in, untouched when covering, never under legacy).
* `tests/unit`: 617 passed locally and on the dev box; the 4 `test_lora_facade_session::test_drain_*` failures pre-exist on `main`.
* Unused `trt_duration_cap_s` removed.

## Follow-ups

* Sweep the label value (180 vs 240 vs 384), the wrap length (is 1–2 s enough? that buys back most of the 60 s TRT clamp) and `schedule=window` by ear on real DreamSampler loops — the probe only measures energy at the boundary, not musicality.
* The wrapped anchor also hands the model the loop seam mid-window; worth checking whether loop joins got smoother as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
