### PR TITLE
feat(session): generate from the prompt alone, with no source upload

### DIFF
--- a/acestep/streaming/config.py
+++ b/acestep/streaming/config.py
@@ -72,6 +72,25 @@ class SessionConfig:
     # this is fixed for the session lifetime.
     sa3_duration_s: float | None = None
 
+    # Pure text-to-audio: generate from the prompt alone, with NO source
+    # audio uploaded. The client sends no binary PCM frame, so the adapter
+    # must not block waiting for one — it synthesises a silent anchor at
+    # ``sa3_duration_s`` instead.
+    #
+    # Only honoured alongside ``telemetry_version``. A client that did not
+    # opt into ``init_ack`` never saw this server advertise
+    # ``supports_text_only``, so it cannot know the frame is optional and
+    # must still be sending one; consuming that frame is the only safe
+    # reading. See the adapter's session_init for the full handshake.
+    text_only: bool = False
+
+    # Opt-in to the ``init_ack`` telemetry/capability ack (any truthy value).
+    # Read straight off the raw config dict by the adapter; declared here so
+    # it reaches the generated wire contract that the C++ and TS clients
+    # build their key constants from, rather than being spelled by hand at
+    # each call site.
+    telemetry_version: int | None = None
+
     @classmethod
     def from_dict(cls, data: dict) -> "SessionConfig":
         """Parse a raw config dict (as the WS adapter received it from

--- a/demos/realtime_motion_graph_web/protocol.py
+++ b/demos/realtime_motion_graph_web/protocol.py
@@ -546,6 +546,14 @@ EVENTS: tuple = (
             FieldSpec("client_id", "str", nullable=True,
                       description="The config client_id echoed back, or null "
                                   "when the client sent none."),
+            FieldSpec("supports_text_only", "bool",
+                      description="This server understands config.text_only "
+                                  "(pure text-to-audio, no source upload). "
+                                  "Absent on servers that predate it. This is "
+                                  "the ONLY pre-upload capability signal: it "
+                                  "lands after config parse but before the "
+                                  "audio recv, which is exactly when a client "
+                                  "must decide whether to send a PCM frame."),
         ),
         description="Optional telemetry ack emitted after config parse but "
                     "before audio/model init. Sent ONLY when the config opts "

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -90,6 +90,7 @@ from acestep.streaming.session import (
     UnsupportedTrtCheckpointError,
 )
 from acestep.streaming import registry as session_registry
+from acestep.streaming.sa3_backend import SA3_MAX_DURATION_S
 from acestep.streaming.source import (
     _decode_audio_msg,
     _load_clip_waveform,
@@ -612,6 +613,50 @@ def _truncate_upload_waveform(waveform: torch.Tensor) -> torch.Tensor:
     return truncate_to_pool(waveform[:2, :max_samples])
 
 
+# Fallback window for a text-only session that declares no duration. Matches
+# the client's own default ask rather than the old 6 s carrier: the carrier's
+# length was the upload, never the render.
+TEXT_ONLY_DEFAULT_DURATION_S = 60.0
+
+
+def _text_only_requested(config_dict: dict) -> bool:
+    """Is this a pure text-to-audio session with no source upload coming?
+
+    Both keys are required, and the second one is the load-bearing half.
+    ``supports_text_only`` rides on ``init_ack``, which is emitted ONLY when
+    the config carries ``telemetry_version``. So a client without it never
+    saw the advert, cannot know the PCM frame is optional, and is therefore
+    still sending one — and a frame nobody reads desynchronises every
+    control message after it. When in doubt, read the frame.
+    """
+    return bool(config_dict.get("text_only")) and bool(
+        config_dict.get("telemetry_version"))
+
+
+def _silent_source_waveform(config_dict: dict) -> torch.Tensor:
+    """The null source anchor for a text-only session.
+
+    SA3 still needs a source to hang geometry off (sample rate, channels,
+    render window) even when nothing in it can reach the output: at
+    ``sa3_denoise`` 1.0 slot init is pure noise and ``source_latents`` never
+    enters. Synthesised at the REQUESTED render length so
+    ``source_duration_s`` and ``duration_s`` agree in sa3_session and the
+    session needs no render-beyond-source allowance.
+
+    Exact zeros, not the dithered near-silence the client used to upload:
+    there is no encoder that can hear this, and a client-side floor was only
+    ever hedging against a divide-by-peak we could not see from over there.
+    """
+    try:
+        dur = float(config_dict.get("sa3_duration_s") or 0.0)
+    except (TypeError, ValueError):
+        dur = 0.0
+    if dur <= 0.0:
+        dur = TEXT_ONLY_DEFAULT_DURATION_S
+    dur = max(1.0, min(dur, SA3_MAX_DURATION_S))
+    return torch.zeros(2, int(dur * SAMPLE_RATE), dtype=torch.float32)
+
+
 # BPM/key are global track properties; a centered window this long
 # estimates them as well as the full signal (measured identical on
 # 120 s material) at a fraction of the beat-tracker cost, and it caps
@@ -1122,11 +1167,15 @@ def _handle_client_body(
             logger.warning("user_uploads_wipe_at_session_end_failed error={}", exc)
 
     ctx_stack.callback(_wipe_on_session_end)
+    # Emitted BEFORE the audio recv below, which is the whole point:
+    # ``supports_text_only`` is how a client learns it may withhold the PCM
+    # frame, and that decision has to be made before it sends one.
     if config_dict.get("telemetry_version"):
         ws.send(json.dumps({
             "type": "init_ack",
             "session_id": session_id,
             "client_id": _client_id,
+            "supports_text_only": True,
         }))
 
     _t0 = time.monotonic()
@@ -1143,7 +1192,20 @@ def _handle_client_body(
     # download→decode→re-upload round-trip and read the waveform
     # straight from the pod's fixture cache.
     fixture_name = config_dict.get("fixture_name")
-    if config_dict.get("use_server_fixture") and fixture_name in KNOWN_FIXTURES:
+    # Pure text-to-audio: no PCM frame is coming, so recv'ing one would hang
+    # the session forever. Gated on telemetry_version because that is what
+    # made us send ``supports_text_only`` above: a client that never saw that
+    # advert cannot know the frame is optional, so it must still be sending
+    # one and we must still consume it. Old clients set neither key and take
+    # the unchanged path below.
+    if _text_only_requested(config_dict):
+        waveform = _silent_source_waveform(config_dict)
+        logger.info(
+            "text_only_session duration_s={:.1f} (no source upload)",
+            waveform.shape[1] / SAMPLE_RATE,
+        )
+        _ms("audio_text_only_synthesized")
+    elif config_dict.get("use_server_fixture") and fixture_name in KNOWN_FIXTURES:
         try:
             waveform = _load_known_fixture_waveform(fixture_name)
             _ms("audio_serverside_loaded")

--- a/packages/demon-client/types/wireContract.gen.hpp
+++ b/packages/demon-client/types/wireContract.gen.hpp
@@ -237,6 +237,8 @@ namespace event {
     inline constexpr const char* kSessionId = "session_id";
     /** The config client_id echoed back, or null when the client sent none. */
     inline constexpr const char* kClientId = "client_id";
+    /** This server understands config.text_only (pure text-to-audio, no source upload). Absent on servers that predate it. This is the ONLY pre-upload capability signal: it lands after config parse but before the audio recv, which is exactly when a client must decide whether to send a PCM frame. */
+    inline constexpr const char* kSupportsTextOnly = "supports_text_only";
   }  // namespace init_ack
 
   namespace ready {
@@ -447,6 +449,8 @@ namespace config {
   inline constexpr const char* kClientId = "client_id";
   inline constexpr const char* kBackend = "backend";
   inline constexpr const char* kSa3DurationS = "sa3_duration_s";
+  inline constexpr const char* kTextOnly = "text_only";
+  inline constexpr const char* kTelemetryVersion = "telemetry_version";
 }  // namespace config
 
 // ── Init-phase upload handshake ──

--- a/packages/demon-client/types/wireContract.gen.ts
+++ b/packages/demon-client/types/wireContract.gen.ts
@@ -293,6 +293,8 @@ export interface InitAckEvent {
   session_id?: string;
   /** The config client_id echoed back, or null when the client sent none. */
   client_id?: string | null;
+  /** This server understands config.text_only (pure text-to-audio, no source upload). Absent on servers that predate it. This is the ONLY pre-upload capability signal: it lands after config parse but before the audio recv, which is exactly when a client must decide whether to send a PCM frame. */
+  supports_text_only?: boolean;
 }
 
 export interface ReadyEvent {
@@ -495,6 +497,8 @@ export interface SessionConfigPayload {
   client_id?: string | null;
   backend?: string;
   sa3_duration_s?: number | null;
+  text_only?: boolean;
+  telemetry_version?: number | null;
   // SessionConfig is permissive; extras pass through.
   [k: string]: unknown;
 }

--- a/tests/unit/test_text_only_session.py
+++ b/tests/unit/test_text_only_session.py
@@ -1,0 +1,74 @@
+"""Pure text-to-audio sessions: no source upload, synthesised null anchor.
+
+``config.text_only`` tells the adapter that no binary PCM frame is
+coming. Getting the gate wrong is not a cosmetic bug in either
+direction: skip a frame the client DID send and every control message
+after it is read as audio, and the session desynchronises; wait for a
+frame the client did NOT send and ``ws.recv()`` blocks forever, because
+the plugin has no handshake timeout to rescue it.
+
+The gate is therefore two keys, not one. ``supports_text_only`` rides on
+``init_ack``, which is emitted only when the config carries
+``telemetry_version`` — so a client without it never saw the advert,
+cannot know the frame is optional, and must still be sending one.
+
+No GPU, no model load: the helpers under test are pure functions of the
+config dict, same pattern as test_swap_resize_session.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from acestep.streaming.config import SessionConfig
+from acestep.streaming.source import SAMPLE_RATE
+from demos.realtime_motion_graph_web.ws_adapter import (
+    TEXT_ONLY_DEFAULT_DURATION_S,
+    _silent_source_waveform,
+    _text_only_requested,
+)
+
+
+def test_both_keys_required_to_skip_the_upload():
+    assert _text_only_requested({"text_only": True, "telemetry_version": 1})
+
+
+def test_text_only_without_telemetry_still_reads_the_frame():
+    # The client never saw init_ack, so it cannot know the frame is
+    # optional -- it is sending one, and skipping it would desync.
+    assert not _text_only_requested({"text_only": True})
+
+
+def test_old_clients_are_untouched():
+    assert not _text_only_requested({})
+    assert not _text_only_requested({"telemetry_version": 1})
+    assert not _text_only_requested({"text_only": False, "telemetry_version": 1})
+
+
+def test_anchor_is_synthesised_at_the_requested_render_length():
+    # Length matters: sa3_session derives source_duration_s from this, and
+    # matching the requested render keeps the two in agreement.
+    wf = _silent_source_waveform({"sa3_duration_s": 30.0})
+    assert wf.shape == (2, int(30.0 * SAMPLE_RATE))
+    assert not wf.any(), "the null anchor must be exactly silent"
+
+
+def test_anchor_falls_back_when_no_duration_declared():
+    wf = _silent_source_waveform({})
+    assert wf.shape[1] == int(TEXT_ONLY_DEFAULT_DURATION_S * SAMPLE_RATE)
+
+
+def test_anchor_is_clamped_and_survives_junk():
+    assert _silent_source_waveform({"sa3_duration_s": 99999.0}).shape[1] <= int(
+        120.0 * SAMPLE_RATE)
+    for junk in (None, "", "abc", -5.0, 0.0):
+        wf = _silent_source_waveform({"sa3_duration_s": junk})
+        assert wf.shape[1] > 0
+
+
+def test_config_carries_text_only_and_defaults_off():
+    assert SessionConfig.from_dict({}).text_only is False
+    assert SessionConfig.from_dict({"text_only": True}).text_only is True


### PR DESCRIPTION
## What

Adds `config.text_only`: a session that generates from the prompt alone and uploads **no source audio**. The adapter synthesises the null anchor itself at the requested render length instead of blocking on `ws.recv()`.

## Why

SA3 needs a source to hang geometry off (sample rate, channels, render window), but at `sa3_denoise` 1.0 slot init is pure noise and `source_latents` never enters -- `xt = noise.clone()`. So the DreamSampler's "Nothing" source has been uploading ~2.3 MB of silent carrier on every connect purely for the pod to encode and ignore. `x0_target` (the one path that attaches the source latent regardless of denoise) defaults to `0.0` and no client sets it.

This is Ryan's ask from Discord -- "we need `null` audio input rather than `silence`, ie pure text to audio" -- with the upstream half he flagged.

## The gate is two keys, deliberately

Getting this wrong is not cosmetic in either direction:

- Skip a frame the client **did** send, and every later control message is read as audio: the session desyncs.
- Wait for a frame the client did **not** send, and `ws.recv()` blocks forever. Neither side has a handshake timeout.

So `text_only` is honoured only alongside `telemetry_version`. `supports_text_only` rides on `init_ack`, which is emitted only when the config carries `telemetry_version` -- so a client without it never saw the advert, cannot know the frame is optional, and must still be sending one. **When in doubt, read the frame.**

`init_ack` is the only place this advert can live: it lands after config parse but **before** the audio recv, which is exactly when a client has to decide whether to send anything.

## Compatibility -- verified on a live pod, both directions

| client | server | result |
|---|---|---|
| new (`text_only`, no upload) | new | `ready` in 7.6 s, **2304008 bytes withheld** |
| old (no flags, uploads) | new | unchanged, `ready` |
| `text_only` w/o `telemetry_version` + upload | new | frame read, no desync |
| new | old (has `init_ack`) | advert absent, uploads after all, `ready` |
| new | pre-`init_ack` | client 4 s fallback, uploads, `ready` |

The last two were driven from the real DreamSampler standalone against this pod, with the server reverted to `main` and then patched to suppress `init_ack`.

## Notes

- `telemetry_version` was read straight off the raw config dict and was never declared. It is now a `SessionConfig` field so it reaches the generated wire contract that the C++/TS clients build their key constants from.
- Wire types regenerated (`gen_wire_types.py`); the plugin-side vendored header is updated in the matching daydream-plugins PR.
- `tests/unit/test_text_only_session.py` covers the gate, the anchor geometry, and junk input. Full unit suite: 624 passed (the 4 `test_lora_facade_session.py::test_drain_*` failures are pre-existing on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
