### PR TITLE
feat(sa3): support source-time preservation envelopes

### DIFF
--- a/acestep/engine/stream.py
+++ b/acestep/engine/stream.py
@@ -1397,13 +1397,8 @@ class StreamPipeline:
             # materialized when the blend actually fires.
             if "x0_target_strength" in self._shared_curves:
                 strength_active = self._shared_x0_active
-                eff_strength = self._shared_curves["x0_target_strength"]
             else:
                 strength_active = slot.x0_strength_active
-                eff_strength = (
-                    ode_steps.normalize_curve(req.x0_target_strength)
-                    if strength_active else None
-                )
             scalar_x0_target = (
                 req.x0_target is not None
                 and strength_active
@@ -1476,7 +1471,9 @@ class StreamPipeline:
                         x0_pred, req.x0_target, curve * blend_gate,
                     )
             elif scalar_x0_target:
-                alpha = eff_strength.to(device=x0_pred.device, dtype=x0_pred.dtype)
+                alpha = self._shared_curve_dev(
+                    slot, "x0_target_strength", x0_pred.device, x0_pred.dtype,
+                )
                 x0_pred = (1.0 - alpha) * x0_pred + alpha * req.x0_target
 
             if t_next <= 0:

--- a/acestep/streaming/generator_backend.py
+++ b/acestep/streaming/generator_backend.py
@@ -161,6 +161,9 @@ class Capabilities:
     loop_band: bool = False
     depth: bool = False
     curves: bool = False
+    # A circular envelope over source time, applied as an X0 preservation
+    # floor. Distinct from ACE's generic time/step curve command surface.
+    source_preservation: bool = False
     notes_conditioning: bool = False
     # Activation steering (per-layer residual shifts driven by the
     # steer_* / man_*_<N> knobs and the manual_slot_add/pop commands).

--- a/acestep/streaming/preservation.py
+++ b/acestep/streaming/preservation.py
@@ -1,0 +1,26 @@
+"""Transport-neutral validation for a circular source-preservation envelope."""
+
+import math
+
+MAX_PRESERVATION_POINTS = 256
+
+
+def parse_preservation_curve(value):
+    """None/empty clears. Otherwise accept 2..256 finite numbers in [0, 1].
+
+    Samples are equally spaced over playable source time, endpoint excluded;
+    interpolation wraps from the last sample back to the first. Reject whole
+    malformed updates so a partial/bad gesture cannot erase the previous one.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, (list, tuple)):
+        raise ValueError("preservation curve must be a list or null")
+    if not value:
+        return None
+    if not 2 <= len(value) <= MAX_PRESERVATION_POINTS:
+        raise ValueError("preservation curve needs 2..256 samples")
+    if any(isinstance(v, bool) or not isinstance(v, (int, float))
+           or not 0 <= v <= 1 or not math.isfinite(v) for v in value):
+        raise ValueError("preservation samples must be finite numbers in [0, 1]")
+    return tuple(float(v) for v in value)

--- a/acestep/streaming/sa3_backend.py
+++ b/acestep/streaming/sa3_backend.py
@@ -32,9 +32,14 @@ Control surface (everything else off, capability-gated):
 * ``x0_target`` / ``feedback`` / ``feedback_depth`` — taken FROM the
   shared registry (identical semantics to ACE, solver-level latent
   mechanics that are family-agnostic): the source-lock morph toward
-  the anchor latent and the past-latent delay-tap blend. Both are only
-  audible at ``sa3_denoise`` < 1, where slot init actually reads
-  ``source_latents`` — at 1.0 every slot starts from pure noise.
+  the anchor latent and the past-latent delay-tap blend. Feedback needs
+  ``sa3_denoise`` < 1, where slot init reads ``source_latents``. X0
+  preservation also works at full denoise, since it acts later.
+* ``sa3_preservation_curve`` — a params sidecar declared in protocol.py,
+  gated by ``source_preservation``. Circular samples over playable source
+  time add a per-frame floor above scalar ``x0_target`` during late
+  denoising. Null clears the envelope; global X0 still applies. Requires
+  a source anchor. This preserves latents, not exact waveform samples.
 * ``seed`` / ``steps_override`` — shared registry, as before.
 
 Continuity comes the same way the spike demo proved
@@ -76,6 +81,7 @@ from acestep.streaming.knobs import (
     knob_specs as registry_knob_specs,
     lora_strength_spec,
 )
+from acestep.streaming.preservation import parse_preservation_curve
 
 # Delivery rate (v1): SA3's native 44.1 kHz is resampled at the decode
 # boundary so everything downstream of the backend stays at the engine
@@ -653,6 +659,7 @@ class SA3Backend(DiffusionBackend):
         # can trust the bit instead of probing.
         return Capabilities(
             refines_audio=True, loop_band=True, swap=True,
+            source_preservation=True,
             swap_resize=bool(
                 self._resizer is not None and self._source_encoder is not None
             ),
@@ -1266,6 +1273,36 @@ class SA3Backend(DiffusionBackend):
 
     # ---- produce hooks ---------------------------------------------------------
 
+    def _preservation_strength(self, raw, scalar):
+        """Cached CPU [1,T,1] envelope, aligned to playable time, not padding.
+
+        The shared pipeline uploads only on a real change. Keeping validation
+        and interpolation on CPU avoids a GPU sync on every params tick.
+        """
+        try:
+            curve = parse_preservation_curve(raw)
+        except ValueError:
+            curve = getattr(self, "_preservation_valid", None)
+        self._preservation_valid = curve
+        if curve is None or self._source_latent_btc is None:
+            return scalar
+        frames = self._source_latent_btc.shape[1]
+        duration = self.playable_duration_s()
+        key = (curve, scalar, frames, duration)
+        if key != getattr(self, "_preservation_cache_key", None):
+            positions = torch.arange(frames, dtype=torch.float32) / SA3_LATENT_RATE_HZ
+            phase = positions / duration * len(curve)
+            lo = phase.floor().long()
+            weight = phase - lo
+            samples = torch.tensor(curve, dtype=torch.float32)
+            envelope = samples[lo % len(curve)] * (1 - weight) + samples[(lo + 1) % len(curve)] * weight
+            # Duration conditioning adds a model-only tail. Do not stretch
+            # the drawn curve into it or wrap source edits through it.
+            envelope = torch.where(positions < duration, envelope, 0.0)
+            self._preservation_cache = envelope.clamp_min(scalar).view(1, frames, 1)
+            self._preservation_cache_key = key
+        return self._preservation_cache
+
     def _prepare_tick(self, knobs: dict, ctx: TickContext) -> dict:
         # Schedule warp: hot-applied, but cache-coupled — the pipeline
         # caches schedules per denoise value, so a changed alpha must
@@ -1305,8 +1342,9 @@ class SA3Backend(DiffusionBackend):
         # bump engages the blend on in-flight slots submitted while it
         # was 0 — the ACE runner's exact per-tick convention.
         x0_str = float(knobs.get("x0_target", 0.0))
+        preservation = self._preservation_strength(knobs.get("sa3_preservation_curve"), x0_str)
         if self._source_latent_btc is not None:
-            self.pipeline.set_shared_curve("x0_target_strength", x0_str)
+            self.pipeline.set_shared_curve("x0_target_strength", preservation)
 
         try:
             fb_depth_raw = float(knobs.get("feedback_depth", 1.0))
@@ -1318,6 +1356,7 @@ class SA3Backend(DiffusionBackend):
             "steps": int(knobs.get("steps_override", self._steps)),
             "shift": shift,
             "x0_target": x0_str,
+            "preservation_strength": preservation,
             "feedback": float(knobs.get("feedback", 0.0)),
             "feedback_depth": max(
                 1, min(MAX_FEEDBACK_DEPTH, int(round(fb_depth_raw))),
@@ -1379,7 +1418,7 @@ class SA3Backend(DiffusionBackend):
             # (steps rebuild) is correct before the next prepare
             # re-establishes the shared override.
             x0_target=self._source_latent_btc,
-            x0_target_strength=prep["x0_target"],
+            x0_target_strength=prep["preservation_strength"],
             aux_cond=aux_cond,
             latent_frames=latent_frames,
             # Deterministic pingpong: identical requests must replay the

--- a/acestep/streaming/session.py
+++ b/acestep/streaming/session.py
@@ -1802,6 +1802,7 @@ class StreamingSession:
         slice_lead_s: float | None = None,
         render_anchor_s=_RENDER_ANCHOR_UNSET,
         render_anchor_queue_s=_RENDER_ANCHOR_UNSET,
+        sa3_preservation_curve=_RENDER_ANCHOR_UNSET,
     ) -> None:
         """Apply or echo a knob update. ``raw`` is the unfiltered
         wire dict; values land in ``virtual_knobs`` only on PRIMARY.
@@ -1834,7 +1835,22 @@ class StreamingSession:
         lead since its previous report (see the wire contract); the
         runner widens its playback lead until these stay positive."""
         state = self.state
-        raw = raw or {}
+        raw = dict(raw or {})
+        # The list is a protocol sidecar, not a scalar knob. Keep validation
+        # here so WS and direct session callers share the same behavior.
+        # Also sanitize the internal key on raw/MCP calls (unknown knobs
+        # normally pass through), preventing malformed arrays from entering
+        # the render loop or unsupported backends.
+        from acestep.streaming.preservation import parse_preservation_curve
+        if sa3_preservation_curve is not _RENDER_ANCHOR_UNSET:
+            raw["sa3_preservation_curve"] = sa3_preservation_curve
+        if "sa3_preservation_curve" in raw:
+            value = raw.pop("sa3_preservation_curve")
+            if self.backend.capabilities().source_preservation:
+                try:
+                    raw["sa3_preservation_curve"] = parse_preservation_curve(value)
+                except ValueError:
+                    pass  # retain the last valid KnobState value
         # Activity gating: only bump on a real change. ``playback_pos``
         # advances every tick but is excluded from the diff because
         # it's a clock, not user input.

--- a/demos/realtime_motion_graph_web/protocol.py
+++ b/demos/realtime_motion_graph_web/protocol.py
@@ -215,6 +215,17 @@ COMMANDS: tuple = (
             FieldSpec("playback_pos", "float", default=0.0,
                       description="Playhead position in SECONDS (not a 0..1 "
                                   "ratio); used for time-keyed curve sampling."),
+            FieldSpec("sa3_preservation_curve", "list", nullable=True,
+                      description="Circular source-preservation envelope: 2..256 "
+                                  "finite numbers in [0,1], equally spaced over "
+                                  "the playable source (endpoint excluded). "
+                                  "Last sample interpolates back to first. Adds "
+                                  "a per-position X0 floor above scalar x0_target "
+                                  "during late denoising; does not change denoise. "
+                                  "Absent retains; null/empty clears; invalid "
+                                  "updates retain the previous curve. Requires "
+                                  "ready.capabilities.source_preservation. "
+                                  "This is latent preservation, not exact PCM masking."),
             FieldSpec("render_anchor_s", "float", nullable=True,
                       description="Optional stationary render placement in "
                                   "absolute buffer/song seconds. A finite value "

--- a/demos/realtime_motion_graph_web/ws_adapter.py
+++ b/demos/realtime_motion_graph_web/ws_adapter.py
@@ -461,7 +461,7 @@ def _coalesced_slice_lead(prev, new) -> float | None:
 # vanish whenever the recv thread drains a backlog, which is exactly when
 # GPU-heavy generation starves it. The VST re-sends the scalar anchor every
 # tick so it survived by accident; the one-shot queue does not.
-_STICKY_PARAMS_FIELDS = ("render_anchor_s", "render_anchor_queue_s")
+_STICKY_PARAMS_FIELDS = ("render_anchor_s", "render_anchor_queue_s", "sa3_preservation_curve")
 
 
 def _fold_sticky_params(pending: dict, newer: dict) -> dict:
@@ -1801,6 +1801,8 @@ def _handle_client_body(
                 if pp is not None and not math.isfinite(pp):
                     pp = None
                 anchor_kwargs = {}
+                if "sa3_preservation_curve" in data:
+                    anchor_kwargs["sa3_preservation_curve"] = data["sa3_preservation_curve"]
                 if "render_anchor_s" in data:
                     anchor_raw = data.get("render_anchor_s")
                     try:

--- a/packages/demon-client/dist/demon-client.js
+++ b/packages/demon-client/dist/demon-client.js
@@ -10,6 +10,7 @@ var COMMAND_NAMES = [
   "set_depth",
   "enable_lora",
   "disable_lora",
+  "add_lora",
   "manual_slot_add",
   "manual_slot_pop",
   "set_timbre_strength",

--- a/packages/demon-client/dist/demon-client.node.cjs
+++ b/packages/demon-client/dist/demon-client.node.cjs
@@ -1780,6 +1780,7 @@ var COMMAND_NAMES = [
   "set_depth",
   "enable_lora",
   "disable_lora",
+  "add_lora",
   "manual_slot_add",
   "manual_slot_pop",
   "set_timbre_strength",

--- a/packages/demon-client/types/wireContract.gen.hpp
+++ b/packages/demon-client/types/wireContract.gen.hpp
@@ -43,6 +43,8 @@ namespace command {
     inline constexpr const char* kRaw = "raw";
     /** Playhead position in SECONDS (not a 0..1 ratio); used for time-keyed curve sampling. */
     inline constexpr const char* kPlaybackPos = "playback_pos";
+    /** Circular source-preservation envelope: 2..256 finite numbers in [0,1], equally spaced over the playable source (endpoint excluded). Last sample interpolates back to first. Adds a per-position X0 floor above scalar x0_target during late denoising; does not change denoise. Absent retains; null/empty clears; invalid updates retain the previous curve. Requires ready.capabilities.source_preservation. This is latent preservation, not exact PCM masking. */
+    inline constexpr const char* kSa3PreservationCurve = "sa3_preservation_curve";
     /** Optional stationary render placement in absolute buffer/song seconds. A finite value renders exactly at that position, bypassing transport lead and loop-band snapping. Absent retains the prior anchor; null clears it. */
     inline constexpr const char* kRenderAnchorS = "render_anchor_s";
     /** Optional BATCH of stationary render anchors (absolute buffer/song seconds), rendered back-to-back one window per tick whenever the scalar render_anchor_s is clear (the scalar preempts; the queue resumes when it clears). Each anchor is popped after its window emits. A list REPLACES the prior queue; absent retains it; null/empty clears it. Gated on ready.capabilities.render_anchor_queue — older servers ignore the field. Non-finite entries are dropped; length is capped server-side (1024). Like the scalar anchor, IGNORED in walk-window mode (sources longer than walk_window_s): the DiT holds one chunk and cannot render outside it — clients must not queue-warm walk sources. */

--- a/packages/demon-client/types/wireContract.gen.ts
+++ b/packages/demon-client/types/wireContract.gen.ts
@@ -131,6 +131,8 @@ export interface ParamsCommand {
   raw: Record<string, unknown>;
   /** Playhead position in SECONDS (not a 0..1 ratio); used for time-keyed curve sampling. */
   playback_pos?: number;
+  /** Circular source-preservation envelope: 2..256 finite numbers in [0,1], equally spaced over the playable source (endpoint excluded). Last sample interpolates back to first. Adds a per-position X0 floor above scalar x0_target during late denoising; does not change denoise. Absent retains; null/empty clears; invalid updates retain the previous curve. Requires ready.capabilities.source_preservation. This is latent preservation, not exact PCM masking. */
+  sa3_preservation_curve?: unknown[] | null;
   /** Optional stationary render placement in absolute buffer/song seconds. A finite value renders exactly at that position, bypassing transport lead and loop-band snapping. Absent retains the prior anchor; null clears it. */
   render_anchor_s?: number | null;
   /** Optional BATCH of stationary render anchors (absolute buffer/song seconds), rendered back-to-back one window per tick whenever the scalar render_anchor_s is clear (the scalar preempts; the queue resumes when it clears). Each anchor is popped after its window emits. A list REPLACES the prior queue; absent retains it; null/empty clears it. Gated on ready.capabilities.render_anchor_queue — older servers ignore the field. Non-finite entries are dropped; length is capped server-side (1024). Like the scalar anchor, IGNORED in walk-window mode (sources longer than walk_window_s): the DiT holds one chunk and cannot render outside it — clients must not queue-warm walk sources. */

--- a/tests/unit/test_render_anchor.py
+++ b/tests/unit/test_render_anchor.py
@@ -265,3 +265,30 @@ def test_emit_trim_never_suppresses_stationary_anchor_window():
     assert runner._should_trim_window_emit(None, anchored=False) is True
     assert runner._should_trim_window_emit(None, anchored=True) is False
     assert runner._should_trim_window_emit(48000, anchored=False) is False
+
+
+def test_preservation_sidecar_validation_retention_and_capability_gate():
+    from acestep.streaming.generator_backend import Capabilities
+    session = _session_for_params()
+    session.backend = SimpleNamespace(capabilities=lambda: Capabilities(source_preservation=True))
+    session.set_knobs({}, sa3_preservation_curve=[0., 1.])
+    assert session.virtual_knobs['sa3_preservation_curve'] == (0., 1.)
+    session.set_knobs({})  # omission retains
+    for bad in ([float('nan'), 0.], [True, 0.], [1.1, 0.], '0,1', [0.], [0.] * 257, [10**500, 0.]):
+        session.set_knobs({}, sa3_preservation_curve=bad)
+        assert session.virtual_knobs['sa3_preservation_curve'] == (0., 1.)
+    session.set_knobs({}, sa3_preservation_curve=None)
+    assert session.virtual_knobs['sa3_preservation_curve'] is None
+    session.backend = SimpleNamespace(capabilities=lambda: Capabilities())
+    session.set_knobs({}, sa3_preservation_curve=[1., 1.])
+    assert session.virtual_knobs['sa3_preservation_curve'] is None
+
+
+def test_preservation_survives_params_coalescing_and_explicit_clear_wins():
+    from demos.realtime_motion_graph_web.ws_adapter import _fold_sticky_params
+    newer = {'raw': {}}
+    _fold_sticky_params({'sa3_preservation_curve': [0., 1.]}, newer)
+    assert newer['sa3_preservation_curve'] == [0., 1.]
+    cleared = {'sa3_preservation_curve': None}
+    _fold_sticky_params(newer, cleared)
+    assert cleared['sa3_preservation_curve'] is None

--- a/tests/unit/test_sa3_backend.py
+++ b/tests/unit/test_sa3_backend.py
@@ -1037,3 +1037,51 @@ def test_close_drops_mirror_and_pending():
     assert b._refit_mirror is None
     assert b._pending_lora_strengths == {}
     assert mgr.closed is True
+
+# Source-time preservation uses the real SA3 adapter / streaming solver, with
+# a zero DiT. These tests check generated latents, not merely payload shapes.
+def test_preservation_region_changes_only_selected_latent_frames():
+    src = torch.ones(1, C, T)
+    free = _backend(source_latent_bct=src)
+    preserve = _backend(source_latent_bct=src)
+    assert preserve.capabilities().source_preservation
+    curve = [0.0] * (T // 2) + [1.0] * (T // 2)
+    for _ in range(10):
+        free.produce(_knobs(free, seed=9), CTX, 'generate')
+        preserve.produce(_knobs(preserve, seed=9, sa3_preservation_curve=curve), CTX, 'generate')
+    a, b = free._last_result_latent, preserve._last_result_latent
+    torch.testing.assert_close(a[:, :T // 2], b[:, :T // 2])
+    torch.testing.assert_close(b[:, T // 2:], src.movedim(1, 2)[:, T // 2:])
+    assert not torch.equal(a[:, T // 2:], b[:, T // 2:])
+
+
+def test_preservation_wraps_over_playable_time_excluding_padding_and_resizes():
+    b = _backend(source_latent_bct=torch.ones(1, C, T), playable_duration_s=(N44 / SA3_SAMPLE_RATE) / 2)
+    curve = [0, 1, 0, 0.5]
+    result = b._preservation_strength(curve, 0.0).flatten()
+    torch.testing.assert_close(result[:8], torch.tensor([0., .5, 1., .5, 0., .25, .5, .25]))
+    assert result[8:].count_nonzero() == 0  # never paint the padded tail
+    cached = b._preservation_strength(list(curve), 0.0)
+    assert cached is b._preservation_strength(curve, 0.0)
+    b._playable_s *= 2
+    resized = b._preservation_strength(curve, 0.0)
+    assert resized is not cached
+    assert resized.flatten()[4] == 1.0
+
+
+def test_preservation_floor_clear_invalid_and_rebuild():
+    b = _backend(source_latent_bct=torch.ones(1, C, T))
+    curve = [0., 1.]
+    b.produce(_knobs(b, x0_target=.25, sa3_preservation_curve=curve), CTX, 'generate')
+    strength = b.pipeline._shared_curves['x0_target_strength']
+    assert strength.min() == .25
+    assert strength.max() == 1.0
+    # Malformed direct-backend callers cannot clear a valid envelope either.
+    assert b._preservation_strength([float('nan'), 0.], .25) is b._preservation_cache
+    b.produce(_knobs(b, steps_override=5, sa3_preservation_curve=curve), CTX, 'generate')
+    # First request after a pipeline rebuild must carry the curve itself.
+    requests = [s.request for s in b.pipeline._slots if s is not None]
+    requests += list(b.pipeline._queue)
+    assert requests and all(isinstance(r.x0_target_strength, torch.Tensor) for r in requests)
+    b.produce(_knobs(b, x0_target=.25, sa3_preservation_curve=None), CTX, 'generate')
+    assert b.pipeline._shared_curves['x0_target_strength'].flatten().tolist() == [.25]


### PR DESCRIPTION
SA3 currently exposes only a global X0 source lock. This adds a circular source-time envelope so a client can preserve selected positions more strongly while leaving other positions free to transform.

The `params.sa3_preservation_curve` sidecar accepts 2–256 finite samples in [0,1], advertised by `ready.capabilities.source_preservation`. It applies `max(global X0, envelope)` during late denoising, wraps over playable source time, and excludes duration padding. Omission retains the curve; null/empty clears it; invalid updates retain the last valid state. Updates survive params coalescing and step-count rebuilds, and shared CPU envelopes reuse the pipeline's device-cast cache.

Regenerated the wire types and SDK bundles. The bundle build also picks up the previously stale `add_lora` command name already present on main.

Validation: 107 CPU tests pass across SA3 backend/adapter, ACE parity, wire contract, SDK, render placement, knob homonyms, and source resize. The malformed-input suite was rerun after adding an oversized-integer case (20 tests pass). Tests verify actual generated latent changes, unselected-region equality, wrap/padding alignment, scalar floor, clear, malformed input, and rebuild behavior. ACE parity passes its existing cross-platform tolerance tier.

Real SA3 GPU/audio listening and latency validation have not been run. Preservation operates in latent space and does not promise exact PCM masking. No pod deployment is included.
